### PR TITLE
don't sweep SimpleXMLElementIterator

### DIFF
--- a/hphp/runtime/ext/ext_simplexml.cpp
+++ b/hphp/runtime/ext/ext_simplexml.cpp
@@ -1652,15 +1652,11 @@ c_SimpleXMLElementIterator::c_SimpleXMLElementIterator(Class* cb) :
     ExtObjectData(cb), sxe(nullptr) {
 }
 
-void c_SimpleXMLElementIterator::sweep() {
+c_SimpleXMLElementIterator::~c_SimpleXMLElementIterator() {
   if (sxe) {
     sxe->decRefCount();
     sxe = nullptr;
   }
-}
-
-c_SimpleXMLElementIterator::~c_SimpleXMLElementIterator() {
-  c_SimpleXMLElementIterator::sweep();
 }
 
 void c_SimpleXMLElementIterator::t___construct() {

--- a/hphp/runtime/ext/ext_simplexml.h
+++ b/hphp/runtime/ext/ext_simplexml.h
@@ -111,9 +111,9 @@ class c_SimpleXMLElement :
 
 FORWARD_DECLARE_CLASS(SimpleXMLElementIterator);
 
-class c_SimpleXMLElementIterator : public ExtObjectData, public Sweepable {
+class c_SimpleXMLElementIterator : public ExtObjectData {
  public:
-  DECLARE_CLASS(SimpleXMLElementIterator)
+  DECLARE_CLASS_NO_SWEEP(SimpleXMLElementIterator)
 
   public: c_SimpleXMLElementIterator(Class* cls = c_SimpleXMLElementIterator::classof());
   public: ~c_SimpleXMLElementIterator();


### PR DESCRIPTION
Since we're manually juggling refcounts for the sxe object, we cannot be
a sweepable object because we're not allowed to decRefCount during
sweeps.

This fixes an assertion when a fatal error was thrown, and we attempted
to decRefCount in ::sweep because its destructor is never called.
