### PR TITLE
Fix RDTSC calibration in ext_hotprofiler

### DIFF
--- a/hphp/runtime/ext/ext_hotprofiler.cpp
+++ b/hphp/runtime/ext/ext_hotprofiler.cpp
@@ -159,14 +159,18 @@ static int64_t get_cpu_frequency() {
     return 0.0;
   }
   uint64_t tsc_start = cpuCycles();
-  // Sleep for 5 miliseconds. Comparaing with gettimeofday's  few microseconds
-  // execution time, this should be enough.
-  usleep(5000);
-  if (gettimeofday(&end, 0)) {
-    perror("gettimeofday");
-    return 0.0;
-  }
-  uint64_t tsc_end = cpuCycles();
+  uint64_t tsc_end;
+  volatile int i;
+  /* Busy loop for 5 miliseconds. */
+  do {
+    for (i = 0; i < 1000000; i++);
+    if (gettimeofday(&end, 0)) {
+      perror("gettimeofday");
+      return 0.0;
+    }
+    tsc_end = cpuCycles();
+  } while (get_us_interval(&start, &end) < 5000);
+
   return nearbyint((tsc_end - tsc_start) * 1.0
                                    / (get_us_interval(&start, &end)));
 }


### PR DESCRIPTION
Do a busy loop instead of usleep(5000), since usleep(5000) causes the
CPU to halt, giving meaningless results.

Originally submitted by Tim Starling to https://github.com/preinheimer/xhprof/pull/65.
