### PR TITLE
Changed exit-code for errors in binary execution

### DIFF
--- a/hphp/runtime/base/program-functions.cpp
+++ b/hphp/runtime/base/program-functions.cpp
@@ -1353,7 +1353,7 @@ static int execute_program_impl(int argc, char** argv) {
       ret = 0;
       for (int i = 0; i < po.count; i++) {
         execute_command_line_begin(new_argc, new_argv, po.xhprofFlags);
-        ret = 1;
+        ret = 255;
         if (hphp_invoke_simple(file)) {
           ret = ExitException::ExitCode;
         }


### PR DESCRIPTION
Errors now return 255 like PHP does. (Solution to #1350) 

I tested locally for the following error-conditions:
- Fatal error `<?php class self {} // reserved keyword as classname`
- Parse error `<?php if(;`
- Uncaught Exception `<?php throw new Exception();`

PHP returns in all cases 255.
