### PR TITLE
Implement Password extension

### DIFF
--- a/hphp/system/php.txt
+++ b/hphp/system/php.txt
@@ -77,6 +77,7 @@ hphp/system/php/lang/ErrorException.php
 hphp/system/php/misc/highlight.php
 hphp/system/php/misc/php_strip_whitespace.php
 hphp/system/php/misc/str_getcsv.php
+hphp/system/php/password/password.php
 hphp/system/php/pdo/PDOException.php
 hphp/system/php/redis/Redis.php
 hphp/system/php/redis/RedisSessionModule.php

--- a/hphp/system/php/password/password.php
+++ b/hphp/system/php/password/password.php
@@ -1,4 +1,4 @@
-<?hh
+<?php
 /**
 * A Compatibility library with PHP 5.5's simplified password hashing API.
 *
@@ -6,11 +6,11 @@
 * @license http://www.opensource.org/licenses/mit-license.html MIT License
 * @copyright 2012 The Authors
 *
-* Some changes by James Miller for integration with the HipHop VM
+* Some changes by James Miller <james@pocketrent.com> for integration with the HipHop VM
 */
 
 define('PASSWORD_BCRYPT', 1);
-define('PASSWORD_DEFAULT', PASSWORD_BCRYPT);
+define('PASSWORD_DEFAULT', 1);
 
 /**
 * Hash the password using the specified algorithm
@@ -21,7 +21,7 @@ define('PASSWORD_DEFAULT', PASSWORD_BCRYPT);
 *
 * @return string|false The hashed password, or false on error.
 */
-function password_hash(string $password, string $algo, array $options = array()) : mixed {
+function password_hash(string $password, int $algo, array $options = array()) : mixed {
 	if (!function_exists('crypt')) {
 		trigger_error("Crypt must be loaded for password_hash to function", E_USER_WARNING);
 		return null;
@@ -35,7 +35,7 @@ function password_hash(string $password, string $algo, array $options = array())
 		return null;
 	}
 	switch ($algo) {
-		case PASSWORD_BCRYPT:
+		case \PASSWORD_BCRYPT:
 			// Note that this is a C constant, but not exposed to PHP, so we don't define it here.
 			$cost = 10;
 			if (isset($options['cost'])) {

--- a/hphp/test/slow/password/get_info.php
+++ b/hphp/test/slow/password/get_info.php
@@ -1,0 +1,14 @@
+<?php
+
+function print_info($info) {
+	echo $info['algo']."\n";
+	echo $info['algoName']."\n";
+	if (isset($info['options']['cost']))
+		echo $info['options']['cost']."\n";
+	echo "====\n";
+}
+
+print_info(password_get_info('foo'));
+print_info(password_get_info('$2y$'));
+print_info(password_get_info('$2y$07$usesomesillystringfore2uDLvp1Ii2e./U9C8sBjqp8I90dH6hi'));
+print_info(password_get_info('$2y$10$usesomesillystringfore2uDLvp1Ii2e./U9C8sBjqp8I90dH6hi'));

--- a/hphp/test/slow/password/get_info.php.expect
+++ b/hphp/test/slow/password/get_info.php.expect
@@ -1,0 +1,15 @@
+0
+unknown
+====
+0
+unknown
+====
+1
+bcrypt
+7
+====
+1
+bcrypt
+10
+====
+

--- a/hphp/test/slow/password/hash.php
+++ b/hphp/test/slow/password/hash.php
@@ -1,0 +1,12 @@
+<?php
+
+echo strlen(password_hash('foo', PASSWORD_BCRYPT))."\n";
+
+$hash = password_hash('foo', PASSWORD_BCRYPT);
+echo ($hash == crypt('foo', $hash) ? "yes" : "no")."\n";
+echo "\n";
+
+echo password_hash("rasmusledorf", PASSWORD_BCRYPT,
+	["cost" => 7, "salt" => "usesomesillystringforsalt"])."\n";
+echo password_hash("test", PASSWORD_BCRYPT,
+	["salt" => "123456789012345678901" . chr(0)])."\n";

--- a/hphp/test/slow/password/hash.php.expect
+++ b/hphp/test/slow/password/hash.php.expect
@@ -1,0 +1,6 @@
+60
+yes
+
+$2y$07$usesomesillystringforeGt9Mi2BQoSKpEE6n3.spxry59DfCXle
+$2y$10$MTIzNDU2Nzg5MDEyMzQ1Nej0NmcAWSLR.oP7XOR9HD/vjUuOj100y
+

--- a/hphp/test/slow/password/invalid_algo.php
+++ b/hphp/test/slow/password/invalid_algo.php
@@ -1,0 +1,2 @@
+<?php
+password_hash('foo', array());

--- a/hphp/test/slow/password/invalid_algo.php.expectf
+++ b/hphp/test/slow/password/invalid_algo.php.expectf
@@ -1,0 +1,1 @@
+HipHop Fatal error: Argument 2 passed to password_hash() must be an instance of int, array given in %s/test/slow/password/invalid_algo.php on line 2

--- a/hphp/test/slow/password/invalid_algo2.php
+++ b/hphp/test/slow/password/invalid_algo2.php
@@ -1,0 +1,2 @@
+<?php
+password_hash('foo', 2);

--- a/hphp/test/slow/password/invalid_algo2.php.expectf
+++ b/hphp/test/slow/password/invalid_algo2.php.expectf
@@ -1,0 +1,1 @@
+HipHop Warning: password_hash(): Unknown password hashing algorithm: 2

--- a/hphp/test/slow/password/invalid_bcrypt_cost_high.php
+++ b/hphp/test/slow/password/invalid_bcrypt_cost_high.php
@@ -1,0 +1,2 @@
+<?php
+password_hash('foo', PASSWORD_BCRYPT, ["cost" => 32]);

--- a/hphp/test/slow/password/invalid_bcrypt_cost_high.php.expectf
+++ b/hphp/test/slow/password/invalid_bcrypt_cost_high.php.expectf
@@ -1,0 +1,1 @@
+HipHop Warning: password_hash(): Invalid bcrypt cost parameter specified: 32

--- a/hphp/test/slow/password/invalid_bcrypt_cost_invalid.php
+++ b/hphp/test/slow/password/invalid_bcrypt_cost_invalid.php
@@ -1,0 +1,2 @@
+<?php
+password_hash('foo', PASSWORD_BCRYPT, ["cost" => 'foo']);

--- a/hphp/test/slow/password/invalid_bcrypt_cost_invalid.php.expectf
+++ b/hphp/test/slow/password/invalid_bcrypt_cost_invalid.php.expectf
@@ -1,0 +1,1 @@
+HipHop Warning: password_hash(): Invalid bcrypt cost parameter specified: 0

--- a/hphp/test/slow/password/invalid_bcrypt_cost_low.php
+++ b/hphp/test/slow/password/invalid_bcrypt_cost_low.php
@@ -1,0 +1,2 @@
+<?php
+password_hash('foo', PASSWORD_BCRYPT, ["cost" => 3]);

--- a/hphp/test/slow/password/invalid_bcrypt_cost_low.php.expectf
+++ b/hphp/test/slow/password/invalid_bcrypt_cost_low.php.expectf
@@ -1,0 +1,1 @@
+HipHop Warning: password_hash(): Invalid bcrypt cost parameter specified: 3

--- a/hphp/test/slow/password/invalid_bcrypt_salt_short.php
+++ b/hphp/test/slow/password/invalid_bcrypt_salt_short.php
@@ -1,0 +1,2 @@
+<?php
+password_hash('foo', PASSWORD_BCRYPT, ["salt" => 'abc']);

--- a/hphp/test/slow/password/invalid_bcrypt_salt_short.php.expectf
+++ b/hphp/test/slow/password/invalid_bcrypt_salt_short.php.expectf
@@ -1,0 +1,1 @@
+HipHop Warning: password_hash(): Provided salt is too short: 3 expecting 22

--- a/hphp/test/slow/password/invalid_password.php
+++ b/hphp/test/slow/password/invalid_password.php
@@ -1,0 +1,2 @@
+<?php
+password_hash(array(), 1);

--- a/hphp/test/slow/password/invalid_password.php.expectf
+++ b/hphp/test/slow/password/invalid_password.php.expectf
@@ -1,0 +1,1 @@
+HipHop Fatal error: Argument 1 passed to password_hash() must be an instance of string, array given in %s/test/slow/password/invalid_password.php on line 2

--- a/hphp/test/slow/password/invalid_salt.php
+++ b/hphp/test/slow/password/invalid_salt.php
@@ -1,0 +1,2 @@
+<?php
+password_hash('foo', PASSWORD_BCRYPT, array('salt' => array()));

--- a/hphp/test/slow/password/invalid_salt.php.expectf
+++ b/hphp/test/slow/password/invalid_salt.php.expectf
@@ -1,0 +1,1 @@
+HipHop Warning: password_hash(): Non-string salt parameter supplied

--- a/hphp/test/slow/password/rehash.php
+++ b/hphp/test/slow/password/rehash.php
@@ -1,0 +1,11 @@
+<?php
+
+function test_rehash($hash, $algo, $options) {
+	echo password_needs_rehash($hash, $algo, $options) ? "true\n" : "false\n";
+}
+
+test_rehash('foo', 0, []);
+test_rehash('foo', 1, []);
+test_rehash('$2y$07$usesomesillystringfore2uDLvp1Ii2e./U9C8sBjqp8I90dH6hi', PASSWORD_BCRYPT, array());
+test_rehash('$2y$07$usesomesillystringfore2uDLvp1Ii2e./U9C8sBjqp8I90dH6hi', PASSWORD_BCRYPT, array('cost' => 7));
+test_rehash('$2y$07$usesomesillystringfore2uDLvp1Ii2e./U9C8sBjqp8I90dH6hi', PASSWORD_BCRYPT, array('cost' => 5));

--- a/hphp/test/slow/password/rehash.php.expect
+++ b/hphp/test/slow/password/rehash.php.expect
@@ -1,0 +1,6 @@
+false
+true
+true
+false
+true
+

--- a/hphp/test/slow/password/verify.php
+++ b/hphp/test/slow/password/verify.php
@@ -1,0 +1,10 @@
+<?php
+
+function test_verify($pass, $hash) {
+	echo password_verify($pass, $hash) ? "true\n" : "false\n";
+}
+
+test_verify('foo','$2a$07$usesomesillystringforsalt$');
+test_verify('rasmusler','$2a$07$usesomesillystringfore2uDLvp1Ii2e./U9C8sBjqp8I90dH6hi');
+test_verify('rasmuslerdorf','$2a$07$usesomesillystringfore2uDLvp1Ii2e./U9C8sBjqp8I90dH6hi');
+test_verify('rasmuslerdorf','$2a$07$usesomesillystringfore2uDLvp1Ii2e./U9C8sBjqp8I90dH6hj');

--- a/hphp/test/slow/password/verify.php.expect
+++ b/hphp/test/slow/password/verify.php.expect
@@ -1,0 +1,4 @@
+false
+false
+true
+false


### PR DESCRIPTION
This uses @ircmaxell's password_compat library to implement the `password` extension on top of the underlying crypt functions.

Closes #992
