### PR TITLE
Allow inclusion of own files inside phar.

### DIFF
--- a/hphp/runtime/base/builtin-functions.cpp
+++ b/hphp/runtime/base/builtin-functions.cpp
@@ -72,7 +72,8 @@ const StaticString
   s_function("function"),
   s_constant("constant"),
   s_type("type"),
-  s_failure("failure");
+  s_failure("failure"),
+  s_phar("phar://");
 
 ///////////////////////////////////////////////////////////////////////////////
 
@@ -891,9 +892,18 @@ String resolve_include(const String& file, const char* currentDir,
   const char* c_file = file.data();
 
   if (!File::IsPlainFilePath(file)) {
+    String abs_file = file;
+    if (file.length() >= 8) {
+      if (file.substr(0, 7) == s_phar) {
+        if (file[7] != '/') {
+          abs_file = s_phar + String(currentDir) + "/" + file.substr(7);
+        }
+      }
+    }
+
     // URIs don't have an include path
-    if (tryFile(file, ctx)) {
-      return file;
+    if (tryFile(abs_file, ctx)) {
+      return abs_file;
     }
 
   } else if (c_file[0] == '/') {

--- a/hphp/system/php/phar/Phar.php
+++ b/hphp/system/php/phar/Phar.php
@@ -68,7 +68,7 @@ class Phar extends RecursiveDirectoryIterator
     }
     $data = file_get_contents($filename);
 
-    $halt_token = "\n__HALT_COMPILER();";
+    $halt_token = "__HALT_COMPILER();";
     $pos = strpos($data, $halt_token);
     if ($pos === false) {
       throw new PharException("__HALT_COMPILER(); must be declared in a phar");


### PR DESCRIPTION
Allows phars to include their own contents. Previously the path did not resolve correctly.

Fix for https://github.com/facebook/hhvm/issues/2116.
