### PR TITLE
fix DOMDocument simplexml import

### DIFF
--- a/hphp/runtime/ext/ext_domdocument.cpp
+++ b/hphp/runtime/ext/ext_domdocument.cpp
@@ -61,6 +61,7 @@ IMPLEMENT_DEFAULT_EXTENSION_VERSION(dom, 20031129);
 // defined in ext_simplexml.cpp
 extern bool libxml_use_internal_error();
 extern void libxml_add_error(const std::string &msg);
+extern xmlNodePtr simplexml_export_node(c_SimpleXMLElement* sxe);
 
 static void php_libxml_internal_error_handler(int error_type, void *ctx,
                                               const char *fmt,
@@ -5821,7 +5822,7 @@ Variant f_dom_xpath_register_php_functions(const Variant& obj,
 Variant f_dom_import_simplexml(const Object& node) {
 
   c_SimpleXMLElement *elem = node.getTyped<c_SimpleXMLElement>();
-  xmlNodePtr nodep = elem->node;
+  xmlNodePtr nodep = simplexml_export_node(elem);
 
   if (nodep && (nodep->type == XML_ELEMENT_NODE ||
                 nodep->type == XML_ATTRIBUTE_NODE)) {

--- a/hphp/runtime/ext/ext_simplexml.cpp
+++ b/hphp/runtime/ext/ext_simplexml.cpp
@@ -289,6 +289,10 @@ static xmlNodePtr php_sxe_get_first_node(c_SimpleXMLElement* sxe,
   }
 }
 
+xmlNodePtr simplexml_export_node(c_SimpleXMLElement* sxe) {
+  return php_sxe_get_first_node(sxe, sxe->node);
+}
+
 static Variant cast_object(char* contents, int type) {
   String str = String((char*)contents);
   Variant obj;

--- a/hphp/test/slow/dom_document/import_simlexml.php
+++ b/hphp/test/slow/dom_document/import_simlexml.php
@@ -1,0 +1,18 @@
+<?php
+
+$xml = simplexml_load_string(<<<XML
+<top>
+    <first>
+        <second>second</second>
+    </first>
+</top>
+XML
+);
+
+$node = dom_import_simplexml($xml->first[0]->second);
+var_dump($node->tagName);
+var_dump($node->parentNode->tagName);
+
+$node = dom_import_simplexml($xml->first[0]->second[0]);
+var_dump($node->tagName);
+var_dump($node->parentNode->tagName);

--- a/hphp/test/slow/dom_document/import_simlexml.php.expect
+++ b/hphp/test/slow/dom_document/import_simlexml.php.expect
@@ -1,0 +1,4 @@
+string(6) "second"
+string(5) "first"
+string(6) "second"
+string(5) "first"


### PR DESCRIPTION
Due to the SimpleXML rewrite, the internal node property has changed.

php-src instead grabs the node from the object, and on top of that
calls an export function that in some circumstances will return the
node's children instead:
https://github.com/php/php-src/blob/PHP-5.6/ext/simplexml/simplexml.c#L2434

Fixes #2029
