### PR TITLE
Switch PHPUnit to 4.0.x branch.

### DIFF
--- a/hphp/test/frameworks/composer.json
+++ b/hphp/test/frameworks/composer.json
@@ -1,7 +1,7 @@
 {
     "minimum-stability": "dev",
     "require-dev": {
-        "phpunit/phpunit": "3.8.x-dev#fd67d0929d3c71bf348cfe3b6950c4f0aeecd077",
+        "phpunit/phpunit": "4.0.x-dev#fd67d0929d3c71bf348cfe3b6950c4f0aeecd077",
         "phpunit/php-invoker": "1.1.3",
         "phpunit/dbunit": "1.2.3",
         "phpunit/phpunit-selenium": "1.3.2",


### PR DESCRIPTION
3.8.x-dev is no longer available from the composer repository. Since this commit only switches branch but retain the same git commit id, it should not affected any testing result.
