### PR TITLE
Remove Redis::_eval* methods, apply minor fixes and cleanups

### DIFF
--- a/hphp/system/php/redis/Redis.php
+++ b/hphp/system/php/redis/Redis.php
@@ -133,12 +133,12 @@ class Redis {
     if ($op == 'GET') {
       $this->processCommand('CONFIG', 'GET', $key);
       return $this->processMapResponse(false, false);
-    } else if ($op == 'SET') {
+    }
+    if ($op == 'SET') {
       $this->processCommand('CONFIG', 'SET', $key, $val);
       return $this->processBooleanResponse();
-    } else {
-      throw new RedisException('First arg must be GET or SET');
     }
+    throw new RedisException('First arg must be GET or SET');
   }
 
   public function info($option = '') {
@@ -175,9 +175,8 @@ class Redis {
     }
     if ($cmd == 'list') {
       return $this->processClientListResponse();
-    } else {
-      return $this->processVariantResponse();
     }
+    return $this->processVariantResponse();
   }
 
   /* Strings ------------------------------------------------------------- */
@@ -268,9 +267,8 @@ class Redis {
     $this->processArrayCommand('SORT', $args);
     if ($using_store) {
       return $this->processVectorResponse(true);
-    } else {
-      return $this->processLongResponse();
     }
+    return $this->processLongResponse();
   }
 
   public function sortAsc($key,
@@ -442,9 +440,8 @@ class Redis {
     $this->processArrayCommand('ZRANGE', $args);
     if ($withscores) {
       return $this->processMapResponse(true, false);
-    } else {
-      return $this->processVectorResponse(true);
     }
+    return $this->processVectorResponse(true);
   }
 
   protected function zRangeByScoreImpl($cmd,
@@ -467,9 +464,8 @@ class Redis {
     $this->processArrayCommand($cmd, $args);
     if (!empty($opts['withscores'])) {
       return $this->processMapResponse(true, false);
-    } else {
-      return $this->processVectorResponse(true);
     }
+    return $this->processVectorResponse(true);
   }
 
   public function zRangeByScore($key, $start, $end, array $opts = null) {
@@ -494,9 +490,8 @@ class Redis {
     $this->processArrayCommand('ZREVRANGE', $args);
     if ($withscores) {
       return $this->processMapResponse(true, false);
-    } else {
-      return $this->processVectorResponse(true);
     }
+    return $this->processVectorResponse(true);
   }
 
   /* Multi --------------------------------------------------------------- */
@@ -534,7 +529,8 @@ class Redis {
       $this->mode = self::ATOMIC;
       $this->processCommand('EXEC');
       return $this->flushCallbacks();
-    } else if ($this->mode === self::PIPELINE) {
+    }
+    if ($this->mode === self::PIPELINE) {
       $this->mode = self::ATOMIC;
       foreach ($this->commands as $cmd) {
         $this->processArrayCommand($cmd['cmd'], $cmd['args']);
@@ -603,11 +599,11 @@ class Redis {
     return $this->processVariantResponse();
   }
 
-  public function _eval($script, array $args = array(), $numKeys = 0) {
+  public function evaluate($script, array $args = [], $numKeys = 0) {
     return $this->doEval('EVAL', $script, $args, $numKeys);
   }
 
-  public function _evalSha($sha, array $args = array(), $numKeys = 0) {
+  public function evaluateSha($sha, array $args = [], $numKeys = 0) {
     return $this->doEval('EVALSHA', $sha, $args, $numKeys);
   }
 
@@ -684,7 +680,7 @@ class Redis {
   /* Standard Function Map ----------------------------------------------- */
 
   /**
-   * The majority of the Redis API is implemnted by __call
+   * The majority of the Redis API is implemented by __call
    * which references this list for how the individual command
    * should be handled.
    *
@@ -880,10 +876,8 @@ class Redis {
     'getmultiple' => [ 'alias' => 'mget' ],
 
     // Eval
-    'eval' => [ 'alias' => '_eval' ],
-    'evalSha' => [ 'alias' => '_evalSha' ],
-    'evaluate' => [ 'alias' => '_eval' ],
-    'evaluateSha' => [ 'alias'=> '_evalSha' ],
+    'eval' => [ 'alias' => 'evaluate' ],
+    'evalsha' => [ 'alias' => 'evaluateSha' ],
   ];
 
 

--- a/hphp/test/slow/ext_redis/evalevalSha.php
+++ b/hphp/test/slow/ext_redis/evalevalSha.php
@@ -8,10 +8,10 @@ $prefix = $key . ':';
 $r->delete($key);
 $r->setOption(Redis::OPT_PREFIX, $prefix);
 
-foreach (['_eval', 'eval', 'evaluate'] as $method) {
+foreach (['eval', 'evaluate'] as $method) {
     echo $method . "\n";
     var_dump($r->$method('return 42')); // Return integer -> 42
-    // Return resutls as array()
+    // Return results as array()
     var_dump($r->$method('return {1,2,{3,4,{"a","b"}}}'));
     // Script with parameters -> OK
     var_dump($r->eval("return redis.call('set',KEYS[1],ARGV[1])",
@@ -24,10 +24,7 @@ foreach (['_eval', 'eval', 'evaluate'] as $method) {
 }
 
 $sha = $r->script('load', 'return 42');
-var_dump($r->evalSha($sha));
-var_dump($r->evaluateSha($sha));
-
-foreach (['_evalSha', 'evalSha', 'evaluateSha'] as $method) {
+foreach (['evalSha', 'evaluateSha'] as $method) {
     echo $method . "\n";
     var_dump($r->$method($sha)); // Return integer -> 42
     // SHA1SUM of with parameters -> OK

--- a/hphp/test/slow/ext_redis/evalevalSha.php.expect
+++ b/hphp/test/slow/ext_redis/evalevalSha.php.expect
@@ -1,36 +1,3 @@
-_eval
-int(42)
-array(3) {
-  [0]=>
-  int(1)
-  [1]=>
-  int(2)
-  [2]=>
-  array(3) {
-    [0]=>
-    int(3)
-    [1]=>
-    int(4)
-    [2]=>
-    array(2) {
-      [0]=>
-      string(1) "a"
-      [1]=>
-      string(1) "b"
-    }
-  }
-}
-string(2) "OK"
-array(4) {
-  [0]=>
-  string(24) "ext_redis_eval_test:key1"
-  [1]=>
-  string(24) "ext_redis_eval_test:key2"
-  [2]=>
-  string(5) "first"
-  [3]=>
-  string(6) "second"
-}
 eval
 int(42)
 array(3) {
@@ -97,10 +64,6 @@ array(4) {
   [3]=>
   string(6) "second"
 }
-_evalSha
-int(42)
-string(2) "OK"
-string(45) "NOSCRIPT No matching script. Please use EVAL."
 evalSha
 int(42)
 string(2) "OK"


### PR DESCRIPTION
The `_eval` method was named so because `eval` is a reserved word in php, `_evalSha` was introduced for the sake of consistency with `_eval`. I believe that we do not need this methods anymore since we could use `Redis::eval()` (or `Redis::evaluate()`), thanks to method aliases.
