### PR TITLE
fix soap calls for objects with __call

### DIFF
--- a/hphp/runtime/ext/ext_soap.cpp
+++ b/hphp/runtime/ext/ext_soap.cpp
@@ -2092,7 +2092,7 @@ static bool valid_function(c_SoapServer *server, Object &soap_obj,
     return server->m_soap_functions.ft.exists(f_strtolower(fn_name));
   }
   HPHP::Func* f = cls ? cls->lookupMethod(fn_name.get()) : nullptr;
-  return (f && f->isPublic());
+  return (f && f->isPublic()) || soap_obj->getAttribute(ObjectData::HasCall);
 }
 
 const StaticString


### PR DESCRIPTION
Once again not quite sure how to work this into a HHVM test (like my previous PR #2505).

When the soap object has a __call method we should consider it as a valid function and let the VM deal with it.
