### PR TITLE
Don't set $_SERVER['HOSTNAME'] in CLI SAPI

### DIFF
--- a/hphp/runtime/base/program-functions.cpp
+++ b/hphp/runtime/base/program-functions.cpp
@@ -596,7 +596,7 @@ void execute_command_line_begin(int argc, char **argv, int xhprof,
     serverArr.set(s_argc, php_global(s_argc));
     serverArr.set(s_PWD, g_context->getCwd());
     char hostname[1024];
-    if (!gethostname(hostname, 1024)) {
+    if (!RuntimeOption::ClientExecutionMode() && !gethostname(hostname, 1024)) {
       serverArr.set(s_HOSTNAME, String(hostname, CopyString));
     }
 


### PR DESCRIPTION
Matches the behavior of PHP.
