### PR TITLE
Fix case where a final method will not report itself as final in Reflect...

### DIFF
--- a/hphp/runtime/ext/reflection/ext_reflection-classes.php
+++ b/hphp/runtime/ext/reflection/ext_reflection-classes.php
@@ -950,15 +950,6 @@ class ReflectionClass implements Reflector {
 
     $info['attributes_rec'] = $info['attributes'];
 
-    $abstract = isset($info['abstract']) || isset($info['interface']);
-    // flattening the trees, so it's easier for lookups
-    foreach ($info['interfaces'] as $interface => $_) {
-      $p = self::fetch_recur($interface);
-      if ($abstract) $info['methods'] += $p['methods'];
-      $info['constants'] += $p['constants'];
-      $info['interfaces'] += $p['interfaces'];
-    }
-
     $parent = $info['parent'];
     if (!empty($parent)) {
       $p = self::fetch_recur($parent);
@@ -990,6 +981,16 @@ class ReflectionClass implements Reflector {
       $info['interfaces'] += $p['interfaces'];
       $info['attributes_rec'] += $p['attributes_rec'];
     }
+
+    $abstract = isset($info['abstract']) || isset($info['interface']);
+    // flattening the trees, so it's easier for lookups
+    foreach ($info['interfaces'] as $interface => $_) {
+      $p = self::fetch_recur($interface);
+      if ($abstract) $info['methods'] += $p['methods'];
+      $info['constants'] += $p['constants'];
+      $info['interfaces'] += $p['interfaces'];
+    }
+
     if (is_string($name)) {
       self::$fetched[$name] = $info;
     }

--- a/hphp/test/slow/reflection_classes/1524.php
+++ b/hphp/test/slow/reflection_classes/1524.php
@@ -1,0 +1,30 @@
+<?php
+
+interface I {
+  function m();
+}
+
+class A implements I {
+  final function m() { }
+}
+
+class B extends A { }
+
+abstract class C extends B implements I { }
+
+class D extends C { }
+
+$rc = new ReflectionClass('I');
+var_dump($rc->getMethods()[0]->isFinal());
+
+$rc = new ReflectionClass('A');
+var_dump($rc->getMethods()[0]->isFinal());
+
+$rc = new ReflectionClass('B');
+var_dump($rc->getMethods()[0]->isFinal());
+
+$rc = new ReflectionClass('C');
+var_dump($rc->getMethods()[0]->isFinal());
+
+$rc = new ReflectionClass('D');
+var_dump($rc->getMethods()[0]->isFinal());

--- a/hphp/test/slow/reflection_classes/1524.php.expect
+++ b/hphp/test/slow/reflection_classes/1524.php.expect
@@ -1,0 +1,5 @@
+bool(false)
+bool(true)
+bool(true)
+bool(true)
+bool(true)


### PR DESCRIPTION
...ionMethod (#1524)

This seems to be isolated to the case where an interface declares a method (without final), an implementer implements it as final, and an abstract subclass of the implementer declares it is implementing the same interface.

This brings monolog to 100% again.
