### PR TITLE
Parse the config file as .ini unless it is explicitly .hdf

### DIFF
--- a/hphp/doc/options.compiled
+++ b/hphp/doc/options.compiled
@@ -656,7 +656,7 @@ a web server, hence eliminating a lot of setups.
     SandboxMode = false
     Pattern = www.[user]-[sandbox].[machine].facebook.com
     Home = /home
-    ConfFile = ~/.hphp
+    ConfFile = ~/.hhvm.hdf
 
     ServerVariables {
       name = value

--- a/hphp/runtime/base/program-functions.cpp
+++ b/hphp/runtime/base/program-functions.cpp
@@ -59,10 +59,12 @@
 #include "hphp/runtime/base/stream-wrapper-registry.h"
 #include "hphp/runtime/vm/debug/debug.h"
 
+#include <boost/algorithm/string/predicate.hpp>
 #include <boost/program_options/options_description.hpp>
 #include <boost/program_options/positional_options.hpp>
 #include <boost/program_options/variables_map.hpp>
 #include <boost/program_options/parsers.hpp>
+
 #include <libgen.h>
 #include <oniguruma.h>
 #include <signal.h>
@@ -1202,11 +1204,15 @@ static int execute_program_impl(int argc, char** argv) {
 
   Hdf config;
   for (auto& c : po.config) {
-    config.append(c);
+    if (boost::ends_with(c, ".hdf")) {
+      config.append(c);
+    }
   }
   RuntimeOption::Load(config, &po.confStrings);
   for (auto& c : po.config) {
-    process_ini_settings(c);
+    if (!boost::ends_with(c, ".hdf")) {
+      process_ini_settings(c);
+    }
   }
 
   vector<string> badnodes;

--- a/hphp/util/hdf.cpp
+++ b/hphp/util/hdf.cpp
@@ -15,9 +15,6 @@
 */
 
 #include "hphp/util/hdf.h"
-
-#include <boost/algorithm/string/predicate.hpp>
-
 #include "hphp/util/lock.h"
 
 namespace HPHP {
@@ -131,9 +128,6 @@ void Hdf::open(const char *filename) {
 
 void Hdf::append(const char *filename) {
   assert(filename && *filename);
-  if (!boost::ends_with(filename, ".hdf")) {
-    return;
-  }
   CheckNeoError(hdf_read_file(getRaw(), (char*)filename));
 }
 


### PR DESCRIPTION
This has the side effect of fixing a silent failure (caused by d37399d) when loading a Sandbox HDF file without an extension.
