### PR TITLE
Fix Segfault for LONGTEXT in bind_result

### DIFF
--- a/hphp/test/slow/ext_mysqli/store_result_updatemaxlength.php
+++ b/hphp/test/slow/ext_mysqli/store_result_updatemaxlength.php
@@ -1,0 +1,23 @@
+<?php
+$host   = getenv("MYSQL_TEST_HOST")   ? getenv("MYSQL_TEST_HOST") : "localhost";
+$port   = getenv("MYSQL_TEST_PORT")   ? getenv("MYSQL_TEST_PORT") : 3306;
+$user   = getenv("MYSQL_TEST_USER")   ? getenv("MYSQL_TEST_USER") : "root";
+$passwd = getenv("MYSQL_TEST_PASSWD") ? getenv("MYSQL_TEST_PASSWD") : "";
+$db     = getenv("MYSQL_TEST_DB")     ? getenv("MYSQL_TEST_DB") : "test";
+
+$mysqli = new mysqli($host, $user, $passwd, $db, $port);
+
+if (!$mysqli->query("CREATE TABLE IF NOT EXISTS test (test LONGTEXT)") || 
+    !$mysqli->query("INSERT INTO test (test) VALUES (`test`)")) {
+  die("Error creating or inserting table: " . $mysqli->error);
+}
+
+$stmt = $mysqli->prepare("SELECT * FROM test");
+$stmt->execute();
+echo "Before store_result(): ";
+var_dump($stmt->attr_get(MYSQLI_STMT_ATTR_UPDATE_MAX_LENGTH));
+$stmt->store_result();
+echo "\nAfter store_result(): ";
+var_dump($stmt->attr_get(MYSQLI_STMT_ATTR_UPDATE_MAX_LENGTH));
+
+$mysqli->query("DROP TABLE IF EXISTS test");

--- a/hphp/test/slow/ext_mysqli/store_result_updatemaxlength.php.expect
+++ b/hphp/test/slow/ext_mysqli/store_result_updatemaxlength.php.expect
@@ -1,0 +1,3 @@
+Before store_result(): int(0)
+
+After store_result(): int(1)

--- a/hphp/test/slow/ext_mysqli/store_result_updatemaxlength.php.skipif
+++ b/hphp/test/slow/ext_mysqli/store_result_updatemaxlength.php.skipif
@@ -1,0 +1,2 @@
+<?php
+if (!getenv('MYSQL_TEST_HOST')) echo 'skip';


### PR DESCRIPTION
It actually does not fix the bug itself because PHP behaves the same.
The cause of the segfault is that some people run out of memory resulting in a bad call to calloc.
calloc returns a nullptr which later in mysql is dereferenced.

PHP's solution to this is to call store_result before binding. But this will also fail in hhvm.
This fixes it.

TL;DR: TEXT in mysql is now variable length instead of 4GB when calling store_result

Fixes #2377
