### PR TITLE
Add "hhvm.server.ip" ini setting, matching "Server.IP" HDF setting

### DIFF
--- a/hphp/runtime/base/runtime-option.cpp
+++ b/hphp/runtime/base/runtime-option.cpp
@@ -787,6 +787,8 @@ void RuntimeOption::Load(const IniSetting::Map& ini,
     IniSetting::Bind(IniSetting::CORE, IniSetting::PHP_INI_SYSTEM,
                      "hhvm.server.type", &ServerType);
     ServerIP = Config::GetString(ini, server["IP"]);
+    IniSetting::Bind(IniSetting::CORE, IniSetting::PHP_INI_SYSTEM,
+                     "hhvm.server.ip", &ServerIP);
     ServerFileSocket = Config::GetString(ini, server["FileSocket"]);
     IniSetting::Bind(IniSetting::CORE, IniSetting::PHP_INI_SYSTEM,
                      "hhvm.server.file_socket", &ServerFileSocket);


### PR DESCRIPTION
For exemple, this allows to specify which IP address the FastCGI server will listen on. On a dual-IP-stack system (IPv4+IPv6), HHVM would listen on `::` by default (IPv6). With this setting, one can make it listen to `0.0.0.0` instead (IPv4) using a php.ini file, instead of an HDF configuration file.
