### PR TITLE
Stop setting global variables, it can conflict with other plugins

### DIFF
--- a/hphp/hack/editor-plugins/vim/plugin/hack-color.vim
+++ b/hphp/hack/editor-plugins/vim/plugin/hack-color.vim
@@ -34,8 +34,7 @@ import vim, os, sys
 sys.path.append(os.path.abspath(os.path.dirname(vim.eval('s:vim_script_filename'))))
 
 import hackcolor
-path = vim.eval('a:path')
-hackcolor.HackColorMode(path).main()
+hackcolor.HackColorMode(vim.eval('a:path')).main()
 endpython
 endfun
 

--- a/hphp/hack/editor-plugins/vim/plugin/hack-omni.vim
+++ b/hphp/hack/editor-plugins/vim/plugin/hack-omni.vim
@@ -25,9 +25,7 @@ sys.path.append(os.path.abspath(os.path.dirname(vim.eval('s:vim_script_filename'
 import hackomni
 
 # 2. delegate
-base = vim.eval('a:base')
-findstart = bool(int(vim.eval('a:findstart')))
-hackomni.HackOmniComplete(findstart, base).main()
+hackomni.HackOmniComplete(bool(int(vim.eval('a:findstart'))), vim.eval('a:base')).main()
 
 endpython
 endfun


### PR DESCRIPTION
Specifically is _does_ conflict with YouCompleteMe that imports it's own `base` module. Python support in vim is buggy, but this is an easy fix.
