### PR TITLE
Fixed ArrayIterator constructor zend compatibility

### DIFF
--- a/hphp/system/php/spl/iterators/ArrayIterator.php
+++ b/hphp/system/php/spl/iterators/ArrayIterator.php
@@ -32,7 +32,11 @@ class ArrayIterator implements ArrayAccess, SeekableIterator, Countable {
    * @return     mixed   An ArrayIterator object.
    */
   public function __construct($array = array(), $flags = 0) {
-    $this->arr = (array) $array;
+    if (($array instanceof ArrayObject) || ($array instanceof ArrayIterator)) {
+      $this->arr = $array->getArrayCopy();
+    } else {
+      $this->arr = (array) $array;
+    }
     $this->flags = $flags;
     reset($this->arr);
   }


### PR DESCRIPTION
The following PHP code

``` php
$arr = new ArrayObject(array(1, 2));

$iter1 = new ArrayIterator($arr);
var_dump($iter1->getArrayCopy());

$iter2 = new ArrayIterator($iter1);
var_dump($iter2->getArrayCopy());
```

prints before patch:

```
array(3) {
  [".ArrayObject.storage"]=>
  array(2) {
    [0]=>
    int(1)
    [1]=>
    int(2)
  }
  [".ArrayObject.flags"]=>
  int(0)
  [".ArrayObject.iteratorClass"]=>
  string(13) "ArrayIterator"
}
array(2) {
  [".*.arr"]=>
  array(3) {
    [".ArrayObject.storage"]=>
    array(2) {
      [0]=>
      int(1)
      [1]=>
      int(2)
    }
    [".ArrayObject.flags"]=>
    int(0)
    [".ArrayObject.iteratorClass"]=>
    string(13) "ArrayIterator"
  }
  [".*.flags"]=>
  int(0)
}
```

and after patch (as in PHP 5.3-5.5):

```
array(2) {
  [0]=>
  int(1)
  [1]=>
  int(2)
}
array(2) {
  [0]=>
  int(1)
  [1]=>
  int(2)
}
```

This trick is used in Propel ORM and in many other frameworks.
