### PR TITLE
close pdo connection after request ends

### DIFF
--- a/hphp/runtime/ext/ext_pdo.cpp
+++ b/hphp/runtime/ext/ext_pdo.cpp
@@ -926,13 +926,6 @@ c_PDO::c_PDO(Class* cb) : ExtObjectData(cb) {
 c_PDO::~c_PDO() {
 }
 
-void c_PDO::sweep() {
-  // PDOConnection is not sweepable, so clean it up manually.
-  static_assert(!std::is_base_of<Sweepable, PDOConnection>::value,
-                "Remove the call to reset() below.");
-  m_dbh.detach();
-}
-
 void c_PDO::t___construct(const String& dsn, const String& username /* = null_string */,
                           const String& password /* = null_string */,
                           CArrRef options /* = null_array */) {
@@ -2640,10 +2633,6 @@ c_PDOStatement::c_PDOStatement(Class* cb) :
 c_PDOStatement::~c_PDOStatement() {
   m_stmt.reset();
   m_row.reset();
-}
-
-void c_PDOStatement::sweep() {
-  // No resources allocated outside HHVM's control
 }
 
 Variant c_PDOStatement::t_execute(CArrRef params /* = null_array */) {

--- a/hphp/runtime/ext/ext_pdo.h
+++ b/hphp/runtime/ext/ext_pdo.h
@@ -112,9 +112,9 @@ extern const int64_t q_PDO$$MYSQL_ATTR_IGNORE_SPACE;
 // class PDO
 
 FORWARD_DECLARE_CLASS(PDO);
-class c_PDO : public ExtObjectData, public Sweepable {
+class c_PDO : public ExtObjectData {
  public:
-  DECLARE_CLASS(PDO)
+  DECLARE_CLASS_NO_SWEEP(PDO)
 
   // need to implement
   public: c_PDO(Class* cls = c_PDO::classof());
@@ -152,9 +152,9 @@ class c_PDO : public ExtObjectData, public Sweepable {
 // class PDOStatement
 
 FORWARD_DECLARE_CLASS(PDOStatement);
-class c_PDOStatement : public ExtObjectData, public Sweepable {
+class c_PDOStatement : public ExtObjectData {
  public:
-  DECLARE_CLASS(PDOStatement)
+  DECLARE_CLASS_NO_SWEEP(PDOStatement)
 
   // need to implement
   public: c_PDOStatement(Class* cls = c_PDOStatement::classof());

--- a/hphp/runtime/ext/pdo_driver.cpp
+++ b/hphp/runtime/ext/pdo_driver.cpp
@@ -72,6 +72,12 @@ PDOConnection::PDOConnection()
 PDOConnection::~PDOConnection() {
 }
 
+void PDOConnection::sweep() {
+  assert(!is_persistent);
+  def_stmt_ctor_args.asTypedValue()->m_type = KindOfNull;
+  delete this;
+}
+
 void PDOConnection::persistentSave() {
   String serialized = f_serialize(def_stmt_ctor_args);
   serialized_def_stmt_ctor_args = string(serialized.data(), serialized.size());

--- a/hphp/runtime/ext/pdo_driver.h
+++ b/hphp/runtime/ext/pdo_driver.h
@@ -235,7 +235,7 @@ class PDOStatement;
 typedef SmartResource<PDOStatement> sp_PDOStatement;
 
 /* represents a connection to a database */
-class PDOConnection : public ResourceData {
+class PDOConnection : public SweepableResourceData {
 public:
   static const char *PersistentKey;
 
@@ -259,6 +259,7 @@ public:
   PDOConnection();
   virtual ~PDOConnection();
   virtual bool create(CArrRef options) = 0;
+  virtual void sweep();
 
   CLASSNAME_IS("PDOConnection")
   // overriding ResourceData


### PR DESCRIPTION
When a request finishes and the PDO connection is not closed in
userland and it is persistent, we need to explictly close it to
prevent excessive amount of connections (and eventually causing
MySQL to reject them).

This can obviously be solved in userland by closing the connection in a
register_shutdown_function, but we need to be consistent with PHP.
