### PR TITLE
Use /bin/bash for hphpize

### DIFF
--- a/hphp/tools/hphpize/hphpize
+++ b/hphp/tools/hphpize/hphpize
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 if [ ! -f "config.cmake" ]; then
   echo "config.cmake not found" >&2


### PR DESCRIPTION
It contains bash-specific syntax, and /bin/sh is normally symlinked to dash on Debian and Ubuntu, which fails with this syntax.
