### PR TITLE
Script to execute may be outside DOCUMENT_ROOT

### DIFF
--- a/hphp/runtime/server/fastcgi/fastcgi-transport.cpp
+++ b/hphp/runtime/server/fastcgi/fastcgi-transport.cpp
@@ -411,12 +411,15 @@ void FastCGITransport::handleHeader(const std::string& key,
 
 void FastCGITransport::onHeadersComplete() {
   std::string pathTranslated = getRawHeader("PATH_TRANSLATED");
-  std::string documentRoot = getRawHeader("DOCUMENT_ROOT");
   // use PATH_TRANSLATED - DOCUMENT_ROOT if it is valid instead of SCRIPT_NAME
   // for mod_fastcgi support
-  if (!pathTranslated.empty() && !documentRoot.empty() &&
-      pathTranslated.find(documentRoot) == 0) {
-    m_serverObject = pathTranslated.substr(documentRoot.length());
+  if (!pathTranslated.empty() && !m_documentRoot.empty()
+      && pathTranslated.find(m_documentRoot) == 0) {
+    m_serverObject = pathTranslated.substr(m_documentRoot.length());
+  } else if (!pathTranslated.empty() && !RuntimeOption::SourceRoot.empty()
+             && pathTranslated.find(RuntimeOption::SourceRoot) == 0) {
+    m_serverObject = pathTranslated.substr(RuntimeOption::SourceRoot.length());
+    m_documentRoot = RuntimeOption::SourceRoot;
   } else {
     m_serverObject = getRawHeader("SCRIPT_NAME");
   }


### PR DESCRIPTION
Php files are often inside the docroot, but that is not
a requirement of the apache config.  Php files may be aliased
into the docroot.  Accept PATH_TRANSLATED when it is within
the docroot or within the Server.SourceRoot runtime param so
these environments can continue to work similar to how they
worked with php-fpm.
