### PR TITLE
Handle ZendParamMode-style type coercion with nullable types

### DIFF
--- a/hphp/compiler/analysis/emitter.cpp
+++ b/hphp/compiler/analysis/emitter.cpp
@@ -6686,7 +6686,7 @@ void EmitterVisitor::fillFuncEmitterParams(FuncEmitter* fe,
     }
     if (builtin) {
       if (auto const typeAnnotation = par->annotation()) {
-        pi.setBuiltinType(typeAnnotation->dataType());
+        pi.setBuiltinType(typeAnnotation->dataType(true));
       }
     }
 

--- a/hphp/compiler/expression/parameter_expression.cpp
+++ b/hphp/compiler/expression/parameter_expression.cpp
@@ -50,7 +50,15 @@ ParameterExpression::ParameterExpression(
   , m_attributeList(attributeList)
   , m_variadic(variadic)
 {
-  m_type = toLower(type ? type->vanillaName() : "");
+  if (type) {
+    TypeAnnotation t = *type;
+    if (t.isNullable()) {
+      t = t.stripNullable();
+    }
+    m_type = toLower(t.vanillaName());
+  } else {
+    m_type = "";
+  }
   if (m_defaultValue) {
     m_defaultValue->setContext(InParameterExpression);
   }

--- a/hphp/runtime/vm/native.cpp
+++ b/hphp/runtime/vm/native.cpp
@@ -270,18 +270,20 @@ bool coerceFCallArgs(TypedValue* args,
     }                                                   \
     break; /* end of case */
 
-    switch (pi.builtinType()) {
-      CASE(Boolean)
-      CASE(Int64)
-      CASE(Double)
-      CASE(String)
-      CASE(Array)
-      CASE(Object)
-      CASE(Resource)
-      case KindOfUnknown:
-        break;
-      default:
-        not_reached();
+    if (!pi.typeConstraint().isNullable() || args[-i].m_type != KindOfNull) {
+      switch (pi.builtinType()) {
+        CASE(Boolean)
+        CASE(Int64)
+        CASE(Double)
+        CASE(String)
+        CASE(Array)
+        CASE(Object)
+        CASE(Resource)
+        case KindOfUnknown:
+          break;
+        default:
+          not_reached();
+      }
     }
 
 #undef CASE


### PR DESCRIPTION
Bit hard to write tests for, as it needs a HNI __Native function, though it does get used by #1760
