### PR TITLE
make simplexml xpath return original objects

### DIFF
--- a/hphp/runtime/ext/ext_simplexml.h
+++ b/hphp/runtime/ext/ext_simplexml.h
@@ -85,6 +85,7 @@ class c_SimpleXMLElement :
   static double  ToDouble(const ObjectData* obj) noexcept;
   static Array   ToArray(const ObjectData* obj);
 
+  c_SimpleXMLElement *m_root;
   Resource m_doc;
   xmlNodePtr m_node;
   Variant m_children;

--- a/hphp/test/slow/simple_xml/xpath_node.php
+++ b/hphp/test/slow/simple_xml/xpath_node.php
@@ -1,0 +1,17 @@
+<?php
+
+$xml = simplexml_load_string(<<<EOF
+<root>
+  <block name="test" />
+  <test>
+    <blob>test</blob>
+  </test>
+</root>
+EOF
+);
+
+$block = $xml->xpath("//block[@name='test']");
+$block[0]->addAttribute('ignore', true);
+
+var_dump((bool)$block[0]->attributes()->ignore);
+var_dump((bool)$xml->children()->block->attributes()->ignore);

--- a/hphp/test/slow/simple_xml/xpath_node.php.expect
+++ b/hphp/test/slow/simple_xml/xpath_node.php.expect
@@ -1,0 +1,2 @@
+bool(true)
+bool(true)


### PR DESCRIPTION
Currently, xpath just creates new elements. This means that any
modification done to the return object will not change its original
parent.

xpath can also traverse -up- the hierarchical node tree, so we cannot
just recursively go through children to find a matching node. this is
why an additional m_root was introduced, to keep track of the root node
of the current tree.
