### PR TITLE
Fix CMake files

### DIFF
--- a/CMake/EXTFunctions.cmake
+++ b/CMake/EXTFunctions.cmake
@@ -5,20 +5,19 @@
 # will differ slightly.
 
 macro(HHVM_LINK_LIBRARIES EXTNAME)
-	list(REMOVE_AT ARGV 0)
-	foreach (lib ${ARGV})
+	foreach (lib ${ARGN})
 		list(APPEND HRE_LIBRARIES ${lib})
 	endforeach()
 endmacro()
 
 function(HHVM_ADD_INCLUDES EXTNAME)
-	list(REMOVE_AT ARGV 0)
-	include_directories(${ARGV})
+    include_directories(${ARGN})
 endfunction()
 
 macro(HHVM_EXTENSION EXTNAME)
-	list(REMOVE_AT ARGV 0)
-	list(APPEND CXX_SOURCES "${HRE_CURRENT_EXT_PATH}/${ARGV}")
+	foreach (src ${ARGN})
+	    list(APPEND CXX_SOURCES "${HRE_CURRENT_EXT_PATH}/${src}")
+    endforeach()
 endmacro()
 
 function(HHVM_SYSTEMLIB EXTNAME SOURCE_FILE)

--- a/CMake/HPHPIZEFunctions.cmake
+++ b/CMake/HPHPIZEFunctions.cmake
@@ -5,25 +5,21 @@
 # will differ slightly.
 
 function(HHVM_LINK_LIBRARIES EXTNAME)
-	list(REMOVE_AT ARGV 0)
-	target_link_libraries(${EXTNAME} ${ARGV})
+	target_link_libraries(${EXTNAME} ${ARGN})
 endfunction()
 
 function(HHVM_ADD_INCLUDES EXTNAME)
-	list(REMOVE_AT ARGV 0)
-	include_directories(${ARGV})
+	include_directories(${ARGN})
 endfunction()
 
 function(HHVM_EXTENSION EXTNAME)
-	list(REMOVE_AT ARGV 0)
-	add_library(${EXTNAME} SHARED ${ARGV})
+	add_library(${EXTNAME} SHARED ${ARGN})
 	set_target_properties(${EXTNAME} PROPERTIES PREFIX "")
 	set_target_properties(${EXTNAME} PROPERTIES SUFFIX ".so")
 endfunction()
 
 function(HHVM_SYSTEMLIB EXTNAME)
-	list(REMOVE_AT ARGV 0)
-	foreach (SLIB ${ARGV})
+	foreach (SLIB ${ARGN})
 		embed_systemlib_byname(${EXTNAME} ${SLIB})
 	endforeach()
 	embed_systemlibs(${EXTNAME} "${EXTNAME}.so")


### PR DESCRIPTION
Two issues fixed here:
1. CMake treats variables in macros and functions differently, meaning that
   the unescaped ARGV wasn't actually the arguments to the macro, instead it
   was just an undefined variable.
2. CMake has a special ARGN variable, in the same vein as ARGV. However, it
   contains all the arguments _after_ the formal arguments, making the
   existing `list(REMOVE_AT ARGV 0)` pattern pointless.

Should fix #2237

cc @sgolemon
