### PR TITLE
PDOException should have a property "errorInfo"

### DIFF
--- a/hphp/system/php/pdo/PDOException.php
+++ b/hphp/system/php/pdo/PDOException.php
@@ -10,6 +10,7 @@
  *
  */
 class PDOException extends Exception {
+  public $errorInfo;
   public function __construct() {
   }
 }

--- a/hphp/test/quick/ext_pdo_exception.php
+++ b/hphp/test/quick/ext_pdo_exception.php
@@ -1,0 +1,15 @@
+<?php
+try {
+    new PDO('aoeu');
+} catch (PDOException $e) {
+    var_dump($e->errorInfo);
+}
+$db = new PDO('sqlite::memory:');
+$db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+$db->exec('CREATE TABLE test_table (id INTEGER)');
+
+try {
+    $db->exec('CREATE TABLE test_table (id INTEGER)');
+} catch (PDOException $ex) {
+    var_dump($ex->errorInfo);
+}

--- a/hphp/test/quick/ext_pdo_exception.php.expect
+++ b/hphp/test/quick/ext_pdo_exception.php.expect
@@ -1,0 +1,9 @@
+NULL
+array(3) {
+  [0]=>
+  string(5) "HY000"
+  [1]=>
+  int(1)
+  [2]=>
+  string(31) "table test_table already exists"
+}


### PR DESCRIPTION
Added two tests, one to verify the property exists, another one to
verify that the extra error info is actually set.

fixes https://github.com/facebook/hhvm/issues/1412
