### PR TITLE
allow redirects in SoapClient requests

### DIFF
--- a/hphp/runtime/base/http-client.h
+++ b/hphp/runtime/base/http-client.h
@@ -69,6 +69,8 @@ public:
 
   std::string getLastError() const { return m_error;}
 
+  static const int defaultMaxRedirect = 20;
+
 private:
   int m_timeout;
   int m_maxRedirect;

--- a/hphp/runtime/base/url-file.cpp
+++ b/hphp/runtime/base/url-file.cpp
@@ -17,7 +17,6 @@
 #include "hphp/runtime/base/url-file.h"
 #include <vector>
 #include "hphp/runtime/base/hphp-system.h"
-#include "hphp/runtime/base/http-client.h"
 #include "hphp/runtime/base/runtime-error.h"
 #include "hphp/runtime/ext/pcre/ext_pcre.h"
 #include "hphp/runtime/ext/stream/ext_stream.h"

--- a/hphp/runtime/base/url-file.h
+++ b/hphp/runtime/base/url-file.h
@@ -17,6 +17,7 @@
 #ifndef incl_HPHP_URL_FILE_H_
 #define incl_HPHP_URL_FILE_H_
 
+#include "hphp/runtime/base/http-client.h"
 #include "hphp/runtime/base/mem-file.h"
 #include "hphp/runtime/base/string-buffer.h"
 
@@ -31,7 +32,8 @@ public:
   DECLARE_RESOURCE_ALLOCATION(UrlFile);
 
   explicit UrlFile(const char *method = "GET", const Array& headers = null_array,
-                   const String& postData = null_string, int maxRedirect = 20,
+                   const String& postData = null_string,
+                   int maxRedirect = HttpClient::defaultMaxRedirect,
                    int timeout = -1, bool ignoreErrors = false);
 
   // overriding ResourceData

--- a/hphp/runtime/ext/ext_soap.cpp
+++ b/hphp/runtime/ext/ext_soap.cpp
@@ -2347,7 +2347,7 @@ c_SoapClient::c_SoapClient(Class* cb) :
     m_authentication(SOAP_AUTHENTICATION_BASIC),
     m_proxy_port(0),
     m_connection_timeout(0),
-    m_max_redirect(0),
+    m_max_redirect(HttpClient::defaultMaxRedirect),
     m_use11(true),
     m_compression(false),
     m_exceptions(true),


### PR DESCRIPTION
PHP hardcodes this number to 20, but it is never set for SoapClient. I
introduced a constant in HttpClient and replaced 20 in UrlFile as well.

https://github.com/php/php-src/blob/PHP-5.6/ext/standard/http_fopen_wrapper.c#L76
