### PR TITLE
Fix parsing of Content-Type and Content-Length in FastCGI POSTs

### DIFF
--- a/hphp/runtime/server/fastcgi/fastcgi-transport.cpp
+++ b/hphp/runtime/server/fastcgi/fastcgi-transport.cpp
@@ -191,11 +191,24 @@ std::string FastCGITransport::mangleHeader(const std::string& name) {
   return "HTTP_" + ret;
 }
 
+static const std::string
+  s_contentLength("CONTENT_LENGTH"),
+  s_contentType("CONTENT_TYPE"),
+  s_Content_Length("Content-Length"),
+  s_Content_Type("Content-Type");
+
 /**
  * Passed an HTTP header like "Cookie" or "Cache-Control"
  **/
 std::string FastCGITransport::getHeader(const char *name) {
-  return getRawHeader(mangleHeader(name));
+  auto *header = getRawHeaderPtr(mangleHeader(name));
+  if (!header && strcasecmp(name, s_Content_Length.data()) == 0) {
+    return getRawHeader(s_contentLength); // No HTTP_ prefix for CONTENT_LENGTH
+  }
+  if (!header && strcasecmp(name, s_Content_Type.data()) == 0) {
+    return getRawHeader(s_contentType); // No HTTP_ prefix for CONTENT_TYPE
+  }
+  return (header == nullptr) ? std::string{""} : *header;
 }
 
 /**
@@ -254,7 +267,7 @@ void FastCGITransport::removeHeaderImpl(const char* name) {
   m_responseHeaders.erase(name);
 }
 
-const std::string
+static const std::string
   s_status("Status: "),
   s_colon(": "),
   s_newline("\r\n");
@@ -338,7 +351,7 @@ void FastCGITransport::onHeader(std::unique_ptr<folly::IOBuf> key_chain,
   m_requestHeaders.emplace(key, value);
 }
 
-const std::string
+static const std::string
   s_requestURI("REQUEST_URI"),
   s_remoteHost("REMOTE_HOST"),
   s_remoteAddr("REMOTE_ADDR"),
@@ -349,7 +362,6 @@ const std::string
   s_documentRoot("DOCUMENT_ROOT"),
   s_remotePort("REMOTE_PORT"),
   s_serverPort("SERVER_PORT"),
-  s_contentLength("CONTENT_LENGTH"),
   s_pathTranslated("PATH_TRANSLATED"),
   s_scriptName("SCRIPT_NAME"),
   s_scriptFilename("SCRIPT_FILENAME"),


### PR DESCRIPTION
FastCGI PARAMS (and CGI environment variables in general) include all
headers prefixed with HTTP_ except for CONTENT_TYPE and
CONTENT_LENGTH.  This handles these in FastCGITransport::getHeader()
so that other users of getHeader(), like the POST code, get the
correct values.
