### PR TITLE
Change raise_deprecation to raise_deprecated

### DIFF
--- a/hphp/runtime/base/runtime-error.cpp
+++ b/hphp/runtime/base/runtime-error.cpp
@@ -199,11 +199,11 @@ void raise_notice(const char *fmt, ...) {
   raise_message(ErrorConstants::ErrorModes::NOTICE, msg);
 }
 
-void raise_deprecation(const std::string &msg) {
+void raise_deprecated(const std::string &msg) {
   raise_message(ErrorConstants::ErrorModes::PHP_DEPRECATED, msg);
 }
 
-void raise_deprecation(const char *fmt, ...) {
+void raise_deprecated(const char *fmt, ...) {
   std::string msg;
   va_list ap;
   va_start(ap, fmt);

--- a/hphp/runtime/base/runtime-error.h
+++ b/hphp/runtime/base/runtime-error.h
@@ -71,8 +71,8 @@ void raise_warning(const std::string &msg);
 void raise_warning(const char *fmt, ...) ATTRIBUTE_PRINTF(1, 2);
 void raise_notice(const std::string &msg);
 void raise_notice(const char *fmt, ...) ATTRIBUTE_PRINTF(1, 2);
-void raise_deprecation(const std::string &msg);
-void raise_deprecation(const char *fmt, ...) ATTRIBUTE_PRINTF(1, 2);
+void raise_deprecated(const std::string &msg);
+void raise_deprecated(const char *fmt, ...) ATTRIBUTE_PRINTF(1, 2);
 void raise_debugging(const std::string &msg);
 void raise_debugging(const char *fmt, ...) ATTRIBUTE_PRINTF(1, 2);
 void raise_message(ErrorConstants::ErrorModes mode,


### PR DESCRIPTION
This may be a matter of opinion, but the implemented method should be named similarly to the error level, `E_DEPRECATED` http://www.php.net/manual/en/errorfunc.constants.php

This way it follows the naming convention of the other functions; ie. `raise_notice`, `raise_error`, `raise_strict` and is more intuitive.
