### PR TITLE
Attempting to access a property on a non-object now throws a

### DIFF
--- a/hphp/runtime/base/type-object.cpp
+++ b/hphp/runtime/base/type-object.cpp
@@ -107,7 +107,7 @@ bool Object::more(CObjRef v2) const {
 }
 
 static Variant warn_non_object() {
-  raise_warning("Cannot access property on non-object");
+  raise_notice("Cannot access property on non-object");
   return uninit_null();
 }
 

--- a/hphp/runtime/vm/jit/translator-runtime.cpp
+++ b/hphp/runtime/vm/jit/translator-runtime.cpp
@@ -245,7 +245,7 @@ StringData* convCellToStrHelper(TypedValue tv) {
 }
 
 void raisePropertyOnNonObject() {
-  raise_warning("Cannot access property on non-object");
+  raise_notice("Cannot access property on non-object");
 }
 
 void raiseUndefProp(ObjectData* base, const StringData* name) {

--- a/hphp/runtime/vm/member-operations.h
+++ b/hphp/runtime/vm/member-operations.h
@@ -1664,7 +1664,7 @@ inline DataType propPreNull(TypedValue& tvScratch, TypedValue*& result) {
   tvWriteNull(&tvScratch);
   result = &tvScratch;
   if (warn) {
-    raise_warning("Cannot access property on non-object");
+    raise_notice("Cannot access property on non-object");
   }
   return KindOfNull;
 }
@@ -1801,7 +1801,7 @@ inline bool IssetEmptyProp(Class* ctx, TypedValue* base, TypedValue* key) {
 
 template <bool setResult>
 inline void SetPropNull(Cell* val) {
-  raise_warning("Cannot access property on non-object");
+  raise_notice("Cannot access property on non-object");
   if (setResult) {
     tvRefcountedDecRefCell(val);
     tvWriteNull(val);

--- a/hphp/test/quick/SetM-str-promotion.php.expectf
+++ b/hphp/test/quick/SetM-str-promotion.php.expectf
@@ -18,7 +18,7 @@ object(stdClass)#1 (1) {
   ["prop"]=>
   string(1) "A"
 }
-HipHop Warning: Cannot access property on non-object in %s on line 17
+HipHop Notice: Cannot access property on non-object in %s on line 17
 string(1) " "
-HipHop Warning: Cannot access property on non-object in %s on line 17
+HipHop Notice: Cannot access property on non-object in %s on line 17
 string(1) " "

--- a/hphp/test/quick/asm_assert_optobj.hhas.expectf
+++ b/hphp/test/quick/asm_assert_optobj.hhas.expectf
@@ -1,2 +1,2 @@
 hey
-HipHop Warning: Cannot access property on non-object in %s on line -1
+HipHop Notice: Cannot access property on non-object in %s on line -1

--- a/hphp/test/quick/multidim_props.php.expectf
+++ b/hphp/test/quick/multidim_props.php.expectf
@@ -12,16 +12,16 @@ object(A)#1 (2) {
 }
 NULL
 HipHop Notice: Undefined property: A::$x in %s on line 14
-HipHop Warning: Cannot access property on non-object in %s on line 14
-HipHop Warning: Cannot access property on non-object in %s on line 14
-HipHop Warning: Cannot access property on non-object in %s on line 14
-HipHop Warning: Cannot access property on non-object in %s on line 14
+HipHop Notice: Cannot access property on non-object in %s on line 14
+HipHop Notice: Cannot access property on non-object in %s on line 14
+HipHop Notice: Cannot access property on non-object in %s on line 14
+HipHop Notice: Cannot access property on non-object in %s on line 14
 NULL
 HipHop Notice: Undefined property: A::$x in %s on line 16
-HipHop Warning: Cannot access property on non-object in %s on line 16
-HipHop Warning: Cannot access property on non-object in %s on line 16
-HipHop Warning: Cannot access property on non-object in %s on line 16
-HipHop Warning: Cannot access property on non-object in %s on line 16
+HipHop Notice: Cannot access property on non-object in %s on line 16
+HipHop Notice: Cannot access property on non-object in %s on line 16
+HipHop Notice: Cannot access property on non-object in %s on line 16
+HipHop Notice: Cannot access property on non-object in %s on line 16
 NULL
 NULL
 object(A)#1 (2) {
@@ -38,15 +38,15 @@ object(A)#1 (2) {
 }
 NULL
 HipHop Notice: Undefined property: A::$x in %s on line 14
-HipHop Warning: Cannot access property on non-object in %s on line 14
-HipHop Warning: Cannot access property on non-object in %s on line 14
-HipHop Warning: Cannot access property on non-object in %s on line 14
-HipHop Warning: Cannot access property on non-object in %s on line 14
+HipHop Notice: Cannot access property on non-object in %s on line 14
+HipHop Notice: Cannot access property on non-object in %s on line 14
+HipHop Notice: Cannot access property on non-object in %s on line 14
+HipHop Notice: Cannot access property on non-object in %s on line 14
 NULL
 HipHop Notice: Undefined property: A::$x in %s on line 16
-HipHop Warning: Cannot access property on non-object in %s on line 16
-HipHop Warning: Cannot access property on non-object in %s on line 16
-HipHop Warning: Cannot access property on non-object in %s on line 16
-HipHop Warning: Cannot access property on non-object in %s on line 16
+HipHop Notice: Cannot access property on non-object in %s on line 16
+HipHop Notice: Cannot access property on non-object in %s on line 16
+HipHop Notice: Cannot access property on non-object in %s on line 16
+HipHop Notice: Cannot access property on non-object in %s on line 16
 NULL
 NULL

--- a/hphp/test/quick/prop_order_parens.php.expectf
+++ b/hphp/test/quick/prop_order_parens.php.expectf
@@ -12,6 +12,6 @@ int(500)
 int(550)
 HipHop Notice: Array to string conversion in %s on line 50
 HipHop Notice: Undefined property: C::$Array in %s on line 50
-HipHop Warning: Cannot access property on non-object in %s on line 50
+HipHop Notice: Cannot access property on non-object in %s on line 50
 NULL
 int(650)

--- a/hphp/test/slow/eval_order/1523.php.expectf
+++ b/hphp/test/slow/eval_order/1523.php.expectf
@@ -16,7 +16,7 @@ string(2) "01"
 string(8) "testxfoo"
 HipHop Warning: Cannot use a scalar value as an array in %s/test/slow/eval_order/1523.php on line 60
 NULL
-HipHop Warning: Cannot access property on non-object in %s/test/slow/eval_order/1523.php on line 64
+HipHop Notice: Cannot access property on non-object in %s/test/slow/eval_order/1523.php on line 64
 NULL
 string(3) "foo"
 object(stdClass)#2 (1) {

--- a/hphp/test/slow/hhbbc/array_019.php.expectf
+++ b/hphp/test/slow/hhbbc/array_019.php.expectf
@@ -1,5 +1,5 @@
-HipHop Warning: Cannot access property on non-object in %s/slow/hhbbc/array_019.php on line 8
-HipHop Warning: Cannot access property on non-object in %s/slow/hhbbc/array_019.php on line 9
+HipHop Notice: Cannot access property on non-object in %s/slow/hhbbc/array_019.php on line 8
+HipHop Notice: Cannot access property on non-object in %s/slow/hhbbc/array_019.php on line 9
 NULL
 array(1) {
   ["x"]=>

--- a/hphp/test/slow/hhbbc/static_props_010.php.expectf
+++ b/hphp/test/slow/hhbbc/static_props_010.php.expectf
@@ -1,2 +1,2 @@
 bool(true)
-HipHop Warning: Cannot access property on non-object in %s/test/slow/hhbbc/static_props_010.php on line 11
+HipHop Notice: Cannot access property on non-object in %s/test/slow/hhbbc/static_props_010.php on line 11

--- a/hphp/test/slow/invalid_argument/1383.php.expect
+++ b/hphp/test/slow/invalid_argument/1383.php.expect
@@ -1,6 +1,6 @@
 int(4096)
 string(74) "Argument 1 passed to x::__construct() must be an instance of y, null given"
-int(2)
+int(8)
 string(36) "Cannot access property on non-object"
 NULL
 object(x)#1 (0) {

--- a/hphp/test/slow/object_property/701.php.expectf
+++ b/hphp/test/slow/object_property/701.php.expectf
@@ -1,9 +1,9 @@
-HipHop Warning: Cannot access property on non-object in %s/test/slow/object_property/701.php on line 4
+HipHop Notice: Cannot access property on non-object in %s/test/slow/object_property/701.php on line 4
 NULL
-HipHop Warning: Cannot access property on non-object in %s/test/slow/object_property/701.php on line 4
+HipHop Notice: Cannot access property on non-object in %s/test/slow/object_property/701.php on line 4
 NULL
-HipHop Warning: Cannot access property on non-object in %s/test/slow/object_property/701.php on line 4
+HipHop Notice: Cannot access property on non-object in %s/test/slow/object_property/701.php on line 4
 NULL
-HipHop Warning: Cannot access property on non-object in %s/test/slow/object_property/701.php on line 4
+HipHop Notice: Cannot access property on non-object in %s/test/slow/object_property/701.php on line 4
 NULL
 HipHop Fatal error: Cannot access empty property in %s/test/slow/object_property/701.php on line 4

--- a/hphp/test/slow/object_property/703.php.expectf
+++ b/hphp/test/slow/object_property/703.php.expectf
@@ -1,5 +1,5 @@
-HipHop Warning: Cannot access property on non-object in %s/test/slow/object_property/703.php on line 4
+HipHop Notice: Cannot access property on non-object in %s/test/slow/object_property/703.php on line 4
 NULL
-HipHop Warning: Cannot access property on non-object in %s/test/slow/object_property/703.php on line 4
+HipHop Notice: Cannot access property on non-object in %s/test/slow/object_property/703.php on line 4
 NULL
 HipHop Fatal error: Cannot access empty property in %s/test/slow/object_property/703.php on line 4

--- a/hphp/test/slow/reference/1097.php.expectf
+++ b/hphp/test/slow/reference/1097.php.expectf
@@ -1,4 +1,4 @@
-HipHop Warning: Cannot access property on non-object in %s/test/slow/reference/1097.php on line 4
+HipHop Notice: Cannot access property on non-object in %s/test/slow/reference/1097.php on line 4
 NULL
 HipHop Warning: Creating default object from empty value in %s/test/slow/reference/1097.php on line 5
 array(1) {


### PR DESCRIPTION
notice instead of a warning.

This fixes issue #1905
