### PR TITLE
apc_inc/dec should return false on failure

### DIFF
--- a/hphp/runtime/ext/ext_apc.cpp
+++ b/hphp/runtime/ext/ext_apc.cpp
@@ -305,6 +305,7 @@ Variant f_apc_inc(const String& key, int64_t step /* = 1 */,
   bool found = false;
   int64_t newValue = s_apc_store[cache_id].inc(key, step, found);
   success = found;
+  if (!found) return false;
   return newValue;
 }
 
@@ -319,6 +320,7 @@ Variant f_apc_dec(const String& key, int64_t step /* = 1 */,
   bool found = false;
   int64_t newValue = s_apc_store[cache_id].inc(key, -step, found);
   success = found;
+  if (!found) return false;
   return newValue;
 }
 

--- a/hphp/test/slow/ext_apc/inc_dec_failure.php
+++ b/hphp/test/slow/ext_apc/inc_dec_failure.php
@@ -1,0 +1,4 @@
+<?php
+apc_delete('test');
+var_dump(apc_inc('test'));
+var_dump(apc_dec('test'));

--- a/hphp/test/slow/ext_apc/inc_dec_failure.php.expect
+++ b/hphp/test/slow/ext_apc/inc_dec_failure.php.expect
@@ -1,0 +1,2 @@
+bool(false)
+bool(false)


### PR DESCRIPTION
Return false instead of 0 when failure occured while calling apc_inc or apc_dec.

Fixes #1472
