### PR TITLE
Redis EVAL and EVALSHA fixes and tests.

### DIFF
--- a/hphp/system/php/redis/Redis.php
+++ b/hphp/system/php/redis/Redis.php
@@ -597,8 +597,7 @@ class Redis {
       if ($keyCount-- <= 0) break;
       $arg = $this->prefix($arg);
     }
-    array_unshift($args, $numKeys);
-    array_unshift($args, $script);
+    array_unshift($args, $script, $numKeys);
     $this->processArrayCommand($cmd, $args);
     return $this->processVariantResponse();
   }
@@ -607,7 +606,7 @@ class Redis {
     return $this->doEval('EVAL', $script, $args, $numKeys);
   }
 
-  public function evalSha($sha, array $args = array(), $numKeys = 0) {
+  public function _evalSha($sha, array $args = array(), $numKeys = 0) {
     return $this->doEval('EVALSHA', $sha, $args, $numKeys);
   }
 
@@ -878,8 +877,12 @@ class Redis {
     'mget' => [ 'vararg' => self::VAR_KEY_ALL,
                 'return' => 'Vector', 'retargs' => [1] ],
     'getmultiple' => [ 'alias' => 'mget' ],
+
     // Eval
     'eval' => [ 'alias' => '_eval' ],
+    'evalsha' => [ 'alias' => '_evalSha' ],
+    'evaluate' => [ 'alias' => '_eval' ],
+    'evaluatesha' => [ 'alias'=> '_evalSha' ],
   ];
 
 
@@ -1129,17 +1132,6 @@ class Redis {
     }
   }
 
-  protected function processVariantResponse() {
-    if ($this->mode === self::ATOMIC) {
-      return $this->sockReadData($type);
-    }
-    $this->multiHandler[] = [ 'cb' => [$this,'processVariantResponse'] ];
-    if (($this->mode === self::MULTI) && !$this->processQueuedResponse()) {
-      return false;
-    }
-    return $this;
-  }
-
   protected function processClientListResponse() {
     if ($this->mode !== self::ATOMIC) {
       $this->multiHandler[] = [ 'cb' => [$this,'processClientListResponse'] ];
@@ -1149,8 +1141,7 @@ class Redis {
       return $this;
     }
     $resp = $this->sockReadData($type);
-    if (($type !== self::TYPE_LINE) AND
-        ($type !== self::TYPE_BULK)) {
+    if (($type !== self::TYPE_LINE) AND ($type !== self::TYPE_BULK)) {
       return null;
     }
     $ret = [];
@@ -1164,7 +1155,40 @@ class Redis {
         $ret[$k] = $v;
       }
     }
-    return $ret;
+  return $ret;
+  }
+
+  protected function processVariantResponse() {
+    if ($this->mode !== self::ATOMIC) {
+      $this->multiHandler[] = [ 'cb' => [$this,'processVariantResponse'] ];
+      if (($this->mode === self::MULTI) && !$this->processQueuedResponse()) {
+        return false;
+      }
+      return $this;
+    }
+
+    return $this->doProcessVariantResponse();
+  }
+
+  private function doProcessVariantResponse() {
+    $resp = $this->sockReadData($type);
+
+    if ($type === self::TYPE_INT) {
+      return (int) $resp;
+    }
+
+    if ($type === self::TYPE_MULTIBULK) {
+      $ret = [];
+      $lineNo = 0;
+      $count = (int) $resp;
+      while($count--) {
+        $lineNo++;
+        $ret[] = $this->doProcessVariantResponse();
+      }
+      return $ret;
+    }
+
+    return $resp;
   }
 
   protected function processSerializedResponse() {

--- a/hphp/test/slow/ext_redis/evalevalSha.php
+++ b/hphp/test/slow/ext_redis/evalevalSha.php
@@ -4,14 +4,34 @@ include(__DIR__ . '/redis.inc');
 
 $r = NewRedisTestInstance();
 $key = GetTestKeyName(__FILE__);
+$prefix = $key . ':';
 $r->delete($key);
+$r->setOption(Redis::OPT_PREFIX, $prefix);
 
-// eval
-echo "eval\n";
-var_dump($r->eval("return redis.call('set',KEYS[1],ARGV[1])", [$key,'bar'], 1)); // With parameters -> OK
-var_dump($r->eval("return redis.call('get','{$key}')")); // Without parameters -> bar
+foreach (['_eval', 'eval', 'evaluate'] as $method) {
+    echo $method . "\n";
+    var_dump($r->$method('return 42')); // Return integer -> 42
+    var_dump($r->$method('return {1,2,{3,4,{"a","b"}}}')); // Return resutls as array()
+    var_dump($r->eval("return redis.call('set',KEYS[1],ARGV[1])", [$key, 'bar'], 1)); // Script with parameters -> OK
 
-// evalSha
-echo "evalSha\n";
-var_dump($r->evalSha("c686f316aaf1eb01d5a4de1b0b63cd233010e63d",[$key,'bar'], 1)); // SHA1SUM of with parameters -> OK
-var_dump($r->evalSha("ffffffffffffffffffffffffffffffffffffffff")); // No SHA1SUM -> NOSCRIPT error
+    $r->setOption(Redis::OPT_PREFIX, 'ext_redis_eval_test:');
+    var_dump($r->$method('return {KEYS[1],KEYS[2],ARGV[1],ARGV[2]}', ['key1', 'key2', 'first', 'second'], 2));
+    $r->setOption(Redis::OPT_PREFIX, $prefix);
+}
+
+$sha = $r->script('load', 'return 42');
+
+foreach (['_evalSha', 'evalSha', 'evaluateSha'] as $method) {
+    echo $method . "\n";
+    var_dump($r->$method($sha)); // Return integer -> 42
+    var_dump($r->evalSha("c686f316aaf1eb01d5a4de1b0b63cd233010e63d", [$key, 'bar'], 1)); // SHA1SUM of with parameters -> OK
+    var_dump($r->$method("ffffffffffffffffffffffffffffffffffffffff")); // No SHA1SUM -> NOSCRIPT error
+}
+
+echo "script\n";
+
+echo "script\n";
+var_dump($r->script('load', 'return 42'));
+var_dump($r->script('exists', $sha));
+var_dump($r->script('flush'));
+var_dump($r->script('kill'));

--- a/hphp/test/slow/ext_redis/evalevalSha.php.expect
+++ b/hphp/test/slow/ext_redis/evalevalSha.php.expect
@@ -1,6 +1,121 @@
-eval
+_eval
+int(42)
+array(3) {
+  [0]=>
+  int(1)
+  [1]=>
+  int(2)
+  [2]=>
+  array(3) {
+    [0]=>
+    int(3)
+    [1]=>
+    int(4)
+    [2]=>
+    array(2) {
+      [0]=>
+      string(1) "a"
+      [1]=>
+      string(1) "b"
+    }
+  }
+}
 string(2) "OK"
-string(3) "bar"
-evalSha
+array(4) {
+  [0]=>
+  string(24) "ext_redis_eval_test:key1"
+  [1]=>
+  string(24) "ext_redis_eval_test:key2"
+  [2]=>
+  string(5) "first"
+  [3]=>
+  string(6) "second"
+}
+eval
+int(42)
+array(3) {
+  [0]=>
+  int(1)
+  [1]=>
+  int(2)
+  [2]=>
+  array(3) {
+    [0]=>
+    int(3)
+    [1]=>
+    int(4)
+    [2]=>
+    array(2) {
+      [0]=>
+      string(1) "a"
+      [1]=>
+      string(1) "b"
+    }
+  }
+}
+string(2) "OK"
+array(4) {
+  [0]=>
+  string(24) "ext_redis_eval_test:key1"
+  [1]=>
+  string(24) "ext_redis_eval_test:key2"
+  [2]=>
+  string(5) "first"
+  [3]=>
+  string(6) "second"
+}
+evaluate
+int(42)
+array(3) {
+  [0]=>
+  int(1)
+  [1]=>
+  int(2)
+  [2]=>
+  array(3) {
+    [0]=>
+    int(3)
+    [1]=>
+    int(4)
+    [2]=>
+    array(2) {
+      [0]=>
+      string(1) "a"
+      [1]=>
+      string(1) "b"
+    }
+  }
+}
+string(2) "OK"
+array(4) {
+  [0]=>
+  string(24) "ext_redis_eval_test:key1"
+  [1]=>
+  string(24) "ext_redis_eval_test:key2"
+  [2]=>
+  string(5) "first"
+  [3]=>
+  string(6) "second"
+}
+_evalSha
+int(42)
 string(2) "OK"
 string(45) "NOSCRIPT No matching script. Please use EVAL."
+evalSha
+int(42)
+string(2) "OK"
+string(45) "NOSCRIPT No matching script. Please use EVAL."
+evaluateSha
+int(42)
+string(2) "OK"
+string(45) "NOSCRIPT No matching script. Please use EVAL."
+script
+string(40) "1fa00e76656cc152ad327c13fe365858fd7be306"
+array(2) {
+  [0]=>
+  int(1)
+  [1]=>
+  int(0)
+}
+string(2) "OK"
+string(42) "NOTBUSY No scripts in execution right now."


### PR DESCRIPTION
Fixed:
- EVAL and EVALSHA need numKeys as first argument after script / SHA otherwise ERR is thrown - http://redis.io/commands/EVAL
- When calling an aliased method with `__call()` only `$args` should be passed as arguments.

Added:
- Tests for `eval()`, `evalSha()` and `script()`
- Aliases for `eval` and `evaluate` to `_eval`, `evalSha` and `evaluateSha` to `_evalSha`
- Function `doProcessVariantResponse()` to process multibulk responses.
