### PR TITLE
[test-only] ReflectionClass::getDefaultProperties fails with undefined index 'default'

### DIFF
--- a/hphp/test/slow/reflection_classes/1367.php
+++ b/hphp/test/slow/reflection_classes/1367.php
@@ -1,0 +1,13 @@
+<?php
+
+class c {
+  public $a = 'testa';
+
+  protected $b = 'testb';
+}
+
+$c = new c();
+
+$reflection = new \ReflectionClass($c);
+$defaults = $reflection->getDefaultProperties();
+print_r($defaults);

--- a/hphp/test/slow/reflection_classes/1367.php.expect
+++ b/hphp/test/slow/reflection_classes/1367.php.expect
@@ -1,0 +1,5 @@
+Array
+(
+    [a] => testa
+    [b] => testb
+)


### PR DESCRIPTION
The test shows that the getDefaultProperties() results in a
<code>Notice: Undefined index: default</code> error message coming from ReflectionProperty->isDefault().
