### PR TITLE
Detect gnu++11/gnu++1y features

### DIFF
--- a/CMake/HPHPCompiler.cmake
+++ b/CMake/HPHPCompiler.cmake
@@ -21,7 +21,7 @@ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
     message(FATAL_ERROR "${PROJECT_NAME} requires clang 3.3 or later")
   endif()
   # libstdc++ deprecated
-  set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -fno-gcse -fno-omit-frame-pointer -ftemplate-depth-180 -Woverloaded-virtual -Wno-deprecated -Wno-strict-aliasing -Wno-write-strings -Wno-invalid-offsetof -fno-operator-names -Wno-error=array-bounds -Wno-error=switch -Werror=format-security -Wno-unused-result -Wno-sign-compare -Wno-attributes -Wno-maybe-uninitialized -Wno-mismatched-tags -Wno-unknown-warning-option -Wno-return-type-c-linkage -Qunused-arguments")
+  set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -fcolor-diagnostics -fno-gcse -fno-omit-frame-pointer -ftemplate-depth-180 -Woverloaded-virtual -Wno-deprecated -Wno-strict-aliasing -Wno-write-strings -Wno-invalid-offsetof -fno-operator-names -Wno-error=array-bounds -Wno-error=switch -Werror=format-security -Wno-unused-result -Wno-sign-compare -Wno-attributes -Wno-maybe-uninitialized -Wno-mismatched-tags -Wno-unknown-warning-option -Wno-return-type-c-linkage -Qunused-arguments")
   # CMAKE_BUILD_TYPE: http://www.cmake.org/Wiki/CMake_Useful_Variables#Compilers_and_Tools
   set (CMAKE_C_FLAGS_DEBUG            "-g")
   set (CMAKE_CXX_FLAGS_DEBUG          "-g")


### PR DESCRIPTION
Detect Gnu/C++14 define `ifdef (_CPP14)`
- [Current Status : ISO Standard C++](https://isocpp.org/std/status)
- [C++1y/C++14 Support in GCC](https://gcc.gnu.org/projects/cxx1y.html)
- [C++14, C++11 and C++98 Support in Clang](http://clang.llvm.org/cxx_status.html)
- [Working Draft, Standard - C++1y/C++14](http://isocpp.org/files/papers/N3797.pdf)
- [Implementation Status C++ 2011](https://gcc.gnu.org/onlinedocs/libstdc++/manual/status.html#status.iso.2011)
- [Implementation Status C++ 2014](https://gcc.gnu.org/onlinedocs/libstdc++/manual/status.html#status.iso.2014)
- [ GNU C++ library is shaped by several GCC Command Options](https://gcc.gnu.org/onlinedocs/libstdc++/manual/using.html#manual.intro.using.flags)
