### PR TITLE
DirectoryIterator throws RuntimeException on empty string

### DIFF
--- a/hphp/system/php/spl/iterators/DirectoryIterator.php
+++ b/hphp/system/php/spl/iterators/DirectoryIterator.php
@@ -24,6 +24,8 @@ class DirectoryIterator extends SplFileInfo implements SeekableIterator {
    * @path       mixed   The path of the directory to traverse.
    */
   public function __construct($path) {
+    if (empty($path))
+      throw new RuntimeException("Directory name must not be empty.");
     $this->dir = @opendir($path);
     if ($this->dir === false) {
       throw new UnexpectedValueException(

--- a/hphp/test/slow/ext_spl_iterators/DirectoryIterator_ctor_emtpystring.php
+++ b/hphp/test/slow/ext_spl_iterators/DirectoryIterator_ctor_emtpystring.php
@@ -1,0 +1,7 @@
+<?php
+
+try {
+  new DirectoryIterator("");
+} catch (RuntimeException $e) {
+  echo "RuntimeException: " . $e->getMessage() . "\n";
+}

--- a/hphp/test/slow/ext_spl_iterators/DirectoryIterator_ctor_emtpystring.php.expect
+++ b/hphp/test/slow/ext_spl_iterators/DirectoryIterator_ctor_emtpystring.php.expect
@@ -1,0 +1,1 @@
+RuntimeException: Directory name must not be empty.


### PR DESCRIPTION
Fixes zend/bad/ext/spl/tests/DirectoryIterator_empty_constructor.php but I can't move it because of the different representation of uncaught exceptions

The included test is a duplicate of the one above, but with a try-catch block
