### PR TITLE
Properly map the parameters and result from access to stat and back

### DIFF
--- a/hphp/runtime/base/user-file.cpp
+++ b/hphp/runtime/base/user-file.cpp
@@ -362,6 +362,15 @@ int UserFile::urlStat(const String& path, struct stat* stat_sb,
                   stat_sb);
 }
 
+static inline int simulateAccessResult(bool allowed) {
+  if (allowed) {
+    return 0;
+  } else {
+    errno = EACCES;
+    return -1;
+  }
+}
+
 extern const int64_t k_STREAM_URL_STAT_QUIET;
 int UserFile::access(const String& path, int mode) {
   struct stat buf;
@@ -369,7 +378,29 @@ int UserFile::access(const String& path, int mode) {
   if (ret < 0 || mode == F_OK) {
     return ret;
   }
-  return buf.st_mode & mode ? 0 : -1;
+
+  // The mode flags in stat are different from the flags used by access.
+  auto uid = geteuid();
+  auto gid = getegid();
+  switch (mode) {
+    case R_OK: // Test for read permission.
+      return simulateAccessResult(
+              (buf.st_uid == uid && (buf.st_mode & S_IRUSR)) ||
+              (buf.st_gid == gid && (buf.st_mode & S_IRGRP)) ||
+              (buf.st_mode & S_IROTH));
+    case W_OK: // Test for write permission.
+      return simulateAccessResult(
+               (buf.st_uid == uid && (buf.st_mode & S_IWUSR)) ||
+               (buf.st_gid == gid && (buf.st_mode & S_IWGRP)) ||
+               (buf.st_mode & S_IWOTH));
+    case X_OK: // Test for execute permission.
+      return simulateAccessResult(
+               (buf.st_uid == uid && (buf.st_mode & S_IXUSR)) ||
+               (buf.st_gid == gid && (buf.st_mode & S_IXGRP)) ||
+               (buf.st_mode & S_IXOTH));
+    default: // Unknown mode.
+      return -1;
+  }
 }
 
 extern const int64_t k_STREAM_URL_STAT_LINK;


### PR DESCRIPTION
Since stream wrappers only implement stat. Fixes #2304.

I'm not sure how to do unit tests for this, since the file permissions do not seem to be guaranteed on the test server, and definitely not when using repo authoritative mode. I also don't see tests for is_writable and friends, so I've not implemented any here.
