### PR TITLE
Add missing libxml constants

### DIFF
--- a/hphp/system/idl/constants.idl.json
+++ b/hphp/system/idl/constants.idl.json
@@ -1285,7 +1285,7 @@
         },
         {
             "name": "LIBXML_DOTTED_VERSION",
-            "value": "2.6.26"
+            "value": "2.7.6"
         },
         {
             "name": "LIBXML_DTDATTR",
@@ -1314,6 +1314,14 @@
         {
             "name": "LIBXML_ERR_WARNING",
             "value": 1
+        },
+        {
+            "name": "LIBXML_HTML_NODEFDTD",
+            "value": 4
+        },
+        {
+            "name": "LIBXML_HTML_NOIMPLIED",
+            "value": 8192
         },
         {
             "name": "LIBXML_NOBLANKS",
@@ -1368,8 +1376,20 @@
             "value": 8192
         },
         {
+            "name": "LIBXML_PARSEHUGE",
+            "value": 524288
+        },
+        {
+            "name": "LIBXML_PEDANTIC",
+            "value": 128
+        },
+        {
+            "name": "LIBXML_SCHEMA_CREATE",
+            "value": 1 
+        },
+        {
             "name": "LIBXML_VERSION",
-            "value": 20626
+            "value": 20706
         },
         {
             "name": "LIBXML_XINCLUDE",


### PR DESCRIPTION
Some of these constants are only defined in zend php with libxml 2.7.x, so I bumped libxml version.  (Ubuntu 12.04 has 2.7.8.  Ubuntu 10.04 has 2.7.6.)

References #2229
