### PR TITLE
$this not available in included files

### DIFF
--- a/src/compiler/statement/method_statement.cpp
+++ b/src/compiler/statement/method_statement.cpp
@@ -280,7 +280,19 @@ void MethodStatement::analyzeProgramImpl(AnalysisResultPtr ar) {
           funcScope->setOverriding(Type::Variant, Type::Variant);
         }
       }
+		}
+    
+		if (!funcScope->isStatic() && getClassScope() &&
+        funcScope->getVariables()->
+        getAttribute(VariableTable::ContainsDynamicVariable)) {
+      // Add this to variable table if we'll need it in a lookup table
+      // Use object because there's no point to specializing, just makes
+      // code gen harder when dealing with redeclared classes.
+      TypePtr tp(Type::Object);
+      funcScope->getVariables()->add("this", tp, true, ar, shared_from_this(),
+                                     ModifierExpressionPtr());
     }
+
     FunctionScope::RecordRefParamInfo(m_name, funcScope);
   }
 }


### PR DESCRIPTION
[Bug] $this variable discarded in included file scope

In php, when a file is included from within a class method, it is executed
with the variable scope of that method, including $this. Commit ae48b8
introduced a bug where local variables from the method were available in
the included file, but $this was not. This only affects hphp, not hphpi.

Reproduce:
<?php
// foo.php
class Foo {
  var $a;
  function bar() {
    $this->a = "I'm an object property!";
    $b = "I'm a local method variable!";
    echo $this->a . "\n";
    echo $b . "\n";
    include('bar.php');
  }
}

$foo = new Foo();
$foo->bar();
?>
<?php
// bar.php
echo $this->a . "\n";
echo $b . "\n";
?>

Current Output:
I'm an object property!
I'm a local method variable!
HipHop Notice:  Trying to get property of non-object

I'm a local method variable!

Expected output:
I'm an object property!
I'm a local method variable!
I'm an object property!
I'm a local method variable!

Test plan: All tests, scripts above
