### PR TITLE
Pass an error number along when handling a fatal error.

### DIFF
--- a/hphp/runtime/base/execution-context.cpp
+++ b/hphp/runtime/base/execution-context.cpp
@@ -698,7 +698,8 @@ void BaseExecutionContext::recordLastError(const Exception &e,
 }
 
 bool BaseExecutionContext::onFatalError(const Exception &e) {
-  recordLastError(e);
+  int errnum = static_cast<int>(ErrorConstants::ErrorModes::FATAL_ERROR);
+  recordLastError(e, errnum);
   String file = empty_string;
   int line = 0;
   bool silenced = false;
@@ -720,7 +721,6 @@ bool BaseExecutionContext::onFatalError(const Exception &e) {
   }
   bool handled = false;
   if (RuntimeOption::CallUserHandlerOnFatals) {
-    int errnum = static_cast<int>(ErrorConstants::ErrorModes::FATAL_ERROR);
     handled = callUserErrorHandler(e, errnum, true);
   }
   if (!handled && !silenced && !RuntimeOption::AlwaysLogUnhandledExceptions) {

--- a/hphp/test/slow/error_handler/1372.php
+++ b/hphp/test/slow/error_handler/1372.php
@@ -1,0 +1,11 @@
+<?php
+
+register_shutdown_function(function() {
+	$error = error_get_last();
+
+	if($error['type'] & E_ERROR) {
+		echo "Error\n";
+	}
+});
+
+Foo::bar();

--- a/hphp/test/slow/error_handler/1372.php.expectf
+++ b/hphp/test/slow/error_handler/1372.php.expectf
@@ -1,0 +1,2 @@
+HipHop Fatal error: Class undefined: Foo in %s on line 11
+Error


### PR DESCRIPTION
As no error number was being passed when a fatal error occurred, error_get_last() in a shutdown handler wasn't able to check if the error was fatal.
