### PR TITLE
Add option to explicitly turn on tracing

### DIFF
--- a/CMake/HPHPSetup.cmake
+++ b/CMake/HPHPSetup.cmake
@@ -122,6 +122,10 @@ if(APPLE OR FREEBSD)
   add_definitions(-DSKIP_USER_CHANGE=1)
 endif()
 
+if(ENABLE_TRACE)
+    add_definitions(-DUSE_TRACE=1)
+endif()
+
 if(APPLE)
   # We have to be a little more permissive in some cases.
   add_definitions(-fpermissive)

--- a/CMake/Options.cmake
+++ b/CMake/Options.cmake
@@ -16,6 +16,8 @@ option(USE_GOOGLE_CPU_PROFILER "Use Google cpu profiler" OFF)
 
 option(DISABLE_HARDWARE_COUNTERS "Disable hardware counters (for XenU systems)" OFF)
 
+option(ENABLE_TRACE "Enable tracing in release build" OFF)
+
 IF (NOT APPLE)
   option(ENABLE_ZEND_COMPAT "Enable Zend source compatibility" ON)
 ENDIF (NOT APPLE)


### PR DESCRIPTION
Sometimes it is useful to be able to use tracing without using a debug build. Clearly somebody already thought of this, since there is a `USE_TRACE` define already floating around. This adds an option to CMake so you can pass `-DENABLE_TRACE=1` to `cmake` and get tracing.

Good for initially debugging things without having to do a full debug build.
