### PR TITLE
Fixing typo in zRevRange function

### DIFF
--- a/hphp/system/php/redis/Redis.php
+++ b/hphp/system/php/redis/Redis.php
@@ -452,7 +452,7 @@ class Redis {
                                     $key, $start, $end, $opts);
   }
 
-  public function zRevRange($key, $start, $end, $withscore = false) {
+  public function zRevRange($key, $start, $end, $withscores = false) {
     $args = [
       $this->prefix($key),
       (int)$start,


### PR DESCRIPTION
The zRevRange function argument $withscore was referenced within the function as $withscores. Changed argument name to $withscores so they match.
