### PR TITLE
EZC: fix ref counts in _object_and_properties_init()

### DIFF
--- a/hphp/runtime/ext_zend_compat/ezc_test/ext_ezc_test.php
+++ b/hphp/runtime/ext_zend_compat/ezc_test/ext_ezc_test.php
@@ -79,3 +79,8 @@ function ezc_array_val_set(array $a, mixed $key, mixed $value): mixed;
 <<__NativeData("ZendCompat")>> class EzcTestCloneable {}
 <<__NativeData("ZendCompat")>> class EzcTestUncloneable1 {}
 <<__NativeData("ZendCompat")>> class EzcTestUncloneable2 {}
+
+/** Create an array with a TestCloneable object in it. Test of
+ * object_init_ex(). */
+<<__Native("ZendCompat")>>
+function ezc_create_cloneable_in_array(): mixed;

--- a/hphp/runtime/ext_zend_compat/ezc_test/ezc_test.cpp
+++ b/hphp/runtime/ext_zend_compat/ezc_test/ezc_test.cpp
@@ -570,6 +570,23 @@ static zend_object_value EzcTestUncloneable2_create_object(zend_class_entry *ce 
 }
 /* }}} */
 
+/* {{{ proto object ezc_create_cloneable_in_array()
+ * Create an array with a TestCloneable object in it. Test of
+ * object_init_ex(). */
+PHP_FUNCTION(ezc_create_cloneable_in_array)
+{
+  zval * element;
+  if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "") == FAILURE) {
+    return;
+  }
+  array_init_size(return_value, 1);
+  ALLOC_INIT_ZVAL(element);
+  object_init_ex(element, EzcTestCloneable_ce);
+  zend_hash_next_index_insert(Z_ARRVAL_P(return_value),
+      (void*)&element, sizeof(zval*), NULL);
+}
+/* }}} */
+
 /* {{{ arginfo */
 ZEND_BEGIN_ARG_INFO(arginfo_ezc_fetch_global, 0)
 ZEND_END_ARG_INFO()
@@ -634,6 +651,10 @@ ZEND_BEGIN_ARG_INFO(arginfo_ezc_array_val_set, 0)
   ZEND_ARG_INFO(0, key)
   ZEND_ARG_INFO(0, value)
 ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO(arginfo_ezc_create_cloneable_in_array, 0)
+ZEND_END_ARG_INFO()
+
 /* }}} */
 
 /* {{{ ezc_test_functions[]
@@ -653,6 +674,7 @@ const zend_function_entry ezc_test_functions[] = {
   PHP_FE(ezc_hash_get, arginfo_ezc_hash_get)
   PHP_FE(ezc_hash_append, arginfo_ezc_hash_append)
   PHP_FE(ezc_array_val_set, arginfo_ezc_array_val_set)
+  PHP_FE(ezc_create_cloneable_in_array, arginfo_ezc_create_cloneable_in_array)
   PHP_FE_END
 };
 /* }}} */

--- a/hphp/runtime/ext_zend_compat/php-src/Zend/zend_API.cpp
+++ b/hphp/runtime/ext_zend_compat/php-src/Zend/zend_API.cpp
@@ -1626,10 +1626,8 @@ ZEND_API int _object_and_properties_init(zval *arg, zend_class_entry *class_type
     return FAILURE;
   }
   Z_OBJVAL_P(arg) = HPHP::ObjectData::newInstance(cls);
+  Z_OBJVAL_P(arg)->incRefCount();
   Z_TYPE_P(arg) = IS_OBJECT;
-  // Zend doesn't have this, but I think we need it or else new objects have a
-  // refcount of 0
-  Z_ADDREF_P(arg);
   return SUCCESS;
 }
 

--- a/hphp/test/slow/ext_ezc_test/object-refcount.php
+++ b/hphp/test/slow/ext_ezc_test/object-refcount.php
@@ -1,0 +1,5 @@
+<?php
+$x = ezc_create_cloneable_in_array();
+debug_zval_dump($x);
+$x = null;
+print "End\n";

--- a/hphp/test/slow/ext_ezc_test/object-refcount.php.expectf
+++ b/hphp/test/slow/ext_ezc_test/object-refcount.php.expectf
@@ -1,0 +1,7 @@
+array(1) refcount(2){
+  [0]=>
+  object(EzcTestCloneable)#1 (%d) refcount(1){
+  }
+}
+EzcTestCloneable free_storage (clone 0)
+End


### PR DESCRIPTION
In _object_and_properties_init() a.k.a. object_init_ex(), the ObjectData was created and returned to userspace with a refcount of zero, despite being referred to by the RefData. Also, the RefData was inappropriately incref'd, making it unconditionally leak.

The two bugs cancelled out in a common case -- calling tvUnbox() on the RefData caused the ObjectData to be incref'd, leaving it with the correct refcount if you discount the leaked, unreachable RefData. Added a test case showing a less common case which previously failed.

Should fix https://bugzilla.wikimedia.org/show_bug.cgi?id=65796
