### PR TITLE
close pdo connection after request ends

### DIFF
--- a/hphp/runtime/ext/ext_pdo.cpp
+++ b/hphp/runtime/ext/ext_pdo.cpp
@@ -930,6 +930,7 @@ void c_PDO::sweep() {
   // PDOConnection is not sweepable, so clean it up manually.
   static_assert(!std::is_base_of<Sweepable, PDOConnection>::value,
                 "Remove the call to reset() below.");
+  m_dbh->closer();
   m_dbh.detach();
 }
 


### PR DESCRIPTION
When a request finishes and the PDO connection is not closed in
userland, we need to explictly close it to prevent excessive amount of
connections (and eventually causing MySQL to reject them).

This can obviously be solved in userland by closing the connection in a
register_shutdown_function, but we need to be consistent with PHP.

I'm not sure if this is the way to solve this problem, so this pull request is meant as a place for more knowledgeable people to give input on the issue.
