### PR TITLE
hphpize: /bin/sh may not be symlinked to bash

### DIFF
--- a/hphp/tools/hphpize/hphpize
+++ b/hphp/tools/hphpize/hphpize
@@ -5,7 +5,11 @@ if [ ! -f "config.cmake" ]; then
   exit 1
 fi
 
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+if [ ! -z $BASH_SOURCE ]; then
+    DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+else
+    DIR="$( cd "$( dirname "$0" )" && pwd )"
+fi
 
 cp ${DIR}/hphpize.cmake CMakeLists.txt
 


### PR DESCRIPTION
For example, it may be symlinked to dash which doesn't support BASH_SOURCE.

(Or you could change it to use `#!/bin/bash`)
