### PR TITLE
Test case for htmlentities() on UTF-8 strings.

### DIFF
--- a/hphp/test/slow/ext_string/2266-htmlentities-utf8.php
+++ b/hphp/test/slow/ext_string/2266-htmlentities-utf8.php
@@ -1,0 +1,3 @@
+<?php
+var_dump(htmlentities("Europe’s", ENT_QUOTES, 'UTF-8'));
+var_dump(htmlentities("77,39 €", ENT_QUOTES, 'UTF-8'));

--- a/hphp/test/slow/ext_string/2266-htmlentities-utf8.php.expect
+++ b/hphp/test/slow/ext_string/2266-htmlentities-utf8.php.expect
@@ -1,0 +1,2 @@
+string(14) "Europe&rsquo;s"
+string(12) "77,39 &euro;"


### PR DESCRIPTION
Closes #2266
