### PR TITLE
VirtualHost.<name>.Pattern matches host not paths, so avoid prefixing it with ^/

### DIFF
--- a/hphp/runtime/server/virtual-host.cpp
+++ b/hphp/runtime/server/virtual-host.cpp
@@ -159,7 +159,7 @@ void VirtualHost::init(Hdf vh) {
 
   if (prefix) m_prefix = prefix;
   if (pattern) {
-    m_pattern = Util::format_pattern(pattern, true);
+    m_pattern = Util::format_pattern(pattern, false);
     if (!m_pattern.empty()) {
       m_pattern += "i"; // case-insensitive
     }


### PR DESCRIPTION
This allows Patterns with a leading ^ to match.

```
Pattern ^www.example.com$
```
