### PR TITLE
Fix Memcache::get($keys) when $keys is an array

### DIFF
--- a/hphp/runtime/ext/memcache/ext_memcache.cpp
+++ b/hphp/runtime/ext/memcache/ext_memcache.cpp
@@ -299,8 +299,10 @@ static Variant HHVM_METHOD(Memcache, get, const Variant& key,
     for (ArrayIter iter(keyArr); iter; ++iter) {
       auto key = iter.second().toString();
       String serializedKey = memcache_prepare_key(key);
-      real_keys.push_back(const_cast<char *>(serializedKey.c_str()));
-      key_len.push_back(iter.second().toString().length());
+      char *k = new char[serializedKey.length()+1];
+      std::strcpy(k, serializedKey.c_str());
+      real_keys.push_back(k);
+      key_len.push_back(serializedKey.length());
     }
 
     if (!real_keys.empty()) {
@@ -335,6 +337,8 @@ static Variant HHVM_METHOD(Memcache, get, const Variant& key,
                                                    payload_len, flags));
       }
       memcached_result_free(&result);
+      for ( size_t i = 0 ; i < real_keys.size() ; i++ )
+            delete [] real_keys[i];
 
       return return_val;
     }

--- a/hphp/test/slow/ext_memcache/mget.php
+++ b/hphp/test/slow/ext_memcache/mget.php
@@ -1,0 +1,17 @@
+<?php
+
+$memcache = new Memcache();
+$memcache->addServer('localhost', 11211);
+
+$keys = [
+	'abcdef1',
+	'abcdef11',
+	'abcdef12',
+	'abcdef13',
+];
+
+foreach($keys as $k) {
+	$memcache->set($k, "value:" . $k);
+}
+$r = $memcache->get($keys);
+var_dump($r);

--- a/hphp/test/slow/ext_memcache/mget.php.expect
+++ b/hphp/test/slow/ext_memcache/mget.php.expect
@@ -1,0 +1,10 @@
+array(4) {
+  ["abcdef1"]=>
+  string(13) "value:abcdef1"
+  ["abcdef11"]=>
+  string(14) "value:abcdef11"
+  ["abcdef12"]=>
+  string(14) "value:abcdef12"
+  ["abcdef13"]=>
+  string(14) "value:abcdef13"
+}


### PR DESCRIPTION
Without this patch, the result of the test is:

array(2) {
  ["abcdef1"]=>
  string(13) "value:abcdef1"
  ["abcdef13"]=>
  string(14) "value:abcdef13"
}

This fix is needed for drupal (with the memcache module).
