### PR TITLE
Fixed imagick ext build error

### DIFF
--- a/CMake/EXTFunctions.cmake
+++ b/CMake/EXTFunctions.cmake
@@ -5,8 +5,7 @@
 # will differ slightly.
 
 macro(HHVM_LINK_LIBRARIES EXTNAME)
-	list(REMOVE_AT ARGV 0)
-	foreach (lib ${ARGV})
+	foreach (lib ${ARGN})
 		list(APPEND HRE_LIBRARIES ${lib})
 	endforeach()
 endmacro()
@@ -17,8 +16,9 @@ function(HHVM_ADD_INCLUDES EXTNAME)
 endfunction()
 
 macro(HHVM_EXTENSION EXTNAME)
-	list(REMOVE_AT ARGV 0)
-	list(APPEND CXX_SOURCES "${HRE_CURRENT_EXT_PATH}/${ARGV}")
+	foreach (filename ${ARGN})
+		list(APPEND CXX_SOURCES "${HRE_CURRENT_EXT_PATH}/${filename}")
+	endforeach()
 endmacro()
 
 function(HHVM_SYSTEMLIB EXTNAME SOURCE_FILE)

--- a/CMake/HPHPIZEFunctions.cmake
+++ b/CMake/HPHPIZEFunctions.cmake
@@ -5,25 +5,21 @@
 # will differ slightly.
 
 function(HHVM_LINK_LIBRARIES EXTNAME)
-	list(REMOVE_AT ARGV 0)
-	target_link_libraries(${EXTNAME} ${ARGV})
+	target_link_libraries(${EXTNAME} ${ARGN})
 endfunction()
 
 function(HHVM_ADD_INCLUDES EXTNAME)
-	list(REMOVE_AT ARGV 0)
-	include_directories(${ARGV})
+	include_directories(${ARGN})
 endfunction()
 
 function(HHVM_EXTENSION EXTNAME)
-	list(REMOVE_AT ARGV 0)
-	add_library(${EXTNAME} SHARED ${ARGV})
+	add_library(${EXTNAME} SHARED ${ARGN})
 	set_target_properties(${EXTNAME} PROPERTIES PREFIX "")
 	set_target_properties(${EXTNAME} PROPERTIES SUFFIX ".so")
 endfunction()
 
 function(HHVM_SYSTEMLIB EXTNAME)
-	list(REMOVE_AT ARGV 0)
-	foreach (SLIB ${ARGV})
+	foreach (SLIB ${ARGN})
 		embed_systemlib_byname(${EXTNAME} ${SLIB})
 	endforeach()
 	embed_systemlibs(${EXTNAME} "${EXTNAME}.so")


### PR DESCRIPTION
This fix error when build:

```
CMake Error at CMake/EXTFunctions.cmake:20 (list):
  list sub-command REMOVE_AT requires list to be present.
Call Stack (most recent call first):
  hphp/runtime/ext/imagick/config.cmake:6 (HHVM_EXTENSION)
  hphp/runtime/ext/CMakeLists.txt:24 (include)


CMake Error at CMake/EXTFunctions.cmake:8 (list):
  list sub-command REMOVE_AT requires list to be present.
Call Stack (most recent call first):
  hphp/runtime/ext/imagick/config.cmake:12 (HHVM_LINK_LIBRARIES)
  hphp/runtime/ext/CMakeLists.txt:24 (include)
```

It also simplify cmake macro/functions using ARGN instead of ARGV
