### PR TITLE
Fix memory leak in PDOStatement::fetchAll()

### DIFF
--- a/hphp/runtime/ext/ext_pdo.cpp
+++ b/hphp/runtime/ext/ext_pdo.cpp
@@ -2865,7 +2865,7 @@ Variant c_PDOStatement::t_fetchall(int64_t how /* = 0 */,
   if (!error) {
     if ((how & PDO_FETCH_GROUP)) {
       do {
-        data.reset();
+        data.unset();
       } while (do_fetch(m_stmt, true, data, (PDOFetchType)(how | flags),
                         PDO_FETCH_ORI_NEXT, 0, return_all));
     } else if (how == PDO_FETCH_KEY_PAIR ||
@@ -2877,7 +2877,7 @@ Variant c_PDOStatement::t_fetchall(int64_t how /* = 0 */,
       return_value = Array::Create();
       do {
         return_value.append(data);
-        data.reset();
+        data.unset();
       } while (do_fetch(m_stmt, true, data, (PDOFetchType)(how | flags),
                         PDO_FETCH_ORI_NEXT, 0, NULL));
     }


### PR DESCRIPTION
Fixed memory leak while fetching data in PDOStatement::fetchAll().

Fixes #1567
