### PR TITLE
Fix the build with the newer versions of libdwarf

### DIFF
--- a/hphp/runtime/vm/debug/elfwriter.cpp
+++ b/hphp/runtime/vm/debug/elfwriter.cpp
@@ -42,7 +42,7 @@ void ElfWriter::logError(const std::string& msg) {
   std::cerr << msg << '\n';
 }
 
-int ElfWriter::dwarfCallback(char *name, int size, Dwarf_Unsigned type,
+int ElfWriter::dwarfCallback(LIBDWARF_CALLBACK_NAME_TYPE name, int size, Dwarf_Unsigned type,
   Dwarf_Unsigned flags, Dwarf_Unsigned link, Dwarf_Unsigned info) {
   if (!strncmp(name, ".rel", 4))
     return 0;
@@ -449,7 +449,7 @@ bool ElfWriter::addFrameInfo(DwarfChunk* d) {
   return true;
 }
 
-int ElfWriter::newSection(char *name,
+int ElfWriter::newSection(LIBDWARF_CALLBACK_NAME_TYPE name,
   uint64_t size, uint32_t type, uint64_t flags,
   uint64_t addr/* = 0*/) {
   Elf_Scn *scn = elf_newscn(m_elf);

--- a/hphp/runtime/vm/debug/elfwriter.h
+++ b/hphp/runtime/vm/debug/elfwriter.h
@@ -38,7 +38,7 @@ struct ElfWriter {
 
   explicit ElfWriter(DwarfChunk* d);
   ~ElfWriter();
-  int dwarfCallback(char *name, int size, Dwarf_Unsigned type,
+  int dwarfCallback(LIBDWARF_CALLBACK_NAME_TYPE name, int size, Dwarf_Unsigned type,
     Dwarf_Unsigned flags, Dwarf_Unsigned link, Dwarf_Unsigned info);
   void logError(const std::string& msg);
   int addSectionString(const std::string& name);
@@ -51,7 +51,7 @@ struct ElfWriter {
   bool addFrameInfo(DwarfChunk* d);
   bool writeDwarfInfo();
   int newSection(
-    char *name, uint64_t size, uint32_t type,
+    LIBDWARF_CALLBACK_NAME_TYPE name, uint64_t size, uint32_t type,
     uint64_t flags, uint64_t addr = 0);
   bool addSectionData(int section, void *data, uint64_t size);
   int writeStringSection();


### PR DESCRIPTION
This fixes an error with inconsistent types being used for the 'name'
parameter when registering a libdwarf callback against newer versions
of libdwarf (versions where the 'name' parameter is a const char*).

I verified that this compiles with the latest version of libdwarf.
