### PR TITLE
Fix arguments when calling magic method through call_user_func_array.

### DIFF
--- a/hphp/runtime/vm/bytecode.cpp
+++ b/hphp/runtime/vm/bytecode.cpp
@@ -6017,7 +6017,7 @@ bool VMExecutionContext::doFCallArray(PC& pc) {
       - (uintptr_t)m_fp->m_func->base();
     assert(pcOff() > m_fp->m_func->base());
 
-    if (UNLIKELY(!prepareArrayArgs(ar, args.get()))) return false;
+    if (UNLIKELY(!prepareArrayArgs(ar, args.values().get()))) return false;
   }
 
   if (UNLIKELY(!(prepareFuncEntry(ar, pc)))) {

--- a/hphp/test/quick/cuf08.php
+++ b/hphp/test/quick/cuf08.php
@@ -1,0 +1,23 @@
+<?php
+
+class Test {
+
+  public function __call($method, $args) {
+    var_dump($args);
+  }
+
+  public static function __callStatic($method, $args) {
+    var_dump($args);
+  }
+
+  public function normal($args) {
+    var_dump($args);
+  }
+
+}
+
+$test = new Test();
+call_user_func_array(array($test, 'magic'), array('bur' => 'bar'));
+call_user_func_array(array($test, 'normal'), array('badum' => 'tss'));
+call_user_func_array('Test::hi', array('bleep', 'bloop')); 
+$test->hi('hello world!');

--- a/hphp/test/quick/cuf08.php.expect
+++ b/hphp/test/quick/cuf08.php.expect
@@ -1,0 +1,15 @@
+array(1) {
+  [0]=>
+  string(3) "bar"
+}
+string(3) "tss"
+array(2) {
+  [0]=>
+  string(5) "bleep"
+  [1]=>
+  string(5) "bloop"
+}
+array(1) {
+  [0]=>
+  string(12) "hello world!"
+}


### PR DESCRIPTION
Associative arrays turn into numeric arrays.

Related to issue #938. I have added tests and appear not to have broken anything else.
