### PR TITLE
Support file::// by pulling plain file support from FileStreamWrapper

### DIFF
--- a/hphp/runtime/base/file-repository.cpp
+++ b/hphp/runtime/base/file-repository.cpp
@@ -523,7 +523,8 @@ static bool findFileWrapper(const String& file, void* ctx) {
   assert(context->path.isNull());
 
   Stream::Wrapper* w = Stream::getWrapperFromURI(file);
-  if (!dynamic_cast<FileStreamWrapper*>(w)) {
+  if (!dynamic_cast<FileStreamWrapper*>(w) &&
+      !dynamic_cast<PlainStreamWrapper*>(w)) {
     if (w->stat(file, context->s) == 0) {
       context->path = file;
       return true;

--- a/hphp/runtime/base/stream-wrapper-registry.cpp
+++ b/hphp/runtime/base/stream-wrapper-registry.cpp
@@ -185,7 +185,9 @@ Wrapper* getWrapper(const String& scheme) {
   return nullptr;
 }
 
-Wrapper* getWrapperFromURI(const String& uri, int* pathIndex /* = NULL */) {
+static PlainStreamWrapper s_plain_stream_wrapper;
+
+Wrapper* getWrapperFromURI(const String& uri) {
   const char *uri_string = uri.data();
 
   /* Special case for PHP4 Backward Compatability */
@@ -200,15 +202,15 @@ Wrapper* getWrapperFromURI(const String& uri, int* pathIndex /* = NULL */) {
 
   const char *colon = strstr(uri_string, "://");
   if (!colon) {
-    return getWrapper(s_file);
+    return &s_plain_stream_wrapper;
   }
 
   int len = colon - uri_string;
-  if (pathIndex != nullptr) *pathIndex = len + sizeof("://") - 1;
   if (Wrapper *w = getWrapper(String(uri_string, len, CopyString))) {
     return w;
   }
-  return getWrapper(s_file);
+  // FIXME: return nullptr for an unhandled stream
+  return &s_plain_stream_wrapper;
 }
 
 static FileStreamWrapper s_file_stream_wrapper;

--- a/hphp/runtime/base/stream-wrapper-registry.h
+++ b/hphp/runtime/base/stream-wrapper-registry.h
@@ -34,7 +34,7 @@ bool restoreWrapper(const String& scheme);
 bool registerRequestWrapper(const String& scheme, std::unique_ptr<Wrapper> wrapper);
 Array enumWrappers();
 Wrapper* getWrapper(const String& scheme);
-Wrapper* getWrapperFromURI(const String& uri, int* pathIndex = nullptr);
+Wrapper* getWrapperFromURI(const String& uri);
 
 /* Called during process init to register core wrappers */
 void RegisterCoreWrappers();

--- a/hphp/runtime/ext/ext_file.cpp
+++ b/hphp/runtime/ext/ext_file.cpp
@@ -113,9 +113,6 @@ static int accessSyscall(
     int mode,
     bool useFileCache = false) {
   Stream::Wrapper* w = Stream::getWrapperFromURI(path);
-  if (useFileCache && dynamic_cast<FileStreamWrapper*>(w)) {
-    return ::access(File::TranslatePathWithFileCache(path).data(), mode);
-  }
   return w->access(path, mode);
 }
 
@@ -123,29 +120,8 @@ static int statSyscall(
     const String& path,
     struct stat* buf,
     bool useFileCache = false) {
-  bool isRelative = path.charAt(0) != '/';
-  int pathIndex = 0;
-  Stream::Wrapper* w = Stream::getWrapperFromURI(path, &pathIndex);
-  bool isFileStream = dynamic_cast<FileStreamWrapper*>(w);
-  auto canUseFileCache = useFileCache && isFileStream;
-  if (isRelative && !pathIndex) {
-    auto fullpath = g_context->getCwd() + String::FromChar('/') + path;
-    std::string realpath = StatCache::realpath(fullpath.data());
-    // realpath will return an empty string for nonexistent files
-    if (realpath.empty()) {
-      return ENOENT;
-    }
-    auto translatedPath = canUseFileCache ?
-      File::TranslatePathWithFileCache(realpath) :
-      File::TranslatePath(realpath);
-    return ::stat(translatedPath.data(), buf);
-  }
-
-  auto properPath = isFileStream ? path.substr(pathIndex) : path;
-  if (canUseFileCache) {
-    return ::stat(File::TranslatePathWithFileCache(properPath).data(), buf);
-  }
-  return w->stat(properPath, buf);
+  Stream::Wrapper* w = Stream::getWrapperFromURI(path);
+  return w->stat(path, buf);
 }
 
 static int lstatSyscall(
@@ -153,9 +129,6 @@ static int lstatSyscall(
     struct stat* buf,
     bool useFileCache = false) {
   Stream::Wrapper* w = Stream::getWrapperFromURI(path);
-  if (useFileCache && dynamic_cast<FileStreamWrapper*>(w)) {
-    return ::lstat(File::TranslatePathWithFileCache(path).data(), buf);
-  }
   return w->lstat(path, buf);
 }
 
@@ -919,6 +892,10 @@ Variant f_readlink(const String& path) {
 }
 
 Variant f_realpath(const String& path) {
+  // Zend doesn't support streams in realpath
+  if (!File::IsPlainFilePath(path)) {
+    return false;
+  }
   String translated = File::TranslatePath(path);
   if (translated.empty()) {
     return false;
@@ -926,11 +903,6 @@ Variant f_realpath(const String& path) {
   if (StaticContentCache::TheFileCache &&
       StaticContentCache::TheFileCache->exists(translated.data(), false)) {
     return translated;
-  }
-  // Zend doesn't support streams in realpath
-  Stream::Wrapper* w = Stream::getWrapperFromURI(path);
-  if (!dynamic_cast<FileStreamWrapper*>(w)) {
-    return false;
   }
   char resolved_path[PATH_MAX];
   if (!realpath(translated.c_str(), resolved_path)) {

--- a/hphp/runtime/ext/zlib/ext_zlib.cpp
+++ b/hphp/runtime/ext/zlib/ext_zlib.cpp
@@ -58,13 +58,14 @@ static class ZlibStreamWrapper : public Stream::Wrapper {
       return NULL;
     }
 
-    if (MemFile* file = FileStreamWrapper::openFromCache(fname, mode)) {
+    String translated = File::TranslatePath(fname);
+    if (MemFile* file = PlainStreamWrapper::openFromCache(translated, mode)) {
       file->unzip();
       return file;
     }
 
     std::unique_ptr<ZipFile> file(NEWOBJ(ZipFile)());
-    bool ret = file->open(File::TranslatePath(fname), mode);
+    bool ret = file->open(translated, mode);
     if (!ret) {
       raise_warning("%s", file->getLastError().c_str());
       return NULL;

--- a/hphp/test/slow/streams/file.php
+++ b/hphp/test/slow/streams/file.php
@@ -1,0 +1,57 @@
+<?php
+
+var_dump(file_exists(          __FILE__));
+var_dump(file_exists('file://'.__FILE__)); echo "\n";
+
+var_dump(is_file(          __FILE__));
+var_dump(is_file('file://'.__FILE__)); echo "\n";
+
+var_dump(is_dir(          __DIR__));
+var_dump(is_dir('file://'.__DIR__)); echo "\n";
+
+var_dump(is_readable(          __FILE__));
+var_dump(is_readable('file://'.__FILE__)); echo "\n";
+
+var_dump(is_writable(          __FILE__) ===
+         is_writable('file://'.__FILE__));
+
+var_dump(is_executable(          __FILE__) ===
+         is_executable('file://'.__FILE__));
+
+var_dump(fileperms(          __FILE__) ===
+         fileperms('file://'.__FILE__));
+
+var_dump(fileinode(          __FILE__) ===
+         fileinode('file://'.__FILE__));
+
+var_dump(fileowner(          __FILE__) ===
+         fileowner('file://'.__FILE__));
+
+var_dump(filegroup(          __FILE__) ===
+         filegroup('file://'.__FILE__));
+
+var_dump(fileatime(          __FILE__) ===
+         fileatime('file://'.__FILE__));
+
+var_dump(filemtime(          __FILE__) ===
+         filemtime('file://'.__FILE__));
+
+var_dump(filectime(          __FILE__) ===
+         filectime('file://'.__FILE__));
+
+echo "\n";
+
+var_dump(stat(          __FILE__) ===
+         stat('file://'.__FILE__));
+
+var_dump(lstat(          __FILE__) ===
+         lstat('file://'.__FILE__));
+
+echo "\n";
+
+echo "file://file should not be treated as a relative path nor a hostname\n";
+var_dump(chdir(__DIR__) !== false);
+var_dump(is_dir('file://'.basename(__FILE__)));
+
+//echo "file://localhost/dir should work\n";
+//var_dump(is_dir('file://localhost' + __DIR__));

--- a/hphp/test/slow/streams/file.php.expectf
+++ b/hphp/test/slow/streams/file.php.expectf
@@ -1,0 +1,30 @@
+bool(true)
+bool(true)
+
+bool(true)
+bool(true)
+
+bool(true)
+bool(true)
+
+bool(true)
+bool(true)
+
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+
+bool(true)
+bool(true)
+
+file://file should not be treated as a relative path nor a hostname
+bool(true)
+
+Warning: Only hostless file::// URLs are supported: %s
+bool(false)


### PR DESCRIPTION
… into `PlainStreamWrapper`.

The expands `file://` support while removing a special case.  It also disallows relative  `file://`
paths (i.e. hostless URLs).

Fixes #1847.
