### PR TITLE
Updated frameworks.yaml to include more appropriate branch for phpbb

### DIFF
--- a/hphp/test/frameworks/frameworks.yaml
+++ b/hphp/test/frameworks/frameworks.yaml
@@ -291,8 +291,8 @@
     # Stable is release-3.0.12, but we have pull requests in develop
     # https://github.com/phpbb/phpbb/pull/1908
     # https://github.com/phpbb/phpbb/pull/2232
-    branch: develop
-    commit: a5216e1b0483bc5db96f10d3b3504d1fe5ab850d
+    branch: develop-ascraeus
+    commit: 2284e2897f2573467a20cb90579e7b4bb8af392c
     install_root: phpbb3
     test_root: phpbb3
     clowns:

--- a/hphp/test/frameworks/results/phpbb3.expect
+++ b/hphp/test/frameworks/results/phpbb3.expect
@@ -4456,3 +4456,7 @@ pphpbb_tests_tree_nestedset_forum_test::test_get_sql_where with data set #2
 S
 pphpbb_tests_tree_nestedset_forum_test::test_get_sql_where with data set #3
 S
+schmema_generator_test::test_check_dependencies_fail
+.
+schmema_generator_test::test_get_schema_success
+.


### PR DESCRIPTION
The phpbb devs mentioned that develop branch is potentially unstable with new features and that develop-ascraeus is more stable as it is the development branch for the next stable version, 3.1 (ascraeus).
https://wiki.phpbb.com/PhpBB3.1    

It also includes the fixes @joelm submitted to them as mentioned in frameworks.yaml.

```
# Stable is release-3.0.12, but we have pull requests in develop
# https://github.com/phpbb/phpbb/pull/1908
# https://github.com/phpbb/phpbb/pull/2232
```
