### PR TITLE
Add CMake support for using clang++ as the C++ compiler

### DIFF
--- a/CMake/FollySetup.cmake
+++ b/CMake/FollySetup.cmake
@@ -13,11 +13,8 @@ if (FOLLY_IFUNC)
 endif()
 
 set(CMAKE_REQUIRED_LIBRARIES rt)
-CHECK_CXX_SOURCE_COMPILES("#include <time.h>
-int main() {
-  clock_gettime((clockid_t)0, NULL);
-  return 0;
-}" HAVE_CLOCK_GETTIME)
+include(CheckFunctionExists)
+CHECK_FUNCTION_EXISTS("clock_gettime" HAVE_CLOCK_GETTIME)
 
 if (HAVE_CLOCK_GETTIME)
 	add_definitions("-DFOLLY_HAVE_CLOCK_GETTIME=1")

--- a/CMake/HPHPCompiler.cmake
+++ b/CMake/HPHPCompiler.cmake
@@ -42,6 +42,10 @@ else()
 	set(CMAKE_CXX_FLAGS "-fno-gcse -fno-omit-frame-pointer -ftemplate-depth-180 -Wall -Woverloaded-virtual -Wno-deprecated -Wno-strict-aliasing -Wno-write-strings -Wno-invalid-offsetof -fno-operator-names -Wno-error=array-bounds -Wno-error=switch -std=gnu++11 -Werror=format-security -Wno-unused-result -Wno-sign-compare -Wno-attributes -Wno-maybe-uninitialized -mcrc32 ${GNUCC_48_OPT}")
 endif()
 
+if(${CMAKE_CXX_COMPILER} MATCHES ".*clang.*")
+	set(CMAKE_CXX_FLAGS "-fno-gcse -fno-omit-frame-pointer -ftemplate-depth-180 -Wall -Woverloaded-virtual -Wno-deprecated -Wno-strict-aliasing -Wno-write-strings -Wno-invalid-offsetof -fno-operator-names -Wno-error=array-bounds -Wno-error=switch -std=gnu++11 -Werror=format-security -Wno-unused-result -Wno-sign-compare -Wno-attributes -Wno-maybe-uninitialized -Wno-mismatched-tags -Wno-unknown-warning-option -Wno-return-type-c-linkage -Qunused-arguments")
+endif()
+
 if(CMAKE_COMPILER_IS_GNUCC)
 	set(CMAKE_C_FLAGS_RELEASE "-O3")
 endif()


### PR DESCRIPTION
There was a weird issue where CHECK_CXX_SOURCE_COMPILES wouldn't find
clock_gettime under clang++, switching to CHECK_FUNCTION_EXISTS worked
both under clang++ and g++ on Ubuntu 13.10
