### PR TITLE
redis should report as a loaded extension

### DIFF
--- a/hphp/runtime/ext/extension.cpp
+++ b/hphp/runtime/ext/extension.cpp
@@ -195,10 +195,13 @@ void Extension::ShutdownModules() {
 }
 
 const StaticString s_apc("apc");
+const StaticString s_redis("redis");
 
 bool Extension::IsLoaded(const String& name) {
   if (name == s_apc) {
     return apcExtension::Enable;
+  } else if (name == s_redis) {
+    return Unit::getClass(s_redis.get(), false);   
   }
   assert(s_registered_extensions);
   return s_registered_extensions->find(name.data()) !=

--- a/hphp/test/slow/ext_redis/extension_loaded.php
+++ b/hphp/test/slow/ext_redis/extension_loaded.php
@@ -1,0 +1,3 @@
+<?php
+
+var_dump(extension_loaded('redis'));

--- a/hphp/test/slow/ext_redis/extension_loaded.php.expect
+++ b/hphp/test/slow/ext_redis/extension_loaded.php.expect
@@ -1,0 +1,1 @@
+bool(true)


### PR DESCRIPTION
Redis has been implemented in its entirety in PHP by @sgolemon,
and there currently is no way of specifying that it should show
as a loaded extension.

This is a temporary workaround (such as the APC one) to just return true
for extension_loaded('redis') when the Redis class exists. Eventually
this should probably be done from PHP, such as done with
IMPLEMENT_DEFAULT_EXTENSION in C++.
