### PR TITLE
Allow the Sandbox to work in FastCGI mode

### DIFF
--- a/hphp/runtime/server/fastcgi/fastcgi-transport.cpp
+++ b/hphp/runtime/server/fastcgi/fastcgi-transport.cpp
@@ -379,7 +379,10 @@ void FastCGITransport::onHeadersComplete() {
   m_httpVersion = getRawHeader(s_httpVersion);
   m_serverObject = getRawHeader(s_scriptName);
   m_pathTranslated = getRawHeader(s_pathTranslated);
-  m_documentRoot = getRawHeader(s_documentRoot) + "/";
+  m_documentRoot = getRawHeader(s_documentRoot);
+  if (!m_documentRoot.empty() && m_documentRoot[m_documentRoot.length() - 1] != '/') {
+    m_documentRoot += '/';
+  }
 
   m_serverPort = getIntHeader(s_serverPort);
   m_requestSize = getIntHeader(s_contentLength);


### PR DESCRIPTION
Passing through the FastCGI DOCUMENT_ROOT unmolested, in particular allowing it to be empty(), is what the Sandbox requires.
