### PR TITLE
Handle unserializing a finfo object.

### DIFF
--- a/hphp/runtime/ext/fileinfo/ext_fileinfo.php
+++ b/hphp/runtime/ext/fileinfo/ext_fileinfo.php
@@ -5,6 +5,9 @@ class finfo {
 
   private $resource;
 
+  private $options;
+  private $magic_file;
+
   /**
    * Create a new fileinfo resource
    *
@@ -18,10 +21,21 @@ class finfo {
   public function finfo(int $options = FILEINFO_NONE,
                         ?string $magic_file = NULL): finfo {
     $this->resource = finfo_open($options, $magic_file);
+
+    $this->options = $options;
+    $this->magic_file = $magic_file;
   }
 
   public function __destruct() {
     finfo_close($this->resource);
+  }
+
+  public function __sleep() {
+    return array('options', 'magic_file');
+  }
+
+  public function __wakeup() {
+    $this->resource = finfo_open($this->options, $this->magic_file);
   }
 
   /**
@@ -64,7 +78,11 @@ class finfo {
    * @return bool -
    */
   public function set_flags(int $options): bool {
-    return finfo_set_flags($this->resource, $options);
+    $ret = finfo_set_flags($this->resource, $options);
+    if ($ret) {
+      $this->options = $options;
+    }
+    return $ret;
   }
 
 }

--- a/hphp/test/slow/ext_fileinfo/Finfo_unserialize.php
+++ b/hphp/test/slow/ext_fileinfo/Finfo_unserialize.php
@@ -1,0 +1,6 @@
+<?php
+
+$f = new finfo(FILEINFO_MIME_TYPE);
+echo unserialize(serialize($f))->file(__FILE__), "\n";
+$f->set_flags(FILEINFO_NONE);
+echo unserialize(serialize($f))->file(__FILE__), "\n";

--- a/hphp/test/slow/ext_fileinfo/Finfo_unserialize.php.expect
+++ b/hphp/test/slow/ext_fileinfo/Finfo_unserialize.php.expect
@@ -1,0 +1,2 @@
+text/x-php
+PHP script, ASCII text


### PR DESCRIPTION
Zend currently throws:
`Warning: finfo::file(): The invalid fileinfo object.`
when trying to do something on an unserialised object. I consider this a bug in Zend and there doesn't appear to be any tests covering that behaviour.

This currently segfaults when deconstructing the unserialised object in HHVM.
