### PR TITLE
Fix memory leak in pdo_parse_params

### DIFF
--- a/hphp/runtime/ext/ext_pdo.cpp
+++ b/hphp/runtime/ext/ext_pdo.cpp
@@ -2548,7 +2548,7 @@ rewrite:
       newbuffer += t;
     }
     *newbuffer = '\0';
-    out = out.substr(0, newbuffer - out.data());
+    out.setSize(newbuffer - out.data());
 
     ret = 1;
     goto clean_up;
@@ -2609,6 +2609,7 @@ clean_up:
   while (placeholders) {
     plc = placeholders;
     placeholders = plc->next;
+    plc->quoted.reset();
     free(plc);
   }
 


### PR DESCRIPTION
Fixed memory leak after executing PDOStatement::execute() with bound parameters. Also removed unnecessary copying of result query string.

Test case (I don't know whether it can be tested with Travis because it requires MySQL connection):

``` php
<?php
$pdo = new PDO('mysql:dbname=test;host=localhost', 'root', '');
$data = str_repeat('a', 1000000);

for ($n = 0; $n < 50; $n++) {
    $stmt = $pdo->prepare('SELECT :data = 1');
    $stmt->bindValue(':data', $data);
    $stmt->execute();
    $stmt = null;
    echo sprintf("%dM\n", memory_get_usage(true) / 1048576);
}
```
