### PR TITLE
Fix bug with (p)fsockopen() returning invalid sockets

### DIFF
--- a/src/runtime/base/file/socket.cpp
+++ b/src/runtime/base/file/socket.cpp
@@ -109,6 +109,26 @@ void Socket::setTimeout(struct timeval &tv) {
   }
 }
 
+bool Socket::checkLiveness() {
+   if (m_fd == -1 || m_timedOut) {
+     return false;
+   }
+
+   pollfd p;
+   p.fd = m_fd;
+   p.events = POLLIN | POLLERR | POLLHUP | POLLPRI;
+   p.revents = 0;
+   if (poll(&p, 1, 0) > 0 && p.revents > 0) {
+     char buf;
+     if (0 == recv(m_fd, &buf, sizeof(buf), MSG_PEEK) &&
+                errno != EAGAIN) {
+       return false;
+     }
+   }
+   return true;
+}
+
+
 bool Socket::setBlocking(bool blocking) {
   int flags = fcntl(m_fd, F_GETFL, 0);
   if (blocking) {

--- a/src/runtime/base/file/socket.h
+++ b/src/runtime/base/file/socket.h
@@ -54,8 +54,8 @@ public:
   virtual Array getMetaData();
   virtual int64 tell();
 
-  // allows SSLSocket to perform special checking
-  virtual bool checkLiveness() { return true;}
+  // check if the socket is open
+  virtual bool checkLiveness();
 
   void setError(int err);
   int getError() const { return m_error;}


### PR DESCRIPTION
Summary: If the peer doesn't close the connection properly or under high-load
situations (or tcp_tw_recycle=1), Hiphop-php can return invalid sockets
because it didn't detect the socket is not valid anymore.

This affects fsockopen and pfsockopen.

This is the state of stream_get_meta_data during the problem:
array (\n  'wrapper_type' => 'Socket',\n  'stream_type' => '',\n
'mode' => '',\n  'unread_bytes' => 0,\n  'seekable' => false,\n
 'uri' => '',\n  'timed_out' => false,\n  'blocked' => false,\n
 'eof' => false,\n)

Hiphop-php can also return timed_out sockets with pfsockopen().
\n  'wrapper_type' => 'Socket',\n  'stream_type' => '',\n
'mode' => '',\n  'unread_bytes' => 0,\n  'seekable' => false,\n
'uri' => '',\n  'timed_out' => true,\n  'blocked' => false,\n
'eof' => false,\n

How to reproduce:
- Start a daemon (e.g. nc -l)
- Open a connection with pfsockopen to localhost
- pfsockopen returns a resource #A
- fwrite(#A, $foo); => OK
- Close the daemon
- Open a connection with pfsockopen to localhost
  => pfsockopen() returns the same resource #A and $errno == 0 (Success)
- fwrite($resource, $foo); => "Not a valid stream resource"

Expected output:
- pfsockopen() should establish a new connection and drop the old one.

Fix:
Hiphop-php shouldn't return invalid sockets. This is default
PHP behaviour.

What is the fix:
Testing if the socket is still alive using poll() and MSG_PEEK.
Perf looks ok.

Test Plan:
Checked connections were kept permanent (tcpdump).
Tested on 100'000'000 queries in production.

Revert Plan: easy
