### PR TITLE
docs for hhvm -a, --interactive

### DIFF
--- a/hphp/doc/command.compiled
+++ b/hphp/doc/command.compiled
@@ -15,7 +15,7 @@ daemon: starts an HTTP server and runs it as a daemon.
 replay: replays a previously recorded HTTP request file.
 translate: translates a hex-encoded stacktrace.
 
-= -a
+= -a, --interactive
 
 Starts hhvm Read-Eval-Print-Loop (REPL). Works just like an alias for `hhvm --mode debug`.
 


### PR DESCRIPTION
Just updating docs with  hhvm -a, --interactive information. These are the docs I read when searched for hhvm REPL for the first time and didn't find it. #1694

Cheers!
