### PR TITLE
Make ArrayObject::offsetExists return true for keys with null values

### DIFF
--- a/hphp/system/php/spl/miscellaneous/ArrayObject.php
+++ b/hphp/system/php/spl/miscellaneous/ArrayObject.php
@@ -235,7 +235,7 @@ class ArrayObject implements \HH\KeyedIterable, ArrayAccess,
    */
   public function offsetExists($index) {
     if ($this->isArray()) {
-      return isset($this->storage[$index]);
+      return array_key_exists($index, $this->storage);
     } else {
       return property_exists($this->storage, $index);
     }

--- a/hphp/test/slow/array_object/offsetExists.php
+++ b/hphp/test/slow/array_object/offsetExists.php
@@ -1,6 +1,7 @@
 <?php
 
-$arrayobj = new ArrayObject(array('zero', 'one', 'example'=>'e.g.'));
+$arrayobj = new ArrayObject(array('zero', 'one', 'example'=>'e.g.', 'another'=>null));
 var_dump($arrayobj->offsetExists(1));
 var_dump($arrayobj->offsetExists('example'));
 var_dump($arrayobj->offsetExists('notfound'));
+var_dump($arrayobj->offsetExists('another'));

--- a/hphp/test/slow/array_object/offsetExists.php.expect
+++ b/hphp/test/slow/array_object/offsetExists.php.expect
@@ -1,3 +1,4 @@
 bool(true)
 bool(true)
 bool(false)
+bool(true)


### PR DESCRIPTION
Fixes #2181.
