### PR TITLE
Change hash_hmac to accept all types for the second argument

### DIFF
--- a/hphp/system/php/hash/hash.php
+++ b/hphp/system/php/hash/hash.php
@@ -67,7 +67,7 @@ function hash_final(resource $context, bool $raw_output = false): string;
  *
  * @param string $algo     - Name of selected hashing algorithm
  *                           (i.e. "md5", "sha256", "haval160,4", etc..)
- * @param string $data     - Message to be hashed.
+ * @param mixed $data      - Message to be hashed. Will be cast to a string
  * @param string $key      - Shared secret key used for generating the
  *                           HMAC variant of the message digest.
  * @param bool $raw_output - When set to TRUE, outputs raw binary data.
@@ -80,7 +80,7 @@ function hash_final(resource $context, bool $raw_output = false): string;
  *                  On error, FALSE is returned.
  */
 function hash_hmac(?string $algo = null,
-                   ?string $data = null,
+                   ?mixed $data = null,
                    ?string $key = null,
                    ?bool $raw_output = false): mixed {
   // Behave like a builtin function so that we pass Zend's tests
@@ -99,7 +99,7 @@ function hash_hmac(?string $algo = null,
   if (!$ctx) {
     return false;
   }
-  hash_update($ctx, $data);
+  hash_update($ctx, (string) $data);
   return hash_final($ctx, $raw_output);
 }
 

--- a/hphp/test/slow/ext_hash/hash_hmac_str_cast.php
+++ b/hphp/test/slow/ext_hash/hash_hmac_str_cast.php
@@ -1,0 +1,9 @@
+<?php
+$key = "c0793dfd477a2ff11b7cd5636594a76b518f3a6df8fb450d90ac52457833604e";
+class Stringy {
+  public function __toString() { return "hello"; }
+}
+$hello_hash = hash_hmac("sha256", "hello", $key, false);
+$one_hash = hash_hmac("sha256", "1", $key, false);
+var_dump( $hello_hash === hash_hmac("sha256", new Stringy(), $key, false) );
+var_dump( $one_hash === hash_hmac("sha256", 1, $key, false) );

--- a/hphp/test/slow/ext_hash/hash_hmac_str_cast.php.expect
+++ b/hphp/test/slow/ext_hash/hash_hmac_str_cast.php.expect
@@ -1,0 +1,2 @@
+bool(true)
+bool(true)


### PR DESCRIPTION
and automatically cast it to a string before hashing, as Zend does

I verified that zend exhibits the exact same behavior.
