### PR TITLE
set default HTTP_VERSION in fastcgi transport

### DIFF
--- a/hphp/runtime/server/fastcgi/fastcgi-transport.cpp
+++ b/hphp/runtime/server/fastcgi/fastcgi-transport.cpp
@@ -422,6 +422,12 @@ void FastCGITransport::onHeadersComplete() {
     m_method = Method::POST;
   }
 
+  if (m_httpVersion.empty()) {
+    // If we didn't receive a version, assume default transport version.
+    // Flushing the request early requires HTTP_VERSION to be 1.1.
+    m_httpVersion = Transport::getHTTPVersion();
+  }
+
   if (m_pathTranslated.empty()) {
     // If someone follows http://wiki.nginx.org/HttpFastcgiModule they won't
     // pass in PATH_TRANSLATED and instead will just send SCRIPT_FILENAME


### PR DESCRIPTION
Flushing the output buffer before the end of request requires a
HTTP_VERSION of 1.1 in HHVM. FastCGI will currently set this to an empty
string when it is not specified in webserver configuration.

If we don't get a HTTP_VERSION header, just set it to the default
Transport HTTP version.

Closes #2256.
