### PR TITLE
Update .gitignore for "CMake DSO build system improvements"

### DIFF
--- a/hphp/tools/hphpize/.gitignore
+++ b/hphp/tools/hphpize/.gitignore
@@ -1,2 +1,3 @@
 Makefile
+hphpize
 hphpize.cmake


### PR DESCRIPTION
As noted by @JoelMarcey in a comment on 5d277bfb783c14fc81fdf182b581053d50cb4af1 , hphpize is now generated from hphpize.in, so needs to be in .gitignore like hphpize.cmake.
