### PR TITLE
Add several missing MYSQLI_ constants

### DIFF
--- a/hphp/system/idl/constants.idl.json
+++ b/hphp/system/idl/constants.idl.json
@@ -4240,6 +4240,10 @@
             "value": 512
         },
         {
+            "name": "MYSQLI_BINARY_FLAG",
+            "value": 128
+        },
+        {
             "name": "MYSQLI_BLOB_FLAG",
             "value": 16
         },
@@ -4290,6 +4294,14 @@
         {
             "name": "MYSQLI_DATA_TRUNCATED",
             "value": 101
+        },
+        {
+            "name": "MYSQLI_DEBUG_TRACE_ENABLED",
+            "value": 0
+        },
+        {
+            "name": "MYSQLI_ENUM_FLAG",
+            "value": 256
         },
         {
             "name": "MYSQLI_GROUP_FLAG",
@@ -4344,6 +4356,38 @@
             "value": 5
         },
         {
+            "name": "MYSQLI_REFRESH_GRANT",
+            "value": 1
+        },
+        {
+            "name": "MYSQLI_REFRESH_LOG",
+            "value": 2
+        },
+        {
+            "name": "MYSQLI_REFRESH_TABLES",
+            "value": 4
+        },
+        {
+            "name": "MYSQLI_REFRESH_HOSTS",
+            "value": 8
+        },
+        {
+            "name": "MYSQLI_REFRESH_STATUS",
+            "value": 16
+        },
+        {
+            "name": "MYSQLI_REFRESH_THREADS",
+            "value": 32
+        },
+        {
+            "name": "MYSQLI_REFRESH_SLAVE",
+            "value": 64
+        },
+        {
+            "name": "MYSQLI_REFRESH_MASTER",
+            "value": 128
+        },
+        {
             "name": "MYSQLI_REPORT_ALL",
             "value": 255
         },
@@ -4376,6 +4420,14 @@
             "value": 1
         },
         {
+            "name": "MYSQLI_SERVER_QUERY_NO_GOOD_INDEX_USED",
+            "value": 16
+        },
+        {
+            "name": "MYSQLI_SERVER_QUERY_NO_INDEX_USED",
+            "value": 32
+        },
+        {
             "name": "MYSQLI_SET_CHARSET_NAME",
             "value": 7
         },
@@ -4402,6 +4454,22 @@
         {
             "name": "MYSQLI_TIMESTAMP_FLAG",
             "value": 1024
+        },
+        {
+            "name": "MYSQLI_TRANS_COR_AND_CHAIN",
+            "value": 1
+        },
+        {
+            "name": "MYSQLI_TRANS_COR_AND_NO_CHAIN",
+            "value": 2
+        },
+        {
+            "name": "MYSQLI_TRANS_COR_RELEASE",
+            "value": 4
+        },
+        {
+            "name": "MYSQLI_TRANS_COR_NO_RELEASE",
+            "value": 8
         },
         {
             "name": "MYSQLI_TYPE_BIT",


### PR DESCRIPTION
All values current as of PHP 5.5.4.

I also found two other constants  [on php.net](http://php.net/manual/en/mysqli.constants.php) (MYSQLI_CLIENT_MULTI_QUERIES & MYSQLI_NEED_DATA), but outside of that mention I can't find them...they're not in the 5.5.4 or master source, and I can't find any supporting documentation for them (or that they've been deprecated/removed).
