### PR TITLE
Populate ReflectionClass::$this on creation.

### DIFF
--- a/hphp/runtime/ext/reflection/ext_reflection-classes.php
+++ b/hphp/runtime/ext/reflection/ext_reflection-classes.php
@@ -899,7 +899,7 @@ class ReflectionClass implements Reflector {
   const IS_FINAL = 64 ;
 
   public $name;
-  private $info = null;
+  private $info;
   private $obj = null;
   private static $fetched = array();
 
@@ -925,6 +925,8 @@ class ReflectionClass implements Reflector {
     if (empty($this->name)) {
       throw new ReflectionException("Class $name does not exist");
     }
+
+    $this->getInfo();
   }
 
   private function getInfo() {

--- a/hphp/test/slow/reflection_classes/ReflectionClass_info.php
+++ b/hphp/test/slow/reflection_classes/ReflectionClass_info.php
@@ -1,0 +1,14 @@
+<?php
+class Foo {
+}
+
+$mirror = new ReflectionClass("ReflectionClass");
+$foo_reflectorA = new ReflectionClass("Foo");
+$foo_reflectorB = new ReflectionClass("Foo");
+$foo_reflectorB->getMethods();
+$info_property = $mirror->getProperty("info");
+$info_property->setAccessible(true);
+$infoA = $info_property->getValue($foo_reflectorA);
+$infoB = $info_property->getValue($foo_reflectorB);
+var_dump($infoA == $infoB);
+

--- a/hphp/test/slow/reflection_classes/ReflectionClass_info.php.expect
+++ b/hphp/test/slow/reflection_classes/ReflectionClass_info.php.expect
@@ -1,0 +1,1 @@
+bool(true)


### PR DESCRIPTION
ReflectionClass does not populate $info until a function such as getMethods() is called. This causes the ReflectionClass instance to compare differently before and after these methods are called, causing several tests in the symfony Validator component to fail (AnnotationLoaderTest.php).

Repro code:

```
<?php
 class Foo {
 }

 $mirror = new ReflectionClass("ReflectionClass");
 $foo_reflectorA = new ReflectionClass("Foo");
 $foo_reflectorB = new ReflectionClass("Foo");
 $foo_reflectorB->getMethods();
 $info_property = $mirror->getProperty("info");
 $info_property->setAccessible(true);
 $infoA = $info_property->getValue($foo_reflectorA);
 $infoB = $info_property->getValue($foo_reflectorB);
 var_dump($infoA == $infoB);
```

Expected output:

```
bool(true)
```

Actual output:

```
bool(false)
```
