### PR TITLE
Unbreak EVALSHA in Redis client

### DIFF
--- a/hphp/system/php/redis/Redis.php
+++ b/hphp/system/php/redis/Redis.php
@@ -884,9 +884,9 @@ class Redis {
 
     // Eval
     'eval' => [ 'alias' => '_eval' ],
-    'evalSha' => [ 'alias' => '_evalSha' ],
+    'evalsha' => [ 'alias' => '_evalSha' ],
     'evaluate' => [ 'alias' => '_eval' ],
-    'evaluateSha' => [ 'alias'=> '_evalSha' ],
+    'evaluatesha' => [ 'alias'=> '_evalSha' ],
   ];
 
 


### PR DESCRIPTION
Keys in Redis::$map have to be all lowercase, because Redis::_call calls
strtolower on the method name before it looks it up in the table.
