### PR TITLE
avoid using memory manager in pthread destructor

### DIFF
--- a/hphp/runtime/base/zend-strtod.cpp
+++ b/hphp/runtime/base/zend-strtod.cpp
@@ -367,7 +367,7 @@ struct Bigint {
 
 typedef struct Bigint Bigint;
 
-void destroy_freelist(void);
+void destroy_freelist(Bigint** freelist);
 
 class BigintData {
 public:
@@ -375,7 +375,7 @@ public:
     freelist = (Bigint **)calloc(Kmax + 1, sizeof(Bigint *));
   }
   ~BigintData() {
-    destroy_freelist();
+    destroy_freelist(freelist);
     free(freelist);
   }
 
@@ -1264,12 +1264,11 @@ static int quorem(Bigint *b, Bigint *S)
   return q;
 }
 
-void destroy_freelist(void)
+void destroy_freelist(Bigint** freelist)
 {
   int i;
   Bigint *tmp;
 
-  Bigint **&freelist = s_bigint_data->freelist;
   for (i = 0; i <= Kmax; i++) {
     Bigint **listp = &freelist[i];
     while ((tmp = *listp) != nullptr) {


### PR DESCRIPTION
When a pthread exits, it will call the destructor function specified as
second argument to pthread_key_create. For some objects, this means
ThreadLocalOnThreadExit<T> which will simply delete the object.

In the case of BigintData, the destructor will try to access a property
for cleanup (freelist). Accessing this property requires a call to
pthread_getspecific. Calling pthread_getspecific from a pthread
destructor is undefined behavior and returns a nullptr on OS X
(and possibly BSD).

Let's avoid the need for pthread_getspecific by passing freelist as an
argument to destroy_freelist instead.
