### PR TITLE
added support for VirtualHost StaticFastPath directive. 

### DIFF
--- a/hphp/doc/options.compiled
+++ b/hphp/doc/options.compiled
@@ -373,6 +373,13 @@ These are experimental LFU settings.
       Prefix = prefix.
       Pattern = regex pattern
       PathTranslation = html
+      
+      # by default, if a static file is present it is served before
+      # rewrite rules are applied. (e.g. when true, you can't write 
+      # a rule to hide .htaccess files). Set to false to force rewrite
+      # rules to be applied to all requests.
+ 
+      StaticFastPath = true
       ServerName =
       ServerVariables {
         name = value

--- a/hphp/runtime/server/request-uri.cpp
+++ b/hphp/runtime/server/request-uri.cpp
@@ -68,14 +68,22 @@ bool RequestURI::process(const VirtualHost *vhost, Transport *transport,
   m_originalURL = StringUtil::UrlDecode(m_originalURL, false);
   m_rewritten = false;
 
-  // Fast path for files that exist
+  // Fast path for files that exist unless VirtualHost option StaticFastPath is false, in
+  // which case rewrite rules are applied even if the original path points to an existing static file.
+
   String canon(Util::canonicalize(m_originalURL.c_str(), m_originalURL.size()),
                AttachString);
-  if (virtualFileExists(vhost, sourceRoot, pathTranslation, canon)) {
-    m_rewrittenURL = canon;
-    m_resolvedURL = canon;
-    return true;
+
+
+  if ( vhost->staticfastpath() )
+    {
+    if (virtualFileExists(vhost, sourceRoot, pathTranslation, canon)) {
+      m_rewrittenURL = canon;
+      m_resolvedURL = canon;
+      return true;
+    }
   }
+
 
   if (!rewriteURL(vhost, transport, pathTranslation, sourceRoot)) {
     // Redirection

--- a/hphp/runtime/server/virtual-host.cpp
+++ b/hphp/runtime/server/virtual-host.cpp
@@ -175,6 +175,8 @@ void VirtualHost::init(Hdf vh) {
 
   m_disabled = vh["Disabled"].getBool(false);
 
+  m_staticfastpath = vh[ "StaticFastPath" ].getBool(true);
+
   Hdf rewriteRules = vh["RewriteRules"];
   for (Hdf hdf = rewriteRules.firstChild(); hdf.exists(); hdf = hdf.next()) {
     RewriteRule dummy;

--- a/hphp/runtime/server/virtual-host.h
+++ b/hphp/runtime/server/virtual-host.h
@@ -55,6 +55,9 @@ public:
   bool match(const std::string &host) const;
   bool disabled() const { return m_disabled; }
 
+  // whether to apply rewrite rules before serving a static file that exists. 
+  bool staticfastpath() const { return m_staticfastpath; }
+
   // url rewrite rules
   bool rewriteURL(const String& host, String &url, bool &qsa, int &redirect) const;
 
@@ -101,6 +104,7 @@ private:
 
   void initRuntimeOption(Hdf overwrite);
   bool m_disabled;
+  bool m_staticfastpath; // whether to serve a file that exists before checking rewrite rules. default true.
   std::string m_name;
   std::string m_prefix;
   std::string m_pattern;


### PR DESCRIPTION
added support for VirtualHost StaticFastPath directive to enable rewrite rule processing even if a static file is present.

issue https://github.com/facebook/hhvm/issues/1283

I am a github noob, I am unfamiliar with this codebase and my C++ is rusty. Please let me know if I have done something wrong. I have attempted to follow your guidelines, but since this is my first pull request, I may have missed something; any guidance will be appreciated. 

I am not sure how to create a test case for this fix but based on my manual testing it seems to work. 

I filled out the contributors form and agreed to the terms via the facebook link.
