### PR TITLE
[hphp/test/run] Sub path support in the directory aliases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,13 +18,17 @@ env:
   - TEST_RUN_MODE="-m jit zend"
   - TEST_RUN_MODE="-m jit -r quick"
   - TEST_RUN_MODE="-m jit -r slow"
-  - TEST_RUN_MODE="-m jit -r zend"
+  - TEST_RUN_MODE="-m jit -r zend/ext"
+  - TEST_RUN_MODE="-m jit -r zend/tests"
+  - TEST_RUN_MODE="-m jit -r zend/Zend"
   - TEST_RUN_MODE="-m interp quick"
   - TEST_RUN_MODE="-m interp slow"
   - TEST_RUN_MODE="-m interp zend"
   - TEST_RUN_MODE="-m interp -r quick"
   - TEST_RUN_MODE="-m interp -r slow"
-  - TEST_RUN_MODE="-m interp -r zend"
+  - TEST_RUN_MODE="-m interp -r zend/ext"
+  - TEST_RUN_MODE="-m interp -r zend/tests"
+  - TEST_RUN_MODE="-m interp -r zend/Zend"
 
 script: time hphp/hhvm/hhvm hphp/test/run $TEST_RUN_MODE
 

--- a/hphp/test/run
+++ b/hphp/test/run
@@ -6,7 +6,7 @@
 
 function usage() {
   global $argv;
-  return "usage: $argv[0] [-m jit|interp] [-r] <test/directories>";
+  return "usage: $argv[0] [-m jit|interp] [-r] <test-file/directories/directory-alias>";
 }
 
 function help() {
@@ -56,6 +56,21 @@ Examples:
 
   # All tests whose name containing pdo_mysql
   % $argv[0] -i pdo_mysql -m jit -r zend
+
+Directory Aliases:
+
+ Currently the following are the supported mappings for the directory aliases
+ i.e An alias 'quick' is translated to directory 'hphp/test/quick' and so on
+
+    'quick'    => 'hphp/test/quick'
+    'slow'     => 'hphp/test/slow'
+    'debugger' => 'hphp/test/server/debugger/tests'
+    'zend'     => 'hphp/test/zend/good'
+    'zend_bad' => 'hphp/test/zend/bad'
+    'facebook' => 'hphp/facebook/test'
+
+ Sub-paths inside the Directory Aliases can be looked up with the / convention
+ i.e 'zend/ext' is translated to directory 'hphp/test/zend/good/ext'
 
 EOT;
   return usage().$help;
@@ -193,11 +208,22 @@ function map_convenience_filename($file) {
     'zend_bad' => 'hphp/test/zend/bad',
     'facebook' => 'hphp/facebook/test',
   );
-
+  // code to easily determine the sub-paths from the
+  // above map
+  // i.e zend/ext in the command line translates to
+  //     hphp/test/zend/good/ext
   if (!isset($mappage[$file])) {
+    if (strpos($file, '/') !== false) {
+      foreach ($mappage as $k => $v) {
+        if (preg_match("/^$k/", $file) === 1) {
+            return hphp_home().'/'.preg_replace("/^$k/", $v, $file);
+        }
+      }
+    }
     return $file;
+  } else {
+    return hphp_home().'/'.$mappage[$file];
   }
-  return hphp_home().'/'.$mappage[$file];
 }
 
 function find_tests($files, array $options = null) {


### PR DESCRIPTION
Add support for mentioning sub-paths in the directory aliases `zend, slow, quick, zend_bad`

For example `zend/tests` translate to `hphp/test/zend/good/tests` directory. Similarly works for other aliases.

Sample run is below

```
bash$ hhvm hphp/test/run zend/tests -i /001 -v -r 
Running 4 tests in 3 threads
hphp/test/zend/good/tests/basic/001.php passed
hphp/test/zend/good/tests/func/001.php passed
hphp/test/zend/good/tests/lang/001.php passed
hphp/test/zend/good/tests/strings/001.php passed

All tests passed.

              |    |    |
             )_)  )_)  )_)
            )___))___))___)\
           )____)____)_____)\
         _____|____|____|____\\__
---------\      SHIP IT      /---------
  ^^^^^ ^^^^^^^^^^^^^^^^^^^^^
    ^^^^      ^^^^     ^^^    ^^
         ^^^^      ^^^

```

`.travis.yml` has zend tests further split in `Repo` mode to avoid timing out on slower Travis VMs
