### PR TITLE
Fix systemlib native return type hint error handling

### DIFF
--- a/hphp/compiler/statement/method_statement.cpp
+++ b/hphp/compiler/statement/method_statement.cpp
@@ -201,8 +201,12 @@ FunctionScopePtr MethodStatement::onInitialParse(AnalysisResultConstPtr ar,
   funcScope->setParamCounts(ar, -1, -1);
 
   if (funcScope->isNative()) {
-    funcScope->setReturnType(
-      ar, Type::FromDataType(m_retTypeAnnotation->dataType(), Type::Variant));
+    if (m_retTypeAnnotation) {
+      funcScope->setReturnType(
+        ar, Type::FromDataType(m_retTypeAnnotation->dataType(), Type::Variant));
+    } else {
+      funcScope->setReturnType(ar, Type::Variant);
+    }
   }
 
   return funcScope;


### PR DESCRIPTION
If a native systemlib function lacks a return type hint, give a fatal error instead of segfaulting.
