### PR TITLE
handle class keyword case-insentive.

### DIFF
--- a/hphp/tools/check_native_signatures.php
+++ b/hphp/tools/check_native_signatures.php
@@ -123,7 +123,7 @@ function parse_php_methods(string $file):
     return ImmMap {};
   }
 
-  static $class_regex = "#class ([^\\s{]+)[^{]*\\{(.*?)\n\\}#ms";
+  static $class_regex = "#class ([^\\s{]+)[^{]*\\{(.*?)\n\\}#msi";
   static $method_regex =
     "#<<[^>]*__Native([^>]*)>>\n\\s*.*?function +([^(]*)\(([^)]*)\) *: *(.+?);#m";
 


### PR DESCRIPTION
In php the class keyword is case-insentive.

therefore `class A` and `Class A` and even `CLASS A` are valid php classes.
