### PR TITLE
Re-add the leading : and % to XHP tokens in token_get_all

### DIFF
--- a/hphp/runtime/ext/ext_misc.cpp
+++ b/hphp/runtime/ext/ext_misc.cpp
@@ -638,10 +638,19 @@ Array f_token_get_all(const String& source) {
     if (tokid < 256) {
       res.append(String::FromChar((char)tokid));
     } else {
+      String value;
+      const int tokVal = get_user_token_id(tokid);
+      if (tokVal == UserTokenId_T_XHP_LABEL) {
+        value = String(":" + tok.text());
+      } else if (tokVal == UserTokenId_T_XHP_CATEGORY_LABEL) {
+        value = String("%" + tok.text());
+      } else {
+        value = String(tok.text());
+      }
       Array p = make_packed_array(
         // Convert the internal token ID to a user token ID
-        get_user_token_id(tokid),
-        String(tok.text()),
+        tokVal,
+        value,
         loc.line0
       );
       res.append(p);

--- a/hphp/test/slow/ext_misc/php_strip_whitespace_xhp.php
+++ b/hphp/test/slow/ext_misc/php_strip_whitespace_xhp.php
@@ -1,0 +1,6 @@
+<?hh
+echo php_strip_whitespace(__FILE__);
+
+class :test {
+  category %test;
+}

--- a/hphp/test/slow/ext_misc/php_strip_whitespace_xhp.php.expect
+++ b/hphp/test/slow/ext_misc/php_strip_whitespace_xhp.php.expect
@@ -1,0 +1,2 @@
+<?hh
+echo php_strip_whitespace(__FILE__); class :test { category %test; }

--- a/hphp/test/slow/ext_misc/token_get_all_xhp.php
+++ b/hphp/test/slow/ext_misc/token_get_all_xhp.php
@@ -1,0 +1,44 @@
+<?php
+
+$src = token_get_all('<?hh class :test{category %test}');
+$expected = array(
+  array(
+    T_OPEN_TAG,
+    '<?hh ',
+    1,
+  ),
+  array(
+    T_CLASS,
+    'class',
+    1,
+  ),
+  array(
+    T_WHITESPACE,
+    ' ',
+    1,
+  ),
+  array(
+    T_XHP_LABEL,
+    ':test',
+    1,
+  ),
+  '{',
+  array(
+    T_XHP_CATEGORY,
+    'category',
+    1,
+  ),
+  array(
+    T_WHITESPACE,
+    ' ',
+    1,
+  ),
+  array(
+    T_XHP_CATEGORY_LABEL,
+    '%test',
+    1,
+  ),
+  '}',
+);
+
+var_dump($src == $expected);

--- a/hphp/test/slow/ext_misc/token_get_all_xhp.php.expect
+++ b/hphp/test/slow/ext_misc/token_get_all_xhp.php.expect
@@ -1,0 +1,1 @@
+bool(true)


### PR DESCRIPTION
Special cases T_XHP_LABEL and T_XHP_CATEGORY_LABEL as their leading characters
are stripped be the lexer.

Fixes #2736
