### PR TITLE
Fix conflicts iwth unimplemented PHP ENT_* constants

### DIFF
--- a/hphp/runtime/base/string-util.h
+++ b/hphp/runtime/base/string-util.h
@@ -40,8 +40,10 @@ public:
     Double       = 2,  // k_ENT_COMPAT:   escape double quotes only
     Both         = 3,  // k_ENT_QUOTES:   escape both double and single quotes
     No           = 0,  // k_ENT_NOQUOTES: leave all quotes alone
-    FBUtf8       = 4,
-    FBUtf8Only   = 8
+    // high values to avoid conflicts with currently non-implemented PHP ENT_ constants
+    // and for possible future new constants in PHP
+    FBUtf8       = 32768,
+    FBUtf8Only   = 65536
   };
 
 public:

--- a/hphp/system/idl/constants.idl.json
+++ b/hphp/system/idl/constants.idl.json
@@ -1497,11 +1497,11 @@
         },
         {
             "name": "ENT_FB_UTF8",
-            "value": 4
+            "value": 32768
         },
         {
             "name": "ENT_FB_UTF8_ONLY",
-            "value": 8
+            "value": 65536
         },
         {
             "name": "ERA",


### PR DESCRIPTION
When using `htmlspecialchars`, a bunch of constants can be used to configure the way the function behaves:

``` c
#define ENT_HTML_QUOTE_NONE         0
#define ENT_HTML_QUOTE_SINGLE       1
#define ENT_HTML_QUOTE_DOUBLE       2
#define ENT_HTML_IGNORE_ERRORS      4
#define ENT_HTML_SUBSTITUTE_ERRORS  8
#define ENT_HTML_DOC_TYPE_MASK      (16|32)
#define ENT_HTML_DOC_HTML401        0
#define ENT_HTML_DOC_XML1           16
#define ENT_HTML_DOC_XHTML          32
#define ENT_HTML_DOC_HTML5          (16|32)
/* reserve bit 6 */
#define ENT_HTML_SUBSTITUTE_DISALLOWED_CHARS    128


#define ENT_COMPAT      ENT_HTML_QUOTE_DOUBLE
#define ENT_QUOTES      (ENT_HTML_QUOTE_DOUBLE | ENT_HTML_QUOTE_SINGLE)
#define ENT_NOQUOTES    ENT_HTML_QUOTE_NONE
#define ENT_IGNORE      ENT_HTML_IGNORE_ERRORS
#define ENT_SUBSTITUTE  ENT_HTML_SUBSTITUTE_ERRORS
#define ENT_HTML401     0
#define ENT_XML1        16
#define ENT_XHTML       32
#define ENT_HTML5       (16|32)
#define ENT_DISALLOWED  128
```

So, the current (as of PHP 5.4) `ENT_*` constants values are as follows:

```
ENT_COMPAT: 2
ENT_QUOTES: 3
ENT_NOQUOTES: 0
ENT_IGNORE: 4
ENT_SUBSTITUTE: 8
ENT_DISALLOWED: 128
ENT_HTML401: 0
ENT_XML1: 16
ENT_XHTML: 32
ENT_HTML5: 48
```

HHVM does not support all those constants, but more important, it defines its own constants with values used by some `ENT_*` constants:

``` c++
  enum class QuoteStyle {
    Double       = 2,  // k_ENT_COMPAT:   escape double quotes only
    Both         = 3,  // k_ENT_QUOTES:   escape both double and single quotes
    No           = 0,  // k_ENT_NOQUOTES: leave all quotes alone
    FBUtf8       = 4,
    FBUtf8Only   = 8
  };
```

As you can see, the `ENT_SUBSTITUTE` and `FBUtf8Only` values are the same, but they are doing different things.

In Twig (https://github.com/fabpot/Twig), we are using the following snippet of code quite heavily to escape some outputs:

``` php
htmlspecialchars($string, ENT_QUOTES | ENT_SUBSTITUTE, $charset);
```

When run under HHVM, and because of the conflict, it does not work as expected. One simple way to make it work is to define the `ENT_SUBSTITUTE` value to `0` as HHVM does not define this constant yet but I can imagine that when implemented, you will have a problem.

So, I propose to change the values of the `FB*` constants.

The other and most important problem is that the code in HHVM does not support several flags, but only one at a time.
