### PR TITLE
Convert arguments that take StreamContext to take Resources not Variants

### DIFF
--- a/hphp/runtime/base/data-stream-wrapper.cpp
+++ b/hphp/runtime/base/data-stream-wrapper.cpp
@@ -27,7 +27,7 @@ namespace HPHP {
 ///////////////////////////////////////////////////////////////////////////////
 
 File* DataStreamWrapper::open(const String& filename, const String& mode,
-                              int options, const Variant& context) {
+                              int options, const Resource& context) {
 
   // @todo: check allow_url_include?
 

--- a/hphp/runtime/base/data-stream-wrapper.h
+++ b/hphp/runtime/base/data-stream-wrapper.h
@@ -31,7 +31,7 @@ class DataStreamWrapper : public Stream::Wrapper {
     m_isLocal = true;
   }
   virtual File* open(const String& filename, const String& mode,
-                     int options, const Variant& context);
+                     int options, const Resource& context);
 };
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/hphp/runtime/base/file-repository.cpp
+++ b/hphp/runtime/base/file-repository.cpp
@@ -206,7 +206,7 @@ PhpFile *FileRepository::checkoutFile(StringData *rname,
       );
     }
     Stream::Wrapper* w = Stream::getWrapperFromURI(name);
-    File* f = w->open(name, "r", 0, null_variant);
+    File* f = w->open(name, "r", 0, null_resource);
     if (!f) return nullptr;
     StringBuffer sb;
     sb.read(f);

--- a/hphp/runtime/base/file-stream-wrapper.cpp
+++ b/hphp/runtime/base/file-stream-wrapper.cpp
@@ -44,7 +44,7 @@ MemFile* FileStreamWrapper::openFromCache(const String& filename,
 }
 
 File* FileStreamWrapper::open(const String& filename, const String& mode,
-                              int options, const Variant& context) {
+                              int options, const Resource& context) {
   String fname =
     !strncmp(filename.data(), "file://", sizeof("file://") - 1)
     ? filename.substr(sizeof("file://") - 1) : filename;

--- a/hphp/runtime/base/file-stream-wrapper.h
+++ b/hphp/runtime/base/file-stream-wrapper.h
@@ -35,7 +35,7 @@ class FileStreamWrapper : public Stream::Wrapper {
  public:
   static MemFile* openFromCache(const String& filename, const String& mode);
   virtual File* open(const String& filename, const String& mode,
-                     int options, const Variant& context);
+                     int options, const Resource& context);
   virtual int access(const String& path, int mode) {
     return ::access(File::TranslatePath(path).data(), mode);
   }

--- a/hphp/runtime/base/file.cpp
+++ b/hphp/runtime/base/file.cpp
@@ -140,10 +140,9 @@ bool File::IsPlainFilePath(const String& filename) {
 
 Variant File::Open(const String& filename, const String& mode,
                    int options /* = 0 */,
-                   const Variant& context /* = null */) {
+                   const Resource& context /* = null */) {
   Stream::Wrapper *wrapper = Stream::getWrapperFromURI(filename);
-  Resource rcontext =
-    context.isNull() ? g_context->getStreamContext() : context.toResource();
+  Resource rcontext = context.isNull() ? g_context->getStreamContext() : context;
   File *file = wrapper->open(filename, mode, options, rcontext);
   if (file != nullptr) {
     file->m_name = filename.data();

--- a/hphp/runtime/base/file.h
+++ b/hphp/runtime/base/file.h
@@ -56,7 +56,7 @@ public:
   static String TranslatePathWithFileCache(const String& filename);
   static String TranslateCommand(const String& cmd);
   static Variant Open(const String& filename, const String& mode,
-                      int options = 0, const Variant& context = uninit_null());
+                      int options = 0, const Resource& context = null_resource);
 
   static bool IsVirtualDirectory(const String& filename);
   static bool IsPlainFilePath(const String& filename);

--- a/hphp/runtime/base/glob-stream-wrapper.cpp
+++ b/hphp/runtime/base/glob-stream-wrapper.cpp
@@ -25,7 +25,7 @@ namespace HPHP {
 File* GlobStreamWrapper::open(const String& filename,
                               const String& mode,
                               int options,
-                              const Variant& context) {
+                              const Resource& context) {
   // Can't open a glob as a file, it's meant to be opened as a directory
 
   // if the function was called via FCallBuiltin, we'll get a bogus name as

--- a/hphp/runtime/base/glob-stream-wrapper.h
+++ b/hphp/runtime/base/glob-stream-wrapper.h
@@ -26,7 +26,7 @@ namespace HPHP {
 class GlobStreamWrapper : public Stream::Wrapper {
  public:
   virtual File* open(const String& filename, const String& mode,
-                     int options, const Variant& context);
+                     int options, const Resource& context);
   virtual Directory* opendir(const String& path);
 };
 

--- a/hphp/runtime/base/http-stream-wrapper.cpp
+++ b/hphp/runtime/base/http-stream-wrapper.cpp
@@ -36,7 +36,7 @@ const StaticString
   s_User_Agent("User-Agent");
 
 File* HttpStreamWrapper::open(const String& filename, const String& mode,
-                              int options, const Variant& context) {
+                              int options, const Resource& context) {
   if (RuntimeOption::ServerHttpSafeMode) {
     return nullptr;
   }
@@ -47,8 +47,7 @@ File* HttpStreamWrapper::open(const String& filename, const String& mode,
   }
 
   std::unique_ptr<UrlFile> file;
-  StreamContext *ctx = !context.isResource() ? nullptr :
-                        context.toResource().getTyped<StreamContext>();
+  StreamContext *ctx = context.getTyped<StreamContext>();
   if (!ctx || ctx->getOptions().isNull() ||
       ctx->getOptions()[s_http].isNull()) {
     file = std::unique_ptr<UrlFile>(NEWOBJ(UrlFile)());

--- a/hphp/runtime/base/http-stream-wrapper.h
+++ b/hphp/runtime/base/http-stream-wrapper.h
@@ -31,7 +31,7 @@ class HttpStreamWrapper : public Stream::Wrapper {
     m_isLocal = false;
   }
   virtual File* open(const String& filename, const String& mode,
-                     int options, const Variant& context);
+                     int options, const Resource& context);
 };
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/hphp/runtime/base/php-stream-wrapper.cpp
+++ b/hphp/runtime/base/php-stream-wrapper.cpp
@@ -57,7 +57,7 @@ File *PhpStreamWrapper::openFD(const char *sFD) {
 
 
 File* PhpStreamWrapper::open(const String& filename, const String& mode,
-                             int options, const Variant& context) {
+                             int options, const Resource& context) {
   if (strncasecmp(filename.c_str(), "php://", 6)) {
     return nullptr;
   }

--- a/hphp/runtime/base/php-stream-wrapper.h
+++ b/hphp/runtime/base/php-stream-wrapper.h
@@ -27,7 +27,7 @@ class PhpStreamWrapper : public Stream::Wrapper {
  public:
   File *openFD(const char *sFD);
   virtual File* open(const String& filename, const String& mode,
-                     int options, const Variant& context);
+                     int options, const Resource& context);
 };
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/hphp/runtime/base/stream-wrapper.h
+++ b/hphp/runtime/base/stream-wrapper.h
@@ -38,7 +38,7 @@ class Wrapper : boost::noncopyable {
   void registerAs(const std::string &scheme);
 
   virtual File* open(const String& filename, const String& mode,
-                     int options, const Variant& context) = 0;
+                     int options, const Resource& context) = 0;
   virtual int access(const String& path, int mode) {
     return -1;
   }

--- a/hphp/runtime/base/type-resource.h
+++ b/hphp/runtime/base/type-resource.h
@@ -26,7 +26,7 @@
 namespace HPHP {
 ///////////////////////////////////////////////////////////////////////////////
 
-#define null_resource Resource::s_nullResource
+#define null_resource HPHP::Resource::s_nullResource
 
 /**
  * Object type wrapping around ObjectData to implement reference count.

--- a/hphp/runtime/base/user-file.cpp
+++ b/hphp/runtime/base/user-file.cpp
@@ -52,7 +52,7 @@ StaticString s_rmdir("rmdir");
 
 ///////////////////////////////////////////////////////////////////////////////
 
-UserFile::UserFile(Class *cls, const Variant& context /*= null */) : UserFSNode(cls) {
+UserFile::UserFile(Class *cls, const Resource& context /*= null */) : UserFSNode(cls) {
   m_StreamOpen  = lookupMethod(s_stream_open.get());
   m_StreamClose = lookupMethod(s_stream_close.get());
   m_StreamRead  = lookupMethod(s_stream_read.get());

--- a/hphp/runtime/base/user-file.h
+++ b/hphp/runtime/base/user-file.h
@@ -27,7 +27,7 @@ class UserFile : public File, public UserFSNode {
 public:
   DECLARE_RESOURCE_ALLOCATION(UserFile);
 
-  explicit UserFile(Class *cls, const Variant& context = uninit_null());
+  explicit UserFile(Class *cls, const Resource& context = null_resource);
   virtual ~UserFile();
 
   // overriding ResourceData

--- a/hphp/runtime/base/user-stream-wrapper.cpp
+++ b/hphp/runtime/base/user-stream-wrapper.cpp
@@ -32,7 +32,7 @@ UserStreamWrapper::UserStreamWrapper(const String& name,
 }
 
 File* UserStreamWrapper::open(const String& filename, const String& mode,
-                              int options, const Variant& context) {
+                              int options, const Resource& context) {
   auto file = NEWOBJ(UserFile)(m_cls, context);
   Resource wrapper(file);
   auto ret = file->openImpl(filename, mode, options);

--- a/hphp/runtime/base/user-stream-wrapper.h
+++ b/hphp/runtime/base/user-stream-wrapper.h
@@ -29,7 +29,7 @@ class UserStreamWrapper : public Stream::Wrapper {
  public:
   UserStreamWrapper(const String& name, const String& clsname, int flags);
   virtual File* open(const String& filename, const String& mode,
-                     int options, const Variant& context);
+                     int options, const Resource& context);
   virtual int access(const String& path, int mode);
   virtual int lstat(const String& path, struct stat* buf);
   virtual int stat(const String& path, struct stat* buf);

--- a/hphp/runtime/ext/ext_file.h
+++ b/hphp/runtime/ext/ext_file.h
@@ -35,7 +35,7 @@ extern const int64_t k_STREAM_URL_STAT_QUIET;
 
 Variant f_fopen(
   const String& filename, const String& mode, bool use_include_path = false,
-  const Variant& context = uninit_null());
+  const Resource& context = null_resource);
 Variant f_popen(const String& command, const String& mode);
 bool f_fclose(const Resource& handle);
 Variant f_pclose(const Resource& handle);
@@ -72,14 +72,14 @@ Variant f_fgetcsv(
 
 Variant f_file_get_contents(
   const String& filename, bool use_include_path = false,
-  const Variant& context = uninit_null(),
+  const Resource& context = null_resource,
   int64_t offset = -1, int64_t maxlen = -1);
 Variant f_file_put_contents(const String& filename, const Variant& data, int flags = 0,
-                            const Variant& context = uninit_null());
+                            const Resource& context = null_resource);
 Variant f_file(
-  const String& filename, int flags = 0, const Variant& context = uninit_null());
+  const String& filename, int flags = 0, const Resource& context = null_resource);
 Variant f_readfile(const String& filename, bool use_include_path = false,
-                   const Variant& context = uninit_null());
+                   const Resource& context = null_resource);
 bool f_move_uploaded_file(const String& filename, const String& destination);
 Variant f_parse_ini_file(const String& filename, bool process_sections = false,
                          int scanner_mode = k_INI_SCANNER_NORMAL);
@@ -98,12 +98,12 @@ bool f_chgrp(const String& filename, const Variant& group);
 bool f_lchgrp(const String& filename, const Variant& group);
 bool f_touch(const String& filename, int64_t mtime = 0, int64_t atime = 0);
 bool f_copy(
-  const String& source, const String& dest, const Variant& context = uninit_null());
+  const String& source, const String& dest, const Resource& context = null_resource);
 bool f_rename(
   const String& oldname, const String& newname,
-  const Variant& context = uninit_null());
+  const Resource& context = null_resource);
 int64_t f_umask(const Variant& mask = null_variant);
-bool f_unlink(const String& filename, const Variant& context = uninit_null());
+bool f_unlink(const String& filename, const Resource& context = null_resource);
 bool f_link(const String& target, const String& link);
 bool f_symlink(const String& target, const String& link);
 String f_basename(const String& path, const String& suffix = null_string);
@@ -151,18 +151,18 @@ Variant f_disk_total_space(const String& directory);
 
 bool f_mkdir(
   const String& pathname, int64_t mode = 0777, bool recursive = false,
-  const Variant& context = uninit_null());
-bool f_rmdir(const String& dirname, const Variant& context = uninit_null());
+  const Resource& context = null_resource);
+bool f_rmdir(const String& dirname, const Resource& context = null_resource);
 String f_dirname(const String& path);
 Variant f_getcwd();
 bool f_chdir(const String& directory);
 bool f_chroot(const String& directory);
 Variant f_dir(const String& directory);
-Variant f_opendir(const String& path, const Variant& context = uninit_null());
+Variant f_opendir(const String& path, const Resource& context = null_resource);
 Variant f_readdir(const Resource& dir_handle = null_resource);
 void f_rewinddir(const Resource& dir_handle = null_resource);
 Variant f_scandir(const String& directory, bool descending = false,
-                  const Variant& context = uninit_null());
+                  const Resource& context = null_resource);
 void f_closedir(const Resource& dir_handle = null_resource);
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/hphp/runtime/ext/fileinfo/ext_fileinfo.cpp
+++ b/hphp/runtime/ext/fileinfo/ext_fileinfo.cpp
@@ -167,7 +167,7 @@ static Variant php_finfo_get_type(
       }
 
       auto wrapper = Stream::getWrapperFromURI(buffer);
-      auto stream = wrapper->open(buffer, "rb", 0, HPHP::Variant());
+      auto stream = wrapper->open(buffer, "rb", 0, null_resource);
 
       if (!stream) {
         ret_val = null_string;

--- a/hphp/runtime/ext/fileinfo/libmagic/apprentice.cpp
+++ b/hphp/runtime/ext/fileinfo/libmagic/apprentice.cpp
@@ -945,7 +945,7 @@ load_1(struct magic_set *ms, int action, const char *fn, int *errs,
 
   ms->file = fn;
   auto wrapper = HPHP::Stream::getWrapperFromURI(fn);
-  stream = wrapper->open(fn, "rb", 0, HPHP::Variant());
+  stream = wrapper->open(fn, "rb", 0, null_resource);
 
   if (stream == NULL) {
     if (errno != ENOENT)
@@ -2625,7 +2625,7 @@ apprentice_map(struct magic_set *ms, const char *fn)
     goto error;
 
   wrapper = HPHP::Stream::getWrapperFromURI(fn);
-  stream = wrapper->open(fn, "rb", 0, HPHP::Variant());
+  stream = wrapper->open(fn, "rb", 0, null_resource);
 
   if (!stream) {
     goto error;
@@ -2759,7 +2759,7 @@ apprentice_compile(struct magic_set *ms, struct magic_map *map, const char *fn)
 
 /* wb+ == O_WRONLY|O_CREAT|O_TRUNC|O_BINARY */
   wrapper = HPHP::Stream::getWrapperFromURI(fn);
-  stream = wrapper->open(fn, "wb+", 0, HPHP::Variant());
+  stream = wrapper->open(fn, "wb+", 0, null_resource);
 
   if (!stream) {
     file_error(ms, errno, "cannot open `%s'", dbname);

--- a/hphp/runtime/ext/fileinfo/libmagic/magic.cpp
+++ b/hphp/runtime/ext/fileinfo/libmagic/magic.cpp
@@ -378,7 +378,7 @@ file_or_stream(struct magic_set *ms, const char *inname, php_stream *stream)
   if (!stream && inname) {
     no_in_stream = 1;
     auto wrapper = HPHP::Stream::getWrapperFromURI(inname);
-    stream = wrapper->open(inname, "rb", 0, HPHP::Variant());
+    stream = wrapper->open(inname, "rb", 0, null_resource);
   }
 
   if (!stream) {

--- a/hphp/runtime/ext/phar/ext_phar.cpp
+++ b/hphp/runtime/ext/phar/ext_phar.cpp
@@ -41,7 +41,7 @@ static const StaticString
 static class PharStreamWrapper : public Stream::Wrapper {
  public:
   virtual File* open(const String& filename, const String& mode,
-                     int options, const Variant& context) {
+                     int options, const Resource& context) {
     static const char cz[] = "phar://";
     if (strncmp(filename.data(), cz, sizeof(cz) - 1)) {
       return nullptr;

--- a/hphp/runtime/ext/soap/xml.cpp
+++ b/hphp/runtime/ext/soap/xml.cpp
@@ -80,7 +80,7 @@ xmlDocPtr soap_xmlParseFile(const char *filename) {
   Variant content = f_apc_fetch(cache_key);
   if (same(content, false)) {
     Variant stream = File::Open(filename, "rb", 0, f_stream_context_create(
-                make_map_array(s_http, make_map_array(s_timeout, 1000))));
+                make_map_array(s_http, make_map_array(s_timeout, 1000))).toResource());
     if (!same(stream, false)) {
       content = f_stream_get_contents(stream.toResource());
       if (!same(content, false)) {

--- a/hphp/runtime/ext/stream/ext_stream.cpp
+++ b/hphp/runtime/ext/stream/ext_stream.cpp
@@ -49,7 +49,7 @@ namespace HPHP {
 
 ///////////////////////////////////////////////////////////////////////////////
 
-static StreamContext* get_stream_context(const Variant& stream_or_context);
+static StreamContext* get_stream_context(const Resource& stream_or_context);
 
 ///////////////////////////////////////////////////////////////////////////////
 
@@ -89,7 +89,7 @@ bool f_stream_context_set_option1(StreamContext* context,
   return true;
 }
 
-bool f_stream_context_set_option(const Variant& stream_or_context,
+bool f_stream_context_set_option(const Resource& stream_or_context,
                                  const Variant& wrapper_or_options,
                                  const Variant& option /* = null_variant */,
                                  const Variant& value /* = null_variant */) {
@@ -545,16 +545,12 @@ bool f_stream_socket_shutdown(const Resource& stream, int how) {
   return f_socket_shutdown(stream, how);
 }
 
-static StreamContext* get_stream_context(const Variant& stream_or_context) {
-  if (!stream_or_context.isResource()) {
-    return nullptr;
-  }
-  const Resource& resource = stream_or_context.asCResRef();
-  StreamContext* context = resource.getTyped<StreamContext>(true, true);
+static StreamContext* get_stream_context(const Resource& stream_or_context) {
+  StreamContext* context = stream_or_context.getTyped<StreamContext>(true, true);
   if (context != nullptr) {
     return context;
   }
-  File *file = resource.getTyped<File>(true, true);
+  File *file = stream_or_context.getTyped<File>(true, true);
   if (file != nullptr) {
     Resource resource = file->getStreamContext();
     if (file->getStreamContext().isNull()) {

--- a/hphp/runtime/ext/zip/ext_zip.cpp
+++ b/hphp/runtime/ext/zip/ext_zip.cpp
@@ -84,7 +84,7 @@ void ZipStream::sweep() {
 class ZipStreamWrapper : public Stream::Wrapper {
  public:
   virtual File* open(const String& filename, const String& mode,
-                     int options, const Variant& context) {
+                     int options, const Resource& context) {
     std::string url(filename.c_str());
     auto pound = url.find('#');
     if (pound == std::string::npos) {

--- a/hphp/runtime/ext/zlib/ext_zlib.cpp
+++ b/hphp/runtime/ext/zlib/ext_zlib.cpp
@@ -46,7 +46,7 @@ namespace {
 static class ZlibStreamWrapper : public Stream::Wrapper {
  public:
   virtual File* open(const String& filename, const String& mode,
-                     int options, const Variant& context) {
+                     int options, const Resource& context) {
     String fname;
     static const char cz[] = "compress.zlib://";
 

--- a/hphp/system/idl/file.idl.json
+++ b/hphp/system/idl/file.idl.json
@@ -48,8 +48,8 @@
                 },
                 {
                     "name": "context",
-                    "type": "Variant",
-                    "value": "null"
+                    "type": "Resource",
+                    "value": "null_resource"
                 }
             ]
         },
@@ -600,8 +600,8 @@
                 },
                 {
                     "name": "context",
-                    "type": "Variant",
-                    "value": "null",
+                    "type": "Resource",
+                    "value": "null_resource",
                     "desc": "A valid context resource created with stream_context_create(). If you don't need to use a custom context, you can skip this parameter by NULL."
                 },
                 {
@@ -646,8 +646,8 @@
                 },
                 {
                     "name": "context",
-                    "type": "Variant",
-                    "value": "null",
+                    "type": "Resource",
+                    "value": "null_resource",
                     "desc": "A valid context resource created with stream_context_create()."
                 }
             ]
@@ -675,8 +675,8 @@
                 },
                 {
                     "name": "context",
-                    "type": "Variant",
-                    "value": "null",
+                    "type": "Resource",
+                    "value": "null_resource",
                     "desc": "Do not add newline at the end of each array element"
                 }
             ]
@@ -704,8 +704,8 @@
                 },
                 {
                     "name": "context",
-                    "type": "Variant",
-                    "value": "null",
+                    "type": "Resource",
+                    "value": "null_resource",
                     "desc": "A context stream resource."
                 }
             ]
@@ -996,8 +996,8 @@
                 },
                 {
                     "name": "context",
-                    "type": "Variant",
-                    "value": "null",
+                    "type": "Resource",
+                    "value": "null_resource",
                     "desc": "A valid context resource created with stream_context_create()."
                 }
             ]
@@ -1024,8 +1024,8 @@
                 },
                 {
                     "name": "context",
-                    "type": "Variant",
-                    "value": "null",
+                    "type": "Resource",
+                    "value": "null_resource",
                     "desc": "Context support was added with PHP 5.0.0. For a description of contexts, refer to Stream Functions."
                 }
             ]
@@ -1065,8 +1065,8 @@
                 },
                 {
                     "name": "context",
-                    "type": "Variant",
-                    "value": "null",
+                    "type": "Resource",
+                    "value": "null_resource",
                     "desc": "Context support was added with PHP 5.0.0. For a description of contexts, refer to Stream Functions."
                 }
             ]
@@ -1735,8 +1735,8 @@
                 },
                 {
                     "name": "context",
-                    "type": "Variant",
-                    "value": "null",
+                    "type": "Resource",
+                    "value": "null_resource",
                     "desc": "Context support was added with PHP 5.0.0. For a description of contexts, refer to Stream Functions."
                 }
             ]
@@ -1758,8 +1758,8 @@
                 },
                 {
                     "name": "context",
-                    "type": "Variant",
-                    "value": "null",
+                    "type": "Resource",
+                    "value": "null_resource",
                     "desc": "Context support was added with PHP 5.0.0. For a description of contexts, refer to Stream Functions."
                 }
             ]
@@ -1859,8 +1859,8 @@
                 },
                 {
                     "name": "context",
-                    "type": "Variant",
-                    "value": "null",
+                    "type": "Resource",
+                    "value": "null_resource",
                     "desc": "For a description of the context parameter, refer to the streams section of the manual."
                 }
             ]
@@ -1922,8 +1922,8 @@
                 },
                 {
                     "name": "context",
-                    "type": "Variant",
-                    "value": "null",
+                    "type": "Resource",
+                    "value": "null_resource",
                     "desc": "For a description of the context parameter, refer to the streams section of the manual."
                 }
             ]

--- a/hphp/system/idl/stream.idl.json
+++ b/hphp/system/idl/stream.idl.json
@@ -87,9 +87,9 @@
             "args": [
                 {
                     "name": "stream_or_context",
-                    "type": "Variant",
+                    "type": "Resource",
                     "desc": "The stream or context resource to apply the options too.",
-                    "value": "null_variant"
+                    "value": "null_resource"
                 },
                 {
                     "name": "wrapper_or_options",


### PR DESCRIPTION
This removes some converting back and forth and further documents and centralizes the type-checking for these interfaces.
