### PR TITLE
close the connection in admin server

### DIFF
--- a/hphp/runtime/server/admin-request-handler.cpp
+++ b/hphp/runtime/server/admin-request-handler.cpp
@@ -510,6 +510,7 @@ void AdminRequestHandler::handleRequest(Transport *transport) {
 
     transport->sendString("Unknown command: " + cmd + "\n", 404);
   } while (0);
+  transport->onSendEnd();
   GetAccessLog().log(transport, nullptr);
 }
 


### PR DESCRIPTION
Just like in http-request-handler, we must call onSendEnd after
sending our response in the admin-request-handler.
