### PR TITLE
Add a script to check that the signatures of native functions match the C++ signatures

### DIFF
--- a/hphp/tools/check_native_signatures.php
+++ b/hphp/tools/check_native_signatures.php
@@ -1,5 +1,25 @@
 <?hh
+/*
+   +----------------------------------------------------------------------+
+   | HipHop for PHP                                                       |
+   +----------------------------------------------------------------------+
+   | Copyright (c) 2014      Facebook, Inc. (http://www.facebook.com)     |
+   +----------------------------------------------------------------------+
+   | This source file is subject to version 3.01 of the PHP license,      |
+   | that is bundled with this package in the file LICENSE, and is        |
+   | available through the world-wide-web at the following url:           |
+   | http://www.php.net/license/3_01.txt                                  |
+   | If you did not receive a copy of the PHP license and are unable to   |
+   | obtain it through the world-wide-web, please send a note to          |
+   | license@php.net so we can mail you a copy immediately.               |
+   +----------------------------------------------------------------------+
+*/
+/*
+A helper script to check that HNI signatures in a PHP file match how the
+functions are defined in the C++ file.
 
+Currently only matches functions, so won't match classes/methods.
+*/
 // expects argv[1] to be the C++ file, argv[2] to be the PHP file
 if (empty($_SERVER['argv'][2])) {
   fwrite(STDERR, "Usage: {$_SERVER['argv'][0]} <extfile.cpp> <extfile.php>\n");


### PR DESCRIPTION
Currently only matches functions.

Since signature mismatches in HNI natives just cause really weird segfaults, and I keep missing the odd one, a way to make sure the signatures match would be of use.
