### PR TITLE
add explicit size_t cast to gen-ext-hhvm

### DIFF
--- a/hphp/tools/bootstrap/gen-ext-hhvm.cpp
+++ b/hphp/tools/bootstrap/gen-ext-hhvm.cpp
@@ -262,7 +262,7 @@ void emitBuildExtraArgs(const PhpFunc& func, std::ostream& out,
     R"(
 {0}Array extraArgs;
 {0}{{
-{0}  ArrayInit ai(count-{1}, ArrayInit::Mixed{{}});
+{0}  ArrayInit ai((size_t)count-{1}, ArrayInit::Mixed{{}});
 {0}  for (int32_t i = {1}; i < count; ++i) {{
 {0}    TypedValue* extraArg = ar->getExtraArg(i-{1});
 {0}    if (tvIsStronglyBound(extraArg)) {{


### PR DESCRIPTION
This fixes the OSX build.
