### PR TITLE
Handle UNIX domain sockets correctly in memcache & memcached extensions

### DIFF
--- a/hphp/runtime/ext/ext_memcache.cpp
+++ b/hphp/runtime/ext/ext_memcache.cpp
@@ -127,8 +127,9 @@ bool c_Memcache::t_connect(const String& host, int port /*= 0*/,
                            int timeoutms /*= 0*/) {
   memcached_return_t ret;
 
-  if (!host.empty() && host[0] == '/') {
-    ret = memcached_server_add_unix_socket(&m_memcache, host.c_str());
+  if (!host.empty() && !strncmp(host.c_str(), "unix://", sizeof("unix://") - 1)) {
+    const char *socket_path = host.substr(sizeof("unix://") - 1).c_str();
+    ret = memcached_server_add_unix_socket(&m_memcache, socket_path);
   } else {
     ret = memcached_server_add(&m_memcache, host.c_str(), port);
   }
@@ -547,9 +548,10 @@ bool c_Memcache::t_addserver(const String& host, int port /* = 11211 */,
                              int timeoutms /* = 0 */) {
   memcached_return_t ret;
 
-  if (!host.empty() && host[0] == '/') {
+  if (!host.empty() && !strncmp(host.c_str(), "unix://", sizeof("unix://") - 1)) {
+    const char *socket_path = host.substr(sizeof("unix://") - 1).c_str();
     ret = memcached_server_add_unix_socket_with_weight(&m_memcache,
-                                                       host.c_str(), weight);
+                                                       socket_path, weight);
   } else {
     ret = memcached_server_add_with_weight(&m_memcache, host.c_str(),
                                            port, weight);

--- a/hphp/runtime/ext/ext_memcached.cpp
+++ b/hphp/runtime/ext/ext_memcached.cpp
@@ -566,8 +566,13 @@ Variant c_Memcached::incDecOperationImpl(IncDecOperation op, const String& key,
 
 bool c_Memcached::t_addserver(const String& host, int port, int weight /*= 0*/) {
   m_impl->rescode = q_Memcached$$RES_SUCCESS;
-  return handleError(memcached_server_add_with_weight(&m_impl->memcached,
-      host.c_str(), port, weight));
+  if (!host.empty() && host[0] == '/') {
+    return handleError(memcached_server_add_unix_socket_with_weight(&m_impl->memcached,
+        host.c_str(), weight));
+  } else {
+    return handleError(memcached_server_add_with_weight(&m_impl->memcached,
+        host.c_str(), port, weight));
+  }
 }
 
 bool c_Memcached::t_addservers(const Array& servers) {
@@ -599,8 +604,16 @@ bool c_Memcached::t_addservers(const Array& servers) {
       weight = entryIter.second().toInt32(10);
     }
 
-    if (!handleError(memcached_server_add_with_weight(&m_impl->memcached,
-          host.c_str(), port, weight))) {
+    memcached_return status;
+    if (!host.empty() && host[0] == '/') {
+      status = memcached_server_add_unix_socket_with_weight(&m_impl->memcached,
+                                                            host.c_str(),
+                                                            weight);
+    } else {
+      status = memcached_server_add_with_weight(&m_impl->memcached,
+                                                host.c_str(), port, weight);
+    }
+    if (!handleError(status)) {
       raise_warning("could not add entry #%d to the server list", i);
     }
   }


### PR DESCRIPTION
- Memcache::addServer checks for 'unix://' to determine if the host argument
  represents is a UNIX domain socket. HHVM's version checked for a leading '/'.
- Memcached::addServer checks for a leading '/' to determine if the host
  argument is a UNIX domain socket. HHVM's version did not handle UNIX domain
  sockets at all.

This patch adds UNIX domain socket support to Memcached::addServer, and it
corrects the handling of the host argument in Memcache::addServer.

Fixes #1375.
