### PR TITLE
CMake: install headers under DESTDIR

### DIFF
--- a/CMake/HPHPFunctions.cmake
+++ b/CMake/HPHPFunctions.cmake
@@ -179,7 +179,7 @@ function(HHVM_INSTALL_HEADERS TARGET SRCROOT DEST)
         string(SUBSTRING ${dest_rel} 0 ${slash_pos} dest_rel)
       endif()
       file(COPY ${src_rel}
-        DESTINATION "${DEST}/${dest_rel}"
+        DESTINATION "$ENV{DESTDIR}${DEST}/${dest_rel}"
         NO_SOURCE_PERMISSIONS)
     endif()
   endforeach()


### PR DESCRIPTION
The relatively new HHVM_INSTALL_HEADERS function has some special code
to recursively copy files to the target, using file(COPY ). However,
file(COPY) does not by default prefix with DESTDIR and would install the
headers into the system paths, instead of under the supplied destination
directory.

Change the function to prefix the target with $ENV{DESTDIR} to fix this.

This matters especially for downstream packagers, as packages usually
build by running "make install" using a DESTDIR, then packaging that
directory up. Without this, compilation would fail, as the build system
would attempt to install in a privileged system directory.
