### PR TITLE
Fixed automatic register_shutdown in session_set_save_handler

### DIFF
--- a/hphp/system/php/sessions/session_set_save_handler.php
+++ b/hphp/system/php/sessions/session_set_save_handler.php
@@ -67,6 +67,7 @@ function session_set_save_handler(
     return hphp_session_set_save_handler($open, $close);
   }
   return hphp_session_set_save_handler(
-    new _SessionForwardingHandler($open, $close, $read, $write, $destroy, $gc)
+    new _SessionForwardingHandler($open, $close, $read, $write, $destroy, $gc),
+    false
   );
 }


### PR DESCRIPTION
Do not register automatically session shutdown function when session_set_save_handler called in PHP <5.4 style.

PHP Manual (http://php.net/manual/en/function.session-set-save-handler.php):

> When using objects as session save handlers, it is important to register the shutdown function with PHP to avoid unexpected side-effects from the way PHP internally destroys objects on shutdown and may prevent the write and close from being called. Typically you should register 'session_write_close' using the register_shutdown_function() function.

Example N2 Custom session save handler using objects: 

> Note we additionally register the shutdown function session_write_close() using register_shutdown_function() under PHP less than 5.4.0. This is generally advised when registering objects as session save handlers under PHP less than 5.4.0.
