### PR TITLE
improve performance in simplexml

### DIFF
--- a/hphp/runtime/ext/ext_simplexml.cpp
+++ b/hphp/runtime/ext/ext_simplexml.cpp
@@ -819,9 +819,10 @@ next_iter:
 static Variant sxe_object_cast(c_SimpleXMLElement* sxe, int8_t type) {
   if (type == HPHP::KindOfBoolean) {
     xmlNodePtr node = php_sxe_get_first_node(sxe, nullptr);
+    if (node) return true;
     Array properties = Array::Create();
     sxe_get_prop_hash(sxe, true, properties);
-    return node != nullptr || properties.size();
+    return properties.size() != 0;
   }
 
   xmlChar* contents = nullptr;


### PR DESCRIPTION
When casting a SimpleXML element to boolean, we're only concerned with
the object having an XML node, _or_ having attributes. Building
attributes is done by sxe_get_prop_hash that also recursively builds the
entire element tree starting from that element.

We shortcircuit when the object has a valid XML node to prevent excessive
amount of object creation when all your program is doing is loading
XML strings and doing read/toBool operations.

Before: http://i.imgur.com/TFFj97u.gif
After:  http://i.imgur.com/3kNpwIM.gif
