### PR TITLE
Fix not_implemented() macro

### DIFF
--- a/hphp/util/assertions.h
+++ b/hphp/util/assertions.h
@@ -58,11 +58,7 @@ T bad_value() {
 
 #define NOT_REACHED not_reached
 
-#define not_implemented() do {                   \
-  fprintf(stderr, "not implemented: %s:%d %s\n", \
-          __FILE__, __LINE__, __FUNCTION__);     \
-  not_reached();                                 \
-} while(0)
+#define not_implemented() assert_throw_fail_impl("not implemented")
 
 #define assert_not_implemented(pred) do {        \
   if (! (pred) ) {                               \


### PR DESCRIPTION
not_reached() is not appropriate to use in cases where the code may actually be reached due to a developer error, since it does not emit an abort, rather it signals to the compiler that optimisations may be made assuming the code is never reached, such as omitting RET instructions.
