### PR TITLE
Check for 32 bit OS first in the CMake file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,10 @@
 CMAKE_MINIMUM_REQUIRED(VERSION 2.8.7 FATAL_ERROR)
 PROJECT(hphp C CXX ASM)
 
+IF(CMAKE_SIZEOF_VOID_P EQUAL 4)
+	message(FATAL_ERROR "32-bit support is currently unsupported, check back with a later version of HipHop")
+ENDIF()
+
 IF("$ENV{HPHP_HOME}" STREQUAL "")
 	message(FATAL_ERROR "You should set the HPHP_HOME environmental")
 ENDIF()
@@ -21,10 +25,6 @@ include("${CMAKE_CURRENT_SOURCE_DIR}/CMake/HPHPFunctions.cmake")
 include(CheckFunctionExists)
 
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/hphp)
-
-IF(CMAKE_SIZEOF_VOID_P EQUAL 4)
-	message(FATAL_ERROR "32-bit support is currently unsupported, check back with a later version of HipHop")
-ENDIF()
 
 if ("$ENV{USE_HHVM}" STREQUAL "1")
 	message("Building for HHVM")


### PR DESCRIPTION
Otherwise users may waste time installing missing dependencies just to get that error at the end.

Yes, I did this. I was attempting to compile on a 32 bit VM and had a bunch of missing dependencies which I went through and installed, only to get this at the end. I assume the 64-bit VM will be the missing the same dependencies so it's not wasted time for me, but it could be annoying to other users. 

Also, if we know it won't work on a 32 bit OS, why do anything else?
