### PR TITLE
[hhvm/test/run] script enhancements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,13 +18,17 @@ env:
   - TEST_RUN_MODE="-m jit zend"
   - TEST_RUN_MODE="-m jit -r quick"
   - TEST_RUN_MODE="-m jit -r slow"
-  - TEST_RUN_MODE="-m jit -r zend"
+  - TEST_RUN_MODE="-m jit -r zend/ext"
+  - TEST_RUN_MODE="-m jit -r zend/tests"
+  - TEST_RUN_MODE="-m jit -r zend/Zend"
   - TEST_RUN_MODE="-m interp quick"
   - TEST_RUN_MODE="-m interp slow"
   - TEST_RUN_MODE="-m interp zend"
   - TEST_RUN_MODE="-m interp -r quick"
   - TEST_RUN_MODE="-m interp -r slow"
-  - TEST_RUN_MODE="-m interp -r zend"
+  - TEST_RUN_MODE="-m interp -r zend/ext"
+  - TEST_RUN_MODE="-m interp -r zend/tests"
+  - TEST_RUN_MODE="-m interp -r zend/Zend"
 
 script: hphp/hhvm/hhvm hphp/test/run $TEST_RUN_MODE
 

--- a/hphp/test/run
+++ b/hphp/test/run
@@ -6,7 +6,7 @@
 
 function usage() {
   global $argv;
-  return "usage: $argv[0] [-m jit|interp] [-r] <test/directories>";
+  return "usage: $argv[0] [-m jit|interp] [-r] <test/directories/virtual-path>";
 }
 
 function help() {
@@ -56,6 +56,21 @@ Examples:
 
   # All tests whose name containing pdo_mysql
   % $argv[0] -i pdo_mysql -m jit -r zend
+
+Virtual-Path:
+
+ Currently the following are the supported mappings for the virtual-paths
+ i.e 'quick' is translated to directory 'hphp/test/quick' and so on
+
+    'quick'    => 'hphp/test/quick'
+    'slow'     => 'hphp/test/slow'
+    'debugger' => 'hphp/test/server/debugger/tests'
+    'zend'     => 'hphp/test/zend/good'
+    'zend_bad' => 'hphp/test/zend/bad'
+    'facebook' => 'hphp/facebook/test'
+
+ Sub-paths inside the virtual-paths can be looked up with the / convention
+ i.e 'zend/ext' is translated to directory 'hphp/test/zend/good/ext'
 
 EOT;
   return usage().$help;
@@ -192,11 +207,22 @@ function map_convenience_filename($file) {
     'zend_bad' => 'hphp/test/zend/bad',
     'facebook' => 'hphp/facebook/test',
   );
-
+  // code to easily determine the sub-paths from the
+  // above map
+  // i.e zend/ext in the command line translates to
+  //     hphp/test/zend/good/ext
   if (!isset($mappage[$file])) {
+    if (strpos($file, '/') !== false) {
+      foreach ($mappage as $k => $v) {
+        if (preg_match("/^$k/", $file) === 1) {
+            return hphp_home().'/'.preg_replace("/^$k/", $v, $file);
+        }
+      }
+    }
     return $file;
+  } else {
+    return hphp_home().'/'.$mappage[$file];
   }
-  return hphp_home().'/'.$mappage[$file];
 }
 
 function find_tests($files, array $options = null) {


### PR DESCRIPTION
1. Added -i option to include only certain tests to be executed.

Example and output below

```
bash$ hphp/test/run -v -m jit -r zend -i tests/bug335
Running 7 tests in 5 threads
hphp/test/zend/good/Zend/tests/bug33558.php passed
hphp/test/zend/good/Zend/tests/bug33512.php passed
hphp/test/zend/good/ext/date/tests/bug33536.php passed
hphp/test/zend/good/ext/date/tests/bug33562.php passed
hphp/test/zend/good/ext/date/tests/bug33532.php passed
hphp/test/zend/good/ext/date/tests/bug33578.php passed
hphp/test/zend/good/ext/date/tests/bug33563.php passed

All tests passed.

              |    |    |
             )_)  )_)  )_)
            )___))___))___)\
           )____)____)_____)\
         _____|____|____|____\\__
---------\      SHIP IT      /---------
  ^^^^^ ^^^^^^^^^^^^^^^^^^^^^
    ^^^^      ^^^^     ^^^    ^^
         ^^^^      ^^^

```
1. Print the `norepo` reason next to skipped message for tests with .norepo file

```
bash$ hphp/test/run -v -m jit -r zend -i tests/bug338
Running 3 tests in 3 threads
hphp/test/zend/good/ext/pdo_sqlite/tests/bug33841.php skipped norepo
hphp/test/zend/good/Zend/tests/bug33802.php passed
hphp/test/zend/good/ext/date/tests/bug33869.php passed

All tests passed.

              |    |    |
             )_)  )_)  )_)
            )___))___))___)\
           )____)____)_____)\
         _____|____|____|____\\__
---------\      SHIP IT      /---------
  ^^^^^ ^^^^^^^^^^^^^^^^^^^^^
    ^^^^      ^^^^     ^^^    ^^
         ^^^^      ^^^

```
1. Add sub-path selection in the virtual-paths
   i.e `zend/ext` will map to `hphp/test/zend/good/ext` automatically

Example showing both -i and sub-virtual-path usage

```
 bash$ hhvm hphp/test/run -m jit -r zend/Zend -v -i /00
Running 4 tests in 3 threads
hphp/test/zend/good/Zend/tests/006.php passed
hphp/test/zend/good/Zend/tests/004.php passed
hphp/test/zend/good/Zend/tests/005.php passed
hphp/test/zend/good/Zend/tests/007.php passed

All tests passed.

              |    |    |
             )_)  )_)  )_)
            )___))___))___)\
           )____)____)_____)\
         _____|____|____|____\\__
---------\      SHIP IT      /---------
  ^^^^^ ^^^^^^^^^^^^^^^^^^^^^
    ^^^^      ^^^^     ^^^    ^^
         ^^^^      ^^^
```

EDIT-1: Added support for sub-paths in the virtual-paths
