### PR TITLE
Make valid_statement_class more permissive [Fixes #1874]

### DIFF
--- a/hphp/runtime/ext/ext_pdo.cpp
+++ b/hphp/runtime/ext/ext_pdo.cpp
@@ -616,7 +616,7 @@ static bool valid_statement_class(sp_PDOConnection dbh, const Variant& opt,
     ctor_args = Variant(Array());
     return true;
   }
-  if (!f_is_subclass_of(clsname, "PDOStatement")) {
+  if (!f_is_a(clsname, "PDOStatement", true)) {
     pdo_raise_impl_error
       (dbh, nullptr, "HY000",
        "user-supplied statement class must be derived from PDOStatement");


### PR DESCRIPTION
[Link](https://github.com/facebook/hhvm/issues/1874) to original issue. All existing tests pass.

CLA sent to @ptarjan at listed Github email address.

Validation process on Debian 7

``` sh
#Create an "hdrush" command that runs drush via hhvm
sudo apt-get install drush
sudo sed "1s/php/hhvm/" /usr/share/drush/drush.php > /usr/share/drush/hdrush.php
sudo ln -s /usr/share/drush/hdrush.php /usr/bin/hdrush
sudo chmod a+x /usr/bin/hdrush

#Install Drupal
wget http://ftp.drupal.org/files/projects/drupal-7.26.tar.gz
tar -xf drupal-7.26.tar.gz
cd drupal-7.26
sudo hdrush site-install --db-url=mysql://root@localhost/testdatabase #modify mysql connection info as needed

#Observe no hhvm error
drush php-eval "db_close();" #observe lack of error when using normal php interpreter
hdrush php-eval "db_close();" #observe lack of error when using hhvm
```

In particular:

``` sh
$ drush php-eval "db_close();" -v
Initialized Drupal 7.26 root directory at /home/jhenahan/drupal-7.26      [notice]
Initialized Drupal site default at sites/default                          [notice]
Command dispatch complete                                                [notice]
```

``` sh
$ hdrush php-eval "db_close();" -v
Initialized Drupal 7.26 root directory at /home/jhenahan/drupal-7.26      [notice]
Initialized Drupal site default at sites/default                          [notice]
Command dispatch complete                                                [notice]
```
