### PR TITLE
EZC: Match BEGIN_EXTERN_C() with END_EXTERN_C() instead of a bare brace.

### DIFF
--- a/hphp/runtime/ext_zend_compat/php-src/Zend/zend_strtod.cpp
+++ b/hphp/runtime/ext_zend_compat/php-src/Zend/zend_strtod.cpp
@@ -2698,4 +2698,4 @@ ZEND_API double zend_bin_strtod(const char *str, const char **endptr)
 	return value;
 }
 
-}
+END_EXTERN_C()


### PR DESCRIPTION
Helps if you want to make BEGIN_EXTERN_C() a no-op.
