### PR TITLE
Add branch back to the Travis CI icon.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# HHVM [![Build Status](https://travis-ci.org/facebook/hhvm.svg)](https://travis-ci.org/facebook/hhvm)
+# HHVM [![Build Status](https://travis-ci.org/facebook/hhvm.svg?branch=master)](https://travis-ci.org/facebook/hhvm)
 
 HHVM (aka the HipHop Virtual Machine) is an open-source virtual machine designed for executing programs written in [Hack](http://hacklang.org) and PHP. HHVM uses a just-in-time compilation approach to achieve superior performance while maintaining the flexibility that PHP developers are accustomed to. To date, HHVM (and its predecessor HPHPc before it) has realized over a 9x increase in web request throughput and over a 5x reduction in memory consumption for Facebook compared with the PHP 5.2 engine + APC.
 


### PR DESCRIPTION
It was inadvertently removed in 99d0c79.
