### PR TITLE
Enable ZNC core by default, for real this time

### DIFF
--- a/CMake/Options.cmake
+++ b/CMake/Options.cmake
@@ -16,4 +16,4 @@ option(USE_GOOGLE_CPU_PROFILER "Use Google cpu profiler" OFF)
 
 option(DISABLE_HARDWARE_COUNTERS "Disable hardware counters (for XenU systems)" OFF)
 
-option(ENABLE_ZEND_COMPAT "Enable Zend source compatibility" OFF)
+option(ENABLE_ZEND_COMPAT "Enable Zend source compatibility" ON)


### PR DESCRIPTION
This was supposed to have been turned on by default in change 7bdfc2d, but it
wasn't, possibly because ZNC was pretty broken at the time. It no longer is, so
it makes sense to make this the default.
