### PR TITLE
targetting 3.1.0 on master

### DIFF
--- a/hphp/system/idl/constants.idl.json
+++ b/hphp/system/idl/constants.idl.json
@@ -797,11 +797,11 @@
         },
         {
             "name": "HPHP_VERSION",
-            "value": "3.0.0-dev"
+            "value": "3.1.0-dev"
         },
         {
             "name": "HHVM_VERSION",
-            "value": "3.0.0-dev"
+            "value": "3.1.0-dev"
         },
         {
             "name": "HTML_ENTITIES",


### PR DESCRIPTION
atm users on hhvm-nightly/hhvm-master doesn't get the "correct" version number for `hhvm --version`
