### PR TITLE
fix stream_get_contents when no offset is specified

### DIFF
--- a/hphp/runtime/base/file.h
+++ b/hphp/runtime/base/file.h
@@ -98,7 +98,8 @@ public:
    */
   virtual int64_t readImpl(char *buffer, int64_t length) = 0;
   virtual int getc();
-  virtual String read(int64_t length = 0);
+  virtual String read(int64_t length);
+  virtual String read();
 
   /**
    * Write one chunk of output. Returns bytes written.

--- a/hphp/runtime/base/plain-file.cpp
+++ b/hphp/runtime/base/plain-file.cpp
@@ -141,6 +141,10 @@ int PlainFile::getc() {
   return File::getc();
 }
 
+String PlainFile::read() {
+  return File::read();
+}
+
 String PlainFile::read(int64_t length) {
   if (length) m_eof = false;
   return File::read(length);

--- a/hphp/runtime/base/plain-file.h
+++ b/hphp/runtime/base/plain-file.h
@@ -42,7 +42,8 @@ public:
   virtual bool close();
   virtual int64_t readImpl(char *buffer, int64_t length);
   virtual int getc();
-  virtual String read(int64_t length = 0);
+  virtual String read();
+  virtual String read(int64_t length);
   virtual int64_t writeImpl(const char *buffer, int64_t length);
   virtual bool seekable() { return true;}
   virtual bool seek(int64_t offset, int whence = SEEK_SET);

--- a/hphp/runtime/ext/ext_stream.cpp
+++ b/hphp/runtime/ext/ext_stream.cpp
@@ -235,17 +235,12 @@ Variant f_stream_get_contents(CResRef handle, int maxlen /* = -1 */,
 
   String ret;
   if (maxlen != -1) {
-    ret = String(maxlen, ReserveString);
-    char *buf = ret.bufferSlice().ptr;
-    maxlen = file->readImpl(buf, maxlen);
     if (maxlen < 0) {
       return false;
     }
-    ret.setSize(maxlen);
+    ret = file->read(maxlen);
   } else {
-    StringBuffer sb;
-    sb.read(file);
-    ret = sb.detach();
+    ret = file->read();
   }
   return ret;
 }

--- a/hphp/test/slow/ext_stream/stream_file_offset.php
+++ b/hphp/test/slow/ext_stream/stream_file_offset.php
@@ -1,0 +1,14 @@
+<?php
+
+$fd = fopen(__DIR__.'/stream_file_offset.php.sample', 'rb');
+
+// fgets moves the read position.
+var_dump(trim(fgets($fd)));
+
+// when no offset is given, use read position.
+var_dump(trim(stream_get_contents($fd)));   
+
+// otherwise just use the offset.
+var_dump(trim(stream_get_contents($fd, -1, 5)));
+
+fclose($fd);

--- a/hphp/test/slow/ext_stream/stream_file_offset.php.expect
+++ b/hphp/test/slow/ext_stream/stream_file_offset.php.expect
@@ -1,0 +1,3 @@
+string(5) "hello"
+string(5) "world"
+string(5) "world"

--- a/hphp/test/slow/ext_stream/stream_file_offset.php.sample
+++ b/hphp/test/slow/ext_stream/stream_file_offset.php.sample
@@ -1,0 +1,2 @@
+hello
+world


### PR DESCRIPTION
File does its own internal buffering and uses m_readpos, m_writepos,
m_position for the purpose of keeping track of file offsets. This means
that current (PHP) position is not in sync with the underlying file
descriptor (m_fd).

This works fine, were it not for the fact that ext_stream calls directly
into pure virtual method readImpl that generally lives in PlainFile
and works directly on the file descriptor that might contain an
invalid (buffered-ahead) position.

This pull request does several things:
- Remove default value 0 for File::read(int64_t length), since that
  implementation returns earlier for 0 values anyway.
- Implement an overloaded method File::read() that reads the remainder
  of the file (until EOF) by using proper File::m_\* properties.
- Make ext_stream call into File::read instead of PlainFile::readImpl.

Obviously, comments on this are very much appreciated!
