### PR TITLE
fix compatibility on OS X by adding an include

### DIFF
--- a/hphp/util/compatibility.cpp
+++ b/hphp/util/compatibility.cpp
@@ -20,6 +20,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <cstdarg>
 #include <fcntl.h>
 #include <sys/stat.h>
 #include <sys/time.h>


### PR DESCRIPTION
va_start / va_end are in <cstdarg> which wasn't included.
