### PR TITLE
HHVM itself does not depend on boost_regex.

### DIFF
--- a/CMake/HPHPFindLibs.cmake
+++ b/CMake/HPHPFindLibs.cmake
@@ -30,7 +30,7 @@ if (LIBDL_INCLUDE_DIRS)
 endif()
 
 # boost checks
-find_package(Boost 1.49.0 COMPONENTS system program_options filesystem regex REQUIRED)
+find_package(Boost 1.49.0 COMPONENTS system program_options filesystem REQUIRED)
 include_directories(${Boost_INCLUDE_DIRS})
 link_directories(${Boost_LIBRARY_DIRS})
 add_definitions("-DHAVE_BOOST1_49")


### PR DESCRIPTION
Only third-party/folly depends on libboost_regex, but HHVM has a
dependency that causes a bogus linkage in the final binary.

Sync with Debian patch 09_remove_boost_regex_hhvm.patch from 2.4.1-1.
