### PR TITLE
don't let root objects go out of scope

### DIFF
--- a/hphp/runtime/ext/ext_simplexml.cpp
+++ b/hphp/runtime/ext/ext_simplexml.cpp
@@ -39,6 +39,9 @@ public:
   DECLARE_RESOURCE_ALLOCATION_NO_SWEEP(XmlDocWrapper)
 
   CLASSNAME_IS("xmlDoc");
+
+  Object m_element;
+
   // overriding ResourceData
   virtual CStrRef o_getClassNameHook() const { return classnameof(); }
 
@@ -285,9 +288,9 @@ Variant f_simplexml_import_dom(CObjRef node,
   }
 
   if (nodep && nodep->type == XML_ELEMENT_NODE) {
-    Resource obj =
-      Resource(NEWOBJ(XmlDocWrapper)(nodep->doc, class_name, node));
-    return create_element(nullptr, obj, nodep, String(), false);
+    XmlDocWrapper *obj = NEWOBJ(XmlDocWrapper)(nodep->doc, class_name, node);
+    obj->m_element = create_element(nullptr, Resource(obj), nodep, String(), false);
+    return obj->m_element;
   } else {
     raise_warning("Invalid Nodetype to import");
     return uninit_null();
@@ -324,9 +327,9 @@ Variant f_simplexml_load_string(CStrRef data,
     return false;
   }
 
-  return create_element(nullptr,
-                        Resource(NEWOBJ(XmlDocWrapper)(doc, cls->nameRef())),
-                        root, ns, is_prefix);
+  XmlDocWrapper *obj = NEWOBJ(XmlDocWrapper)(doc, cls->nameRef());
+  obj->m_element = create_element(nullptr, Resource(obj), root, ns, is_prefix);
+  return obj->m_element;
 }
 
 Variant f_simplexml_load_file(CStrRef filename,
@@ -399,9 +402,9 @@ void c_SimpleXMLElement::t___construct(CStrRef data, int64_t options /* = 0 */,
   xmlDocPtr doc = xmlReadMemory(xml.data(), xml.size(),
                                 nullptr, nullptr, options);
   if (doc) {
-    m_root = this;
-    m_doc =
-      Resource(NEWOBJ(XmlDocWrapper)(doc, o_getClassName()));
+    XmlDocWrapper *obj = NEWOBJ(XmlDocWrapper)(doc, o_getClassName());
+    obj->m_element = m_root = this;
+    m_doc = Resource(obj);
     m_node = xmlDocGetRootElement(doc);
     if (m_node) {
       m_children = create_children(m_root, m_doc, m_node, ns, is_prefix);

--- a/hphp/test/slow/simple_xml/xpath_scope.php
+++ b/hphp/test/slow/simple_xml/xpath_scope.php
@@ -1,0 +1,24 @@
+<?php
+
+class Config {
+
+  protected $_sections;
+
+  public function __construct() {
+    $config = simplexml_load_string('<config><sections><payment type="group" /><a /><b /></sections></config>');
+    $this->_sections = $config->sections;
+  }
+    
+  public function getSections() {
+    return $this->_sections;
+  }
+
+}
+
+$config = new Config();
+$sections = $config->getSections();
+
+// We should still have our original root object here,
+// so we can do xpath lookups in the tree.
+$node = $sections->xpath('payment[@type="group"]');
+var_dump($node);

--- a/hphp/test/slow/simple_xml/xpath_scope.php.expect
+++ b/hphp/test/slow/simple_xml/xpath_scope.php.expect
@@ -1,0 +1,10 @@
+array(1) {
+  [0]=>
+  object(SimpleXMLElement)#4 (1) {
+    ["@attributes"]=>
+    array(1) {
+      ["type"]=>
+      string(5) "group"
+    }
+  }
+}


### PR DESCRIPTION
Similar to m_domNode, we must store a reference to the root object.

We may need the root object to do xpath lookups on child objects, regardless of parent object going out of scope.

The attached test is self-explanatory.
