### PR TITLE
Link the new hphp_ext_zend_compat library into the binaries

### DIFF
--- a/CMake/HPHPSetup.cmake
+++ b/CMake/HPHPSetup.cmake
@@ -33,6 +33,7 @@ set(HHVM_LINK_LIBRARIES
     ${HHVM_ANCHOR_SYMS}
     hphp_analysis
     ext_hhvm_static
+    hphp_ext_zend_compat
     hphp_system
     hphp_parser
     hphp_zend


### PR DESCRIPTION
So that the build won't be totally, unconditionally broken.
