### PR TITLE
Fix fatal error in hphp/test/run

### DIFF
--- a/hphp/test/run
+++ b/hphp/test/run
@@ -1224,7 +1224,7 @@ function main($argv) {
     if (isset($options['repo'])) {
       error("Server mode repo tests are not supported");
     }
-    $configs = Set {};
+    $configs = HH\Set {};
     foreach ($tests as $test) {
       if (!can_run_server_test($test)) continue;
       $config = find_file_for_dir(dirname($test), 'config.hdf');
@@ -1271,7 +1271,7 @@ function main($argv) {
   drain_queue($queue);
 
   // Spawn off worker threads
-  $children = Set {};
+  $children = HH\Set {};
   // A poor man's shared memory
   $bad_test_files = array();
   for ($i = 0; $i < $options['threads']; $i++) {


### PR DESCRIPTION
Fatal error: Cannot use collection initialization for non-collection
class in .../run on line 1227
