### PR TITLE
Allow empty keys in hash_hmac() and hash_hmac_file()

### DIFF
--- a/hphp/system/php/hash/hash.php
+++ b/hphp/system/php/hash/hash.php
@@ -96,7 +96,7 @@ function hash_hmac(?string $algo = null,
     return null;
   }
 
-  $ctx = hash_init($algo, HASH_HMAC, $key);
+  $ctx = hash_init($algo, HASH_HMAC, $key !== '' ? $key : "\0");
   if (!$ctx) {
     return false;
   }
@@ -132,7 +132,7 @@ function hash_hmac_file(?string $algo = null,
     return null;
   }
 
-  $ctx = hash_init($algo, HASH_HMAC, $key);
+  $ctx = hash_init($algo, HASH_HMAC, $key !== '' ? $key : "\0");
   if (!$ctx) {
     return false;
   }

--- a/hphp/test/slow/ext_hash/ext_hash.php
+++ b/hphp/test/slow/ext_hash/ext_hash.php
@@ -71,6 +71,12 @@ function test_hash_file() {
   var_dump(hash_hmac_file("md5", __DIR__.'/test_file.txt', "secret"));
 }
 
+function test_hash_hmac() {
+  $data = "the quick brown fox jumped over the lazy dog.";
+  var_dump(hash_hmac("md5", $data, "secret"));
+  var_dump(hash_hmac("md5", $data, ""));
+}
+
 function test_furchash() {
   if (is_facebook()) {
     var_dump(furchash_hphp_ext("15minutesoffame", 15, 86) == '25');
@@ -83,3 +89,4 @@ brown_fox();
 test_hash_init();
 test_hash_file();
 test_furchash();
+test_hash_hmac();

--- a/hphp/test/slow/ext_hash/ext_hash.php.expect
+++ b/hphp/test/slow/ext_hash/ext_hash.php.expect
@@ -41,3 +41,5 @@ string(32) "5c6ffbdd40d9556b73a21e63c3e0e904"
 string(32) "5c6ffbdd40d9556b73a21e63c3e0e904"
 string(32) "7eb2b5c37443418fc77c136dd20e859c"
 bool(true)
+string(32) "a5e7661a0da3d265700cc17e0dc0400a"
+string(32) "2d1cc1832eef32d7fbe4805ab585fb4a"


### PR DESCRIPTION
Zend PHP accepts the empty string as a key for hash_hmac() and
hash_hmac_file(), but HHVM doesn't, because its implementation of these
functions delegates to hash_init(), which does not accept an empty key when
HASH_HMAC is specified.

Fix this by exploting the fact that we can sneak an empty key past hash_init()
(on both Zend and HHVM) by sending it "\0" for a key value. "\0" and "" are
equivalent because the HMAC algorithm pads the key to the right with extra
zeros to the input block size of the hash function.

An empty key test vector is explicitly included in RFC 5869[1](http://tools.ietf.org/html/rfc5869#appendix-A.3). MediaWiki's unit
tests verify MediaWiki's HKDF implementation for conformance by using the
test cases that accompany the spec.
