### PR TITLE
Allow passing NULL to a native call taking a Resource with NULL default

### DIFF
--- a/hphp/test/slow/ext_hhvm_null_resource.php
+++ b/hphp/test/slow/ext_hhvm_null_resource.php
@@ -1,0 +1,3 @@
+<?php
+ var_dump(opendir(__DIR__));
+ var_dump(closedir(NULL));

--- a/hphp/test/slow/ext_hhvm_null_resource.php.expectf
+++ b/hphp/test/slow/ext_hhvm_null_resource.php.expectf
@@ -1,0 +1,2 @@
+resource(%d) of type (Directory)
+NULL

--- a/hphp/tools/bootstrap/gen-ext-hhvm.cpp
+++ b/hphp/tools/bootstrap/gen-ext-hhvm.cpp
@@ -244,6 +244,9 @@ void emitTypechecks(const PhpFunc& func, std::ostream& out, const char* ind) {
       out << "IS_STRING_TYPE((args - " << k << ")->m_type)";
     } else {
       out << "(args - " << k << ")->m_type == KindOf" << kindOfString(kindof);
+      if (param.defValueIsNullResource()) {
+        out << " || (args - " << k << ")->m_type == KindOfNull";
+      }
     }
 
     if (isOptional) {
@@ -318,7 +321,11 @@ void emitCallExpression(const PhpFunc& func, const fbstring& prefix,
     isFirstParam = false;
 
     if (param.hasDefault()) {
-      out << "(count > " << k << ") ? ";
+      out << "(count > " << k << ")";
+      if (param.defValueIsNullResource()) {
+        out << " && (args-" << k << ")->m_type != KindOfNull";
+      }
+      out << " ? ";
     }
 
     if (param.isIndirectPass()) {

--- a/hphp/tools/bootstrap/idl.cpp
+++ b/hphp/tools/bootstrap/idl.cpp
@@ -564,6 +564,10 @@ PhpParam::PhpParam(const folly::dynamic& param,
   m_phpType = phpTypeFromDataType(m_kindOf);
 }
 
+bool PhpParam::defValueIsNullResource() const {
+  return kindOf() == KindOfResource && hasDefault() && getDefault() == "null_resource";
+}
+
 bool PhpParam::defValueNeedsVariable() const {
   DataType cppKindOf = kindOf();
 

--- a/hphp/tools/bootstrap/idl.h
+++ b/hphp/tools/bootstrap/idl.h
@@ -204,6 +204,7 @@ class PhpParam {
   bool isCheckedType() const {
     return !isRef() && (kindOf() != KindOfAny);
   }
+  bool defValueIsNullResource() const;
   bool defValueNeedsVariable() const;
 
   bool isIndirectPass() const { return isKindOfIndirect(kindOf()); }


### PR DESCRIPTION
The code generated by `gen-ext-hhvm` is wrong for `null_resource` defaults. In particular, when PHP code passes a PHP NULL to a C++ function argument with a `null_resource` default it will end up going though `tvCastToResourceInPlace()` which ends up converting the NULL to a DummyResource instead of `null_resource`. It does this because a `NULL` currently **cannot** be converted into a `null_resource`.

It in essence converts

``` c++
    (count > 3) ? &args[-3].m_data : (Value*)(&null_resource)
```

to

``` c++
    (count > 3) && (args-3)->m_type != KindOfNull ? &args[-3].m_data : (Value*)(&null_resource)
```

This doesn't work with the JIT yet.  I was hoping for feedback / pointers before proceeding.  CC: @fredemmott, @swtaarrs.
