### PR TITLE
[php-52971] Port fix for PHP bug #52971

### DIFF
--- a/hphp/runtime/base/preg.cpp
+++ b/hphp/runtime/base/preg.cpp
@@ -280,7 +280,14 @@ pcre_get_compiled_regex_cache(const String& regex) {
     case 'S':  do_study = true;                 break;
     case 'U':  coptions |= PCRE_UNGREEDY;       break;
     case 'X':  coptions |= PCRE_EXTRA;          break;
-    case 'u':  coptions |= PCRE_UTF8;           break;
+    case 'u':  coptions |= PCRE_UTF8;
+  /* In  PCRE,  by  default, \d, \D, \s, \S, \w, and \W recognize only ASCII
+       characters, even in UTF-8 mode. However, this can be changed by setting
+       the PCRE_UCP option. */
+#ifdef PCRE_UCP
+            coptions |= PCRE_UCP;
+#endif
+      break;
 
       /* Custom preg options */
     case 'e':  poptions |= PREG_REPLACE_EVAL;   break;

--- a/hphp/test/zend/good/ext/pcre/tests/bug52971.phpt
+++ b/hphp/test/zend/good/ext/pcre/tests/bug52971.phpt
@@ -1,0 +1,43 @@
+--TEST--
+Bug #52971 (PCRE-Meta-Characters not working with utf-8)
+--SKIPIF--
+<?php if ((double)PCRE_VERSION < 8.1) die('skip PCRE_VERSION >= 8.1 is required!'); ?>
+--FILE--
+<?php
+
+$message = 'Der ist ein Süßwasserpool Süsswasserpool ... verschiedene Wassersportmöglichkeiten bei ...';
+
+$pattern = '/\bwasser/iu';
+preg_match_all($pattern, $message, $match, PREG_OFFSET_CAPTURE);
+var_dump($match);
+
+$pattern = '/[^\w]wasser/iu';
+preg_match_all($pattern, $message, $match, PREG_OFFSET_CAPTURE);
+var_dump($match);
+
+?>
+--EXPECTF--
+array(1) {
+  [0]=>
+  array(1) {
+    [0]=>
+    array(2) {
+      [0]=>
+      string(6) "Wasser"
+      [1]=>
+      int(61)
+    }
+  }
+}
+array(1) {
+  [0]=>
+  array(1) {
+    [0]=>
+    array(2) {
+      [0]=>
+      string(7) " Wasser"
+      [1]=>
+      int(60)
+    }
+  }
+}


### PR DESCRIPTION
https://bugs.php.net/bug.php?id=52971
- Fixed bug #52971 (PCRE-Meta-Characters not working with utf-8)
  #   In  PCRE,  by  default, \d, \D, \s, \S, \w, and \W recognize only ASCII
  #       characters, even in UTF-8 mode. However, this can be changed by setting
  #       the PCRE_UCP option.
