### PR TITLE
don't seek to end of destination in stream_copy_to_stream

### DIFF
--- a/hphp/runtime/ext/stream/ext_stream.cpp
+++ b/hphp/runtime/ext/stream/ext_stream.cpp
@@ -167,9 +167,6 @@ Variant f_stream_copy_to_stream(const Resource& source, const Resource& dest,
     raise_warning("Failed to seek to position %d in the stream", offset);
     return false;
   }
-  if (destFile->seekable()) {
-    (void)destFile->seek(0, SEEK_END);
-  }
   int cbytes = 0;
   if (maxlength == 0) maxlength = INT_MAX;
   while (cbytes < maxlength) {

--- a/hphp/test/slow/ext_stream/stream_copy_to_stream-seek.php
+++ b/hphp/test/slow/ext_stream/stream_copy_to_stream-seek.php
@@ -1,0 +1,20 @@
+<?php
+
+// Create two temporary files.
+$file1 = tmpfile();
+$file2 = tmpfile();
+fwrite($file1, 'input');
+fwrite($file2, 'before');
+
+// Seek to specific position in destination.
+rewind($file1);
+fseek($file2, 2);
+
+stream_copy_to_stream($file1, $file2);
+
+// Show us all of file2.
+echo stream_get_contents($file2, -1, 0);
+
+// Cleanup.
+fclose($file1);
+fclose($file2);

--- a/hphp/test/slow/ext_stream/stream_copy_to_stream-seek.php.expect
+++ b/hphp/test/slow/ext_stream/stream_copy_to_stream-seek.php.expect
@@ -1,0 +1,1 @@
+beinput


### PR DESCRIPTION
- Doesn't break any stream related tests.
- php-src doesn't seem to do the seek:
  https://github.com/php/php-src/blob/8d4ee1dbedcd339f119f04058e72eebba272bdb5/main/streams/streams.c#L1496

See the test for an example of how this would break.

Fixes #2453.
