### PR TITLE
Added monolog to the tested frameworks

### DIFF
--- a/hphp/test/frameworks/run.php
+++ b/hphp/test/frameworks/run.php
@@ -1093,6 +1093,19 @@ class Assetic extends Framework {
 }
 
 
+class Monolog extends Framework {
+  public function __construct(string $name) { parent::__construct($name); }
+  protected function getInfo(): Map {
+    return Map {
+      "install_root" => __DIR__."/frameworks/monolog",
+      "git_path" => "https://github.com/Seldaek/monolog.git",
+      'git_commit' => "6225b22de9dcf36546be3a0b2fa8e3d986153f57", // stable 1.7
+      "test_path" => __DIR__."/frameworks/monolog",
+    };
+  }
+}
+
+
 class CodeIgniter extends Framework {
   public function __construct(string $name) { parent::__construct($name); }
   protected function getInfo(): Map {


### PR DESCRIPTION
Added [monolog](https://github.com/Seldaek/monolog) (current stable version - 1.7) to the tested frameworks. Monolog is the defacto default logging library for Symfony2/Silex/... based applications.

Everything looks well expect 3 failing unit-test. The failing tests seem to be related to a unsupported syntax for `DateTime`. When you pass in `@<int>` in PHP you get the Unix-timestamp with _timezone set to GMT+0_. In HHVM the timezone is kept at the configured timezone.

Test script:

```
<?php

$d = new DateTime("@0");
echo $d->format('c'), "\n";
```

Results:

```
bz@hhvm-dev:~/hhvm$ date
Fr 20. Dez 10:25:27 CET 2013

bz@hhvm-dev:~/hhvm$ php test.php
1970-01-01T00:00:00+00:00

bz@hhvm-dev:~/hhvm$ hhvm test.php
1970-01-01T00:00:00+01:00
```

I couldn't find an existing issue for this problem - do you want me to open one?

Failing tests:

```
1) Monolog\Formatter\LogstashFormatterTest::testDefaultFormatter

RUN TEST FILE:  cd /home/bz/hhvm/hphp/test/frameworks/frameworks/monolog && /home/bz/hhvm/hphp/test/frameworks/../../hhvm/hhvm -v Repo.Local.Mode=-- -v Repo.Central.Path=/tmp/framework-testE800ie --config /home/bz/hhvm/hphp/test/frameworks/config.hdf -v Server.IniFile=/home/bz/hhvm/hphp/test/frameworks/php.ini -v Eval.Jit=true /home/bz/hhvm/hphp/test/frameworks/vendor/bin/phpunit --debug -c /home/bz/hhvm/hphp/test/frameworks/frameworks/monolog/phpunit.xml.dist --filter 'Monolog\\Formatter\\LogstashFormatterTest::testDefaultFormatter'

Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'1970-01-01T00:00:00.000000+00:00'
+'1970-01-01T00:00:00.000000-08:00'

/home/bz/hhvm/hphp/test/frameworks/frameworks/monolog/tests/Monolog/Formatter/LogstashFormatterTest.php:38
/home/bz/hhvm/hphp/test/frameworks/vendor/phpunit/phpunit/PHPUnit/TextUI/Command.php:176
/home/bz/hhvm/hphp/test/frameworks/vendor/phpunit/phpunit/PHPUnit/TextUI/Command.php:129

2) Monolog\Formatter\LogstashFormatterTest::testDefaultFormatterV1

RUN TEST FILE:  cd /home/bz/hhvm/hphp/test/frameworks/frameworks/monolog && /home/bz/hhvm/hphp/test/frameworks/../../hhvm/hhvm -v Repo.Local.Mode=-- -v Repo.Central.Path=/tmp/framework-testE800ie --config /home/bz/hhvm/hphp/test/frameworks/config.hdf -v Server.IniFile=/home/bz/hhvm/hphp/test/frameworks/php.ini -v Eval.Jit=true /home/bz/hhvm/hphp/test/frameworks/vendor/bin/phpunit --debug -c /home/bz/hhvm/hphp/test/frameworks/frameworks/monolog/phpunit.xml.dist --filter 'Monolog\\Formatter\\LogstashFormatterTest::testDefaultFormatterV1'

Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'1970-01-01T00:00:00.000000+00:00'
+'1970-01-01T00:00:00.000000-08:00'

/home/bz/hhvm/hphp/test/frameworks/frameworks/monolog/tests/Monolog/Formatter/LogstashFormatterTest.php:179
/home/bz/hhvm/hphp/test/frameworks/vendor/phpunit/phpunit/PHPUnit/TextUI/Command.php:176
/home/bz/hhvm/hphp/test/frameworks/vendor/phpunit/phpunit/PHPUnit/TextUI/Command.php:129

1) Monolog\Formatter\ElasticaFormatterTest::testFormat

RUN TEST FILE:  cd /home/bz/hhvm/hphp/test/frameworks/frameworks/monolog && /home/bz/hhvm/hphp/test/frameworks/../../hhvm/hhvm -v Repo.Local.Mode=-- -v Repo.Central.Path=/tmp/framework-testE800ie --config /home/bz/hhvm/hphp/test/frameworks/config.hdf -v Server.IniFile=/home/bz/hhvm/hphp/test/frameworks/php.ini -v Eval.Jit=true /home/bz/hhvm/hphp/test/frameworks/vendor/bin/phpunit --debug -c /home/bz/hhvm/hphp/test/frameworks/frameworks/monolog/phpunit.xml.dist --filter 'Monolog\\Formatter\\ElasticaFormatterTest::testFormat'

Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'1970-01-01T00:00:00+0000'
+'1970-01-01T00:00:00-0800'

/home/bz/hhvm/hphp/test/frameworks/frameworks/monolog/tests/Monolog/Formatter/ElasticaFormatterTest.php:66
/home/bz/hhvm/hphp/test/frameworks/vendor/phpunit/phpunit/PHPUnit/TextUI/Command.php:176
/home/bz/hhvm/hphp/test/frameworks/vendor/phpunit/phpunit/PHPUnit/TextUI/Command.php:129
```

Runner result:

```
bz@hhvm-dev:~/hhvm$ hhvm hphp/test/frameworks/run.php monolog
monolog: running. Comparing against 256 tests
Beginning the unit tests.....
........................................................................................................................................................................    ........................................................................................
All tests ran as expected.

          _
         /(|
        (  :
       __\  \  _____
     (____)  -|
    (____)|   |
     (____).__|
      (___)__.|_____

ALL TESTS COMPLETE!
SUMMARY:
monolog=98.41

To run differing tests (if they exist), see above for the
commands or the results/.diff file. To run erroring or
fataling tests see results/.errors and results/.fatals
files, respectively
```
