### PR TITLE
Add second parameter to nl2br

### DIFF
--- a/hphp/runtime/ext/ext_string.cpp
+++ b/hphp/runtime/ext/ext_string.cpp
@@ -272,10 +272,15 @@ Variant f_hex2bin(const String& str) {
 
 const StaticString
   s_nl("\n"),
-  s_br("<br />\n");
+  s_br("<br />\n"),
+  s_non_xhtml_br("<br>\n");
 
-String f_nl2br(const String& str) {
-  return string_replace(str, s_nl, s_br);
+String f_nl2br(const String& str, bool is_xhtml /* = true */) {
+  if (is_xhtml) {
+    return string_replace(str, s_nl, s_br);
+  } else {
+    return string_replace(str, s_nl, s_non_xhtml_br);
+  }
 }
 
 String f_quotemeta(const String& str) {

--- a/hphp/runtime/ext/ext_string.h
+++ b/hphp/runtime/ext/ext_string.h
@@ -36,7 +36,7 @@ String f_addslashes(const String& str);
 String f_stripslashes(const String& str);
 String f_bin2hex(const String& str);
 Variant f_hex2bin(const String& str);
-String f_nl2br(const String& str);
+String f_nl2br(const String& str, bool is_xhtml = true);
 String f_quotemeta(const String& str);
 String f_str_shuffle(const String& str);
 String f_strrev(const String& str);

--- a/hphp/system/idl/string.idl.json
+++ b/hphp/system/idl/string.idl.json
@@ -125,6 +125,12 @@
                     "name": "str",
                     "type": "String",
                     "desc": "The input string."
+                },
+                {
+                    "name": "is_xhtml",
+                    "type": "Boolean",
+                    "value": "true",
+                    "desc": "Whether to use XHTML compatible line breaks or not."
                 }
             ]
         },

--- a/hphp/test/slow/ext_string/ext_string.php
+++ b/hphp/test/slow/ext_string/ext_string.php
@@ -22,6 +22,8 @@ VS(bin2hex("ABC\n"), "4142430a");
 VS(hex2bin("4142430a"), "ABC\n");
 
 VS(nl2br("A\nB"), "A<br />\nB");
+VS(nl2br("A\nB", true), "A<br />\nB");
+VS(nl2br("A\nB", false), "A<br>\nB");
 
 VS(quotemeta(". \\ + * ? [ ^ ] ( $ )"),
    "\\. \\\\ \\+ \\* \\? \\[ \\^ \\] \\( \\$ \\)");

--- a/hphp/test/slow/ext_string/ext_string.php.expectf
+++ b/hphp/test/slow/ext_string/ext_string.php.expectf
@@ -176,7 +176,9 @@ bool(true)
 bool(true)
 bool(true)
 bool(true)
-HipHop Warning: Empty delimiter in %s/test/slow/ext_string/ext_string.php on line 393
+bool(true)
+bool(true)
+HipHop Warning: Empty delimiter in %s/test/slow/ext_string/ext_string.php on line 395
 bool(true)
 bool(true)
 bool(true)


### PR DESCRIPTION
Adds the optional second `is_html` boolean parameter to match the Zend
implementation. The nl2br function still needs some work to have full
parity with zend, so the zend testcases aren't moved from bad to good
yet.

fixes #1351

Edit: the current implementation only replaces `\n` using a naive implementation. In Zend `\r\n`, `\n\r` and `\r` are also replaced.
