### PR TITLE
Fixes #1768: Use nullptr instead of 0 or NULL in C++11 code.

### DIFF
--- a/hphp/runtime/vm/class.h
+++ b/hphp/runtime/vm/class.h
@@ -692,7 +692,7 @@ struct Class : AtomicCountable {
   Slot traitsEndIdx() const   { return m_traitsEndIdx; }
 
   Func* lookupMethod(const StringData* methName) const {
-    return m_methods.lookupDefault(methName, 0);
+    return m_methods.lookupDefault(methName, nullptr);
   }
 
   bool isPersistent() const { return m_attrCopy & AttrPersistent; }


### PR DESCRIPTION
Fixes #1768.
