### PR TITLE
make SimpleXML boolean casts even faster

### DIFF
--- a/hphp/runtime/ext/ext_simplexml.cpp
+++ b/hphp/runtime/ext/ext_simplexml.cpp
@@ -711,7 +711,7 @@ static void sxe_properties_add(Array& rv, char* name, const Variant& value) {
 }
 
 static void sxe_get_prop_hash(c_SimpleXMLElement* sxe, bool is_debug,
-                              Array& rv) {
+                              Array& rv, bool isBoolCast = false) {
   rv.clear();
 
   Object iter_data = nullptr;
@@ -802,6 +802,7 @@ static void sxe_get_prop_hash(c_SimpleXMLElement* sxe, bool is_debug,
       } else {
         sxe_properties_add(rv, name, value);
       }
+      if (isBoolCast) break;
 next_iter:
       if (use_iter) {
         node = php_sxe_iterator_fetch(sxe, node->next, 0);
@@ -821,7 +822,7 @@ static Variant sxe_object_cast(c_SimpleXMLElement* sxe, int8_t type) {
     xmlNodePtr node = php_sxe_get_first_node(sxe, nullptr);
     if (node) return true;
     Array properties = Array::Create();
-    sxe_get_prop_hash(sxe, true, properties);
+    sxe_get_prop_hash(sxe, true, properties, true);
     return properties.size() != 0;
   }
 


### PR DESCRIPTION
This is a follow up to PR #2855.

When we need to build our element's child tree (sxe_get_prop_hash) to
determine if it casts to true/false, we can get away with bailing after
finding the first element.

In my small Magento siege tests these result in significant
improvements:

Before:
Transactions:               1551 hits
Transaction rate:           51.79 trans/sec
Lowest response time:       97ms
Callgrind:                  http://i.imgur.com/npxMo0q.png

After:
Transactions:               1730 hits
Transaction rate:           58.43 trans/sec
Lowest response time:       89ms
Callgrind:                  http://i.imgur.com/Dgojb9Y.png
