### PR TITLE
added support for mod_fastcgi

### DIFF
--- a/hphp/runtime/server/fastcgi/fastcgi-transport.cpp
+++ b/hphp/runtime/server/fastcgi/fastcgi-transport.cpp
@@ -341,7 +341,22 @@ void FastCGITransport::handleHeader(const std::string& key,
 }
 
 void FastCGITransport::onHeadersComplete() {
-  m_serverObject = getRawHeader("SCRIPT_NAME");
+  m_pathTranslated = getRawHeader("PATH_TRANSLATED");
+  // use PATH_TRANSLATED instead of script_name and subtract document_root
+  // for mod_fastcgi support
+  if(!m_pathTranslated.empty()) {
+    if(m_pathTranslated.find(getRawHeader("DOCUMENT_ROOT")) != std::string::npos) {
+      // document_root found in path_translated. remove it!
+      size_t ptlen = strlen(getRawHeader("DOCUMENT_ROOT").c_str());
+      m_serverObject = m_pathTranslated.substr(ptlen, strlen(m_pathTranslated.c_str()));
+    } else {
+      // not sure if i should be settings this to path_translated or default it back to script_name.
+      // this will probaly never get executed.
+      m_serverObject = m_pathTranslated;
+    }
+  } else {
+    m_serverObject = getRawHeader("SCRIPT_NAME");
+  }
   std::string queryString = getRawHeader("QUERY_STRING");
   if (!queryString.empty()) {
     m_serverObject += "?" + queryString;

--- a/hphp/runtime/server/fastcgi/fastcgi-transport.h
+++ b/hphp/runtime/server/fastcgi/fastcgi-transport.h
@@ -122,6 +122,7 @@ private:
   Method m_method;
   std::string m_extendedMethod;
   std::string m_httpVersion;
+  std::string m_pathTranslated;
   std::string m_serverObject;
   size_t m_requestSize;
   ResponseHeaders m_responseHeaders;


### PR DESCRIPTION
when using mod_fastcgi SCRIPT_NAME is the Action instead of the actual document you want
this commit uses PATH_TRANSLATED - DOCUMENT_ROOT

tested with:
apache+mod_fastcgi
apache+mod_proxy_fcgi
nginx with no PATH_TRANSLATED header
nginx with this as PATH_TRANSLATED: fastcgi_param  PATH_TRANSLATED    $document_root$fastcgi_script_name;
