### PR TITLE
The method RedisSessionModule::destroy is supposed to return a bool

### DIFF
--- a/hphp/system/php/redis/RedisSessionModule.php
+++ b/hphp/system/php/redis/RedisSessionModule.php
@@ -152,7 +152,12 @@ class RedisSessionModule implements SessionHandlerInterface {
 
   public function destroy($key) {
     $redis = $this->connect($key);
-    return $redis->del($key);
+    if ($redis === false) {
+        return false;
+    } else {
+        $redis->del($key);
+        return true;
+    }
   }
 
   public function gc($maxlifetime) {


### PR DESCRIPTION
Without this change, the following php fails in session_destroy :

```
<?php
ini_set('session.save_handler', 'redis');
ini_set('session.save_path', 'tcp://127.0.0.1:6379?database=5&prefix=PHPREDIS_SESSION:');
session_start();
session_destroy();
?>
```

because $redis->del($key) returns a long and not a boolean
