### PR TITLE
$_SESSION global should start uninitialized

### DIFF
--- a/hphp/hhvm/global-variables.cpp
+++ b/hphp/hhvm/global-variables.cpp
@@ -63,7 +63,7 @@ GlobalNameValueTableWrapper::GlobalNameValueTableWrapper(
   X(_FILES,               arr);
   X(_ENV,                 arr);
   X(_REQUEST,             arr);
-  X(_SESSION,             arr);
+  X(_SESSION,             init_null_variant);
   X(HTTP_RAW_POST_DATA,   init_null_variant);
   X(http_response_header, init_null_variant);
 #undef X


### PR DESCRIPTION
`$_SESSION` doesn't exist until `session_start()` is called.

Simple testcase;

``` php
<?php 

$existsBefore = isset($_SESSION);
session_start();
var_dump($existsBefore);
var_dump(isset($_SESSION)); 
```
