### PR TITLE
Update to framework.php to check version before using log-json

### DIFF
--- a/hphp/test/frameworks/Framework.php
+++ b/hphp/test/frameworks/Framework.php
@@ -284,7 +284,15 @@ class Framework {
     } else {
       $this->test_command .= " --debug";
     }
-    $this->test_command .= " --log-json %json_file%";
+    
+    $version = 0;
+    $version_string = shell_exec(get_runtime_build(). " --version");
+    if (preg_match('/\d+(?:\.\d+)+/', $version_string, $matches)) { 
+      $version = floatval($matches[0]); 
+    }
+    if ($version >= 4.0){
+      $this->test_command .= " --log-json %json_file%";
+    }
     if ($this->config_file !== null) {
       $this->test_command .= " -c ".$this->config_file;
     }


### PR DESCRIPTION
Found `Fatal error:  Call to undefined method PHPUnit_Framework_TestSuite::hasOutput()` when using `--log-json` with phpbb.

It can occur when a framework uses its own phpunit that is older than 4.0.
https://github.com/sebastianbergmann/phpunit/blob/4.0/src/Util/Log/JSON.php#L251

This fix adds a version check for phpunit before appending log-json
