### PR TITLE
UrlFile::sweep, avoid freeing smart allocated objects

### DIFF
--- a/hphp/runtime/base/url-file.cpp
+++ b/hphp/runtime/base/url-file.cpp
@@ -23,7 +23,6 @@
 
 namespace HPHP {
 
-IMPLEMENT_OBJECT_ALLOCATION(UrlFile)
 ///////////////////////////////////////////////////////////////////////////////
 
 const StaticString s_http_response_header("http_response_header");
@@ -41,6 +40,12 @@ UrlFile::UrlFile(const char *method /* = "GET" */,
   m_maxRedirect = maxRedirect;
   m_timeout = timeout;
   m_isLocal = false;
+}
+
+void UrlFile::sweep() {
+  using std::string;
+  m_error.~string();
+  MemFile::sweep();
 }
 
 const StaticString


### PR DESCRIPTION
Thanks @jdelong, for pointing me in the right direction.
