### PR TITLE
use f_php_uname("s") to replace hardcode PHP_OS.

### DIFF
--- a/hphp/runtime/base/externals.h
+++ b/hphp/runtime/base/externals.h
@@ -72,11 +72,12 @@ struct EnvConstants {
   static void requestInit(EnvConstants* gt);
   static void requestExit();
   Variant __lvalProxy;
-  Variant stgv_Variant[4];
+  Variant stgv_Variant[5];
 #define k_SID stgv_Variant[0]
 #define k_PHP_SAPI stgv_Variant[1]
 #define k_PHP_BINARY stgv_Variant[2]
 #define k_PHP_BINDIR stgv_Variant[3]
+#define k_PHP_OS stgv_Variant[4]
 };
 extern EnvConstants* get_env_constants();
 

--- a/hphp/runtime/base/program_functions.cpp
+++ b/hphp/runtime/base/program_functions.cpp
@@ -49,6 +49,7 @@
 #include "hphp/runtime/ext/ext_variable.h"
 #include "hphp/runtime/ext/ext_apc.h"
 #include "hphp/runtime/ext/ext_function.h"
+#include "hphp/runtime/ext/ext_options.h"
 #include "hphp/runtime/debugger/debugger.h"
 #include "hphp/runtime/debugger/debugger_client.h"
 #include "hphp/runtime/base/simple_counter.h"
@@ -1432,6 +1433,7 @@ void hphp_session_init() {
   g->k_PHP_SAPI = StringData::GetStaticString(RuntimeOption::ExecutionMode);
   g->k_PHP_BINARY = current_executable_path();
   g->k_PHP_BINDIR = current_executable_directory();
+  g->k_PHP_OS = f_php_uname("s");
 }
 
 bool hphp_is_warmup_enabled() {

--- a/hphp/system/idl/constants.idl.json
+++ b/hphp/system/idl/constants.idl.json
@@ -4986,7 +4986,8 @@
         },
         {
             "name": "PHP_OS",
-            "value": "Linux"
+            "type": "String",
+            "desc": "Dynamic constant - php_uname('s')"
         },
         {
             "name": "PHP_OUTPUT_HANDLER_CONT",

--- a/hphp/tools/bootstrap/gen-class-map.cpp
+++ b/hphp/tools/bootstrap/gen-class-map.cpp
@@ -251,7 +251,8 @@ static void writeConstant(std::ostream& out, const PhpConst& cns) {
   if (cns.isSystem()) {
     // Special "magic" constants
     if ((name == "SID") || (name == "PHP_SAPI") ||
-       (name == "PHP_BINARY") || (name == "PHP_BINDIR")) {
+       (name == "PHP_BINARY") || (name == "PHP_BINDIR") ||
+       (name == "PHP_OS")) {
       out << "(const char *)((offsetof(EnvConstants, k_" << name << ") - "
           << "offsetof(EnvConstants, stgv_Variant)) / sizeof(Variant)), "
           << castLong(1) << ",\n";


### PR DESCRIPTION
as I know, hphp/test/run use PHP_OS to check different OS,

but on my FreeBSD box, PHP_OS return 'Linux', it's wired.

so I make this patch to return right variable.
