### PR TITLE
Fix Ratchet expected in test runner to reflect 100%

### DIFF
--- a/hphp/test/frameworks/results/ratchet.expect
+++ b/hphp/test/frameworks/results/ratchet.expect
@@ -257,7 +257,7 @@ Ratchet\Session\SessionProviderTest::testOnMessageDecorator
 Ratchet\Session\SessionProviderTest::testOpen
 .
 Ratchet\Session\SessionProviderTest::testRejectInvalidSeralizers
-E
+.
 Ratchet\Session\SessionProviderTest::testToClassCase with data set #0
 .
 Ratchet\Session\SessionProviderTest::testToClassCase with data set #1


### PR DESCRIPTION
One of the expected tests was still expected to be an error, which returns thumbs down.

Ratchet is now 100%, so they should all be `.`
