### PR TITLE
Support for curl-7.21.7 and possibly newer 

### DIFF
--- a/src/third_party/libcurl.fb-changes.diff
+++ b/src/third_party/libcurl.fb-changes.diff
@@ -36,6 +36,7 @@ diff -u -r1.210 multi.c
  #include "sendf.h"
  #include "timeval.h"
  #include "http.h"
+ #include "warnless.h"
 +#include "select.h"
  
  #define _MPRINTF_REPLACE /* use our functions only */


### PR DESCRIPTION
Curl 7.21.3 through 7.21.7 and possibly newer versions require this modification to the patch file.  7.21.3 or newer is needed to compile with newer versions of libssh2.  7.21.2 and earlier die with "ssh.c:121:8: error: conflicting types for ‘libssh2_free’" because the symbol is defined twice.
