### PR TITLE
hiphop-php does not compile under FreeBSD 9

### DIFF
--- a/src/runtime/base/preg.cpp
+++ b/src/runtime/base/preg.cpp
@@ -135,7 +135,7 @@ static pcre_cache_entry *pcre_get_compiled_regex_cache(CStrRef regex) {
      * We use a quick pcre_info() check to see whether cache is corrupted,
      * and if it is, we flush it and compile the pattern from scratch.
      */
-    if (pcre_info(pce->re, NULL, NULL) == PCRE_ERROR_BADMAGIC) {
+    if (pcre_fullinfo(pce->re, NULL, NULL, NULL) == PCRE_ERROR_BADMAGIC) {
       pcre_cache.cleanup();
     } else {
 #if HAVE_SETLOCALE


### PR DESCRIPTION
---

/root/hhbuild/hiphop-php/src/runtime/base/preg.cpp: In function 'HPHP::pcre_cache_entry\* HPHP::pcre_get_compiled_regex_cache(HPHP::CStrRef)':
/root/hhbuild/hiphop-php/src/runtime/base/preg.cpp:138:38: error: 'pcre_info' was not declared in this scope
**\* Error code 1
Stop in /root/hhbuild/hiphop-php.

pcre_info in 9.0-release and ports shows it as obsolete and replaced by pcre_fullinfo() so we need to fix it in line 138

138 -       if (pcre_info(pce->re, NULL, NULL) == PCRE_ERROR_BADMAGIC) {
138 +       if (pcre_fullinfo(pce->re, NULL, NULL, NULL) == PCRE_ERROR_BADMAGIC) {

With this patch hiphop-php was compiled successful.
