### PR TITLE
MysqlResults that have been mysql_free_result()'d should not be valid

### DIFF
--- a/hphp/runtime/ext/mysql/mysql_common.h
+++ b/hphp/runtime/ext/mysql/mysql_common.h
@@ -207,6 +207,8 @@ public:
     }
   }
 
+  virtual bool isInvalid() const { return m_res == nullptr; }
+
   MYSQL_RES *get() {
     return m_res;
   }

--- a/hphp/test/ext/test_ext_mysql.cpp
+++ b/hphp/test/ext/test_ext_mysql.cpp
@@ -458,7 +458,9 @@ bool TestExtMysql::test_mysql_free_result() {
   VS(f_mysql_query("insert into test (name) values ('test'),('test2')"), true);
 
   Variant res = f_mysql_query("select * from test");
+  VS(f_is_resource("result is a resource"), true);
   f_mysql_free_result(res);
+  VS(f_is_resource("result is not a resource after being freed"), false);
   return Count(true);
 }
 


### PR DESCRIPTION
In particular now

``` php
mysql_free_result($result);
assert(is_resource($result) === false);
```

This is tested for in a still-failing-for-other-reasons Zend test.
