### PR TITLE
Handle importing directories with a trailing slash.

### DIFF
--- a/hphp/tools/import_zend_test.py
+++ b/hphp/tools/import_zend_test.py
@@ -474,7 +474,7 @@ def mkdir_p(path):
         pass
 
 def walk(filename, source):
-    if not '/tests' in source:
+    if not '/tests' in source and not source.startswith('tests'):
         return
 
     dest_filename = os.path.basename(filename)


### PR DESCRIPTION
This only is necessary when the zend_path points to a directory that
contains a folder called 'tests' and the path was supplied with a
trailing slash.
