### PR TITLE
Major fix: In FastCGI mode the server address could not be set

### DIFF
--- a/hphp/runtime/server/fastcgi/fastcgi-server.cpp
+++ b/hphp/runtime/server/fastcgi/fastcgi-server.cpp
@@ -177,7 +177,7 @@ FastCGIServer::FastCGIServer(const std::string &address,
                  RuntimeOption::ServerThreadJobMaxQueuingMilliSeconds,
                  RequestPriority::k_numPriorities) {
   TSocketAddress sock_addr;
-  if (sock_addr.empty()) {
+  if (address.empty()) {
     sock_addr.setFromLocalPort(port);
   } else {
     sock_addr.setFromHostPort(address, port);


### PR DESCRIPTION
Due to a bug in the FastCGI server the start up of the server with
a specific IP address was not possible.
Example:
`hhvm --config /etc/hhvm/server.hdf -m server -vServer.Type=fastcgi -vServer.IP=127.0.0.1 -vServer.Port=9100`

Before bugfix:

```
netstat -tulpen|grep 9100
> tcp6       0      0 :::9100                 :::*                    LISTEN
```

After bugfix:

```
netstat -tulpen|grep 9100
> tcp        0      0 127.0.0.1:9100          0.0.0.0:*               LISTEN
```
