### PR TITLE
Fallback to config.hdf

### DIFF
--- a/hphp/runtime/base/program-functions.cpp
+++ b/hphp/runtime/base/program-functions.cpp
@@ -1149,7 +1149,7 @@ static int execute_program_impl(int argc, char** argv) {
         Logger::Verbose("Using default config file: %s", default_config_file);
         po.config.push_back(default_config_file);
       }
-      auto default_config_file = "/etc/hhvm/config.hdf";
+      default_config_file = "/etc/hhvm/config.hdf";
       if (access(default_config_file, R_OK) != -1) {
         Logger::Verbose("Using default config file: %s", default_config_file);
         po.config.push_back(default_config_file);


### PR DESCRIPTION
If we can't read /etc/hhvm/php.ini, then try reading /etc/hhvm/config.hdf
instead.
