### PR TITLE
Remove unused function ArrayIter::zSecond()

### DIFF
--- a/hphp/runtime/base/array-iterator.cpp
+++ b/hphp/runtime/base/array-iterator.cpp
@@ -582,15 +582,6 @@ Variant ArrayIter::iterValue(VersionableSparse) {
   return tvAsCVarRef(static_cast<Mappish*>(getObject())->iter_value(m_pos));
 }
 
-RefData* ArrayIter::zSecond() {
-  auto tv = nvSecond();
-  if (tv->m_type != KindOfRef) {
-    // FIXME: this is not allowed.
-    tvBox(const_cast<TypedValue*>(tv));
-  }
-  return tv->m_data.pref;
-}
-
 //////////////////////////////////////////////////////////////////////
 
 namespace {

--- a/hphp/runtime/base/array-iterator.h
+++ b/hphp/runtime/base/array-iterator.h
@@ -192,12 +192,6 @@ struct ArrayIter {
     return ad->getValueRef(m_pos).asTypedValue();
   }
 
-  /*
-   * Used by the ext_zend_compat layer.
-   * Identical to nvSecond but the output is boxed.
-   */
-  RefData* zSecond();
-
   bool hasArrayData() const {
     return !((intptr_t)m_data & 1);
   }


### PR DESCRIPTION
Unused since a2c5dc6fd9790870643cdf5a99e650c11faa308a
