### PR TITLE
Use timeout from GNU coreutils instead of bash hack

### DIFF
--- a/hphp/test/run
+++ b/hphp/test/run
@@ -834,7 +834,11 @@ function run_test($options, $test) {
   $test_ext = pathinfo($test, PATHINFO_EXTENSION);
   list($hhvm, $hhvm_env) = hhvm_cmd($options, $test);
 
-  $hhvm = __DIR__.'/../tools/timeout.sh -t 300 '.$hhvm;
+  if (is_executable('/usr/bin/timeout')) {
+    $hhvm = '/usr/bin/timeout 300 '.$hhvm;
+  } else {
+    $hhvm = __DIR__.'/../tools/timeout.sh -t 300 '.$hhvm;
+  }
 
   if (isset($options['repo'])) {
     if ($test_ext === 'hhas' ||


### PR DESCRIPTION
When using timeout.sh to run tests, test execution hangs until the
"sleep 1" finishes, probably because the monitor process keeps
filehandles open. If you instead use timeout from GNU coreutils, test
execution is about 2.5 times faster -- I measured a drop from 75 to 30
seconds for test/quick.
