### PR TITLE
Implement correct behavior on stream connect and send/recv timeout

### DIFF
--- a/hphp/runtime/ext/ext_socket.cpp
+++ b/hphp/runtime/ext/ext_socket.cpp
@@ -1061,14 +1061,15 @@ Variant sockopen_impl(const Util::HostURL &hosturl, VRefParam errnum,
 
   Resource ret;
   Socket *sock = NULL;
+  double default_timeout = RuntimeOption::SocketDefaultTimeout;
+  if (timeout < 0) timeout = default_timeout;
 
-  if (timeout < 0) timeout = RuntimeOption::SocketDefaultTimeout;
   // test if protocol is SSL
-  SSLSocket *sslsock = SSLSocket::Create(hosturl, timeout);
+  SSLSocket *sslsock = SSLSocket::Create(hosturl, default_timeout);
   if (sslsock) {
     sock = sslsock;
     ret = sock;
-  } else if (!create_new_socket(hosturl, errnum, errstr, ret, sock, timeout)) {
+  } else if (!create_new_socket(hosturl, errnum, errstr, ret, sock, default_timeout)) {
     return false;
   }
   assert(ret.get() && sock);

--- a/hphp/runtime/ext/ext_stream.cpp
+++ b/hphp/runtime/ext/ext_stream.cpp
@@ -254,9 +254,13 @@ const StaticString
 bool f_stream_set_timeout(CResRef stream, int seconds,
                           int microseconds /* = 0 */) {
   if (stream.getTyped<Socket>(false, true)) {
-    return f_socket_set_option
+    return (
+      f_socket_set_option
       (stream, SOL_SOCKET, SO_RCVTIMEO,
-       make_map_array(s_sec, seconds, s_usec, microseconds));
+       make_map_array(s_sec, seconds, s_usec, microseconds)) &&
+      f_socket_set_option
+      (stream, SOL_SOCKET, SO_SNDTIMEO,
+       make_map_array(s_sec, seconds, s_usec, microseconds)));
   }
   return false;
 }


### PR DESCRIPTION
This PR fixes facebook/hhvm#1361, as reported on that issue:
- As document http://www.php.net/manual/zh/function.fsockopen.php
  says, timeout parameter to fsockopen() only applies while
  connecting the socket. , but hhvm use this parameter as socket
  send and recv timeout.
- In Zend php, stream_set_timeout set both send and recv timeout,
  while in hhvm it set only recv timeout.
