### PR TITLE
Test case for resolving absolute paths for magic constants

### DIFF
--- a/hphp/test/quick/resolve_magic_constants.php
+++ b/hphp/test/quick/resolve_magic_constants.php
@@ -1,0 +1,1 @@
+resolve_magic_constants/resolve_magic_constants.phps

--- a/hphp/test/quick/resolve_magic_constants.php.expect
+++ b/hphp/test/quick/resolve_magic_constants.php.expect
@@ -1,0 +1,2 @@
+test/quick/resolve_magic_constants/resolve_magic_constants.phps
+test/quick/resolve_magic_constants

--- a/hphp/test/quick/resolve_magic_constants/resolve_magic_constants.phps
+++ b/hphp/test/quick/resolve_magic_constants/resolve_magic_constants.phps
@@ -1,0 +1,9 @@
+<?php
+
+function make_relative_to_repo($path) {
+    $pos = strpos($path, "test/quick");
+    return substr($path, $pos);
+}
+
+echo make_relative_to_repo(__FILE__)."\n";
+echo make_relative_to_repo(__DIR__)."\n";


### PR DESCRIPTION
This is the best I could come up with to showcase the issue.

The [PHP Manual](http://php.net/manual/en/language.constants.predefined.php) states: 

> __FILE__   The full path and filename of the file. If used inside an include, the name of the included file is returned. Since PHP 4.0.2, __FILE__ always contains an absolute path with symlinks resolved whereas in older versions it contained relative path under some circumstances.
> __DIR__    The directory of the file. If used inside an include, the directory of the included file is returned. This is equivalent to dirname(__FILE__). This directory name does not have a trailing slash unless it is the root directory. (Added in PHP 5.3.0.)

If I'm correct, I'll somehow get the CLA scanned (would a hi-res photo do?) and would be happy to dive in to the code and try and fix it.
