### PR TITLE
curl moved git. so curl's diff now use git command.(and fix SSLv2_client_method build error.)

### DIFF
--- a/src/third_party/libcurl.fb-changes.diff
+++ b/src/third_party/libcurl.fb-changes.diff
@@ -125,7 +125,7 @@ index 474bc9a..f87db4a 100644
    case CURL_SSLVERSION_SSLv2:
 +#ifdef OPENSSL_NO_SSL2
 +    failf(data, "OpenSSL was built without SSLv2 support");
-+    return CURLE_UNSUPPORTED_PROTOCOL;
++    return CURLE_SSL_CONNECT_ERROR;
 +#endif
      req_method = SSLv2_client_method();
      use_sni(FALSE);


### PR DESCRIPTION
create libcurl.fb-changes.diff use git diff command. because curl's repository already moved git.
and add new diff to lib/ssluse.c. that fix build error about SSLv2_client_method.
