### PR TITLE
Fix #1261: Modified error_get_last output elements to be comaptible with...

### DIFF
--- a/hphp/runtime/base/execution-context.cpp
+++ b/hphp/runtime/base/execution-context.cpp
@@ -75,6 +75,7 @@ VMExecutionContext::VMExecutionContext() :
     m_lambdaCounter(0), m_nesting(0),
     m_breakPointFilter(nullptr), m_lastLocFilter(nullptr),
     m_dbgNoBreak(false), m_coverPrevLine(-1), m_coverPrevUnit(nullptr),
+    m_lastErrorPath(""), m_lastErrorLine(0),
     m_executingSetprofileCallback(false) {
 
   // Make sure any fields accessed from the TC are within a byte of

--- a/hphp/runtime/base/execution-context.h
+++ b/hphp/runtime/base/execution-context.h
@@ -296,7 +296,7 @@ public:
                    bool skipFrame = false);
   bool callUserErrorHandler(const Exception &e, int errnum,
                             bool swallowExceptions);
-  void recordLastError(const Exception &e, int errnum = 0);
+  virtual void recordLastError(const Exception &e, int errnum = 0);
   bool onFatalError(const Exception &e); // returns handled
   bool onUnhandledException(Object e);
   ErrorState getErrorState() const { return m_errorState;}
@@ -641,6 +641,9 @@ public:
   bool doFCallArray(PC& pc);
   bool doFCallArrayTC(PC pc);
   CVarRef getEvaledArg(const StringData* val, const String& namespacedName);
+  virtual void recordLastError(const Exception &e, int errnum = 0);
+  String getLastErrorPath() const { return m_lastErrorPath;}
+  int getLastErrorLine() const { return m_lastErrorLine;}
 
 private:
   void enterVMWork(ActRec* enterFnAr);
@@ -659,6 +662,8 @@ private:
   int m_coverPrevLine;
   HPHP::Unit* m_coverPrevUnit;
   Array m_evaledArgs;
+  String m_lastErrorPath;
+  int m_lastErrorLine;
 public:
   void resetCoverageCounters();
   void shuffleMagicArgs(ActRec* ar);

--- a/hphp/runtime/ext/ext_error.cpp
+++ b/hphp/runtime/ext/ext_error.cpp
@@ -125,8 +125,10 @@ Array f_error_get_last() {
   if (lastError.isNull()) {
     return (ArrayData *)NULL;
   }
-  return make_map_array(s_message, g_context->getLastError(),
-                     s_type, g_context->getLastErrorNumber());
+  return make_map_array(s_type, g_context->getLastErrorNumber(),
+                        s_message, g_context->getLastError(),
+                        s_file, g_context->getLastErrorPath(),
+                        s_line, g_context->getLastErrorLine());
 }
 
 bool f_error_log(const String& message, int message_type /* = 0 */,

--- a/hphp/runtime/vm/bytecode.cpp
+++ b/hphp/runtime/vm/bytecode.cpp
@@ -2516,6 +2516,13 @@ CVarRef VMExecutionContext::getEvaledArg(const StringData* val,
   return lv;
 }
 
+void VMExecutionContext::recordLastError(const Exception &e, int errnum) {
+  BaseExecutionContext::recordLastError(e, errnum);
+  m_lastErrorPath = getContainingFileName();
+  m_lastErrorLine = getLine();
+}
+
+
 /*
  * Helper for function entry, including pseudo-main entry.
  */

--- a/hphp/test/slow/call_error_get_last.php
+++ b/hphp/test/slow/call_error_get_last.php
@@ -1,0 +1,5 @@
+<?php
+echo $a;
+print_r(error_get_last());
+?>
+

--- a/hphp/test/slow/call_error_get_last.php.expectf
+++ b/hphp/test/slow/call_error_get_last.php.expectf
@@ -1,0 +1,9 @@
+HipHop Notice: %s
+Array
+(
+    [type] => 8
+    [message] => Undefined variable: a
+    [file] => %s/call_error_get_last.php
+    [line] => 2
+)
+


### PR DESCRIPTION
... zend

This fixed issue #1261

I changed BaseExecutionContext::recordLastError() to be virtual function, and override it in VMExecutionContext class.
The reason why I override it is that VMExecutionContext is accessible for file path and line number, which don't accessible by BaseExecutionContext.

Although it seems that recordLastError() would be a bit slower due to change to be virtual function, I adopted this method.
Because recordLastError() is called when some error is occurred, I guess this method don't affect a performance of hhvm very much.
