### PR TITLE
Make it clearer to gcc that open(2) is never called with O_CREAT without mode

### DIFF
--- a/hphp/runtime/ext_zend_compat/php-src/Zend/zend_virtual_cwd.cpp
+++ b/hphp/runtime/ext_zend_compat/php-src/Zend/zend_virtual_cwd.cpp
@@ -145,7 +145,7 @@ CWD_API int virtual_open(const char *path TSRMLS_DC, int flags, ...) /* {{{ */
 
     f = open(translated.c_str(), flags, mode);
   } else {
-    f = open(translated.c_str(), flags);
+    f = open(translated.c_str(), flags & ~O_CREAT);
   }
   return f;
 }


### PR DESCRIPTION
We already ensure that this is never done, but `gcc` isn't smart enough to tell that.
