### PR TITLE
Use trigger_error instead of error_log for providing error messages

### DIFF
--- a/hphp/system/php/redis/Redis.php
+++ b/hphp/system/php/redis/Redis.php
@@ -1373,7 +1373,7 @@ class Redis {
   public function __call($fname, $args) {
     $fname = strtolower($fname);
     if (!isset(self::$map[$fname])) {
-      error_log("Call to undefined function Redis::$fname", E_USER_ERROR);
+      trigger_error("Call to undefined function Redis::$fname", E_USER_ERROR);
       return null;
     }
     $func = self::$map[$fname];
@@ -1423,7 +1423,7 @@ class Redis {
             array_key_exists($func['defaults'], $i)) {
           $args[$i] = $func['defualts'][$i];
         } else {
-          error_log("Redis::$fname requires at least $flen parameters ".
+          trigger_error("Redis::$fname requires at least $flen parameters ".
                     "$argc given", E_USER_ERROR);
           return null;
         }
@@ -1437,7 +1437,7 @@ class Redis {
         case 'b': $args[$i] = (bool)$arts[$i]; break;
         case 'p':
           if (($args[$i] !== self::BEFORE) AND ($args[$i] !== self::AFTER)) {
-            error_log("Argument $i to Redis::$fname must be ".
+            trigger_error("Argument $i to Redis::$fname must be ".
                       "'before' or 'after'", E_USER_ERROR);
             return null;
           } break;
@@ -1484,7 +1484,7 @@ class Redis {
     $this->mode = self::ATOMIC;
 
     if (!$conn) {
-      error_log("Failed connecting to redis server at {$host}: {$errstr}",
+      trigger_error("Failed connecting to redis server at {$host}: {$errstr}",
                 E_USER_WARNING);
       return false;
     }


### PR DESCRIPTION
The error_log function is expecting a message_type describing where the error is to be sent. Given that none of the E_USER_\* constants are valid values for this, a notice is generated instead and no error is logged.

Judging by the way the function's being called it looks like it's just trying to throw errors, in which case trigger_error is the correct function to call.
