### PR TITLE
Send Travis notifications to #hhvm-dev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -75,7 +75,7 @@ script: time PHP_CURL_HTTP_REMOTE_SERVER="http://localhost:8444" hphp/hhvm/hhvm 
 
 notifications:
   email: false
-  irc: "chat.freenode.net#hhvm"
+  irc: "chat.freenode.net#hhvm-dev"
 
 matrix:
   fast_finish: true


### PR DESCRIPTION
As #hhvm is a more user-facing channel, posting build information to it doesn't make as much sense.
