### PR TITLE
[PCRE] Fixed undefined constant PHP_PCRE_BAD_UTF8_OFFSET_ERROR

### DIFF
--- a/hphp/system/idl/constants.idl.json
+++ b/hphp/system/idl/constants.idl.json
@@ -3602,6 +3602,10 @@
             "value": 4
         },
         {
+            "name": "PREG_BAD_UTF8_OFFSET_ERROR",
+            "value": 5
+        },
+        {
             "name": "PREG_GREP_INVERT",
             "value": 1
         },


### PR DESCRIPTION
This PR is about fixing an undefined constant:

Code (from https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Yaml/Parser.php#L239-L241) that was generating an error:

``` php
switch (preg_last_error()) {
    case PREG_INTERNAL_ERROR:
        $error = 'Internal PCRE error.';
        break;
    case PREG_BACKTRACK_LIMIT_ERROR:
        $error = 'pcre.backtrack_limit reached.';
        break;
    case PREG_RECURSION_LIMIT_ERROR:
        $error = 'pcre.recursion_limit reached.';
        break;
    case PREG_BAD_UTF8_ERROR:
        $error = 'Malformed UTF-8 data.';
        break;
    case PREG_BAD_UTF8_OFFSET_ERROR:
        $error = 'Offset doesn\'t correspond to the begin of a valid UTF-8 code point.'.
        break;
    default:
        $error = 'Unable to parse.';
}
```

This was displaying message on output:

```
Use of undefined constant PREG_BAD_UTF8_OFFSET_ERROR - assumed 'PREG_BAD_UTF8_OFFSET_ERROR'
```
