### PR TITLE
fix segfault when cloning objects

### DIFF
--- a/hphp/runtime/base/object-data.cpp
+++ b/hphp/runtime/base/object-data.cpp
@@ -1759,16 +1759,32 @@ void ObjectData::cloneSet(ObjectData* clone) {
       auto props = static_cast<HphpArray*>(dynProps.get());
       TypedValue key;
       props->nvGetKey(&key, iter);
-      assert(tvIsString(&key));
-      StringData* strKey = key.m_data.pstr;
-      TypedValue* val = props->nvGet(strKey);
+    
+      TypedValue *val, *ret;
+      switch (key.m_type) {
+      case HPHP::KindOfString: {
+        StringData* str = key.m_data.pstr;
+        val = props->nvGet(str);
+        ret = reinterpret_cast<TypedValue*>(
+          &cloneProps.lvalAt(String(str), AccessFlags::Key)
+        );
+        decRefStr(str);
+        break;
+      }
+      case HPHP::KindOfInt64: {
+        int64_t num = key.m_data.num;
+        val = props->nvGet(num);
+        ret = reinterpret_cast<TypedValue*>(
+          &cloneProps.lvalAt(num, AccessFlags::Key)
+        );
+        break;
+      }
+      default:
+        always_assert(false);
+      }
 
-      auto const retval = reinterpret_cast<TypedValue*>(
-        &cloneProps.lvalAt(String(strKey), AccessFlags::Key)
-      );
-      tvDupFlattenVars(val, retval, cloneProps.get());
+      tvDupFlattenVars(val, ret, cloneProps.get());
       iter = dynProps.get()->iter_advance(iter);
-      decRefStr(strKey);
     }
   }
 }

--- a/hphp/test/slow/clone/numeric-dynprops.php
+++ b/hphp/test/slow/clone/numeric-dynprops.php
@@ -1,0 +1,5 @@
+<?php
+
+$a = (object)array(0 => '#');
+$b = clone $a;
+var_dump($b);

--- a/hphp/test/slow/clone/numeric-dynprops.php.expectf
+++ b/hphp/test/slow/clone/numeric-dynprops.php.expectf
@@ -1,0 +1,4 @@
+object(stdClass)#%d (1) {
+  [0]=>
+  string(1) "#"
+}


### PR DESCRIPTION
ObjectData::cloneSet makes the false assertion that an objects dynamic
properties can only have string-based keys.

When casting an array with numeric keys to an object and then cloning
this object will cause HHVM to segfault due to lack of KindOfInt64
support.

Closes #2200.
