### PR TITLE
Change File::Open() to return a Resource instead of a Variant

### DIFF
--- a/hphp/runtime/base/file.cpp
+++ b/hphp/runtime/base/file.cpp
@@ -139,9 +139,9 @@ bool File::IsPlainFilePath(const String& filename) {
   return filename.find("://") == String::npos;
 }
 
-Variant File::Open(const String& filename, const String& mode,
-                   int options /* = 0 */,
-                   const Variant& context /* = null */) {
+Resource File::Open(const String& filename, const String& mode,
+                    int options /* = 0 */,
+                    const Variant& context /* = null */) {
   Stream::Wrapper *wrapper = Stream::getWrapperFromURI(filename);
   Resource rcontext =
     context.isNull() ? g_context->getStreamContext() : context.toResource();
@@ -150,9 +150,8 @@ Variant File::Open(const String& filename, const String& mode,
     file->m_name = filename.data();
     file->m_mode = mode.data();
     file->m_streamContext = rcontext;
-    return Variant(file);
   }
-  return false;
+  return Resource(file);
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/hphp/runtime/base/file.h
+++ b/hphp/runtime/base/file.h
@@ -57,8 +57,8 @@ public:
   // Same as TranslatePath except checks the file cache on miss
   static String TranslatePathWithFileCache(const String& filename);
   static String TranslateCommand(const String& cmd);
-  static Variant Open(const String& filename, const String& mode,
-                      int options = 0, const Variant& context = uninit_null());
+  static Resource Open(const String& filename, const String& mode,
+                       int options = 0, const Variant& context = uninit_null());
 
   static bool IsVirtualDirectory(const String& filename);
   static bool IsPlainFilePath(const String& filename);

--- a/hphp/runtime/ext/ext_file.cpp
+++ b/hphp/runtime/ext/ext_file.cpp
@@ -205,9 +205,13 @@ Variant f_fopen(const String& filename, const String& mode,
     return false;
   }
 
-  return File::Open(filename, mode,
-                    use_include_path ? File::USE_INCLUDE_PATH : 0,
-                    context);
+  Resource resource = File::Open(filename, mode,
+                                 use_include_path ? File::USE_INCLUDE_PATH : 0,
+                                 context);
+  if (resource.isNull()) {
+    return false;
+  }
+  return resource;
 }
 
 Variant f_popen(const String& command, const String& mode) {
@@ -422,14 +426,14 @@ Variant f_file_get_contents(const String& filename,
 Variant f_file_put_contents(const String& filename, const Variant& data,
                             int flags /* = 0 */,
                             const Variant& context /* = null */) {
-  Variant fvar = File::Open(filename, (flags & PHP_FILE_APPEND) ? "ab" : "wb",
-                            flags, context);
-  if (!fvar.toBoolean()) {
+  Resource resource = File::Open(filename, (flags & PHP_FILE_APPEND) ? "ab" : "wb",
+                                 flags, context);
+  File *f = resource.getTyped<File>(true);
+  if (!f) {
     return false;
   }
-  File *f = fvar.asResRef().getTyped<File>();
 
-  if ((flags & LOCK_EX) && flock(f->fd(), LOCK_EX)) {
+  if ((flags & LOCK_EX) && !f->lock(LOCK_EX)) {
     return false;
   }
 

--- a/hphp/runtime/ext/ext_mailparse.cpp
+++ b/hphp/runtime/ext/ext_mailparse.cpp
@@ -141,9 +141,9 @@ bool f_mailparse_msg_free(const Resource& mimemail) {
 }
 
 Variant f_mailparse_msg_parse_file(const String& filename) {
-  Variant stream = File::Open(filename, "rb");
-  if (same(stream, false)) return false;
-  File *f = stream.toResource().getTyped<File>();
+  Resource resource = File::Open(filename, "rb");
+  File *f = resource.getTyped<File>(true);
+  if (!f) return false;
 
   MimePart *p = NEWOBJ(MimePart)();
   Resource ret(p);

--- a/hphp/runtime/ext/ext_pdo.cpp
+++ b/hphp/runtime/ext/ext_pdo.cpp
@@ -953,11 +953,11 @@ void c_PDO::t___construct(const String& dsn, const String& username /* = null_st
 
   if (!strncmp(data_source.data(), "uri:", 4)) {
     /* the specified URI holds connection details */
-    Variant stream = File::Open(data_source.substr(4), "rb");
-    if (same(stream, false)) {
+    Resource resource = File::Open(data_source.substr(4), "rb");
+    if (resource.isNull()) {
       throw_pdo_exception(uninit_null(), uninit_null(), "invalid data source URI");
     }
-    data_source = stream.toResource().getTyped<File>()->readLine(1024);
+    data_source = resource.getTyped<File>()->readLine(1024);
     colon = strchr(data_source.data(), ':');
     if (!colon) {
       throw_pdo_exception(uninit_null(), uninit_null(), "invalid data source name (via URI)");
@@ -3107,11 +3107,11 @@ bool c_PDOStatement::t_closecursor() {
 }
 
 Variant c_PDOStatement::t_debugdumpparams() {
-  Variant fobj = File::Open("php://output", "w");
-  if (same(fobj, false)) {
+  Resource resource = File::Open("php://output", "w");
+  File *f = resource.getTyped<File>(true);
+  if (!f) {
     return false;
   }
-  File *f = fobj.toResource().getTyped<File>();
 
   Array params;
   params.append(m_stmt->query_string.size());

--- a/hphp/runtime/ext/ext_xmlwriter.cpp
+++ b/hphp/runtime/ext/ext_xmlwriter.cpp
@@ -273,7 +273,7 @@ String f_xmlwriter_output_memory(const Object& xmlwriter, bool flush /* = true *
 // helpers
 
 static int write_file(void *context, const char *buffer, int len) {
-  return len > 0 ? ((c_XMLWriter*)context)->m_uri->writeImpl(buffer, len) : 0;
+  return len > 0 ? ((c_XMLWriter*)context)->m_uri.getTyped<File>()->writeImpl(buffer, len) : 0;
 }
 
 static int close_file(void *context) {
@@ -324,11 +324,10 @@ bool c_XMLWriter::t_openmemory() {
 }
 
 bool c_XMLWriter::t_openuri(const String& uri) {
-  Variant file = File::Open(uri, "wb");
-  if (same(file, false)) {
+  m_uri = File::Open(uri, "wb");
+  if (m_uri.isNull()) {
     return false;
   }
-  m_uri = file.toResource().getTyped<File>();
 
   xmlOutputBufferPtr uri_output = xmlOutputBufferCreateIO(
     write_file, close_file, this, nullptr);

--- a/hphp/runtime/ext/ext_xmlwriter.h
+++ b/hphp/runtime/ext/ext_xmlwriter.h
@@ -132,7 +132,7 @@ class c_XMLWriter : public ExtObjectData, public Sweepable {
 
 
  public:
-  SmartResource<File>  m_uri;
+  Resource  m_uri;
  private:
   xmlTextWriterPtr   m_ptr;
   xmlBufferPtr       m_output;

--- a/hphp/runtime/ext/fileinfo/ext_fileinfo.cpp
+++ b/hphp/runtime/ext/fileinfo/ext_fileinfo.cpp
@@ -166,24 +166,21 @@ static Variant php_finfo_get_type(
         goto clean;
       }
 
-      auto wrapper = Stream::getWrapperFromURI(buffer);
-      auto stream = wrapper->open(buffer, "rb", 0, HPHP::Variant());
-
+      auto resource = File::Open(buffer, "rb");
+      auto stream = resource.getTyped<File>(true);
       if (!stream) {
         ret_val = null_string;
         goto clean;
       }
 
       struct stat st;
-      if (wrapper->stat(buffer, &st) == 0) {
+      if (stream->stat(&st)) {
         if (st.st_mode & S_IFDIR) {
           ret_val = mime_directory;
         } else {
           ret_val = magic_stream(magic, stream);
         }
       }
-
-      stream->close();
       break;
     }
 

--- a/hphp/runtime/ext/mailparse/mime.cpp
+++ b/hphp/runtime/ext/mailparse/mime.cpp
@@ -911,11 +911,8 @@ Variant MimePart::extract(const Variant& filename, const Variant& callbackfunc, 
   if (filename.isResource()) {
     f = filename.toResource().getTyped<File>();
   } else if (isfile) {
-    Variant stream = File::Open(filename.toString(), "rb");
-    if (!same(stream, false)) {
-      file = stream.toResource();
-      f = file.getTyped<File>();
-    }
+    file = File::Open(filename.toString(), "rb");
+    f = file.getTyped<File>(true);
   } else {
     /* filename is the actual data */
     String data = filename.toString();

--- a/hphp/runtime/ext/soap/xml.cpp
+++ b/hphp/runtime/ext/soap/xml.cpp
@@ -79,10 +79,10 @@ xmlDocPtr soap_xmlParseFile(const char *filename) {
 
   Variant content = f_apc_fetch(cache_key);
   if (same(content, false)) {
-    Variant stream = File::Open(filename, "rb", 0, f_stream_context_create(
+    Resource resource = File::Open(filename, "rb", 0, f_stream_context_create(
                 make_map_array(s_http, make_map_array(s_timeout, 1000))));
-    if (!same(stream, false)) {
-      content = f_stream_get_contents(stream.toResource());
+    if (!resource.isNull()) {
+      content = f_stream_get_contents(resource);
       if (!same(content, false)) {
         f_apc_store(cache_key, content);
       }


### PR DESCRIPTION
This saves a conversion as the callers all really want a smart pointer to a File, and Resource is one step closer than Variant.
