### PR TITLE
Add a space between the command and the args

### DIFF
--- a/hphp/compiler/compiler.cpp
+++ b/hphp/compiler/compiler.cpp
@@ -943,7 +943,7 @@ int runTarget(const CompilerOptions &po) {
   }
   cmd += po.outputDir + '/' + po.program;
   cmd += string(" --file ") +
-    (po.inputs.size() == 1 ? po.inputs[0] : "") + po.programArgs;
+    (po.inputs.size() == 1 ? po.inputs[0] : "") + ' ' + po.programArgs;
   Logger::Info("running executable: %s", cmd.c_str());
   ret = Util::ssystem(cmd.c_str());
   if (ret && ret != -1) ret = 1;


### PR DESCRIPTION
When specifying --args="arg" on the command line it gets appended directly to the cmd string which gets passed to the system() call and you end up with:

HipHop Notice: File could not be loaded: /path/file.phparg

That means you always have to use --args=" arg" which I find silly. (untested, but it looks right)
