### PR TITLE
Ignore editor backup files in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,6 +73,7 @@ install_manifest.txt
 .*.swo
 *.vimrc
 .syntastic_cpp_config
+*~
 
 # tags files
 tags


### PR DESCRIPTION
To support the vim "backup" option.
