### PR TITLE
Take the last value for a fastcgi param if multiple values are provided

### DIFF
--- a/hphp/runtime/server/fastcgi/fastcgi-transport.cpp
+++ b/hphp/runtime/server/fastcgi/fastcgi-transport.cpp
@@ -366,7 +366,10 @@ void FastCGITransport::onHeader(std::unique_ptr<folly::IOBuf> key_chain,
   cursor = Cursor(value_chain.get());
   std::string value = cursor.readFixedString(
                                value_chain->computeChainDataLength());
-  m_requestHeaders.emplace(key, value);
+  auto it = m_requestHeaders.emplace(key, value);
+  if (!it.second) {
+    it.first->second = value;
+  }
 }
 
 static const std::string


### PR DESCRIPTION
If a fastcgi param was provided multiple times in the one request, the first value would be used.  This will now take the last one, which is what PHP does.
