### PR TITLE
Changed warning to notice for acces on non-object error

### DIFF
--- a/hphp/runtime/base/type-object.cpp
+++ b/hphp/runtime/base/type-object.cpp
@@ -111,7 +111,7 @@ bool Object::more(const Object& v2) const {
 }
 
 static Variant warn_non_object() {
-  raise_warning("Cannot access property on non-object");
+  raise_notice("Cannot access property on non-object");
   return uninit_null();
 }
 

--- a/hphp/runtime/vm/jit/translator-runtime.cpp
+++ b/hphp/runtime/vm/jit/translator-runtime.cpp
@@ -267,7 +267,7 @@ StringData* convCellToStrHelper(TypedValue tv) {
 }
 
 void raisePropertyOnNonObject() {
-  raise_warning("Cannot access property on non-object");
+  raise_notice("Cannot access property on non-object");
 }
 
 void raiseUndefProp(ObjectData* base, const StringData* name) {

--- a/hphp/runtime/vm/member-operations.h
+++ b/hphp/runtime/vm/member-operations.h
@@ -1691,7 +1691,7 @@ inline DataType propPreNull(TypedValue& tvScratch, TypedValue*& result) {
   tvWriteNull(&tvScratch);
   result = &tvScratch;
   if (warn) {
-    raise_warning("Cannot access property on non-object");
+    raise_notice("Cannot access property on non-object");
   }
   return KindOfNull;
 }

--- a/hphp/test/quick/asm_assert_optobj.hhas.expectf
+++ b/hphp/test/quick/asm_assert_optobj.hhas.expectf
@@ -1,3 +1,3 @@
 hey
 
-Warning: Cannot access property on non-object in %s on line -1
+Notice: Cannot access property on non-object in %s on line -1

--- a/hphp/test/quick/multidim_props.php.expectf
+++ b/hphp/test/quick/multidim_props.php.expectf
@@ -14,24 +14,24 @@ NULL
 
 Notice: Undefined property: A::$x in %s on line 14
 
-Warning: Cannot access property on non-object in %s on line 14
+Notice: Cannot access property on non-object in %s on line 14
 
-Warning: Cannot access property on non-object in %s on line 14
+Notice: Cannot access property on non-object in %s on line 14
 
-Warning: Cannot access property on non-object in %s on line 14
+Notice: Cannot access property on non-object in %s on line 14
 
-Warning: Cannot access property on non-object in %s on line 14
+Notice: Cannot access property on non-object in %s on line 14
 NULL
 
 Notice: Undefined property: A::$x in %s on line 16
 
-Warning: Cannot access property on non-object in %s on line 16
+Notice: Cannot access property on non-object in %s on line 16
 
-Warning: Cannot access property on non-object in %s on line 16
+Notice: Cannot access property on non-object in %s on line 16
 
-Warning: Cannot access property on non-object in %s on line 16
+Notice: Cannot access property on non-object in %s on line 16
 
-Warning: Cannot access property on non-object in %s on line 16
+Notice: Cannot access property on non-object in %s on line 16
 NULL
 NULL
 object(A)#1 (2) {
@@ -50,23 +50,23 @@ NULL
 
 Notice: Undefined property: A::$x in %s on line 14
 
-Warning: Cannot access property on non-object in %s on line 14
+Notice: Cannot access property on non-object in %s on line 14
 
-Warning: Cannot access property on non-object in %s on line 14
+Notice: Cannot access property on non-object in %s on line 14
 
-Warning: Cannot access property on non-object in %s on line 14
+Notice: Cannot access property on non-object in %s on line 14
 
-Warning: Cannot access property on non-object in %s on line 14
+Notice: Cannot access property on non-object in %s on line 14
 NULL
 
 Notice: Undefined property: A::$x in %s on line 16
 
-Warning: Cannot access property on non-object in %s on line 16
+Notice: Cannot access property on non-object in %s on line 16
 
-Warning: Cannot access property on non-object in %s on line 16
+Notice: Cannot access property on non-object in %s on line 16
 
-Warning: Cannot access property on non-object in %s on line 16
+Notice: Cannot access property on non-object in %s on line 16
 
-Warning: Cannot access property on non-object in %s on line 16
+Notice: Cannot access property on non-object in %s on line 16
 NULL
 NULL

--- a/hphp/test/quick/prop_order_parens.php.expectf
+++ b/hphp/test/quick/prop_order_parens.php.expectf
@@ -17,6 +17,6 @@ Notice: Array to string conversion in %s on line 50
 
 Notice: Undefined property: C::$Array in %s on line 50
 
-Warning: Cannot access property on non-object in %s on line 50
+Notice: Cannot access property on non-object in %s on line 50
 NULL
 int(650)

--- a/hphp/test/slow/eval_order/1523.php.expectf
+++ b/hphp/test/slow/eval_order/1523.php.expectf
@@ -18,7 +18,7 @@ string(8) "testxfoo"
 Warning: Cannot use a scalar value as an array in %s/test/slow/eval_order/1523.php on line 60
 NULL
 
-Warning: Cannot access property on non-object in %s/test/slow/eval_order/1523.php on line 64
+Notice: Cannot access property on non-object in %s/test/slow/eval_order/1523.php on line 64
 NULL
 string(3) "foo"
 object(stdClass)#2 (1) {

--- a/hphp/test/slow/hhbbc/array_019.php.expectf
+++ b/hphp/test/slow/hhbbc/array_019.php.expectf
@@ -1,7 +1,7 @@
 
 Warning: Cannot access property on non-object in %s/slow/hhbbc/array_019.php on line 8
 
-Warning: Cannot access property on non-object in %s/slow/hhbbc/array_019.php on line 9
+Notice: Cannot access property on non-object in %s/slow/hhbbc/array_019.php on line 9
 NULL
 array(1) {
   ["x"]=>

--- a/hphp/test/slow/invalid_argument/1383.php.expect
+++ b/hphp/test/slow/invalid_argument/1383.php.expect
@@ -1,6 +1,6 @@
 int(4096)
 string(74) "Argument 1 passed to x::__construct() must be an instance of y, null given"
-int(2)
+int(8)
 string(36) "Cannot access property on non-object"
 NULL
 object(x)#1 (0) {

--- a/hphp/test/slow/object_property/701.php.expectf
+++ b/hphp/test/slow/object_property/701.php.expectf
@@ -1,14 +1,13 @@
-
-Warning: Cannot access property on non-object in %s/test/slow/object_property/701.php on line 4
+Notice: Cannot access property on non-object in %s/test/slow/object_property/701.php on line 4
 NULL
 
-Warning: Cannot access property on non-object in %s/test/slow/object_property/701.php on line 4
+Notice: Cannot access property on non-object in %s/test/slow/object_property/701.php on line 4
 NULL
 
-Warning: Cannot access property on non-object in %s/test/slow/object_property/701.php on line 4
+Notice: Cannot access property on non-object in %s/test/slow/object_property/701.php on line 4
 NULL
 
-Warning: Cannot access property on non-object in %s/test/slow/object_property/701.php on line 4
+Notice: Cannot access property on non-object in %s/test/slow/object_property/701.php on line 4
 NULL
 
 Fatal error: Cannot access empty property in %s/test/slow/object_property/701.php on line 4

--- a/hphp/test/slow/reference/1097.php.expectf
+++ b/hphp/test/slow/reference/1097.php.expectf
@@ -1,4 +1,4 @@
-Warning: Cannot access property on non-object in %s/test/slow/reference/1097.php on line 4
+Notice: Cannot access property on non-object in %s/test/slow/reference/1097.php on line 4
 NULL
 array(1) {
   [0]=>


### PR DESCRIPTION
Fixes: #1905

This is similar to #1949. I don't get bad tests for current master.
