### PR TITLE
provide support for exit as a function

### DIFF
--- a/hphp/hack/hhi/stdlib/builtins_exit.idl.hhi
+++ b/hphp/hack/hhi/stdlib/builtins_exit.idl.hhi
@@ -1,0 +1,11 @@
+<?hh // decl
+/**
+ * Copyright (c) 2014, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the "hack" directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+function exit($status = null_variant) { }


### PR DESCRIPTION
Currently there is no support for `exit` as either a function or a language construct. The following should all be valid:

``` php
exit("Something went terribly wrong");

exit(1);

exit;

exit 1;
```

This pull request adds support for the function style, but `exit` should still be supported as a language construct.
