### PR TITLE
Add ezpublish-kernel to frameworks.yaml

### DIFF
--- a/hphp/test/frameworks/frameworks.yaml
+++ b/hphp/test/frameworks/frameworks.yaml
@@ -71,6 +71,13 @@
     test_root: drupal/core
     clowns:
       - drupal/core/modules/views/tests/Drupal/views/Tests/ViewsDataHelperTest.php
+  ezpublish-kernel:
+    url: https://github.com/ezsystems/ezpublish-kernel.git
+    # awaiting hhvm 2.5.0 on travis before merging + currently exposes issues in hhvm
+    branch: hhvmfailtesting
+    commit: 07f6f6e58d41cc985e786b94c72c1c1eeb3b6f0a
+    install_root: ezpublish-kernel
+    test_root: ezpublish-kernel
   facebookphpsdk:
     url: https://github.com/facebook/facebook-php-sdk.git
     branch: v3.2.3


### PR DESCRIPTION
This is related to effort in https://github.com/ezsystems/ezpublish-kernel/pull/735 to add HHVM support in eZ Publish, one of the most advanced CMS systems in PHP.

Currently exposes several possible issues in HHVM in handling of DateTime, ArrayObject, XML namespace and others which has not been identified yet.
# Failures

Failures most likely caused by HHVM behaving differently then Zend engine.
## Environment
### php on host (OS X):

> $ php -v
> PHP 5.4.24 (cli) (built: Jan 19 2014 21:32:15) 
> Copyright (c) 1997-2013 The PHP Group
> Zend Engine v2.4.0, Copyright (c) 1998-2013 Zend Technologies
>    with Xdebug v2.2.3, Copyright (c) 2002-2013, by Derick Rethans

Tests:

> Time: 3.71 minutes, Memory: 252.75Mb
> 
> OK, but incomplete or skipped tests!
> Tests: 7197, Assertions: 16885, Incomplete: 3, Skipped: 197.

(yes our code also passes on [PHP 5.5 on travis](https://travis-ci.org/ezsystems/ezpublish-kernel/builds/20518270))
### hhvm on guest vm (Ubuntu 13.10 x64):

> vagrant@vagrant-ubuntu-saucy-64:~/ezpublish-kernel$ hhvm --version
> HipHop VM 2.5.0-dev+2014.03.11 (rel)
> Compiler: heads/master-0-g4165c07c5959ee2b92852b9868b4dd57872b6dde
> Repo schema: 6c75fcca79c02c97a757322bdd870b8a437bae7f

Tests:

> Time: 1.69 minutes, Memory: 859.22Mb
> 
> FAILURES!
> Tests: 7161, Assertions: 16747, Failures: 137, Errors: 6, Incomplete: 3, Skipped: 233.
## Examples
### Datetime

( This seems to have been fixed since this PR was created )

```
4) eZ\Publish\Core\FieldType\Tests\PageTest::testToHash with data set #1 (, array('2ZonesLayout1', array(array('6c7f907b831a819ed8562e3ddce5b264', 'left', array(array('1e1e355c8da3c92e80354f243c6dd37b', 'Campaign', 'Campaign', 'default', '', '6c7f907b831a819ed8562e3ddce5b264', array(array(10, 20, 30, 'Thursday, 01-Jan-70 00:00:01 GMT+0000', 'Thursday, 01-Jan-70 00:00:02 GMT+0000', 'Thursday, 01-Jan-70 00:00:03 GMT+0000', 'Thursday, 01-Jan-70 00:00:04 GMT+0000', '67dd4d9b898d89733e776c714039ae33', 'modify', '594491ab539125dc271807a83724e608', array('value'))), array('value2'))), array('value3'))), array('value4')))
toHash() method did not create expected result.
Failed asserting that two arrays are equal.
--- Expected
+++ Actual
@@ @@
                             'priority' => 30
-                            'publicationDate' => 'Thursday, 01-Jan-70 00:00:01 GMT+0000'
-                            'visibilityDate' => 'Thursday, 01-Jan-70 00:00:02 GMT+0000'
-                            'hiddenDate' => 'Thursday, 01-Jan-70 00:00:03 GMT+0000'
-                            'rotationUntilDate' => 'Thursday, 01-Jan-70 00:00:04 GMT+0000'
+                            'publicationDate' => 'Thursday, 01-Jan-70 00:00:01 CET'
+                            'visibilityDate' => 'Thursday, 01-Jan-70 00:00:02 CET'
+                            'hiddenDate' => 'Thursday, 01-Jan-70 00:00:03 CET'
+                            'rotationUntilDate' => 'Thursday, 01-Jan-70 00:00:04 CET'
                             'movedTo' => '67dd4d9b898d89733e776c714039ae33'
                             'action' => 'modify'
                             'blockId' => '594491ab539125dc271807a83724e608'
                             'attributes' => Array (...)
                         )
                     )
                     'attributes' => Array (...)
                 )
             )
             'attributes' => Array (...)
         )
     )
     'attributes' => Array (...)
 )
```

Code involved: [Link toHash()](https://github.com/ezsystems/ezpublish-kernel/blob/master/eZ/Publish/Core/FieldType/Tests/FieldTypeTest.php#L528), [link to data provider](https://github.com/ezsystems/ezpublish-kernel/blob/master/eZ/Publish/Core/FieldType/Tests/PageTest.php#L283)

```
10) eZ\Publish\Core\Persistence\Legacy\Tests\Content\Type\Gateway\DoctrineDatabaseTest::testLoadGroupData
Failed asserting that two arrays are equal.
--- Expected
+++ Actual
@@ @@
 Array (
     0 => Array (
-        'created' => '1031216941'
+        'created' => '1033922113'
         'creator_id' => '14'
         'id' => '2'
         'modified' => '1033922113'
         'modifier_id' => '14'
         'name' => 'Users'
     )
 )
```

Code involved: [Link test](https://github.com/ezsystems/ezpublish-kernel/blob/master/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Type/Gateway/DoctrineDatabaseTest.php#L292), [link fixture data](https://github.com/ezsystems/ezpublish-kernel/blob/master/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Type/Gateway/_fixtures/existing_groups.php)
### ArrayObject

```
5) eZ\Publish\SPI\Tests\FieldType\DateIntegrationTest::testLoadContentTypeField
eZ\Publish\API\Repository\Exceptions\PropertyNotFoundException: Property 'defaultType' not found on class 'eZ\Publish\Core\FieldType\FieldSettings'

/home/vagrant/ezpublish-kernel/eZ/Publish/Core/FieldType/FieldSettings.php:54
/home/vagrant/ezpublish-kernel/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/Date.php:96
/home/vagrant/ezpublish-kernel/eZ/Publish/Core/Persistence/Legacy/Content/Type/Mapper.php:362
/home/vagrant/ezpublish-kernel/eZ/Publish/Core/Persistence/Legacy/Content/Type/Mapper.php:209
/home/vagrant/ezpublish-kernel/eZ/Publish/Core/Persistence/Legacy/Content/Type/Mapper.php:120
/home/vagrant/ezpublish-kernel/eZ/Publish/Core/Persistence/Legacy/Content/Type/Handler.php:251
/home/vagrant/ezpublish-kernel/eZ/Publish/Core/Persistence/Legacy/Content/Type/Handler.php:196
/home/vagrant/ezpublish-kernel/eZ/Publish/Core/Persistence/Legacy/Content/Type/MemoryCachingHandler.php:155
/home/vagrant/ezpublish-kernel/eZ/Publish/SPI/Tests/FieldType/BaseIntegrationTest.php:317
```

Code involved: [Link to FieldSettings.php:54](https://github.com/ezsystems/ezpublish-kernel/blob/master/eZ/Publish/Core/FieldType/FieldSettings.php#L21), [Link to Date.php:96](https://github.com/ezsystems/ezpublish-kernel/blob/master/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/Date.php#L81)
### XML namespace

```
2) eZ\Publish\Core\FieldType\Tests\RichTextTest::testToPersistenceValue
eZ\Publish\Core\Base\Exceptions\NotFoundException: Could not find 'Validator' with identifier ''

/home/vagrant/ezpublish-kernel/eZ/Publish/Core/FieldType/RichText/ValidatorDispatcher.php:79
/home/vagrant/ezpublish-kernel/eZ/Publish/Core/FieldType/RichText/Type.php:168
/home/vagrant/ezpublish-kernel/eZ/Publish/Core/FieldType/FieldType.php:391
/home/vagrant/ezpublish-kernel/eZ/Publish/Core/FieldType/Tests/RichTextTest.php:216
```

Code involved: [Link to ValidatorDispatcher.php:79](https://github.com/ezsystems/ezpublish-kernel/blob/master/eZ/Publish/Core/FieldType/RichText/ValidatorDispatcher.php#L50), [link to test](https://github.com/ezsystems/ezpublish-kernel/blob/master/eZ/Publish/Core/FieldType/Tests/RichTextTest.php#L203)
