### PR TITLE
added support for mod_fastcgi

### DIFF
--- a/hphp/runtime/server/fastcgi/fastcgi-transport.cpp
+++ b/hphp/runtime/server/fastcgi/fastcgi-transport.cpp
@@ -392,7 +392,16 @@ void FastCGITransport::handleHeader(const std::string& key,
 }
 
 void FastCGITransport::onHeadersComplete() {
-  m_serverObject = getRawHeader("SCRIPT_NAME");
+  std::string pathTranslated = getRawHeader("PATH_TRANSLATED");
+  std::string documentRoot = getRawHeader("DOCUMENT_ROOT");
+  // use PATH_TRANSLATED - DOCUMENT_ROOT if it is valid instead of SCRIPT_NAME
+  // for mod_fastcgi support
+  if (!pathTranslated.empty() && !documentRoot.empty() &&
+      pathTranslated.find(documentRoot) == 0) {
+    m_serverObject = pathTranslated.substr(documentRoot.length());
+  } else {
+    m_serverObject = getRawHeader("SCRIPT_NAME");
+  }
   std::string queryString = getRawHeader("QUERY_STRING");
   if (!queryString.empty()) {
     m_serverObject += "?" + queryString;


### PR DESCRIPTION
when using mod_fastcgi SCRIPT_NAME is the Action instead of the actual document you want
this commit uses PATH_TRANSLATED - DOCUMENT_ROOT

tested with:
apache+mod_fastcgi
apache+mod_proxy_fcgi
nginx with no PATH_TRANSLATED header
nginx with this as PATH_TRANSLATED: fastcgi_param  PATH_TRANSLATED    $document_root$fastcgi_script_name;
