### PR TITLE
Fixed failing curl test.

### DIFF
--- a/hphp/test/zend/good/ext/curl/tests/curl_basic_010.php.expectf
+++ b/hphp/test/zend/good/ext/curl/tests/curl_basic_010.php.expectf
@@ -1,2 +1,2 @@
-%unicode|string%(%d) "%r(Could not resolve:)%r %s"
+%unicode|string%(%d) "%r((Could not|Couldn't) resolve proxy:)%r %s"
 int(5)


### PR DESCRIPTION
The curl error message comes from the curl library, so I changed the regexp to account for travis-ci's curl version ("Couldn't resolve proxy '537a520b69f43'") and my dev curl version 7.35.0 ("Could not resolve proxy: 537a85d077e1d").
