### PR TITLE
Ignore all output after request end

### DIFF
--- a/hphp/runtime/server/libevent-transport.cpp
+++ b/hphp/runtime/server/libevent-transport.cpp
@@ -32,7 +32,7 @@ LibEventTransport::LibEventTransport(LibEventServer *server,
                                      evhttp_request *request,
                                      int workerId)
   : m_server(server), m_request(request), m_eventBasePostData(nullptr),
-    m_workerId(workerId), m_sendStarted(false), m_sendEnded(false) {
+    m_workerId(workerId), m_sendStarted(false) {
   // HttpProtocol::PrepareSystemVariables needs this
   evbuffer *buf = m_request->input_buffer;
   assert(buf);

--- a/hphp/runtime/server/libevent-transport.h
+++ b/hphp/runtime/server/libevent-transport.h
@@ -66,7 +66,6 @@ private:
   const char *m_extended_method;
   HeaderMap m_requestHeaders;
   bool m_sendStarted;
-  bool m_sendEnded;
   int m_requestSize;
 };
 

--- a/hphp/runtime/server/transport.cpp
+++ b/hphp/runtime/server/transport.cpp
@@ -50,7 +50,7 @@ Transport::Transport()
     m_headerCallbackDone(false),
     m_responseCode(-1), m_firstHeaderSet(false), m_firstHeaderLine(0),
     m_responseSize(0), m_responseTotalSize(0), m_responseSentSize(0),
-    m_flushTimeUs(0), m_sendContentType(true),
+    m_flushTimeUs(0), m_sendEnded(false), m_sendContentType(true),
     m_compression(true), m_compressor(nullptr), m_isSSL(false),
     m_compressionDecision(CompressionDecision::NotDecidedYet),
     m_threadType(ThreadType::RequestThread) {
@@ -809,6 +809,13 @@ void Transport::sendRawLocked(void *data, int size, int code /* = 200 */,
                               bool chunked /* = false */,
                               const char *codeInfo /* = "" */
                               ) {
+  // There are post-send functions that can run. Any output from them should
+  // be ignored as it doesn't make sense to try and send data after the
+  // request has ended.
+  if (m_sendEnded) {
+	  return;
+  }
+
   if (!compressed && RuntimeOption::ForceChunkedEncoding) {
     chunked = true;
   }
@@ -886,6 +893,8 @@ void Transport::onSendEnd() {
     {ServiceData::StatsType::SUM});
   httpResponseStats->addValue(1);
   onSendEndImpl();
+  // Record that we have ended the request so any further output is discarded.
+  m_sendEnded = true;
 }
 
 void Transport::redirect(const char *location, int code /* = 302 */,

--- a/hphp/runtime/server/transport.h
+++ b/hphp/runtime/server/transport.h
@@ -473,6 +473,7 @@ protected:
   int m_responseTotalSize; // including added headers
   int m_responseSentSize;
   int64_t m_flushTimeUs;
+  bool m_sendEnded;
 
   std::vector<int> m_chunksSentSizes;
 


### PR DESCRIPTION
`register_postsend_function` allows user code to be run after the request has
be finished. However, because these functions are just arbitrary user code,
they can produce output themselves. There is no sensible way to handle output
at this stage, and it was causing a failure in the FastCGI transport.

This patch makes transports ignore all output once onSendEnd has be called.
This means that cli behaviour is unchanged.

Fixes #2882
