### PR TITLE
Add in the Memcached extension class constants

### DIFF
--- a/hphp/runtime/ext/ext_memcached.cpp
+++ b/hphp/runtime/ext/ext_memcached.cpp
@@ -153,6 +153,10 @@ const int64_t q_Memcached$$RES_BAD_KEY_PROVIDED
           = MEMCACHED_BAD_KEY_PROVIDED;
 const int64_t q_Memcached$$RES_CONNECTION_SOCKET_CREATE_FAILURE
           = MEMCACHED_CONNECTION_SOCKET_CREATE_FAILURE;
+const int64_t q_Memcached$$RES_NOT_SUPPORTED
+          = MEMCACHED_NOT_SUPPORTED;
+const int64_t q_Memcached$$RES_INVALID_HOST_PROTOCOL
+          = MEMCACHED_INVALID_HOST_PROTOCOL;
 
 // Our result codes
 const int64_t q_Memcached$$RES_PAYLOAD_FAILURE = -1001;

--- a/hphp/runtime/ext/ext_memcached.h
+++ b/hphp/runtime/ext/ext_memcached.h
@@ -81,6 +81,8 @@ extern const int64_t q_Memcached$$RES_TIMEOUT;
 extern const int64_t q_Memcached$$RES_BAD_KEY_PROVIDED;
 extern const int64_t q_Memcached$$RES_CONNECTION_SOCKET_CREATE_FAILURE;
 extern const int64_t q_Memcached$$RES_PAYLOAD_FAILURE;
+extern const int64_t q_Memcached$$RES_NOT_SUPPORTED;
+extern const int64_t q_Memcached$$RES_INVALID_HOST_PROTOCOL;
 
 ///////////////////////////////////////////////////////////////////////////////
 // class Memcached

--- a/hphp/system/idl/memcached.idl.json
+++ b/hphp/system/idl/memcached.idl.json
@@ -1153,6 +1153,14 @@
                 {
                     "name": "RES_PAYLOAD_FAILURE",
                     "type": "Int64"
+                },
+                {
+                    "name": "RES_NOT_SUPPORTED",
+                    "type": "Int64"
+                },
+                {
+                    "name": "RES_INVALID_HOST_PROTOCOL",
+                    "type": "Int64"
                 }
             ]
         }


### PR DESCRIPTION
RES_INVALID_HOST_PROTOCOL and RES_NOT_SUPPORTED

These are added in Zends memcached extension, see [here](https://github.com/php-memcached-dev/php-memcached/blob/master/php_memcached.c#L4382) and [here](https://github.com/php-memcached-dev/php-memcached/blob/master/php_memcached.c#L4386). I verified that the constants are now accessible as normal Memcached constants; this struck me as a bit too trivial for a test case, let me know if one is needed.
