### PR TITLE
Fix preg_match returning false instead of null

### DIFF
--- a/hphp/runtime/base/preg.cpp
+++ b/hphp/runtime/base/preg.cpp
@@ -583,7 +583,7 @@ static Variant preg_match_impl(const String& pattern, const String& subject,
                     subpats_order > PREG_SET_ORDER)) ||
         (!global && subpats_order != 0)) {
       raise_warning("Invalid flags specified");
-      return false;
+      return null_variant;
     }
   }
 

--- a/hphp/test/slow/ext_preg/preg_match_invalid_flags.php
+++ b/hphp/test/slow/ext_preg/preg_match_invalid_flags.php
@@ -1,0 +1,2 @@
+<?php
+var_dump(preg_match('/test/', 'Hello World', $dummy, 0xdead));

--- a/hphp/test/slow/ext_preg/preg_match_invalid_flags.php.expectf
+++ b/hphp/test/slow/ext_preg/preg_match_invalid_flags.php.expectf
@@ -1,0 +1,2 @@
+HipHop Warning: Invalid flags specified in %s
+NULL


### PR DESCRIPTION
`preg_match`/`preg_match_all` should return `NULL` not `FALSE` when invalid flags are passed.

Example:

``` php
<?php
var_dump(preg_match('/test/', 'Hello World', $dummy, 0xdead));
```

HHVM Output:

```
HipHop Warning: Invalid flags specified in /var/share/dev/hhvm/hphp/test/slow/ext_preg/preg_match_invalid_flags.php on line 2
false
```

Correct Output (see: PHP 5.5.3):

```
HipHop Warning: Invalid flags specified in /var/share/dev/hhvm/hphp/test/slow/ext_preg/preg_match_invalid_flags.php on line 2
NULL
```
