### PR TITLE
Added a new config variable called FixPathInfo in the Server{} section.

### DIFF
--- a/hphp/runtime/base/runtime-option.cpp
+++ b/hphp/runtime/base/runtime-option.cpp
@@ -127,6 +127,7 @@ int RuntimeOption::ServerThreadJobMaxQueuingMilliSeconds = -1;
 bool RuntimeOption::ServerThreadDropStack = false;
 bool RuntimeOption::ServerHttpSafeMode = false;
 bool RuntimeOption::ServerStatCache = false;
+bool RuntimeOption::ServerFixPathInfo = false;
 std::vector<std::string> RuntimeOption::ServerWarmupRequests;
 boost::container::flat_set<std::string>
 RuntimeOption::ServerHighPriorityEndPoints;
@@ -813,6 +814,7 @@ void RuntimeOption::Load(const IniSetting::Map& ini,
     ServerThreadDropStack = Config::GetBool(ini, server["ThreadDropStack"]);
     ServerHttpSafeMode = Config::GetBool(ini, server["HttpSafeMode"]);
     ServerStatCache = Config::GetBool(ini, server["StatCache"], false);
+    ServerFixPathInfo = Config::GetBool(ini, server["FixPathInfo"], false);
     Config::Get(ini, server["WarmupRequests"], ServerWarmupRequests);
     Config::Get(ini, server["HighPriorityEndPoints"], ServerHighPriorityEndPoints);
     ServerExitOnBindFail = Config::GetBool(ini, server["ExitOnBindFail"], false);

--- a/hphp/runtime/base/runtime-option.h
+++ b/hphp/runtime/base/runtime-option.h
@@ -129,6 +129,7 @@ public:
   static bool ServerThreadDropStack;
   static bool ServerHttpSafeMode;
   static bool ServerStatCache;
+  static bool ServerFixPathInfo;
   static std::vector<std::string> ServerWarmupRequests;
   static boost::container::flat_set<std::string> ServerHighPriorityEndPoints;
   static bool ServerExitOnBindFail;

--- a/hphp/runtime/server/fastcgi/fastcgi-transport.cpp
+++ b/hphp/runtime/server/fastcgi/fastcgi-transport.cpp
@@ -428,10 +428,12 @@ void FastCGITransport::onHeadersComplete() {
     m_httpVersion = Transport::getHTTPVersion();
   }
 
-  if (m_pathTranslated.empty()) {
-    // If someone follows http://wiki.nginx.org/HttpFastcgiModule they won't
-    // pass in PATH_TRANSLATED and instead will just send SCRIPT_FILENAME
-    m_pathTranslated = getRawHeader(s_scriptFilename);
+  if (m_scriptFilename.empty() || RuntimeOption::ServerFixPathInfo) {
+    // According to php-fpm, some servers don't set SCRIPT_FILENAME. In
+    // this case, it uses PATH_TRANSLATED.
+    // Added runtime option to change m_scriptFilename to s_pathTranslated
+    // which will allow mod_fastcgi and mod_action to work correctly.
+    m_scriptFilename = getRawHeader(s_pathTranslated);
   }
 
   // do a check for mod_proxy_cgi and remove the start portion of the string


### PR DESCRIPTION
This adds support to change SCRIPT_FILENAME into PATH_TRANSLATED for the people that are running apache 2.2, mod_fastcgi and mod_actions. ie: multiple php versions and hhvm within the same virtualhost.
