### PR TITLE
Fix: get_loaded_extensions() doesn't shows disabled extensions

### DIFF
--- a/hphp/runtime/ext/extension.cpp
+++ b/hphp/runtime/ext/extension.cpp
@@ -204,6 +204,9 @@ Array Extension::GetLoadedExtensions() {
   Array ret = Array::Create();
   for (ExtensionMap::const_iterator iter = s_registered_extensions->begin();
        iter != s_registered_extensions->end(); ++iter) {
+    if (iter->second->m_name == s_apc && !apcExtension::Enable) {
+      continue;
+    }
     ret.append(iter->second->m_name);
   }
   return ret;


### PR DESCRIPTION
This modified not to show "APC" extension when Server->APC->EnableApc oprion is set to false.
It fixed issue #1103
