### PR TITLE
Fix cmake freetype include directory

### DIFF
--- a/CMake/FindFreetype.cmake
+++ b/CMake/FindFreetype.cmake
@@ -7,7 +7,7 @@ find_path(FREETYPE_INCLUDE_DIRS NAMES freetype/freetype.h)
 if (NOT FREETYPE_INCLUDE_DIRS)
 	find_path(FREETYPE_INCLUDE_DIRS NAMES freetype2/freetype/freetype.h)
 	if (FREETYPE_INCLUDE_DIRS)
-		set(FREETYPE_INCLUDE_DIRS "${FREETYPE_INCLUDE_DIRS}/freetype2")
+		set(FREETYPE_INCLUDE_DIRS "${FREETYPE_INCLUDE_DIRS}/freetype2" CACHE PATH "Freetype include directory" FORCE)
 	endif()
 endif()
 


### PR DESCRIPTION
Fixed overwriting FREETYPE_INCLUDE_DIRS when freetype located at non-default path.

Without this fix CMakeCache.txt contains the following line even when freetype really located in /usr/include/freetype2 (as in Ubuntu 12.04 and others):

```
FREETYPE_INCLUDE_DIRS:PATH=/usr/include
```
