### PR TITLE
wddx_deserialize() systemlib improvements

### DIFF
--- a/hphp/test/slow/ext_wddx/malformed.php
+++ b/hphp/test/slow/ext_wddx/malformed.php
@@ -1,0 +1,18 @@
+<?php
+
+// Based on MediaWiki's ApiFormatWddxTest
+// The omitted data in the "b" variable previously caused a fatal error
+var_dump(wddx_deserialize(<<<EOT
+<wddxPacket version="1.0">
+  <header/>
+  <data>
+    <struct>
+      <var name="a">
+        <string>foo</string>
+      </var>
+      <var name="b"/>
+    </struct>
+  </data>
+</wddxPacket>
+EOT
+));

--- a/hphp/test/slow/ext_wddx/malformed.php.expect
+++ b/hphp/test/slow/ext_wddx/malformed.php.expect
@@ -1,0 +1,4 @@
+array(1) {
+  ["a"]=>
+  string(3) "foo"
+}


### PR DESCRIPTION
- Use stream_get_contents() instead of a loop of fgets(). Loops that read files are deceptively tricky -- it's possible to hit an error in which fgets() permanently returns false but with feof() being false, for example NFS server failure, which would cause an infinite busy loop with the previous code.
- Do not accept SimpleXMLElement objects as input -- this was a hack to allow recursive parsing without creating another global function. Achieve the same ends using a closure instead.
- Do not attempt to call $packet->getName() on any input that is not a string or resource. Instead mimic Zend and give a warning.
- Check for errors from simplexml_load_string(), instead of giving a fatal error due to calling false->xpath().
- Ignore malformed input in various cases, skipping array members etc., instead of assuming the XML is always perfect and inevitably hitting a fatal error due to invalid method calls. This is somewhat similar to what Zend does -- probably not identical though.
- Added a test case for malformed input based on the motivating unit test from MediaWiki.
