### PR TITLE
fix xpath crash when used on elements initialized by __construct

### DIFF
--- a/hphp/runtime/ext/ext_simplexml.cpp
+++ b/hphp/runtime/ext/ext_simplexml.cpp
@@ -405,7 +405,7 @@ void c_SimpleXMLElement::t___construct(CStrRef data, int64_t options /* = 0 */,
       Resource(NEWOBJ(XmlDocWrapper)(doc, o_getClassName()));
     m_node = xmlDocGetRootElement(doc);
     if (m_node) {
-      m_children = create_children(nullptr, m_doc, m_node, ns, is_prefix);
+      m_children = create_children(this, m_doc, m_node, ns, is_prefix);
       m_attributes = collect_attributes(m_node, ns, is_prefix);
     }
   } else {


### PR DESCRIPTION
When creating children, pass current node as root element. This worked fine for simplexml_load_string, but was working incorrectly when called directly from SimpleXMLElement's __construct.

This fixes both an internal issue at FB, and also #1067.
