### PR TITLE
Fixed a typo in Redis __call function

### DIFF
--- a/hphp/system/php/redis/Redis.php
+++ b/hphp/system/php/redis/Redis.php
@@ -1457,7 +1457,7 @@ class Redis {
       if (!isset($args[$i])) {
         if (isset($func['defaults']) AND
             array_key_exists($func['defaults'], $i)) {
-          $args[$i] = $func['defualts'][$i];
+          $args[$i] = $func['defaults'][$i];
         } else {
           trigger_error(
             "Redis::$fname requires at least $flen parameters $argc given",


### PR DESCRIPTION
It seems like there is a typo in the Redis class. The code is reading the value from $func['defualts'] instead of $func['defaults'].
