### PR TITLE
Call objcopy only once

### DIFF
--- a/CMake/HPHPFunctions.cmake
+++ b/CMake/HPHPFunctions.cmake
@@ -89,22 +89,30 @@ macro(MYSQL_SOCKET_SEARCH)
 	endif()
 endmacro()
 
-function(embed_systemlib TARGET DEST SOURCE SECTNAME)
+function(append_systemlib TARGET SOURCE SECTNAME)
 	if (APPLE)
-	        target_link_libraries(${TARGET} -Wl,-sectcreate,__text,${SECTNAME},${SOURCE})
+		set(${TARGET}_SLIBS ${${TARGET}_SLIBS} -Wl,-sectcreate,__text,${SECTNAME},${SOURCE} PARENT_SCOPE)
 	else()
-	        add_custom_command(TARGET ${TARGET} POST_BUILD
-	                   COMMAND "objcopy"
-	                   ARGS "--add-section" "${SECTNAME}=${SOURCE}" ${DEST}
-	                   COMMENT "Embedding ${SOURCE} in ${TARGET} as ${SECTNAME}")
+		set(${TARGET}_SLIBS ${${TARGET}_SLIBS} "--add-section" "${SECTNAME}=${SOURCE}" PARENT_SCOPE)
 	endif()
 	# Add the systemlib file to the "LINK_DEPENDS" for the systemlib, this will cause it
 	# to be relinked and the systemlib re-embedded
 	set_property(TARGET ${TARGET} APPEND PROPERTY LINK_DEPENDS ${SOURCE})
-endfunction(embed_systemlib)
+endfunction(append_systemlib)
+
+function(embed_systemlibs TARGET DEST)
+	if (APPLE)
+	        target_link_libraries(${TARGET} ${${TARGET}_SLIBS})
+	else()
+	        add_custom_command(TARGET ${TARGET} POST_BUILD
+	                   COMMAND "objcopy"
+	                   ARGS ${${TARGET}_SLIBS} ${DEST}
+	                   COMMENT "Embedding php in ${TARGET}")
+	endif()
+endfunction(embed_systemlibs)
 
 function(embed_all_systemlibs TARGET DEST)
-	embed_systemlib(${TARGET} ${DEST} ${HPHP_HOME}/hphp/system/systemlib.php systemlib)
+	append_systemlib(${TARGET} ${HPHP_HOME}/hphp/system/systemlib.php systemlib)
 	auto_sources(SYSTEMLIBS "ext_*.php" "RECURSE" "${HPHP_HOME}/hphp/runtime")
 	foreach(SLIB ${SYSTEMLIBS})
 		get_filename_component(SLIB_BN ${SLIB} "NAME_WE")
@@ -113,8 +121,9 @@ function(embed_all_systemlibs TARGET DEST)
 		string(SUBSTRING ${SLIB_BN} 4 ${SLIB_BN_REL_LEN} SLIB_EXTNAME)
 		string(MD5 SLIB_HASH_NAME ${SLIB_EXTNAME})
 		string(SUBSTRING ${SLIB_HASH_NAME} 0 12 SLIB_HASH_NAME_SHORT)
-		embed_systemlib(${TARGET} ${DEST} ${SLIB} "ext.${SLIB_HASH_NAME_SHORT}")
+		append_systemlib(${TARGET} ${SLIB} "ext.${SLIB_HASH_NAME_SHORT}")
 	endforeach()
+	embed_systemlibs(${TARGET} ${DEST})
 endfunction(embed_all_systemlibs)
 
 # Custom install function that doesn't relink, instead it uses chrpath to change it, if
@@ -143,5 +152,6 @@ function(HHVM_EXTENSION EXTNAME)
 endfunction()
 
 function(HHVM_SYSTEMLIB EXTNAME SOURCE_FILE)
-	embed_systemlib(${EXTNAME} "${EXTNAME}.so" ${SOURCE_FILE} systemlib)
+	append_systemlib(${EXTNAME} ${SOURCE_FILE} systemlib)
+	embed_systemlibs(${EXTNAME} "${EXTNAME}.so")
 endfunction()


### PR DESCRIPTION
On Linux, a trivial debug recompile, e.g.

```
touch random-file.cpp; make
```

is sped up, for me, by 60% (going from 10m to 4m).
