### PR TITLE
Pass PCRE_NO_UTF8_CHECK to pcre_exec more often

### DIFF
--- a/hphp/runtime/base/preg.cpp
+++ b/hphp/runtime/base/preg.cpp
@@ -557,6 +557,7 @@ static Variant preg_match_impl(const String& pattern, const String& subject,
   if (subpats) {
     *subpats = Array::Create();
   }
+  int exoptions = 0; // Execution options
 
   int subpats_order = global ? PREG_PATTERN_ORDER : 0;
   bool offset_capture = false;
@@ -624,7 +625,10 @@ static Variant preg_match_impl(const String& pattern, const String& subject,
   do {
     /* Execute the regular expression. */
     int count = pcre_exec(pce->re, extra, subject.data(), subject.size(),
-                          start_offset, g_notempty, offsets, size_offsets);
+                          start_offset, exoptions|g_notempty, offsets, size_offsets);
+
+    /* the string was already proved to be valid UTF-8 */
+    exoptions |= PCRE_NO_UTF8_CHECK;
 
     /* Check for too many substrings condition. */
     if (count == 0) {
@@ -910,10 +914,14 @@ static Variant php_pcre_replace(const String& pattern, const String& subject,
     int match_len;      // Length of the current match
     int backref;        // Backreference number
     int g_notempty = 0; // If the match should not be empty
+    int exoptions = 0;  // Execution options
     while (1) {
       /* Execute the regular expression. */
       int count = pcre_exec(pce->re, extra, subject.data(), subject.size(),
-                            start_offset, g_notempty, offsets, size_offsets);
+                            start_offset, exoptions|g_notempty, offsets, size_offsets);
+
+      /* the string was already proved to be valid UTF-8 */
+      exoptions |= PCRE_NO_UTF8_CHECK;
 
       /* Check for too many substrings condition. */
       if (count == 0) {


### PR DESCRIPTION
Code as in https://bugs.php.net/bug.php?id=44336 . Omitting
PCRE_NO_UTF8_CHECK causes a massive performance regression for certain
test cases, giving O(N^2) execution time instead of O(N).
