### PR TITLE
htmlspecialchars() checks for type of input parameter before executing.

### DIFF
--- a/hphp/runtime/ext/ext_string.cpp
+++ b/hphp/runtime/ext/ext_string.cpp
@@ -1362,13 +1362,19 @@ String f_htmlspecialchars_decode(const String& str,
                                 "UTF-8", false);
 }
 
-String f_htmlspecialchars(const String& str, int flags /* = k_ENT_COMPAT */,
+String f_htmlspecialchars(const Variant& str, int flags /* = k_ENT_COMPAT */,
                           const String& charset /* = "UTF-8" */,
                           bool double_encode /* = true */) {
+  // Warn if incorrect type supplied, rather than cast.
+  if (!str.isString()) {
+    raise_warning("htmlspecialchars() expects parameter 1 to be string");
+    return null_string;
+  }
+
   // dropping double_encode parameters and see runtime/base/zend-html.h
   const char *scharset = charset.data();
   if (!*scharset) scharset = "ISO-8859-1";
-  return StringUtil::HtmlEncode(str, StringUtil::toQuoteStyleBitmask(flags),
+  return StringUtil::HtmlEncode(str.toString(), StringUtil::toQuoteStyleBitmask(flags),
                                 scharset, double_encode, false);
 }
 

--- a/hphp/runtime/ext/ext_string.h
+++ b/hphp/runtime/ext/ext_string.h
@@ -86,7 +86,7 @@ String f_htmlentities(const String& str, int quote_style = k_ENT_COMPAT,
                       bool double_encode = true);
 String f_htmlspecialchars_decode(const String& str,
                                  int quote_style = k_ENT_COMPAT);
-String f_htmlspecialchars(const String& str, int quote_style = k_ENT_COMPAT,
+String f_htmlspecialchars(const Variant& str, int quote_style = k_ENT_COMPAT,
                           const String& charset = "UTF-8",
                           bool double_encode = true);
 String f_fb_htmlspecialchars(const String& str, int quote_style = k_ENT_COMPAT,

--- a/hphp/system/idl/string.idl.json
+++ b/hphp/system/idl/string.idl.json
@@ -810,7 +810,7 @@
             "args": [
                 {
                     "name": "str",
-                    "type": "String",
+                    "type": "Variant",
                     "desc": "The string being converted."
                 },
                 {

--- a/hphp/test/slow/ext_string/1436-htmlspecialchars.php
+++ b/hphp/test/slow/ext_string/1436-htmlspecialchars.php
@@ -1,0 +1,8 @@
+<?php
+
+// Github Issue #1436: Return type of htmlspecialchars() when
+// wrong type passed.
+
+$string = array('str'=>'aaa');
+$str = htmlspecialchars($string, ENT_QUOTES, 'UTF-8');
+var_dump($str); 

--- a/hphp/test/slow/ext_string/1436-htmlspecialchars.php.expectf
+++ b/hphp/test/slow/ext_string/1436-htmlspecialchars.php.expectf
@@ -1,0 +1,2 @@
+Warning: %s
+NULL


### PR DESCRIPTION
Fixes #1436
