### PR TITLE
Updated configure_ubuntu_12.04.sh to work on a "clean" ubuntu installation

### DIFF
--- a/configure_ubuntu_12.04.sh
+++ b/configure_ubuntu_12.04.sh
@@ -22,6 +22,10 @@ fi
 export CMAKE_PREFIX_PATH=`/bin/pwd`/..
 export HPHP_HOME=`/bin/pwd`
 
+# install python-software-properties  before trying to add a PPA
+sudo apt-get -y update
+sudo apt-get install -y python-software-properties
+
 # install apt-fast to speedup later dependency installation
 sudo add-apt-repository -y ppa:apt-fast/stable
 sudo apt-get -y update
@@ -36,13 +40,16 @@ sudo apt-fast -y install git-core cmake g++ libboost1.48-dev libmysqlclient-dev 
   libboost-program-options1.48-dev libboost-filesystem1.48-dev libboost-thread1.48-dev \
   wget memcached libreadline-dev libncurses-dev libmemcached-dev libbz2-dev \
   libc-client2007e-dev php5-mcrypt php5-imagick libgoogle-perftools-dev \
-  libcloog-ppl0 libelf-dev libdwarf-dev libunwind7-dev subversion \
-  python-software-properties &
+  libcloog-ppl0 libelf-dev libdwarf-dev libunwind7-dev subversion &
 
 git clone git://github.com/libevent/libevent.git --quiet &
 git clone git://github.com/bagder/curl.git --quiet &
 svn checkout http://google-glog.googlecode.com/svn/trunk/ google-glog --quiet &
 wget http://www.canonware.com/download/jemalloc/jemalloc-3.0.0.tar.bz2 --quiet &
+
+# init submodules
+git submodule init
+git submodule update
 
 # wait until all background processes finished
 FAIL=0


### PR DESCRIPTION
Added some fixes to the configuration script which allow it run smoothly on a default, empty Ubuntu 12.04.3 installation:
- python-software-properties are installed before the apt-fast PPA is added
- git submodules get initialized 
