### PR TITLE
Make clearstatcache() compatible with Zend's signature

### DIFF
--- a/hphp/runtime/ext/ext_file.cpp
+++ b/hphp/runtime/ext/ext_file.cpp
@@ -857,7 +857,8 @@ Variant f_lstat(CStrRef filename) {
   return stat_impl(&sb);
 }
 
-void f_clearstatcache() {
+void f_clearstatcache(bool clear_realpath_cache /* false */,
+                      CStrRef filename /* null_string */) {
   // we are not having a cache for file stats, so do nothing here
 }
 

--- a/hphp/runtime/ext/ext_file.h
+++ b/hphp/runtime/ext/ext_file.h
@@ -128,7 +128,8 @@ bool f_is_uploaded_file(CStrRef filename);
 bool f_file_exists(CStrRef filename);
 Variant f_stat(CStrRef filename);
 Variant f_lstat(CStrRef filename);
-void f_clearstatcache();
+void f_clearstatcache(bool clear_realpath_cache = false,
+                      CStrRef filename = null_string);
 Variant f_readlink_internal(CStrRef path, bool warning_compliance);
 Variant f_readlink(CStrRef path);
 Variant f_realpath(CStrRef path);

--- a/hphp/system/idl/file.idl.json
+++ b/hphp/system/idl/file.idl.json
@@ -1638,6 +1638,18 @@
                 "desc": "No value is returned."
             },
             "args": [
+                {
+                    "name": "clear_realpath_cache",
+                    "type": "Boolean",
+                    "desc": "Whether to clear the realpath cache or not.",
+                    "value": "false"
+                },
+                {
+                    "name": "filename",
+                    "type": "String",
+                    "desc": "Clear the realpath and the stat cache for a specific filename only; only used if clear_realpath_cache is TRUE.",
+                    "value": "null"
+                }
             ]
         },
         {

--- a/hphp/test/slow/ext_file/clearstatcache.php
+++ b/hphp/test/slow/ext_file/clearstatcache.php
@@ -1,0 +1,6 @@
+<?php
+
+// clearstatcache do nothing, but there should no warnnings
+var_dump(clearstatcache());
+var_dump(clearstatcache(true));
+var_dump(clearstatcache(false, "test.php"));

--- a/hphp/test/slow/ext_file/clearstatcache.php.expectf
+++ b/hphp/test/slow/ext_file/clearstatcache.php.expectf
@@ -1,0 +1,3 @@
+NULL
+NULL
+NULL


### PR DESCRIPTION
This should close issue #1115

`clearstatcache()` do nothing, but the function signature is not the same as Zend.
