### PR TITLE
Make TYPO3 unit tests works again with HHVM master

### DIFF
--- a/hphp/test/frameworks/framework_class_overrides/TYPO3.php
+++ b/hphp/test/frameworks/framework_class_overrides/TYPO3.php
@@ -8,9 +8,7 @@ class Typo3 extends Framework {
   public function __construct(string $name) {
     $typo3path = Options::$frameworks_root . '/typo3';
     $env_vars = Map { "TYPO3_PATH_WEB" =>  $typo3path };
-    $tc = get_runtime_build().' '.__DIR__.
-      '/../framework_downloads/typo3/bin/phpunit';
-    parent::__construct($name, $tc, $env_vars, null,
+    parent::__construct($name, null, $env_vars, null,
                         false, TestFindModes::TOKEN);
   }
 

--- a/hphp/test/frameworks/frameworks.yaml
+++ b/hphp/test/frameworks/frameworks.yaml
@@ -514,6 +514,17 @@
     commit: 1fb5784662f438d7d96a541e305e28b812e2eeed
     install_root: twig
     test_root: twig
+  typo3:
+    url: git://github.com/TYPO3/TYPO3.CMS.git
+    branch: master
+    commit: 30b091ae307f55581e7e1418891d0e81cf85ccee
+    install_root: typo3
+    test_root: typo3/typo3/sysext/core/Build
+    config_file: typo3/typo3/sysext/core/Build/UnitTests.xml
+    bootstrap_file: typo3/typo3/sysext/core/Build/UnitTestsBootstrap.php
+    blacklist:
+      #fatals because of https://github.com/facebook/hhvm/issues/2740
+      - typo3/typo3/sysext/extbase/Tests/Unit/Mvc/Cli/CommandTest.php
   vfsstream:
     url: https://github.com/mikey179/vfsStream.git
     branch: v1.2.0


### PR DESCRIPTION
Blacklist one tests which throws fatal error because of #2740
Update TYPO3 commit pointer to include PHPUnit 4 compatibility
resolves https://github.com/facebook/hhvm/issues/2103
