### PR TITLE
fix a memory leak in simplexml

### DIFF
--- a/hphp/runtime/ext/ext_simplexml.cpp
+++ b/hphp/runtime/ext/ext_simplexml.cpp
@@ -1656,7 +1656,7 @@ c_SimpleXMLElementIterator::c_SimpleXMLElementIterator(Class* cb) :
 
 c_SimpleXMLElementIterator::~c_SimpleXMLElementIterator() {
   if (sxe) {
-    sxe->decRefCount();
+    decRefObj(sxe);
     sxe = nullptr;
   }
 }


### PR DESCRIPTION
Oops, this one's on me. Since t_getiterator passes control over from the
sxe object to the iterator, we need to actually release sxe when our
iterator's destructor is called.

Fixes #2854.
