### PR TITLE
Fix extra element bug with `$_SERVER['argc']` and `$_SERVER['argv']`.

### DIFF
--- a/hphp/runtime/base/builtin_functions.cpp
+++ b/hphp/runtime/base/builtin_functions.cpp
@@ -1029,11 +1029,9 @@ Variant invoke_file(CStrRef s, bool once, const char *currentDir) {
   SystemGlobals* g = (SystemGlobals*)get_global_variables();
   Variant& v_argc = g->GV(argc);
   Variant& v_argv = g->GV(argv);
-  if (!more(v_argc, int64_t(1))) {
+  if (!more(v_argc, int64_t(0))) {
     return true;
   }
-  v_argc--;
-  v_argv.dequeue();
   String s2 = toString(v_argv.rvalAt(int64_t(0), AccessFlags::Error));
   if (invoke_file_impl(r, s2, once, "")) {
     return r;

--- a/hphp/runtime/base/program_functions.cpp
+++ b/hphp/runtime/base/program_functions.cpp
@@ -657,7 +657,7 @@ static void prepare_args(int &argc, char **&argv, const StringVec &args,
                          const char *file) {
   argv = (char **)malloc((args.size() + 2) * sizeof(char*));
   argc = 0;
-  if (file) {
+  if (*file) {
     argv[argc++] = (char*)file;
   }
   for (int i = 0; i < (int)args.size(); i++) {
@@ -1006,8 +1006,8 @@ static int execute_program_impl(int argc, char **argv) {
 
     if (!po.file.empty()) {
       VM::Repo::setCliFile(po.file);
-    } else if (new_argc >= 2) {
-      VM::Repo::setCliFile(new_argv[1]);
+    } else if (new_argc >= 1) {
+      VM::Repo::setCliFile(new_argv[0]);
     }
 
     int ret = 0;

--- a/hphp/test/slow/program_functions/1235.php
+++ b/hphp/test/slow/program_functions/1235.php
@@ -1,3 +1,16 @@
 <?php
 
- var_dump($argc, count($argv));
+if ($argc == 1) {
+  var_dump($argc, count($argv));
+  var_dump($_SERVER['argc'], count($_SERVER['argv']));
+
+  $cmd = file_get_contents('/proc/self/cmdline');
+  $cmd = str_replace("\000--file\000", ' ', $cmd);
+  $cmd = str_replace("\000", ' ', $cmd);
+  $cmd = sprintf('%s argument', $cmd);
+
+  echo shell_exec($cmd);
+} else {
+  var_dump($argc, count($argv));
+  var_dump($_SERVER['argc'], count($_SERVER['argv']));
+}

--- a/hphp/test/slow/program_functions/1235.php.expect
+++ b/hphp/test/slow/program_functions/1235.php.expect
@@ -1,2 +1,8 @@
 int(1)
 int(1)
+int(1)
+int(1)
+int(2)
+int(2)
+int(2)
+int(2)


### PR DESCRIPTION
This fixes #688.

When a file is executed without the `--file` argument, `$_SERVER['argv']`
contains an extraneous empty string at the beginning of the array.

Consider the following:

**test.php:**

``` php

<?php

print_r($argv);
print_r($_SERVER['argv']);

```

**hhvm --file:**

```
whatthejeff@ubuntu-hhvm:~$ hhvm --file test.php
Array
(
    [0] => test.php
)
Array
(
    [0] => test.php
)
```

**hhvm:**

```
whatthejeff@ubuntu-hhvm:~$ hhvm test.php
Array
(
    [0] => test.php
)
Array
(
    [0] =>
    [1] => test.php
)
```
