### PR TITLE
Add Klein to framework test runner

### DIFF
--- a/hphp/test/frameworks/run.php
+++ b/hphp/test/frameworks/run.php
@@ -1289,6 +1289,20 @@ class Joomla extends Framework {
   }
 }
 
+class Klein extends Framework {
+  public function __construct(string $name) { parent::__construct($name); }
+  protected function getInfo(): Map {
+    return Map {
+      "install_root" => __DIR__."/frameworks/klein",
+      "git_path" => "https://github.com/chriso/klein.php.git",
+      # Most recent stable with 100% code coverage
+      # @link: http://reports.dev.metroserve.me/klein-a4e9c21-code-coverage/
+      "git_commit" => "a4e9c2110933c600b3498b5b42ac9804f9f05a62",
+      "test_path" => __DIR__."/frameworks/klein",
+    };
+  }
+}
+
 class Laravel extends Framework {
   public function __construct(string $name) { parent::__construct($name); }
   protected function getInfo(): Map {


### PR DESCRIPTION
This PR adds [klein](https://github.com/chriso/klein.php) to the framework test runner script mentioned in the [hhvm.com article](http://www.hhvm.com/blog/2813/we-are-the-98-5-and-the-16).

Klein is a popular routing library (with hints of a micro-framework) with [100% code coverage](http://reports.dev.metroserve.me/klein-a4e9c21-code-coverage/) via PHPUnit. Its actively developed and is compatible with 100% passing tests in PHP 5.3, 5.4, and 5.5.

Currently, its [failing a few tests](https://travis-ci.org/chriso/klein.php/jobs/16573803) that have to do with PHPUnit's [Data Providers](http://phpunit.de/manual/3.7/en/writing-tests-for-phpunit.html#writing-tests-for-phpunit.data-providers). It seems that the keys in the provided data arrays are being stripped for some reason.

Also, tests relating to sessions and/or tests run in isolated processes seem to be failing also. I'm not sure on how HHVM operates in this manner.

Finally, it seems as if there is an inconsistency between HHVM and PHP's UTF-8 behaviors with the `htmlentities()` function, as a test using that [method](https://github.com/chriso/klein.php/blob/a4e9c2110933c600b3498b5b42ac9804f9f05a62/src/Klein/ServiceProvider.php#L251) is returning data without UTF-8 characters being escaped.

Please let me know if/how I can help further in fixing any of these issues on my end.
