### PR TITLE
fix SimpleXML::addChild with empty namespace

### DIFF
--- a/hphp/runtime/ext/ext_simplexml.cpp
+++ b/hphp/runtime/ext/ext_simplexml.cpp
@@ -1430,7 +1430,7 @@ Object c_SimpleXMLElement::t_attributes(const String& ns /* = "" */,
 
 Variant c_SimpleXMLElement::t_addchild(const String& qname,
                                        const String& value /* = null_string */,
-                                       const String& ns /* = null_string */) {
+                                       const Variant& ns /* = null */) {
   if (qname.empty()) {
     raise_warning("Element name is required");
     return init_null();
@@ -1462,13 +1462,14 @@ Variant c_SimpleXMLElement::t_addchild(const String& qname,
 
   xmlNsPtr nsptr = nullptr;
   if (!ns.isNull()) {
-    if (ns.empty()) {
+    const String& ns_ = ns.toString();
+    if (ns_.empty()) {
       newnode->ns = nullptr;
-      nsptr = xmlNewNs(newnode, (xmlChar*)ns.data(), prefix);
+      nsptr = xmlNewNs(newnode, (xmlChar*)ns_.data(), prefix);
     } else {
-      nsptr = xmlSearchNsByHref(node->doc, node, (xmlChar*)ns.data());
+      nsptr = xmlSearchNsByHref(node->doc, node, (xmlChar*)ns_.data());
       if (nsptr == nullptr) {
-        nsptr = xmlNewNs(newnode, (xmlChar*)ns.data(), prefix);
+        nsptr = xmlNewNs(newnode, (xmlChar*)ns_.data(), prefix);
       }
       newnode->ns = nsptr;
     }

--- a/hphp/runtime/ext/ext_simplexml.h
+++ b/hphp/runtime/ext/ext_simplexml.h
@@ -79,7 +79,7 @@ class c_SimpleXMLElement :
   public: Object t_children(const String& ns = "", bool is_prefix = false);
   public: String t_getname();
   public: Object t_attributes(const String& ns = "", bool is_prefix = false);
-  public: Variant t_addchild(const String& qname, const String& value = null_string, const String& ns = null_string);
+  public: Variant t_addchild(const String& qname, const String& value = null_string, const Variant& ns = null_string);
   public: void t_addattribute(const String& qname, const String& value = null_string, const String& ns = null_string);
   public: String t___tostring();
   public: Variant t___get(Variant name);

--- a/hphp/system/idl/simplexml.idl.json
+++ b/hphp/system/idl/simplexml.idl.json
@@ -485,8 +485,8 @@
                         },
                         {
                             "name": "ns",
-                            "type": "String",
-                            "value": "null_string"
+                            "type": "Variant",
+                            "value": "null"
                         }
                     ]
                 },

--- a/hphp/test/slow/simple_xml/add_child_empty_ns.php
+++ b/hphp/test/slow/simple_xml/add_child_empty_ns.php
@@ -1,0 +1,8 @@
+<?php
+
+foreach (array(null, "", false, 0) as $type) {
+    $xml = simplexml_load_string('<root />');
+    $xml->addChild("a", "b", $type);
+    var_dump(str_replace(PHP_EOL, "", $xml->a->asXML()));
+}
+

--- a/hphp/test/slow/simple_xml/add_child_empty_ns.php.expect
+++ b/hphp/test/slow/simple_xml/add_child_empty_ns.php.expect
@@ -1,0 +1,4 @@
+string(8) "<a>b</a>"
+string(17) "<a xmlns="">b</a>"
+string(17) "<a xmlns="">b</a>"
+string(18) "<a xmlns="0">b</a>"


### PR DESCRIPTION
In this case an empty string and null result in different behaviors.
See https://github.com/php/php-src/blob/PHP-5.6/ext/simplexml/simplexml.c#L1674
