### PR TITLE
Makes session_id() return empty_string before session initialisation.

### DIFF
--- a/hphp/runtime/ext/session/ext_session.cpp
+++ b/hphp/runtime/ext/session/ext_session.cpp
@@ -1572,9 +1572,14 @@ String f_session_save_path(const String& newname /* = null_string */) {
 
 String f_session_id(const String& newid /* = null_string */) {
   String ret = PS(id);
+  if (ret.isNull()) {
+    ret = empty_string;
+  }
+
   if (!newid.isNull()) {
     PS(id) = newid;
   }
+  
   return ret;
 }
 

--- a/hphp/test/slow/ext_session/2152_session_id.php
+++ b/hphp/test/slow/ext_session/2152_session_id.php
@@ -1,0 +1,9 @@
+<?php
+// Non-initialised session_id behaviour.
+var_dump(session_id());
+
+// session_id initialisation
+var_dump(session_id("foo"));
+
+// Initialised session_id behaviour.
+var_dump(session_id());

--- a/hphp/test/slow/ext_session/2152_session_id.php.expectf
+++ b/hphp/test/slow/ext_session/2152_session_id.php.expectf
@@ -1,0 +1,3 @@
+string(0) ""
+string(0) ""
+string(3) "foo"


### PR DESCRIPTION
Closes #2152
