### PR TITLE
fix compiler warning

### DIFF
--- a/hphp/runtime/base/datetime.cpp
+++ b/hphp/runtime/base/datetime.cpp
@@ -637,7 +637,7 @@ String DateTime::rfcFormat(const String& format) const {
         } else {
           auto offset = m_time->z * -60;
           char abbr[7] = {0};
-          snprintf(abbr, 9, "%c%02d:%02d",
+          snprintf(abbr, sizeof(abbr), "%c%02d:%02d",
             ((offset < 0) ? '-' : '+'),
             abs(offset / 3600),
             abs((offset % 3600) / 60) );


### PR DESCRIPTION
Get rid of scary compiler warning, should not change any behavor.

```
/usr/include/bits/stdio2.h:65:44: warning: call to int __builtin___snprintf_chk(char*, long unsigned int, int, long unsigned int, const char*, ...) will always overflow destination buffer [enabled by default]
```
