### PR TITLE
Changed errormessage in implode()

### DIFF
--- a/hphp/runtime/ext/ext_string.cpp
+++ b/hphp/runtime/ext/ext_string.cpp
@@ -462,7 +462,7 @@ String f_implode(const Variant& arg1, const Variant& arg2 /* = null_variant */) 
     items = arg2;
     delim = arg1.toString();
   } else {
-    throw_bad_type_exception("expected a container as one of the arguments");
+    throw_bad_type_exception("implode() expected a container as one of the arguments");
     return String();
   }
   return StringUtil::Implode(items, delim);


### PR DESCRIPTION
It errors if none of the arguments is a container.
Added the function name to it to be more clear

Resolves #2567
