### PR TITLE
switch VariableSerializer to o_toArray instead of o_getArray

### DIFF
--- a/hphp/runtime/base/object-data.cpp
+++ b/hphp/runtime/base/object-data.cpp
@@ -416,7 +416,7 @@ void ObjectData::o_getArray(Array& props, bool pubOnly /* = false */) const {
   }
 }
 
-Array ObjectData::o_toArray() const {
+Array ObjectData::o_toArray(bool pubOnly /* = false */) const {
   // We can quickly tell if this object is a collection, which lets us avoid
   // checking for each class in turn if it's not one.
   if (isCollection()) {
@@ -447,7 +447,7 @@ Array ObjectData::o_toArray() const {
     return ArrayObject_toArray(this);
   } else {
     Array ret(ArrayData::Create());
-    o_getArray(ret, false);
+    o_getArray(ret, pubOnly);
     return ret;
   }
 }

--- a/hphp/runtime/base/object-data.h
+++ b/hphp/runtime/base/object-data.h
@@ -263,7 +263,7 @@ class ObjectData {
   bool o_toBooleanImpl() const noexcept;
   int64_t o_toInt64Impl() const noexcept;
   double o_toDoubleImpl() const noexcept;
-  Array o_toArray() const;
+  Array o_toArray(bool pubOnly = false) const;
 
   bool destruct();
 

--- a/hphp/runtime/base/variable-serializer.cpp
+++ b/hphp/runtime/base/variable-serializer.cpp
@@ -513,8 +513,7 @@ void VariableSerializer::write(CObjRef v) {
       if (v->isCollection()) {
         collectionSerialize(v.get(), this);
       } else {
-        Array props(ArrayData::Create());
-        v->o_getArray(props, true);
+        Array props = v->o_toArray(true);
         setObjectInfo(v->o_getClassName(), v->o_getId(), 'O');
         props.serialize(this);
       }

--- a/hphp/test/slow/simple_xml/serialize.php
+++ b/hphp/test/slow/simple_xml/serialize.php
@@ -1,0 +1,4 @@
+<?php
+
+$element = new \SimpleXMLElement("<foo><bar>baz</bar></foo>");
+var_dump(json_encode($element));

--- a/hphp/test/slow/simple_xml/serialize.php.expect
+++ b/hphp/test/slow/simple_xml/serialize.php.expect
@@ -1,0 +1,1 @@
+string(13) "{"bar":"baz"}"


### PR DESCRIPTION
Because some classes have custom implementations of ToArray,
we must let o_toArray decide whether or not we should call
o_getArray because the latter only deals with dynamic properties.
