### PR TITLE
 fix mysqli_real_connect flag default value is 0!

### DIFF
--- a/hphp/runtime/ext/mysql/ext_mysqli.php
+++ b/hphp/runtime/ext/mysql/ext_mysqli.php
@@ -2149,7 +2149,7 @@ function mysqli_real_connect(mysqli $link,
                              ?string $dbname = null,
                              ?int $port = null,
                              ?string $socket = null,
-                             ?int $flags = null): bool {
+                             ?int $flags = 0): bool {
   return $link->real_connect($host, $username, $passwd, $dbname, $port, $socket,
                              $flags);
 }


### PR DESCRIPTION
 mysqli_real_connect flag default value is 0 don't null,this default value is wrong,throw fatal:

HipHop Fatal error: Argument 7 passed to mysqli::real_connect() must be an instance of int, null given

fix this flag value is 0,and run right.
