### PR TITLE
Fix behavior of Redis client

### DIFF
--- a/hphp/system/php/redis/Redis.php
+++ b/hphp/system/php/redis/Redis.php
@@ -966,6 +966,15 @@ class Redis {
     $line = fgets($this->connection);
     if (substr($line, -2) == "\r\n") {
       $line = substr($line, 0, -2);
+    } else if (substr($line, -1) == "\r") {
+      $line = substr($line, 0, -1);
+      $lf = fgetc($this->connection);
+      if ($lf === false) {
+        // A response must terminate with both CR and LF. Refuse to guess.
+        return false;
+      } else if ($lf !== "\n") {
+        throw new RedisException("Protocol error: CR not followed by LF");
+      }
     }
 
     return $line;


### PR DESCRIPTION
Because HHVM forces auto_detect_line_ending to be enabled (which is a separate
bug), if a CRLF is split across two TCP packets, fgets() is liable to get
confused and assume that the stream uses CR line ending. As a result, the
return value of Redis::sockReadLine() is liable to have either a trailing CR or
a leading LF, both of which are corruptions. This causes the client to throw an
exception, complaining of a protocol error.

The behavior of fgets() is documented here:
http://www.php.net/manual/en/function.fgets.php#101963

The Redis protocol spec affirms that responses terminate with CRLF and are
guaranteed not to contain either CR or LF in the response body:
http://redis.io/topics/protocol
