### PR TITLE
Fix for when FCGI_ABORT_REQUEST is sent.

### DIFF
--- a/hphp/runtime/server/fastcgi/fastcgi-session.cpp
+++ b/hphp/runtime/server/fastcgi/fastcgi-session.cpp
@@ -274,7 +274,8 @@ size_t FastCGISession::onIngress(const IOBuf* chain) {
       } else break;
     }
   }
-  return avail;
+  assert(avail == 0);
+  return 0;
 }
 
 void FastCGISession::setMaxConns(int max_conns) {


### PR DESCRIPTION
This was returning the size of the initial request on abort instead of the bytes left after parsing causing it to try to read further into the buffer than was available.

avail will equal available minus what was already read.

Closes #2240
