### PR TITLE
Fix isset-related behaviour for ArrayObject subclasses

### DIFF
--- a/hphp/test/slow/array_object/subclass-isset.php
+++ b/hphp/test/slow/array_object/subclass-isset.php
@@ -1,0 +1,19 @@
+<?php
+
+class MyArrayObject extends ArrayObject
+{
+    public function offsetGet($index)
+    {
+        echo "offsetGet Called!\n";
+        if (isset($this[$index])) { // infinite recursion in hhvm
+            return parent::offsetGet($index);
+        }
+
+        return null;
+    }
+}
+$obj = new MyArrayObject(['foo' => true]);
+
+var_dump($obj['foo']);
+var_dump(isset($obj['foo']));
+var_dump(isset($obj['bar']));

--- a/hphp/test/slow/array_object/subclass-isset.php.expect
+++ b/hphp/test/slow/array_object/subclass-isset.php.expect
@@ -1,0 +1,4 @@
+offsetGet Called!
+bool(true)
+bool(true)
+bool(false)


### PR DESCRIPTION
Unlike most objects, using isset on an ArrayObject will return false
if the element is null. However, `offsetExists` will return true in
this case, so we need to special case ArrayObject.

Commit 31104c56 introduced this special case handling, however it
would cause unexpected infinite recursion if `offsetGet` was
overridden in a child class and that child class used an expression
of the form `isset($this[$offset])`. Users were not expecting
`offsetGet` to be called as the result of an `isset` expression.

This commit fixes the behaviour by calling the `offsetGet` method
from the `ArrayObject` class, instead of the `offsetGet` method on
the supplied object.

Fixes #2871 and #2495
