### PR TITLE
EZC: import.php improvements

### DIFF
--- a/hphp/runtime/ext_zend_compat/import.php
+++ b/hphp/runtime/ext_zend_compat/import.php
@@ -7,10 +7,11 @@ if ($argc != 3) {
 
 $source_root = realpath($argv[1]);
 $ext_name = $argv[2];
+$systemlib_name = 'ext_'.$ext_name.'.php';
 $dest_root = __DIR__.'/'.$ext_name;
+$test_root = __DIR__.'/../../test';
 print "Importing from $source_root in $dest_root\n";
 
-mkdir($dest_root);
 $objects = new RecursiveIteratorIterator(
   new RecursiveDirectoryIterator($source_root),
   RecursiveIteratorIterator::SELF_FIRST
@@ -22,18 +23,29 @@ foreach($objects as $name => $object){
     continue;
   }
 
-  if (substr($name, -2, 2) == '.h') {
-    $dest_dir = $dest_root.'/'.substr($object->getPath(),
-                                      strlen($source_root) + 1);
-    mkdir($dest_dir);
-    copy($name, $dest_dir.'/'.$object->getFilename());
+  $dest_dir = $dest_root.'/'.substr($object->getPath(),
+    strlen($source_root) + 1);
 
+  if (substr($name, -2, 2) == '.h') {
+    install_file($name, $dest_dir.'/'.$object->getFilename());
+  } elseif (preg_match("/ext_{$ext_name}.php$/", $name)) {
+    install_file($name, $dest_dir.'/'.$object->getFilename());
   } elseif (substr($name, -2, 2) == '.c') {
-    $sub_path = substr($object->getPath(), strlen($source_root) + 1);
-    mkdir($dest_root.'/'.$sub_path);
+    $sub_path = substr($dest_dir, strlen($dest_root) + 1);
     $dest_file = ($sub_path ? $sub_path.'/' : '').$object->getFilename().'pp';
-    copy($name, $dest_root.'/'.$dest_file);
+    install_file($name, $dest_root.'/'.$dest_file);
     $cpp_files[] = $dest_file;
+  } elseif (substr($name, -5, 5) == '.phpt') {
+    $dest_base_name = $test_root.'/slow/ext_'.$ext_name.'/'.
+      substr($object->getFilename(), 0, -1);
+    $sections = parse_phpt($name);
+    foreach ($sections as $section_name => $section_text) {
+      if ($section_name === 'file') {
+        install_file_contents($dest_base_name, $section_text);
+      } elseif(in_array($section_name, array('expect', 'expectf', 'expectregex', 'skipif'))) {
+        install_file_contents($dest_base_name.'.'.$section_name, $section_text);
+      }
+    }
   }
 }
 
@@ -45,7 +57,7 @@ foreach ($cpp_files as $file) {
 }
 $srcs = trim($srcs);
 $capital_name = strtoupper($ext_name);
-file_put_contents($dest_root.'/TARGETS', <<<END
+install_file_contents($dest_root.'/TARGETS', <<<END
 # -*- mode: python -*-
 
 cpp_library(
@@ -69,7 +81,7 @@ END
 
 // Write link it into the existing TARGETS
 // TODO sort these
-file_put_contents(
+install_file_contents(
   __DIR__.'/TARGETS',
   str_replace(
     // Try to be idempotent
@@ -85,3 +97,40 @@ file_put_contents(
   )
 );
 
+function install_dir($dir) {
+  if (!is_dir($dir)) {
+    if (!mkdir($dir, 0777, true)) {
+      print "Unable to create directory \"$dir\"\n";
+      exit(1);
+    }
+  }
+}
+
+function install_file($source, $dest) {
+  install_dir(dirname($dest));
+  if (!copy($source, $dest)) {
+    print "Unable to create file \"$dest\"\n";
+    exit(1);
+  }
+}
+
+function install_file_contents($dest, $text) {
+  install_dir(dirname($dest));
+  if (file_put_contents($dest, $text) === false) {
+    print "Unable to create file \"$dest\"\n";
+    exit(1);
+  }
+}
+
+function parse_phpt($fileName) {
+  $contents = file_get_contents($fileName);
+  if ($contents === false) {
+    print "Unable to read file \"$fileName\"\n";
+  }
+  $bits = preg_split('/^--([_A-Z]+)--\s*\n/m', $contents, -1,  PREG_SPLIT_DELIM_CAPTURE);
+  $sections = array();
+  for ( $i = 1; $i < count($bits) - 1; $i += 2 ) {
+    $sections[strtolower($bits[$i])] = $bits[$i+1];
+  }
+  return $sections;
+}


### PR DESCRIPTION
- Allow systemlib importation. This is to support extensions which are dual-targeted and kept in an external repository.
- Fix mkdir warnings, check return values
- Add automatic importation of *.phpt files, by splitting them and creating the relevant files in test/slow
