### PR TITLE
unset() on ArrayObject is supposed to raise a notice if undefined key is passed

### DIFF
--- a/hphp/system/php/spl/miscellaneous/ArrayObject.php
+++ b/hphp/system/php/spl/miscellaneous/ArrayObject.php
@@ -294,6 +294,10 @@ class ArrayObject implements IteratorAggregate, ArrayAccess,
    * @return     mixed   No value is returned.
    */
   public function offsetUnset($index) {
+    if(!$this->offsetExists($index)) {
+      [][$index]; // Try to access wrong key so a Notice is raised
+      return;
+    }
     if ($this->isArray()) {
       unset($this->storage[$index]);
     } else {

--- a/hphp/test/slow/array_object/unset_error.php
+++ b/hphp/test/slow/array_object/unset_error.php
@@ -1,0 +1,20 @@
+<?php
+
+$ar = array('a'=>0, 1, 2, 3);
+$ar = new ArrayObject($ar);
+
+unset($ar['a']);
+unset($ar[12]);
+unset($ar['c']);
+$ar->offsetUnset('c');
+
+
+$obj = new stdClass();
+$obj->one = 1;
+$obj->two = 2;
+$ar = new ArrayObject($obj);
+
+unset($ar['one']);
+unset($ar[12]);
+unset($ar['c']);
+$ar->offsetUnset('c');

--- a/hphp/test/slow/array_object/unset_error.php.expectf
+++ b/hphp/test/slow/array_object/unset_error.php.expectf
@@ -1,0 +1,11 @@
+Notice: Undefined index: 12 in %s on line 7
+
+Notice: Undefined index: c in %s on line 8
+
+Notice: Undefined index: c in %s on line 9
+
+Notice: Undefined index: 12 in %s on line 18
+
+Notice: Undefined index: c in %s on line 19
+
+Notice: Undefined index: c in %s on line 20


### PR DESCRIPTION
PHP throws a notice when trying to unset() or offsetUnset() key which aren't defined

I'm not sure if this is the right approach to get the appropriate error
