### PR TITLE
Merge 8c2be2409258c4038b8a8424ca25c0fb352d592c into 3.1

### DIFF
--- a/hphp/runtime/base/runtime-option.h
+++ b/hphp/runtime/base/runtime-option.h
@@ -27,6 +27,7 @@
 #include <boost/container/flat_set.hpp>
 #include <memory>
 
+#include "hphp/runtime/base/config.h"
 #include "hphp/util/hash-map-typedefs.h"
 #include "hphp/util/functional.h"
 


### PR DESCRIPTION
The main reason for this is so that the Config class is available to DSOs without needing to include another header file.
