### PR TITLE
fix stream_get_contents when no offset is specified

### DIFF
--- a/hphp/runtime/base/file.h
+++ b/hphp/runtime/base/file.h
@@ -127,6 +127,8 @@ public:
 
   int64_t bufferedLen() { return m_writepos - m_readpos; }
 
+  int64_t getPosition() { return m_position; }
+
   std::string getMode() { return m_mode; }
 
   /**

--- a/hphp/runtime/ext/ext_stream.cpp
+++ b/hphp/runtime/ext/ext_stream.cpp
@@ -233,6 +233,9 @@ Variant f_stream_get_contents(CResRef handle, int maxlen /* = -1 */,
     return false;
   }
 
+  if (offset == -1 && file->getPosition() > 0) {
+    offset = file->getPosition();
+  }
   if (offset >= 0 && !file->seek(offset, SEEK_SET) ) {
     raise_warning("Failed to seek to position %d in the stream", offset);
     return false;

--- a/hphp/test/slow/ext_stream/stream_file_offset.php
+++ b/hphp/test/slow/ext_stream/stream_file_offset.php
@@ -1,0 +1,14 @@
+<?php
+
+$fd = fopen(__DIR__.'/stream_file_offset.php.sample', 'rb');
+
+// fgets moves the read position.
+var_dump(trim(fgets($fd)));
+
+// when no offset is given, use read position.
+var_dump(trim(stream_get_contents($fd)));   
+
+// otherwise just use the offset.
+var_dump(trim(stream_get_contents($fd, -1, 5)));
+
+fclose($fd);

--- a/hphp/test/slow/ext_stream/stream_file_offset.php.expect
+++ b/hphp/test/slow/ext_stream/stream_file_offset.php.expect
@@ -1,0 +1,3 @@
+string(5) "hello"
+string(5) "world"
+string(5) "world"

--- a/hphp/test/slow/ext_stream/stream_file_offset.php.sample
+++ b/hphp/test/slow/ext_stream/stream_file_offset.php.sample
@@ -1,0 +1,2 @@
+hello
+world


### PR DESCRIPTION
Other file functions can move the offset of the file descriptor. When
the offset is ommitted, use File::m_position to determine where to seek
to.
