### PR TITLE
Fix libzip to check zip archive members pointer before freeing

### DIFF
--- a/hphp/third_party/libzip/zip_fclose.c
+++ b/hphp/third_party/libzip/zip_fclose.c
@@ -47,12 +47,14 @@ zip_fclose(struct zip_file *zf)
     if (zf->src)
 	zip_source_free(zf->src);
 
-    for (i=0; i<zf->za->nfile; i++) {
-	if (zf->za->file[i] == zf) {
-	    zf->za->file[i] = zf->za->file[zf->za->nfile-1];
-	    zf->za->nfile--;
-	    break;
-	}
+    if (zf->za) {
+    	for (i=0; i<zf->za->nfile; i++) {
+	    if (zf->za->file[i] == zf) {
+	    	zf->za->file[i] = zf->za->file[zf->za->nfile-1];
+	    	zf->za->nfile--;
+	    	break;
+	    }
+    	}
     }
 
     ret = 0;


### PR DESCRIPTION
This is a hotfix for #1754. The actual fix is already in the master
branch of the source library:
http://hg.nih.at/libzip/comparison/8cc36648e0a2/lib/zip_fclose.c
