### PR TITLE
Included ReactPHP and Ratchet to framework-test-runner

### DIFF
--- a/hphp/test/frameworks/run.php
+++ b/hphp/test/frameworks/run.php
@@ -1092,6 +1092,29 @@ class Assetic extends Framework {
   }
 }
 
+class ReactPHP extends Framework {
+  public function __construct(string $name) { parent::__construct($name); }
+  protected function getInfo(): Map {
+    return Map {
+      "install_root" => __DIR__."/frameworks/reactphp",
+      "git_path" => "https://github.com/reactphp/react.git",
+      'git_commit' => "210c11a6041cfa2ce1701a4870b69475d9081265", # current stable - v0.3.3
+      "test_path" => __DIR__."/frameworks/reactphp",
+    };
+  }
+}
+
+class Ratchet extends Framework {
+  public function __construct(string $name) { parent::__construct($name); }
+  protected function getInfo(): Map {
+    return Map {
+      "install_root" => __DIR__."/frameworks/ratchet",
+      "git_path" => "https://github.com/cboden/Ratchet.git",
+      'git_commit' => "d756e0b507a5f3cdbf8c59dbb7baf68574dc7d58", # current stable - v0.3.0
+      "test_path" => __DIR__."/frameworks/ratchet",
+    };
+  }
+}
 
 class CodeIgniter extends Framework {
   public function __construct(string $name) { parent::__construct($name); }


### PR DESCRIPTION
Included ReactPHP and Ratchet with their latest stable releases (0.3.3 and 0.3.0) into the framework-test-runner. 

[ReactPHP](https://github.com/reactphp/react) is PHP's most popular reactor pattern implementation, while [Ratchet](https://github.com/cboden/Ratchet) is a Websocket-Server. 
It's built ontop of ReactPHP and one of its most popular applications. 
### Failing tests - ReactPHP:

There are 2 tests failing in ReactPHP which seem revolve around its `usleep()`-usage. Also there is 1 problem with the behaviour of `stream_socket_pair(STREAM_PF_UNIX, STREAM_SOCK_STREAM, STREAM_IPPROTO_IP)`. All 3 of them are OK on PHP 5.3.10.

```
1) React\Tests\EventLoop\Timer\StreamSelectTimerTest::testAddPeriodicTimer

RUN TEST FILE:  cd /home/bz/hhvm/hphp/test/frameworks/frameworks/reactphp && /home/bz/hhvm/hphp/test/frameworks/../../hhvm/hhvm -v Repo.Local.Mode=-- -v Repo.Central.Path=/tmp/framework-testzRz5yd --config /home/bz/hhvm/hphp/test/frameworks/config.hdf -v Server.IniFile=/home/bz/hhvm/hphp/test/frameworks/php.ini -v Eval.Jit=true /home/bz/hhvm/hphp/test/frameworks/vendor/bin/phpunit --debug -c /home/bz/hhvm/hphp/test/frameworks/frameworks/reactphp/phpunit.xml.dist --filter 'React\\Tests\\EventLoop\\Timer\\StreamSelectTimerTest::testAddPeriodicTimer'

React\Tests\Socket\Stub\CallableStub::__invoke(React\EventLoop\Timer\Timer Object (...)) was not expected to be called more than 3 times.

RUN TEST FILE:  cd /home/bz/hhvm/hphp/test/frameworks/frameworks/reactphp && /home/bz/hhvm/hphp/test/frameworks/../../hhvm/hhvm -v Repo.Local.Mode=-- -v Repo.Central.Path=/tmp/framework-testzRz5yd --config /home/bz/hhvm/hphp/test/frameworks/config.hdf -v Server.IniFile=/home/bz/hhvm/hphp/test/frameworks/php.ini -v Eval.Jit=true /home/bz/hhvm/hphp/test/frameworks/vendor/bin/phpunit --debug -c /home/bz/hhvm/hphp/test/frameworks/frameworks/reactphp/phpunit.xml.dist --filter 'React\\Tests\\Socket\\Stub\\CallableStub::__invoke'


/home/bz/hhvm/hphp/test/frameworks/frameworks/reactphp/src/React/EventLoop/Timer/Timers.php:94
/home/bz/hhvm/hphp/test/frameworks/frameworks/reactphp/src/React/EventLoop/StreamSelectLoop.php:164
/home/bz/hhvm/hphp/test/frameworks/frameworks/reactphp/tests/React/Tests/EventLoop/Timer/AbstractTimerTest.php:29

2) React\Tests\EventLoop\Timer\StreamSelectTimerTest::testAddPeriodicTimerWithCancel

RUN TEST FILE:  cd /home/bz/hhvm/hphp/test/frameworks/frameworks/reactphp && /home/bz/hhvm/hphp/test/frameworks/../../hhvm/hhvm -v Repo.Local.Mode=-- -v Repo.Central.Path=/tmp/framework-testzRz5yd --config /home/bz/hhvm/hphp/test/frameworks/config.hdf -v Server.IniFile=/home/bz/hhvm/hphp/test/frameworks/php.ini -v Eval.Jit=true /home/bz/hhvm/hphp/test/frameworks/vendor/bin/phpunit --debug -c /home/bz/hhvm/hphp/test/frameworks/frameworks/reactphp/phpunit.xml.dist --filter 'React\\Tests\\EventLoop\\Timer\\StreamSelectTimerTest::testAddPeriodicTimerWithCancel'

React\Tests\Socket\Stub\CallableStub::__invoke(React\EventLoop\Timer\Timer Object (...)) was not expected to be called more than 2 times.

RUN TEST FILE:  cd /home/bz/hhvm/hphp/test/frameworks/frameworks/reactphp && /home/bz/hhvm/hphp/test/frameworks/../../hhvm/hhvm -v Repo.Local.Mode=-- -v Repo.Central.Path=/tmp/framework-testzRz5yd --config /home/bz/hhvm/hphp/test/frameworks/config.hdf -v Server.IniFile=/home/bz/hhvm/hphp/test/frameworks/php.ini -v Eval.Jit=true /home/bz/hhvm/hphp/test/frameworks/vendor/bin/phpunit --debug -c /home/bz/hhvm/hphp/test/frameworks/frameworks/reactphp/phpunit.xml.dist --filter 'React\\Tests\\Socket\\Stub\\CallableStub::__invoke'


/home/bz/hhvm/hphp/test/frameworks/frameworks/reactphp/src/React/EventLoop/Timer/Timers.php:94
/home/bz/hhvm/hphp/test/frameworks/frameworks/reactphp/src/React/EventLoop/StreamSelectLoop.php:164
/home/bz/hhvm/hphp/test/frameworks/frameworks/reactphp/tests/React/Tests/EventLoop/Timer/AbstractTimerTest.php:43

1) React\Tests\Stream\BufferTest::testWriteDetectsWhenOtherSideIsClosed

RUN TEST FILE:  cd /home/bz/hhvm/hphp/test/frameworks/frameworks/reactphp && /home/bz/hhvm/hphp/test/frameworks/../../hhvm/hhvm -v Repo.Local.Mode=-- -v Repo.Central.Path=/tmp/framework-testzRz5yd --config /home/bz/hhvm/hphp/test/frameworks/config.hdf -v Server.IniFile=/home/bz/hhvm/hphp/test/frameworks/php.ini -v Eval.Jit=true /home/bz/hhvm/hphp/test/frameworks/vendor/bin/phpunit --debug -c /home/bz/hhvm/hphp/test/frameworks/frameworks/reactphp/phpunit.xml.dist --filter 'React\\Tests\\Stream\\BufferTest::testWriteDetectsWhenOtherSideIsClosed'

Expectation failed for method name is equal to <string:__invoke> when invoked 1 time(s).
Method was expected to be called 1 times, actually called 0 times.
```
### Failing tests - Ratchet:

Ratchet has more failing tests, but most of them are because `ini_get('session.serialize_handler')` returns `string(0) ""`. Another 3 are probably due to no errors/warnings being generated for access of undefined properties.
Ratchet's unit-tests run fine on PHP5.3.10 except one - which is caused by inproper feature-detection. A PR is already at [Ratchet#PR159](https://github.com/cboden/Ratchet/pull/159). 

```
1) Ratchet\AbstractConnectionDecoratorTest::testWarningGettingNothing
2) Ratchet\AbstractConnectionDecoratorTest::testWarningGettingNothingLevel1
3) Ratchet\AbstractConnectionDecoratorTest::testWarningGettingNothingLevel2

RUN TEST FILE:  cd /home/bz/hhvm/hphp/test/frameworks/frameworks/ratchet && /home/bz/hhvm/hphp/test/frameworks/../../hhvm/hhvm -v Repo.Local.Mode=-- -v Repo.Central.Path=/tmp/framework-testNthbLo --config /home/bz/hhvm/hphp/test/frameworks/config.hdf -v Server.IniFile=/home/bz/hhvm/hphp/test/frameworks/php.ini -v Eval.Jit=true /home/bz/hhvm/hphp/test/frameworks/vendor/bin/phpunit --debug -c /home/bz/hhvm/hphp/test/frameworks/frameworks/ratchet/phpunit.xml.dist --filter 'Ratchet\\AbstractConnectionDecoratorTest::testWarningGettingNothingLevel2'

Failed asserting that exception of type "PHPUnit_Framework_Error" is thrown.


1) Ratchet\Session\SessionProviderTest::testToClassCase with data set #0 ('php', 'Php')
2) Ratchet\Session\SessionProviderTest::testToClassCase with data set #1 ('php_binary', 'PhpBinary')
3) Ratchet\Session\SessionProviderTest::testConnectionValueFromPdo
4) Ratchet\Session\SessionProviderTest::testOnMessageDecorator
5) Ratchet\Session\SessionProviderTest::testGetSubProtocolsReturnsArray
6) Ratchet\Session\SessionProviderTest::testGetSubProtocolsGetFromApp
7) Ratchet\Session\SessionProviderTest::testRejectInvalidSeralizers
8) Ratchet\Session\SessionProviderTest::testOpen
9) Ratchet\Session\SessionProviderTest::testOnClose
10) Ratchet\Session\SessionProviderTest::testOnError

RUN TEST FILE:  cd /home/bz/hhvm/hphp/test/frameworks/frameworks/ratchet && /home/bz/hhvm/hphp/test/frameworks/../../hhvm/hhvm -v Repo.Local.Mode=-- -v Repo.Central.Path=/tmp/framework-testNthbLo --config /home/bz/hhvm/hphp/test/frameworks/config.hdf -v Server.IniFile=/home/bz/hhvm/hphp/test/frameworks/php.ini -v Eval.Jit=true /home/bz/hhvm/hphp/test/frameworks/vendor/bin/phpunit --debug -c /home/bz/hhvm/hphp/test/frameworks/frameworks/ratchet/phpunit.xml.dist --filter 'Ratchet\\Session\\SessionProviderTest::testOnError'

RuntimeException: Unable to parse session serialize handler

/home/bz/hhvm/hphp/test/frameworks/frameworks/ratchet/src/Ratchet/Session/SessionProvider.php:61
/home/bz/hhvm/hphp/test/frameworks/frameworks/ratchet/tests/unit/Session/SessionComponentTest.php:22
```
