### PR TITLE
frameworks.yaml: upgrade symfony to v2.4.3, add clown.

### DIFF
--- a/hphp/test/frameworks/frameworks.yaml
+++ b/hphp/test/frameworks/frameworks.yaml
@@ -338,6 +338,7 @@
     clowns:
       # Broken test. Fixed in symfony master, but not yet in release.
       - symfony/src/Symfony/Component/ClassLoader/Tests/ApcUniversalClassLoaderTest.php
+      - symfony/src/Symfony/Component/Config/Tests/Definition/Builder/NodeBuilderTest.php
   twig:
     url: https://github.com/fabpot/Twig.git
     branch: v1.15.1


### PR DESCRIPTION
The clown is ApcUniversalClassLoaderTest.php.

The test is incorrect. It's been fixed in symfony's master (https://github.com/symfony/symfony/pull/10577) but not in any of the releases.
