### PR TITLE
LdapLink::sweep, avoid freeing smart allocated objects

### DIFF
--- a/hphp/runtime/ext/ext_ldap.cpp
+++ b/hphp/runtime/ext/ext_ldap.cpp
@@ -67,7 +67,10 @@ public:
   LDAP *link;
   Variant rebindproc;
 };
-IMPLEMENT_OBJECT_ALLOCATION(LdapLink)
+
+void LdapLink::sweep() {
+  close();
+}
 
 class LdapResult : public SweepableResourceData {
 public:


### PR DESCRIPTION
This is totally untested, but if #1643 is correct, then this likely is as well.
