### PR TITLE
Trim expected and actual data before comparing

### DIFF
--- a/hphp/test/run
+++ b/hphp/test/run
@@ -622,8 +622,8 @@ function run_test($options, $test) {
     shell_exec("diff --text -u $test.expectf $test.out > $test.diff 2>&1");
 
     // Normalize newlines
-    $wanted_re = preg_replace("/(\r\n?|\n)/", "\n", $wanted_re);
-    $output    = preg_replace("/(\r\n?|\n)/", "\n", $output);
+    $wanted_re = trim(preg_replace("/(\r\n?|\n)/", "\n", $wanted_re));
+    $output    = trim(preg_replace("/(\r\n?|\n)/", "\n", $output));
 
     return preg_match("/^$wanted_re\$/s", $output);
 


### PR DESCRIPTION
It seems that the Zend test runner ignores at least trailing space, so some of the Zend tests fail when run under HHVM due to different space at the end.
