### PR TITLE
add HHVM_DEFAULT_SCRIPT_CONFIG environment variable

### DIFF
--- a/hphp/runtime/base/program-functions.cpp
+++ b/hphp/runtime/base/program-functions.cpp
@@ -1021,6 +1021,12 @@ static int execute_program_impl(int argc, char** argv) {
       cout << desc << "\n";
       return -1;
     }
+    if (po.mode == "run" && po.config.empty()) {
+      auto default_config_file = getenv("HHVM_DEFAULT_SCRIPT_CONFIG");
+      if (default_config_file) {
+        po.config = default_config_file;
+      }
+    }
   } catch (error &e) {
     Logger::Error("Error in command line: %s", e.what());
     cout << desc << "\n";


### PR DESCRIPTION
- only used if running in script mode
- only used if a configuration file is not set on the command line

Fixes #1251

Test:

```
$ hhvm test.php
Extension not loaded.
$ hhvm -c load-an-extension.hdf test.php
Extension was loaded.
$ export HHVM_DEFAULT_SCRIPT_CONFIG=$(pwd)/load-an-extension.hdf
$ hhvm test.php
Extension was loaded.
$ hhvm -c /dev/null test.php
Extension not loaded.
```

test.php:

```
<?php

if (class_exists('FE_AutoloadMapGenerator')) {
  print "Extension was loaded.\n";
} else {
  print "Extension not loaded.\n";
}
```
