### PR TITLE
EZC: Fix copying of ProxyArray

### DIFF
--- a/hphp/runtime/base/proxy-array.cpp
+++ b/hphp/runtime/base/proxy-array.cpp
@@ -63,6 +63,7 @@ ArrayData* ProxyArray::innerArr(const ArrayData* ad) {
 }
 
 ProxyArray* ProxyArray::Make(ArrayData* ad) {
+  assert_refcount_realistic_nz(ad->m_count);
   auto ret = static_cast<ProxyArray*>(MM().objMallocLogged(sizeof(ProxyArray)));
   ret->m_size            = -1;
   ret->m_kind            = kProxyKind;
@@ -120,119 +121,156 @@ const TypedValue* ProxyArray::NvGetInt(const ArrayData* ad, int64_t k) {
 
 ArrayData*
 ProxyArray::LvalInt(ArrayData* ad, int64_t k, Variant*& ret, bool copy) {
-  ad = copy ? Copy(ad) : ad;
-  auto r = innerArr(ad)->lval(k, ret, innerArr(ad)->hasMultipleRefs());
-  reseatable(ad, r);
-  return ad;
+  if (copy) {
+    return innerArr(ad)->lval(k, ret, true);
+  } else {
+    auto r = innerArr(ad)->lval(k, ret, innerArr(ad)->hasMultipleRefs());
+    reseatable(ad, r);
+    return ad;
+  }
 }
 
 ArrayData*
 ProxyArray::LvalStr(ArrayData* ad, StringData* k, Variant*& ret, bool copy) {
-  ad = copy ? Copy(ad) : ad;
-  auto r = innerArr(ad)->lval(k, ret, innerArr(ad)->hasMultipleRefs());
-  reseatable(ad, r);
-  return ad;
+  if (copy) {
+    return innerArr(ad)->lval(k, ret, true);
+  } else {
+    auto r = innerArr(ad)->lval(k, ret, innerArr(ad)->hasMultipleRefs());
+    reseatable(ad, r);
+    return ad;
+  }
 }
 
 ArrayData*
 ProxyArray::LvalNew(ArrayData* ad, Variant*& ret, bool copy) {
-  ad = copy ? Copy(ad) : ad;
-  auto r = innerArr(ad)->lvalNew(ret, innerArr(ad)->hasMultipleRefs());
-  reseatable(ad, r);
-  return ad;
+  if (copy) {
+    return innerArr(ad)->lvalNew(ret, true);
+  } else {
+    auto r = innerArr(ad)->lvalNew(ret, innerArr(ad)->hasMultipleRefs());
+    reseatable(ad, r);
+    return ad;
+  }
 }
 
 ArrayData* ProxyArray::SetInt(ArrayData* ad,
                               int64_t k,
                               Cell v,
                               bool copy) {
-  ad = copy ? Copy(ad) : ad;
-  auto r = innerArr(ad)->set(k,
-      tvAsCVarRef(&v), innerArr(ad)->hasMultipleRefs());
-  reseatable(ad, r);
-  return ad;
+  if (copy) {
+    return innerArr(ad)->set(k, tvAsCVarRef(&v), true);
+  } else {
+    auto r = innerArr(ad)->set(k,
+        tvAsCVarRef(&v), innerArr(ad)->hasMultipleRefs());
+    reseatable(ad, r);
+    return ad;
+  }
 }
 
 ArrayData* ProxyArray::SetStr(ArrayData* ad,
                               StringData* k,
                               Cell v,
                               bool copy) {
-  ad = copy ? Copy(ad) : ad;
-  auto r = innerArr(ad)->set(k,
-      tvAsCVarRef(&v), innerArr(ad)->hasMultipleRefs());
-  reseatable(ad, r);
-  return ad;
+  if (copy) {
+    return innerArr(ad)->set(k, tvAsCVarRef(&v), copy);
+  } else {
+    auto r = innerArr(ad)->set(k,
+        tvAsCVarRef(&v), innerArr(ad)->hasMultipleRefs());
+    reseatable(ad, r);
+    return ad;
+  }
 }
 
 ArrayData* ProxyArray::SetRefInt(ArrayData* ad,
                                  int64_t k,
                                  Variant& v,
                                  bool copy) {
-  ad = copy ? Copy(ad) : ad;
-  auto r = innerArr(ad)->setRef(k, v, innerArr(ad)->hasMultipleRefs());
-  reseatable(ad, r);
-  return ad;
+  if (copy) {
+    return innerArr(ad)->setRef(k, v, true);
+  } else {
+    auto r = innerArr(ad)->setRef(k, v, innerArr(ad)->hasMultipleRefs());
+    reseatable(ad, r);
+    return ad;
+  }
 }
 
 ArrayData* ProxyArray::SetRefStr(ArrayData* ad,
                                  StringData* k,
                                  Variant& v,
                                  bool copy) {
-  ad = copy ? Copy(ad) : ad;
-  auto r = innerArr(ad)->setRef(k, v, innerArr(ad)->hasMultipleRefs());
-  reseatable(ad, r);
-  return ad;
+  if (copy) {
+    return innerArr(ad)->setRef(k, v, true);
+  } else {
+    auto r = innerArr(ad)->setRef(k, v, innerArr(ad)->hasMultipleRefs());
+    reseatable(ad, r);
+    return ad;
+  }
 }
 
 ArrayData*
 ProxyArray::RemoveInt(ArrayData* ad, int64_t k, bool copy) {
-  ad = copy ? Copy(ad) : ad;
-  auto r = innerArr(ad)->remove(k, innerArr(ad)->hasMultipleRefs());
-  reseatable(ad, r);
-  return ad;
+  if (copy) {
+    return innerArr(ad)->remove(k, true);
+  } else {
+    auto r = innerArr(ad)->remove(k, innerArr(ad)->hasMultipleRefs());
+    reseatable(ad, r);
+    return ad;
+  }
 }
 
 ArrayData*
 ProxyArray::RemoveStr(ArrayData* ad, const StringData* k,
                                  bool copy) {
-  ad = copy ? Copy(ad) : ad;
-  auto r = innerArr(ad)->remove(k, innerArr(ad)->hasMultipleRefs());
-  reseatable(ad, r);
-  return ad;
+  if (copy) {
+    return innerArr(ad)->remove(k, true);
+  } else {
+    auto r = innerArr(ad)->remove(k, innerArr(ad)->hasMultipleRefs());
+    reseatable(ad, r);
+    return ad;
+  }
 }
 
 ArrayData*
 ProxyArray::Copy(const ArrayData* ad) {
-  return Make(innerArr(ad)->copy());
+  return innerArr(ad)->copy();
 }
 
 ArrayData*
 ProxyArray::Append(ArrayData* ad, const Variant& v, bool copy) {
-  ad = copy ? Copy(ad) : ad;
-  auto r = innerArr(ad)->append(v, innerArr(ad)->hasMultipleRefs());
-  reseatable(ad, r);
-  return ad;
+  if (copy) {
+    return innerArr(ad)->append(v, true);
+  } else {
+    auto r = innerArr(ad)->append(v, innerArr(ad)->hasMultipleRefs());
+    reseatable(ad, r);
+    return ad;
+  }
 }
 
 ArrayData*
 ProxyArray::AppendRef(ArrayData* ad, Variant& v, bool copy) {
-  ad = copy ? Copy(ad) : ad;
-  auto r = innerArr(ad)->appendRef(v, innerArr(ad)->hasMultipleRefs());
-  reseatable(ad, r);
-  return ad;
+  if (copy) {
+    return innerArr(ad)->appendRef(v, true);
+  } else {
+    auto r = innerArr(ad)->appendRef(v, innerArr(ad)->hasMultipleRefs());
+    reseatable(ad, r);
+    return ad;
+  }
 }
 
 ArrayData*
 ProxyArray::AppendWithRef(ArrayData* ad, const Variant& v, bool copy) {
-  ad = copy ? Copy(ad) : ad;
-  auto r = innerArr(ad)->appendWithRef(v, innerArr(ad)->hasMultipleRefs());
-  reseatable(ad, r);
-  return ad;
+  if (copy) {
+    return innerArr(ad)->appendWithRef(v, true);
+  } else {
+    auto r = innerArr(ad)->appendWithRef(v, innerArr(ad)->hasMultipleRefs());
+    reseatable(ad, r);
+    return ad;
+  }
 }
 
 ArrayData*
 ProxyArray::PlusEq(ArrayData* ad, const ArrayData* elems) {
-  auto const ret = ad->hasMultipleRefs() ? Copy(ad) : ad;
+  auto const ret = ad->hasMultipleRefs() ? Make(innerArr(ad))
+                                         : asProxyArray(ad);
   auto r = innerArr(ret)->plusEq(elems);
   reseatable(ad, r);
   return ad;
@@ -258,10 +296,13 @@ ArrayData* ProxyArray::Dequeue(ArrayData* ad, Variant &value) {
 }
 
 ArrayData* ProxyArray::Prepend(ArrayData* ad, const Variant& v, bool copy) {
-  ad = copy ? Copy(ad) : ad;
-  auto r = innerArr(ad)->prepend(v, innerArr(ad)->hasMultipleRefs());
-  reseatable(ad, r);
-  return ad;
+  if (copy) {
+    return innerArr(ad)->prepend(v, true);
+  } else {
+    auto r = innerArr(ad)->prepend(v, innerArr(ad)->hasMultipleRefs());
+    reseatable(ad, r);
+    return ad;
+  }
 }
 
 void ProxyArray::Renumber(ArrayData* ad) {

--- a/hphp/runtime/ext_zend_compat/hhvm/zend-wrap-func.cpp
+++ b/hphp/runtime/ext_zend_compat/hhvm/zend-wrap-func.cpp
@@ -34,9 +34,9 @@ void zBoxAndProxy(TypedValue* arg) {
     ArrayData * inner_arr = inner->m_data.parr;
     if (inner_arr->isStatic() || inner_arr->hasMultipleRefs()) {
       ArrayData * tmp = inner_arr->copy();
+      tmp->incRefCount();
       inner_arr->decRefAndRelease();
       inner_arr = tmp;
-      inner_arr->incRefCount();
     }
     inner->m_data.parr = ProxyArray::Make(inner_arr);
   }

--- a/hphp/test/slow/ext_ezc_test/manipulate-proxyarray.php
+++ b/hphp/test/slow/ext_ezc_test/manipulate-proxyarray.php
@@ -1,0 +1,9 @@
+<?php
+
+// Test of ProxyArray::Copy()
+
+$x = array_merge([], ezc_create_cloneable_in_array());
+$x += [];
+var_dump( $x );
+$x = null;
+print "End\n";

--- a/hphp/test/slow/ext_ezc_test/manipulate-proxyarray.php.expectf
+++ b/hphp/test/slow/ext_ezc_test/manipulate-proxyarray.php.expectf
@@ -1,0 +1,7 @@
+array(1) {
+  [0]=>
+  object(EzcTestCloneable)#%d (0) {
+  }
+}
+EzcTestCloneable free_storage (clone 0)
+End


### PR DESCRIPTION
342b1193 introduced several bugs into ProxyArray::Copy and the handling
of "copy" parameters in handlers. I did not realise that Copy() gives a
refcount of zero whereas Make() gives a refcount of 1, and so I
introduced a lot of different ways to get invalid refcounts out of EZC.
- Revert the change to ProxyArray::Copy()
- When a handler is called with copy=true, take this as an opportunity
  to deproxy the array, since the EZC layer itself has no such calls.
  Prior to 342b1193, these handlers just had assert(!copy).
- Revert the change to the first half of ProxyArray::PlusEq()
- In zBoxAndProxy(), incref the result of copy() before decrefing the
  source, to avoid releasing the ArrayData when copy() returns the same
  pointer instead of making a copy. A comment array-data.cpp advises
  that this is possible.
- Added an assert to ProxyArray::Make() which previously failed.
- Added a test case which previously failed.
