### PR TITLE
stream_get_line is supposed to return false on eof or error

### DIFF
--- a/hphp/runtime/base/file.cpp
+++ b/hphp/runtime/base/file.cpp
@@ -627,9 +627,9 @@ String File::readLine(int64_t maxlen /* = 0 */) {
   return String(ret, total_copied, AttachString);
 }
 
-String File::readRecord(const String& delimiter, int64_t maxlen /* = 0 */) {
+Variant File::readRecord(const String& delimiter, int64_t maxlen /* = 0 */) {
   if (eof() && m_writepos == m_readpos) {
-    return empty_string;
+    return false;
   }
 
   if (maxlen <= 0 || maxlen > CHUNK_SIZE) {

--- a/hphp/runtime/base/file.h
+++ b/hphp/runtime/base/file.h
@@ -180,9 +180,9 @@ public:
   String readLine(int64_t maxlen = 0);
 
   /**
-   * Read one record a time. Returns a null string on failure or eof.
+   * Read one record a time. Returns a false on failure or eof.
    */
-  String readRecord(const String& delimiter, int64_t maxlen = 0);
+  Variant readRecord(const String& delimiter, int64_t maxlen = 0);
 
   /**
    * Read entire file and print it out.

--- a/hphp/test/slow/ext_stream/ext_stream.php
+++ b/hphp/test/slow/ext_stream/ext_stream.php
@@ -101,7 +101,7 @@ function test_stream_get_line() {
   fseek($f, 0);
   VS(stream_get_line($f, 300, "@"), "stream_get_line");
   VS(stream_get_line($f, 300, "@"), "test");
-  VS(stream_get_line($f, 300, "@"), "");
+  VS(stream_get_line($f, 300, "@"), false);
   fclose($f);
 }
 

--- a/hphp/test/slow/ext_stream/stream_get_line_returnvalue.php
+++ b/hphp/test/slow/ext_stream/stream_get_line_returnvalue.php
@@ -1,0 +1,20 @@
+<?php
+echo "<pre>";
+test("one\n\nthree\nfour");
+test("one\n\nthree\nfour\n");
+test("\ntwo\nthree\nfour");
+test("\ntwo\nthree\nfour\n");
+test("one\ntwo\n\n\n");
+
+function test($string) {
+    $stream = fopen('php://memory', 'r+');
+    fwrite($stream, $string);
+    rewind($stream);
+
+    for ($i = 0; $i < 6; $i ++) {
+        $line = stream_get_line($stream, 666, "\n");
+        echo "$i" . (feof($stream) ? ' (eof)' : '') . ": ";
+        var_dump($line);
+    }
+    echo "\n";
+}

--- a/hphp/test/slow/ext_stream/stream_get_line_returnvalue.php.expect
+++ b/hphp/test/slow/ext_stream/stream_get_line_returnvalue.php.expect
@@ -1,0 +1,35 @@
+<pre>0: string(3) "one"
+1: string(0) ""
+2: string(5) "three"
+3 (eof): string(4) "four"
+4 (eof): bool(false)
+5 (eof): bool(false)
+
+0: string(3) "one"
+1: string(0) ""
+2: string(5) "three"
+3 (eof): string(4) "four"
+4 (eof): bool(false)
+5 (eof): bool(false)
+
+0: string(0) ""
+1: string(3) "two"
+2: string(5) "three"
+3 (eof): string(4) "four"
+4 (eof): bool(false)
+5 (eof): bool(false)
+
+0: string(0) ""
+1: string(3) "two"
+2: string(5) "three"
+3 (eof): string(4) "four"
+4 (eof): bool(false)
+5 (eof): bool(false)
+
+0: string(3) "one"
+1: string(3) "two"
+2: string(0) ""
+3 (eof): string(0) ""
+4 (eof): bool(false)
+5 (eof): bool(false)
+


### PR DESCRIPTION
Fixes #2759

changed test to match php's behaviour

Also, `stream_get_line`'s second parameter `$length` is optional in hhvm while it isn't optional in zend php. Should this be changed or not?
