### PR TITLE
fix crash with stacktrace on a VALGRIND build

### DIFF
--- a/hphp/util/stack-trace.cpp
+++ b/hphp/util/stack-trace.cpp
@@ -414,6 +414,11 @@ static void find_address_in_section(bfd *abfd, asection *section, void *data) {
     return;
   }
 
+#ifdef VALGRIND
+  adata->found = false;
+  return;
+#endif
+
   adata->found = bfd_find_nearest_line(abfd, section, adata->syms,
                                        adata->pc - vma, &adata->filename,
                                        &adata->functionname, &adata->line);


### PR DESCRIPTION
I'm not sure why this is needed, or how to properly solve this. But it
solves a crash when the JIT is trying to kick in when HHVM has been
built in with VALGRIND=1 (on a debug build).

@ptarjan said this will make @scannell fix it the right way.
