### PR TITLE
Declare Bash dependency in shebang

### DIFF
--- a/configure
+++ b/configure
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 


### PR DESCRIPTION
BASH_SOURCE is obviously Bash specific and so the shebang should tell
the system to use Bash.

Also while I was there I used env to get the Bash in the user's PATH
instead of just the system's Bash.
