### PR TITLE
Use CPU time instead of wall time for time limit.

### DIFF
--- a/hphp/runtime/base/thread-info.cpp
+++ b/hphp/runtime/base/thread-info.cpp
@@ -145,7 +145,7 @@ void RequestInjectionData::setTimeout(int seconds) {
     sev.sigev_notify = SIGEV_SIGNAL;
     sev.sigev_signo = SIGVTALRM;
     sev.sigev_value.sival_ptr = this;
-    if (timer_create(CLOCK_REALTIME, &sev, &m_timer_id)) {
+    if (timer_create(CLOCK_THREAD_CPUTIME_ID, &sev, &m_timer_id)) {
       raise_error("Failed to set timeout: %s", folly::errnoStr(errno).c_str());
     }
     m_hasTimer = true;


### PR DESCRIPTION
Fixes #1279.
