### PR TITLE
FastCGI had a bug where as if the FCGI_STDIN packet was split into two

### DIFF
--- a/hphp/runtime/server/fastcgi/fastcgi-transport.cpp
+++ b/hphp/runtime/server/fastcgi/fastcgi-transport.cpp
@@ -343,7 +343,7 @@ void FastCGITransport::onBody(std::unique_ptr<folly::IOBuf> chain) {
   size_t length = chain->computeChainDataLength();
   std::string s = cursor.readFixedString(length);
   m_monitor.lock();
-  m_bodyQueue.append(std::move(chain));
+  m_bodyQueue.append(s);
   if (m_waiting > 0) {
     m_monitor.notify();
   }


### PR DESCRIPTION
records it would only accept the first one therefore truncating the body.

I'm not sure if this is the correct thing to do but as the string was
getting read from the chain already I suspect this is what was meant
to happen to begin with.
