### PR TITLE
Correct arg type in Scanner::read declaration

### DIFF
--- a/hphp/parser/scanner.cpp
+++ b/hphp/parser/scanner.cpp
@@ -594,7 +594,7 @@ int Scanner::getNextToken(ScannerToken &t, Location &l) {
   return tokid;
 }
 
-int Scanner::read(char *text, int &result, int max) {
+int Scanner::read(char *text, yy_size_t &result, yy_size_t max) {
   if (m_stream) {
     if (!m_stream->eof()) {
       m_stream->read(text, max);

--- a/hphp/parser/scanner.h
+++ b/hphp/parser/scanner.h
@@ -28,6 +28,11 @@
 #include "hphp/parser/location.h"
 #include "hphp/parser/hphp.tab.hpp"
 
+#ifndef YY_TYPEDEF_YY_SIZE_T
+#define YY_TYPEDEF_YY_SIZE_T
+typedef size_t yy_size_t;
+#endif
+
 namespace HPHP {
 ///////////////////////////////////////////////////////////////////////////////
 
@@ -238,7 +243,7 @@ public:
   /**
    * Called by lex.yy.cpp for YY_INPUT (see hphp.x)
    */
-  int read(char *text, int &result, int max);
+  int read(char *text, yy_size_t &result, yy_size_t max);
 
   /**
    * Called by scanner rules.


### PR DESCRIPTION
Flex uses yy_size_t since 2.5.36 (see [1]). This fixes compilation on
an amd64 Debian Jessie for me.

[1] http://sourceforge.net/p/flex/flex/ci/9ba3187a537d6a58d345f2874d06087fd4050399/
