### PR TITLE
Fixed bug #1182: preg_replace should support some sort of cache eviction

### DIFF
--- a/hphp/test/slow/ext_preg/1182.php
+++ b/hphp/test/slow/ext_preg/1182.php
@@ -1,0 +1,8 @@
+<?php
+
+$subject = 'done';
+for ($i = 0; $i < 97 * 1024; $i++) {
+	preg_replace('/(' . $i . ')/ui', 'replaced', $subject);
+}
+
+var_dump($subject);

--- a/hphp/test/slow/ext_preg/1182.php.expectf
+++ b/hphp/test/slow/ext_preg/1182.php.expectf
@@ -1,0 +1,2 @@
+PCRE cache will be re-initialized
+string(4) "done"


### PR DESCRIPTION
## Problem

If we have count of dynamic regexes more than cache capacity, hhvm raised error that "PCRE cache full".
## Solution

Set lock on read cross-thread regex storage, and call reinitialize storage method. Losk set via mutex.
## Test

hphp/test/slow/ext_preg/1182.php

``` php
$subject = 'done';
for ($i = 0; $i < 97 * 1024; $i++) {
    preg_replace('/(' . $i . ')/ui', 'replaced', $subject);
}

var_dump($subject);
```
