### PR TITLE
enable fast_finish on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,3 +46,6 @@ script: time PHP_CURL_HTTP_REMOTE_SERVER="http://localhost:8444" hphp/hhvm/hhvm 
 notifications:
   email: false
   irc: "chat.freenode.net#hhvm"
+
+matrix:
+  fast_finish: true


### PR DESCRIPTION
hvvm requires a lot of travis resources to run the CI builds. travis supports a fast_finish switch which cancels all jobs related to a built when the first job errors.

see http://blog.travis-ci.com/2013-11-27-fast-finishing-builds/
