### PR TITLE
fix soap encoding on non-nillable empty properties

### DIFF
--- a/hphp/runtime/ext/soap/encoding.cpp
+++ b/hphp/runtime/ext/soap/encoding.cpp
@@ -573,8 +573,8 @@ static xmlNodePtr master_to_xml_int(encodePtr encode, const Variant& data, int s
     }
   } else {
     if (check_class_map && !SOAP_GLOBAL(classmap).empty() &&
-        data.isString() && !data.toString().empty()) {
-      String clsname = data.toString();
+        data.isObject()) {
+      const String& clsname = data.toObject()->o_getClassName();
       for (ArrayIter iter(SOAP_GLOBAL(classmap)); iter; ++iter) {
         if (same(iter.second(), clsname)) {
           /* TODO: namespace isn't stored */
@@ -1532,12 +1532,12 @@ static int model_to_xml_object(xmlNodePtr node, sdlContentModelPtr model,
     encodePtr enc;
 
     Variant data;
-    if (get_zval_property(object, model->u_element->name.c_str(), &data) &&
-        data.isNull() && !model->u_element->nillable &&
+    bool propExists = get_zval_property(object, model->u_element->name.c_str(), &data);
+    if (propExists && data.isNull() && !model->u_element->nillable &&
         model->min_occurs > 0 && !strict) {
       return 0;
     }
-    if (!data.isNull()) {
+    if (propExists) {
       enc = model->u_element->encode;
       if ((model->max_occurs == -1 || model->max_occurs > 1) &&
           data.isArray() && data.toArray()->isVectorData()) {


### PR DESCRIPTION
Issue 1: When having an existing SOAP class property that is not
initialized (private $prop), PHP encodes it into an empty element: even
if the WSDL does not set the "nillable" flag for the element. We must
check if the property exists, not just if the returned property isNull.
The following php-src file should make that clear:
https://github.com/php/php-src/blob/PHP-5.6/ext/soap/php_encoding.c#L1697

Issue 2: HHVM simply checks for an incorrect object type: String instead
of Object (and then grabbing its class name). Very obvious:
https://github.com/php/php-src/blob/PHP-5.6/ext/soap/php_encoding.c#L464

Not sure how to create a proper test for this:
- the majority of bad zend tests are currently being skipped
- all good zend tests pass
- HHVM itself only provides 3 tests that focus on SoapServer instead.
- I'd have to find a way to reduce my current setup (3rd-party SOAP
  server, abstracted client) into a small example.

Hopefully you can forgive the lack of a test this time, the 2 php-src
links above should convince you.
