### PR TITLE
Support for UNIX sockets

### DIFF
--- a/hphp/runtime/base/runtime-option.cpp
+++ b/hphp/runtime/base/runtime-option.cpp
@@ -106,6 +106,7 @@ std::string RuntimeOption::Host;
 std::string RuntimeOption::DefaultServerNameSuffix;
 std::string RuntimeOption::ServerType = "libevent";
 std::string RuntimeOption::ServerIP;
+std::string RuntimeOption::ServerFileSocket;
 std::string RuntimeOption::ServerPrimaryIP;
 int RuntimeOption::ServerPort;
 int RuntimeOption::ServerPortFd = -1;
@@ -737,6 +738,7 @@ void RuntimeOption::Load(Hdf &config,
     DefaultServerNameSuffix = server["DefaultServerNameSuffix"].getString();
     ServerType = server["Type"].getString(ServerType);
     ServerIP = server["IP"].getString();
+    ServerFileSocket = server["FileSocket"].getString();
     ServerPrimaryIP = Util::GetPrimaryIP();
     ServerPort = server["Port"].getUInt16(80);
     ServerBacklog = server["Backlog"].getInt16(128);

--- a/hphp/runtime/base/runtime-option.h
+++ b/hphp/runtime/base/runtime-option.h
@@ -107,6 +107,7 @@ public:
   static std::string DefaultServerNameSuffix;
   static std::string ServerType;
   static std::string ServerIP;
+  static std::string ServerFileSocket;
   static std::string ServerPrimaryIP;
   static int ServerPort;
   static int ServerPortFd;

--- a/hphp/runtime/server/fastcgi/fastcgi-server-factory.cpp
+++ b/hphp/runtime/server/fastcgi/fastcgi-server-factory.cpp
@@ -25,7 +25,8 @@ public:
   virtual ServerPtr createServer(const ServerOptions& options) override {
     return std::make_shared<FastCGIServer>(options.m_address,
                                            options.m_port,
-                                           options.m_numThreads);
+                                           options.m_numThreads,
+                                           options.m_useFileSocket);
   }
 };
 

--- a/hphp/runtime/server/fastcgi/fastcgi-server.cpp
+++ b/hphp/runtime/server/fastcgi/fastcgi-server.cpp
@@ -167,7 +167,8 @@ void FastCGIConnection::handleRequest(int transport_id) {
 
 FastCGIServer::FastCGIServer(const std::string &address,
                              int port,
-                             int workers)
+                             int workers,
+                             bool useFileSocket)
   : Server(address, port, workers),
     m_worker(&m_eventBaseManager),
     m_dispatcher(workers,
@@ -179,7 +180,9 @@ FastCGIServer::FastCGIServer(const std::string &address,
                  RuntimeOption::ServerThreadJobMaxQueuingMilliSeconds,
                  RequestPriority::k_numPriorities) {
   TSocketAddress sock_addr;
-  if (address.empty()) {
+  if (useFileSocket) {
+    sock_addr.setFromPath(address);
+  } else if (address.empty()) {
     sock_addr.setFromLocalPort(port);
   } else {
     sock_addr.setFromHostPort(address, port);
@@ -210,8 +213,12 @@ void FastCGIServer::start() {
     m_socket->bind(m_socketConfig.getAddress());
   } catch (const apache::thrift::transport::TTransportException& ex) {
     LOG(ERROR) << ex.what();
-    throw FailedToListenException(m_socketConfig.getAddress().getAddressStr(),
-                                  m_socketConfig.getAddress().getPort());
+    if (m_socketConfig.getAddress().getFamily() == AF_UNIX) {
+      throw FailedToListenException(m_socketConfig.getAddress().getPath());
+    } else {
+      throw FailedToListenException(m_socketConfig.getAddress().getAddressStr(),
+                                    m_socketConfig.getAddress().getPort());
+    }
   }
   m_acceptor.reset(new FastCGIAcceptor(m_socketConfig, this));
   m_acceptor->init(m_socket.get(), m_worker.getEventBase());

--- a/hphp/runtime/server/fastcgi/fastcgi-server.h
+++ b/hphp/runtime/server/fastcgi/fastcgi-server.h
@@ -121,7 +121,8 @@ class FastCGIServer : public Server,
 public:
   FastCGIServer(const std::string &address,
                 int port,
-                int workers);
+                int workers,
+                bool useFileSocket);
   ~FastCGIServer() {
     if (!m_done) {
       waitForEnd();

--- a/hphp/runtime/server/http-server.cpp
+++ b/hphp/runtime/server/http-server.cpp
@@ -76,9 +76,10 @@ HttpServer::HttpServer()
 
   auto serverFactory = ServerFactoryRegistry::getInstance()->getFactory
       (RuntimeOption::ServerType);
-  ServerOptions options
-    (RuntimeOption::ServerIP, RuntimeOption::ServerPort,
-     startingThreadCount);
+  const std::string address = RuntimeOption::ServerFileSocket.empty()
+    ? RuntimeOption::ServerIP : RuntimeOption::ServerFileSocket;
+  ServerOptions options(address, RuntimeOption::ServerPort, startingThreadCount);
+  options.m_useFileSocket = !RuntimeOption::ServerFileSocket.empty();
   options.m_serverFD = RuntimeOption::ServerPortFd;
   options.m_sslFD = RuntimeOption::SSLPortFd;
   options.m_takeoverFilename = RuntimeOption::TakeoverFilename;
@@ -494,7 +495,11 @@ bool HttpServer::startServer(bool pageServer) {
       }
 
       if (errno == EACCES) {
-        Logger::Error("Permission denied listening on port %d", port);
+        if (pageServer && !RuntimeOption::ServerFileSocket.empty()) {
+          Logger::Error("Permission denied opening socket at %s", RuntimeOption::ServerFileSocket.c_str());
+        } else {
+          Logger::Error("Permission denied listening on port %d", port);
+        }
         return false;
       }
 
@@ -507,6 +512,21 @@ bool HttpServer::startServer(bool pageServer) {
       StringBuffer response;
       http.get(url.c_str(), response);
 
+      if (pageServer && !RuntimeOption::ServerFileSocket.empty()) {
+        if (i == 0) {
+          Logger::Info("Unlinking unused socket at %s", RuntimeOption::ServerFileSocket.c_str());
+        }
+        struct stat stat_buf;
+        if (stat(RuntimeOption::ServerFileSocket.c_str(), &stat_buf) == 0
+            && S_ISSOCK(stat_buf.st_mode)) {
+          std::string cmd = "bash -c '! fuser ";
+          cmd += RuntimeOption::ServerFileSocket;
+          cmd += "'";
+          if (Util::ssystem(cmd.c_str()) == 0) {
+            unlink(RuntimeOption::ServerFileSocket.c_str());
+          }
+        }
+      }
       sleep(1);
     }
   }
@@ -542,15 +562,26 @@ bool HttpServer::startServer(bool pageServer) {
         }
         return true;
       } catch (FailedToListenException &e) {
-        if (i == 0) {
-          Logger::Info("killing anything listening on port %d", port);
+        if (pageServer && !RuntimeOption::ServerFileSocket.empty()) {
+          if (i == 0) {
+            Logger::Info("unlinking socket at %s", RuntimeOption::ServerFileSocket.c_str());
+          }
+
+          struct stat stat_buf;
+          if (stat(RuntimeOption::ServerFileSocket.c_str(), &stat_buf) == 0
+              && S_ISSOCK(stat_buf.st_mode)) {
+            unlink(RuntimeOption::ServerFileSocket.c_str());
+          }
+        } else {
+          if (i == 0) {
+            Logger::Info("killing anything listening on port %d", port);
+          }
+
+          std::string cmd = "lsof -t -i :";
+          cmd += lexical_cast<std::string>(port);
+          cmd += " | xargs kill -9";
+          Util::ssystem(cmd.c_str());
         }
-
-        std::string cmd = "lsof -t -i :";
-        cmd += lexical_cast<std::string>(port);
-        cmd += " | xargs kill -9";
-        Util::ssystem(cmd.c_str());
-
         sleep(1);
       }
     }

--- a/hphp/runtime/server/server.h
+++ b/hphp/runtime/server/server.h
@@ -265,7 +265,8 @@ public:
       m_numThreads(numThreads),
       m_serverFD(-1),
       m_sslFD(-1),
-      m_takeoverFilename() {
+      m_takeoverFilename(),
+      m_useFileSocket(false) {
   }
 
   std::string m_address;
@@ -274,6 +275,7 @@ public:
   int m_serverFD;
   int m_sslFD;
   std::string m_takeoverFilename;
+  bool m_useFileSocket;
 };
 
 /**
@@ -329,6 +331,9 @@ class FailedToListenException : public ServerException {
 public:
   FailedToListenException(const std::string &addr, int port)
     : ServerException("Failed to listen on %s:%d", addr.c_str(), port) {
+  }
+  FailedToListenException(const std::string &addr)
+    : ServerException("Failed to listen to unix socket at %s", addr.c_str()) {
   }
 };
 


### PR DESCRIPTION
Add a new config param, Server.FileSocket.  When Server.FileSocket
is set it will be used inplace of a network socket for the primary
server.  This uses a new parameter to ServerOptions, m_useFileSocket,
to toggle between treating the address as a socket path or a network
address.

To initialize a socket connection thrift expects the socket file to not
exist.  To support this the 'something nice' retry in startServer will
unlink an existing socket only if fuser claims it is unused.
Server.EvilShutdown enables unlinking the socket regardless of current
users.
