### PR TITLE
FASTCGI: Check for HTTPS header coming from nginx/apache and setSSL appropriately.

### DIFF
--- a/hphp/runtime/server/fastcgi/fastcgi-transport.cpp
+++ b/hphp/runtime/server/fastcgi/fastcgi-transport.cpp
@@ -29,6 +29,7 @@
 #include "folly/MoveWrapper.h"
 
 #include <boost/algorithm/string/predicate.hpp>
+#include <boost/algorithm/string/case_conv.hpp>
 
 using folly::IOBuf;
 using folly::IOBufQueue;
@@ -311,6 +312,7 @@ const std::string FastCGITransport::k_documentRoot = "DOCUMENT_ROOT";
 const std::string FastCGITransport::k_serverNameKey = "SERVER_NAME";
 const std::string FastCGITransport::k_serverPortKey = "SERVER_PORT";
 const std::string FastCGITransport::k_serverAddrKey = "SERVER_ADDR";
+const std::string FastCGITransport::k_httpsKey = "HTTPS";
 
 void FastCGITransport::onHeader(std::unique_ptr<folly::IOBuf> key_chain,
                                 std::unique_ptr<folly::IOBuf> value_chain) {
@@ -355,6 +357,14 @@ void FastCGITransport::handleHeader(const std::string& key,
     }
   } else if (compareKeys(key, k_serverNameKey)) {
     m_serverName = value;
+  } else if (compareKeys(key, k_httpsKey)) {
+    if(!lValue.empty()) {
+      std::string lValue(value);
+      boost::to_lower(lValue);
+      if(lValue.compare("off") != 0) {
+        setSSL();
+      }
+    }
   } else if (compareKeys(key, k_serverAddrKey)) {
     m_serverAddr = value;
   } else if (compareKeys(key, k_serverPortKey)) {

--- a/hphp/runtime/server/fastcgi/fastcgi-transport.h
+++ b/hphp/runtime/server/fastcgi/fastcgi-transport.h
@@ -118,6 +118,7 @@ private:
   static const std::string k_serverNameKey;
   static const std::string k_serverPortKey;
   static const std::string k_serverAddrKey;
+  static const std::string k_httpsKey;
 
   FastCGIConnection* m_connection;
   int m_id;


### PR DESCRIPTION
Check passed header values for HTTPS.

IIS sets this header to "off" so check for that and empty value before using transport->setSSL().
