### PR TITLE
FastCGI: fix for REMOTE_HOST and REMOTE_ADDR to be like php

### DIFF
--- a/hphp/runtime/server/fastcgi/fastcgi-transport.cpp
+++ b/hphp/runtime/server/fastcgi/fastcgi-transport.cpp
@@ -63,6 +63,10 @@ const char *FastCGITransport::getRemoteHost() {
   return m_remoteHost.c_str();
 }
 
+const char *FastCGITransport::getRemoteAddr() {
+  return m_remoteAddr.c_str();
+}
+
 uint16_t FastCGITransport::getRemotePort() {
   return m_remotePort;
 }
@@ -303,6 +307,7 @@ void FastCGITransport::onBodyComplete() {
 
 const std::string FastCGITransport::k_requestURIKey = "REQUEST_URI";
 const std::string FastCGITransport::k_remoteHostKey = "REMOTE_HOST";
+const std::string FastCGITransport::k_remoteAddrKey = "REMOTE_ADDR";
 const std::string FastCGITransport::k_remotePortKey = "REMOTE_PORT";
 const std::string FastCGITransport::k_methodKey = "REQUEST_METHOD";
 const std::string FastCGITransport::k_httpVersionKey = "HTTP_VERSION";
@@ -340,6 +345,8 @@ void FastCGITransport::handleHeader(const std::string& key,
     m_requestURI = value;
   } else if (compareKeys(key, k_remoteHostKey)) {
     m_remoteHost = value;
+  } else if (compareKeys(key, k_remoteAddrKey)) {
+    m_remoteAddr = value;
   } else if (compareKeys(key, k_remotePortKey)) {
     try {
       int remote_port = std::stoi(value);

--- a/hphp/runtime/server/fastcgi/fastcgi-transport.h
+++ b/hphp/runtime/server/fastcgi/fastcgi-transport.h
@@ -47,6 +47,7 @@ public:
 
   virtual const char *getUrl() override;
   virtual const char *getRemoteHost() override;
+  virtual const char *getRemoteAddr() override;
   virtual uint16_t getRemotePort() override;
   virtual const std::string getDocumentRoot() override;
   virtual const char *getServerName() override;
@@ -110,6 +111,7 @@ private:
 
   static const std::string k_requestURIKey;
   static const std::string k_remoteHostKey;
+  static const std::string k_remoteAddrKey;
   static const std::string k_remotePortKey;
   static const std::string k_methodKey;
   static const std::string k_httpVersionKey;
@@ -127,6 +129,7 @@ private:
   std::string m_requestURI;
   std::string m_documentRoot;
   std::string m_remoteHost;
+  std::string m_remoteAddr;
   uint16_t m_remotePort;
   std::string m_serverName;
   std::string m_serverAddr;

--- a/hphp/runtime/server/http-protocol.cpp
+++ b/hphp/runtime/server/http-protocol.cpp
@@ -465,8 +465,17 @@ void HttpProtocol::CopyServerInfo(Variant& server,
 
 void HttpProtocol::CopyRemoteInfo(Variant& server,
                                   Transport *transport) {
-  server.set(s_REMOTE_ADDR, String(transport->getRemoteHost(), CopyString));
-  server.set(s_REMOTE_HOST, empty_string); // I don't think we need to nslookup
+  String remoteAddr(transport->getRemoteAddr(), CopyString);
+  String remoteHost(transport->getRemoteHost(), CopyString);
+
+  if(remoteAddr.empty()) {
+    remoteAddr = remoteHost;
+  }
+
+  server.set(s_REMOTE_ADDR, remoteAddr);
+  if(!remoteHost.empty()) {
+    server.set(s_REMOTE_HOST, remoteHost);
+  }
   server.set(s_REMOTE_PORT, transport->getRemotePort());
 }
 

--- a/hphp/runtime/server/transport.h
+++ b/hphp/runtime/server/transport.h
@@ -112,6 +112,8 @@ public:
   virtual const char *getUrl() = 0;
   virtual const char *getRemoteHost() = 0;
   virtual uint16_t getRemotePort() = 0;
+  // The transport can override REMOTE_ADDR if it has one
+  virtual const char *getRemoteAddr() { return ""; }
   // The transport can override the virtualhosts' docroot
   virtual const std::string getDocumentRoot() { return ""; }
 


### PR DESCRIPTION
add getRemoteAddr to transport which defaults to empty string.
add getRemoteAddr to fastcgi transport to return the proper header.
fi no remoteAddr set it to the remoteHost ( libevent )
only set REMOTE_HOST if there is something in it as per php-src
