### PR TITLE
Only use the first word when checking the expected type

### DIFF
--- a/hphp/tools/check_native_signatures.php
+++ b/hphp/tools/check_native_signatures.php
@@ -168,7 +168,7 @@ function match_arg_type(string $php, string $cpp): bool {
   if ($php[0] == '?') {
     $expected = 'const Variant&';
   } else {
-    switch (strtolower($php)) {
+    switch (strtolower(strtok($php, ' &'))) {
       case 'bool':
       case 'boolean':
         $expected = 'bool';


### PR DESCRIPTION
Allows handling of references.
