### PR TITLE
Add evaluate and evaluateSha aliases to Redis.php

### DIFF
--- a/hphp/system/php/redis/Redis.php
+++ b/hphp/system/php/redis/Redis.php
@@ -602,11 +602,11 @@ class Redis {
     return $this->processVariantResponse();
   }
 
-  public function _eval($script, array $args = null, $numKeys = 0) {
+  public function evaluate($script, array $args = null, $numKeys = 0) {
     return $this->doEval('EVAL', $script, $args ?: [], $numKeys);
   }
 
-  public function evalSha($sha, array $args = null, $numKeys = 0) {
+  public function evaluateSha($sha, array $args = null, $numKeys = 0) {
     return $this->doEval('EVALSHA', $sha, $args ?: [], $numKeys);
   }
 
@@ -879,9 +879,8 @@ class Redis {
     'getmultiple' => [ 'alias' => 'mget' ],
 
     // Eval
-    'eval' => [ 'alias' => '_eval' ],
-    'evaluate' => [ 'alias' => '_eval' ],
-    'evaluatesha' => [ 'alias' => 'evalSha' ],
+    'eval' => [ 'alias' => 'evaluate' ],
+    'evalsha' => [ 'alias' => 'evaluateSha' ],
   ];
 
 

--- a/hphp/test/slow/ext_redis/eval.php
+++ b/hphp/test/slow/ext_redis/eval.php
@@ -6,7 +6,7 @@ $r = NewRedisTestInstance();
 $prefix = GetTestKeyName(__FILE__).':';
 $r->setOption(Redis::OPT_PREFIX, $prefix);
 
-foreach (['_eval', 'eval', 'evaluate'] as $method) {
+foreach (['eval', 'evaluate'] as $method) {
     var_dump($r->$method('return 42'));
     var_dump($r->$method('return {1,2,{3,4,{"a","b"}}}'));
     var_dump($r->$method('return redis.call("set", KEYS[1], "bar")', ['foo'], 1));

--- a/hphp/test/slow/ext_redis/eval.php.expect
+++ b/hphp/test/slow/ext_redis/eval.php.expect
@@ -63,36 +63,4 @@ array(4) {
   string(6) "second"
 }
 int(42)
-array(3) {
-  [0]=>
-  int(1)
-  [1]=>
-  int(2)
-  [2]=>
-  array(3) {
-    [0]=>
-    int(3)
-    [1]=>
-    int(4)
-    [2]=>
-    array(2) {
-      [0]=>
-      string(1) "a"
-      [1]=>
-      string(1) "b"
-    }
-  }
-}
-string(2) "OK"
-array(4) {
-  [0]=>
-  string(24) "ext_redis_eval_test:key1"
-  [1]=>
-  string(24) "ext_redis_eval_test:key2"
-  [2]=>
-  string(5) "first"
-  [3]=>
-  string(6) "second"
-}
-int(42)
 int(42)


### PR DESCRIPTION
Add evaluate and evaluateSha methods to Redis to be compatible with phpredis, see 
https://github.com/nicolasff/phpredis/commit/c39ecd52f30a573d476e44baeccebd6ba429cafb.
