### PR TITLE
Fix linking libelf when building hack tools

### DIFF
--- a/hphp/hack/CMakeLists.txt
+++ b/hphp/hack/CMakeLists.txt
@@ -12,11 +12,11 @@ if (OCAMLC_FOUND)
     list(APPEND hackcflags -ccopt -DHAVE_ELF_GETSHDRSTRNDX)
   endif()
 
-  unset(hacklibs)
   foreach(lib ${LIBELF_LIBRARIES})
     get_filename_component(pth ${lib} PATH)
     get_filename_component(base ${lib} NAME_WE)
-    list(APPEND hacklibs ${pth}/${base}.a)
+    string(REGEX REPLACE "^lib" "" libname ${base})
+    list(APPEND hackcflags -ccopt -L${pth} -cclib -l${libname})
   endforeach()
 
   add_custom_target(
@@ -25,7 +25,6 @@ if (OCAMLC_FOUND)
     COMMAND make depend &&
       env OPTBIN="${OCAMLC_OPT_SUFFIX}"
           OCAMLCFLAGS_EXTRA="${hackcflags}"
-          EXTLIBS="${hacklibs}"
           make
     WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/src"
   )


### PR DESCRIPTION
Fixes errors when building hack tools which introduced in the commit facebook/hhvm@b3b564d8e1d31c0676440ffe75d48bbf2b36271d

```
[ 32%] Built target hphp_analysis
hhi/libhhi.a(hhi_elf.o): In function `get_embedded_hhi_data':
hphp/hack/src/hhi/hhi_elf.c:41: undefined reference to `elf_version'
hphp/hack/src/hhi/hhi_elf.c:50: undefined reference to `elf_begin'
hphp/hack/src/hhi/hhi_elf.c:51: undefined reference to `elf_kind'
hphp/hack/src/hhi/hhi_elf.c:57: undefined reference to `elf_getshdrstrndx'
hphp/hack/src/hhi/hhi_elf.c:66: undefined reference to `elf_nextscn'
hphp/hack/src/hhi/hhi_elf.c:68: undefined reference to `gelf_getshdr'
hphp/hack/src/hhi/hhi_elf.c:72: undefined reference to `elf_strptr'
hphp/hack/src/hhi/hhi_elf.c:79: undefined reference to `gelf_getshdr'
hphp/hack/src/hhi/hhi_elf.c:101: undefined reference to `elf_end'
hphp/hack/src/hhi/hhi_elf.c:86: undefined reference to `elf_end'
collect2: error: executing ld finished with return code 1
File "caml_startup", line 1, characters 0-1:
Error: Error during linking
make[4]: *** [hh_single.opt] Error 2
make[3]: *** [opt] Error 2
make[2]: *** [hphp/hack/CMakeFiles/hack] Error 2
make[1]: *** [hphp/hack/CMakeFiles/hack.dir/all] Error 2
make: *** [all] Error 2
```
