### PR TITLE
Fix handling of non-int/array flags to filter_var

### DIFF
--- a/hphp/runtime/ext/filter/ext_filter.cpp
+++ b/hphp/runtime/ext/filter/ext_filter.cpp
@@ -212,11 +212,11 @@ static bool filter_var(Variant& ret, CVarRef variable, int64_t filter,
 
   int64_t flags;
   Variant option_array;
-  if (options.isInteger()) {
-    flags = options.toInt64();
-  } else {
+  if (options.isArray()) {
     flags = options[s_flags].toInt64();
     option_array = options[s_options];
+  } else {
+    flags = options.toInt64();
   }
 
   FAIL_IF(variable.isObject() && !variable.getObjectData()->hasToString());

--- a/hphp/test/slow/ext_filter/filter_var_flags.php
+++ b/hphp/test/slow/ext_filter/filter_var_flags.php
@@ -1,0 +1,7 @@
+<?php
+var_dump(filter_var('127.0.0.1', FILTER_VALIDATE_IP, FILTER_FLAG_IPV6));
+var_dump(filter_var('127.0.0.1', FILTER_VALIDATE_IP, 2097152));
+var_dump(filter_var('127.0.0.1', FILTER_VALIDATE_IP, '2097152'));
+
+var_dump(filter_var('127.0.0.1', FILTER_VALIDATE_IP, ''));
+?>

--- a/hphp/test/slow/ext_filter/filter_var_flags.php.expect
+++ b/hphp/test/slow/ext_filter/filter_var_flags.php.expect
@@ -1,0 +1,4 @@
+bool(false)
+bool(false)
+bool(false)
+string(9) "127.0.0.1"


### PR DESCRIPTION
HHVM treats all non-int flags to filter_var as arrays, but Zend treats all non-array flags as ints. This causes spurious notices (#1068), but also causes bugs (e.g. line 3 of the new test rejects the IP on Zend but not HHVM).

Fixes #1068.
