### PR TITLE
Add JCacheStorageTest to the clown test list.

### DIFF
--- a/hphp/test/frameworks/frameworks.yaml
+++ b/hphp/test/frameworks/frameworks.yaml
@@ -133,6 +133,7 @@
       - joomla-cms/tests/unit/suites/libraries/legacy/categories/JCategoryNodeTest.php
       - joomla-cms/tests/unit/suites/libraries/joomla/twitter/JTwitterTest.php
       - joomla-cms/tests/unit/suites/libraries/joomla/document/opensearch/JDocumentOpensearchTest.php
+      - joomla-cms/tests/unit/suites/libraries/joomla/cache/storage/JCacheStorageMainTest.php
   klein:
     url: https://github.com/chriso/klein.php.git
     branch: v2.0.2


### PR DESCRIPTION
Memcache tests fail on both Zend and HHVM. (Both with/without memcache installed in the system)
