### PR TITLE
Allow disabling hardware counters from cmake

### DIFF
--- a/CMake/HPHPSetup.cmake
+++ b/CMake/HPHPSetup.cmake
@@ -123,6 +123,10 @@ if(ENABLE_FASTCGI)
 	add_definitions(-DENABLE_FASTCGI=1)
 endif ()
 
+if(DISABLE_HARDWARE_COUNTERS)
+	add_definitions(-DNO_HARDWARE_COUNTERS=1)
+endif ()
+
 # enable the OSS options if we have any
 add_definitions(-DHPHP_OSS=1)
 

--- a/CMake/Options.cmake
+++ b/CMake/Options.cmake
@@ -13,3 +13,6 @@ option(USE_JEMALLOC "Use jemalloc" ON)
 option(USE_TCMALLOC "Use tcmalloc (if jemalloc is not used)" ON)
 option(USE_GOOGLE_HEAP_PROFILER "Use Google heap profiler" OFF)
 option(USE_GOOGLE_CPU_PROFILER "Use Google cpu profiler" OFF)
+
+option(DISABLE_HARDWARE_COUNTERS "Disable hardware counters (for XenU systems)" OFF)
+


### PR DESCRIPTION
Allows disabling hardware counters with `cmake -DDISABLE_HARDWARE_COUNTERS=1 .`, needed for Linux XenU (paravirtualized Xen) guest systems (see #981, #1065, #1118).

P.S. Maybe could be added to 2.3 branch too, if there will be some more releases there.
