### PR TITLE
Make ALWAYS_ASSERT work

### DIFF
--- a/hphp/hhbbc/misc.h
+++ b/hphp/hhbbc/misc.h
@@ -166,7 +166,12 @@ struct copy_ptr {
     return *this;
   }
 
-  ~copy_ptr() { delete m_p; assert((m_p = nullptr, true)); }
+  ~copy_ptr() {
+    delete m_p;
+#ifdef DEBUG
+    m_p = nullptr;
+#endif
+  }
 
   explicit operator bool() const { return !!m_p; }
 

--- a/hphp/runtime/base/array-init.h
+++ b/hphp/runtime/base/array-init.h
@@ -216,21 +216,27 @@ struct ArrayInit {
   ArrayData *create() {
     ArrayData *ret = m_data;
     m_data = nullptr;
-    assert(true || (m_expectedCount = 0)); // reset; no more adds allowed
+#ifdef DEBUG
+    m_expectedCount = 0; // reset; no more adds allowed
+#endif
     return ret;
   }
 
   Array toArray() {
     auto ptr = m_data;
     m_data = nullptr;
-    assert(true || (m_expectedCount = 0)); // reset; no more adds allowed
+#ifdef DEBUG
+    m_expectedCount = 0; // reset; no more adds allowed
+#endif
     return Array(ptr, Array::ArrayInitCtor::Tag);
   }
 
   Variant toVariant() {
     auto ptr = m_data;
     m_data = nullptr;
-    assert(true || (m_expectedCount = 0)); // reset; no more adds allowed
+#ifdef DEBUG
+    m_expectedCount = 0; // reset; no more adds allowed
+#endif
     return Variant(ptr, Variant::ArrayInitCtor{});
   }
 
@@ -324,21 +330,27 @@ public:
   Variant toVariant() {
     auto ptr = m_vec;
     m_vec = nullptr;
-    assert(true || (m_expectedCount = 0)); // reset; no more adds allowed
+#ifdef DEBUG
+    m_expectedCount = 0; // reset; no more adds allowed
+#endif
     return Variant(ptr, Variant::ArrayInitCtor{});
   }
 
   Array toArray() {
     ArrayData* ptr = m_vec;
     m_vec = nullptr;
-    assert(true || (m_expectedCount = 0)); // reset; no more adds allowed
+#ifdef DEBUG
+    m_expectedCount = 0; // reset; no more adds allowed
+#endif
     return Array(ptr, Array::ArrayInitCtor::Tag);
   }
 
   ArrayData *create() {
     auto ptr = m_vec;
     m_vec = nullptr;
-    assert(true || (m_expectedCount = 0)); // reset; no more adds allowed
+#ifdef DEBUG
+    m_expectedCount = 0; // reset; no more adds allowed
+#endif
     return ptr;
   }
 

--- a/hphp/runtime/base/array-iterator.cpp
+++ b/hphp/runtime/base/array-iterator.cpp
@@ -1273,7 +1273,7 @@ int64_t new_iter_array_key(Iter* dest,
     aiter.m_pos = mixed->getIterBegin();
     aiter.m_itypeAndNextHelperIdx =
       static_cast<uint32_t>(IterNextIndex::ArrayMixed) << 16 | itypeU32;
-    assert(aiter.m_itype = ArrayIter::TypeArray);
+    assert(aiter.m_itype == ArrayIter::TypeArray);
     assert(aiter.m_nextHelperIdx == IterNextIndex::ArrayMixed);
     if (WithRef) {
       mixed->dupArrayElmWithRef(aiter.m_pos, valOut, keyOut);

--- a/hphp/runtime/base/packed-array.cpp
+++ b/hphp/runtime/base/packed-array.cpp
@@ -80,7 +80,7 @@ MixedArray* PackedArray::ToMixedHeader(const ArrayData* old,
   assert(ad->m_count == 0);
   assert(ad->m_used == oldSize);
   assert(ad->m_cap == cap);
-  assert(ad->m_tableMask = mask);
+  assert(ad->m_tableMask == mask);
   assert(ad->m_hLoad == oldSize);
   assert(ad->m_nextKI == oldSize);
   // Can't checkInvariants yet, since we haven't populated the payload.

--- a/hphp/runtime/base/ref-data.h
+++ b/hphp/runtime/base/ref-data.h
@@ -64,7 +64,9 @@ struct RefData {
   void initInRDS() {
     assert(isUninitializedInRDS());
     m_count = 1;
-    assert(static_cast<bool>(m_magic = Magic::kMagic)); // assign magic
+#ifdef DEBUG
+    m_magic = Magic::kMagic;
+#endif
     assert(m_cowAndZ == 0);
   }
 
@@ -109,11 +111,11 @@ struct RefData {
    * Note, despite the name, this can never return a non-Cell.
    */
   const Cell* tv() const {
-    assert(m_magic == Magic::kMagic);
+    debug_assert(m_magic == Magic::kMagic);
     return &m_tv;
   }
   Cell* tv() {
-    assert(m_magic == Magic::kMagic);
+    debug_assert(m_magic == Magic::kMagic);
     return &m_tv;
   }
 
@@ -130,7 +132,7 @@ struct RefData {
   static constexpr int tvOffset() { return offsetof(RefData, m_tv); }
 
   void assertValid() const {
-    assert(m_magic == Magic::kMagic);
+    debug_assert(m_magic == Magic::kMagic);
   }
 
   int32_t getRealCount() const {
@@ -150,8 +152,9 @@ struct RefData {
   // Default constructor, provided so that the PHP extension compatibility
   // layer can stack-allocate RefDatas when needed
   RefData() {
-    // intentional use of = to only assign in debug builds
-    assert(static_cast<bool>(m_magic = Magic::kMagic));
+#ifdef DEBUG
+    m_magic = Magic::kMagic;
+#endif
     m_tv.m_type = KindOfNull;
     m_count = 0;
     m_cowAndZ = 0;
@@ -242,8 +245,9 @@ struct RefData {
 
 private:
   RefData(DataType t, int64_t datum) {
-    // intentional use of = to only assign in debug builds
-    assert(static_cast<bool>(m_magic = Magic::kMagic));
+#ifdef DEBUG
+    m_magic = Magic::kMagic;
+#endif
     // Initialize this value by laundering uninitNull -> Null.
     m_count = 1;
     m_cowAndZ = 0;

--- a/hphp/runtime/base/tv-helpers.cpp
+++ b/hphp/runtime/base/tv-helpers.cpp
@@ -69,7 +69,7 @@ bool cellIsPlausible(const Cell cell) {
     assert(!"KindOfRef found in a Cell");
     break;
   default:
-    not_reached();
+    assert(!"Invalid Cell type");
   }
   return true;
 }

--- a/hphp/util/assertions.h
+++ b/hphp/util/assertions.h
@@ -147,27 +147,28 @@ class FailedAssertion : public std::exception {
   assert_log_impl(e, assert_throw_fail_impl(e), l)
 
 #undef assert
-#ifndef NDEBUG
+#if defined(ALWAYS_ASSERT) || !defined(NDEBUG)
 #define assert(e) always_assert(e)
 #define assert_log(e, l) always_assert_log(e, l)
 #define assert_flog(e, ...) always_assert_flog(e, __VA_ARGS__)
 #define assert_throw(e) always_assert_throw(e)
 #define assert_throw_log(e, l) always_assert_throw_log(e, l)
+const bool do_assert = true;
 #else
 #define assert(e) static_cast<void>(0)
 #define assert_log(e, l) static_cast<void>(0)
 #define assert_flog(e, ...) static_cast<void>(0)
 #define assert_throw(e) static_cast<void>(0)
 #define assert_throw_log(e, l) static_cast<void>(0)
+const bool do_assert = false;
 #endif
 
-const bool do_assert =
-#ifdef NDEBUG
-  false
+// debug_assert() is for assertions that should only be done in debug mode
+#ifdef DEBUG
+#define debug_assert(e) assert(e)
 #else
-  true
+#define debug_assert(e) static_cast<void>(0)
 #endif
-  ;
 
 //////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
ALWAYS_ASSERT didn't do anything, perhaps because various assertions were depending on debug mode being active, and would fail with a compile error if it was not.
- Removed all assignment expressions from assert() invocations. Some were accidental (equality was intended), some were accidentally nonfunctional due to shortcut evaluation (true || foo), and the rest were incompatible with ALWAYS_ASSERT.
- Introduced debug_assert() as a shortcut for an assert() which is only done in debug mode.
- Replaced a not_reached() call with a more informative assertion.
