### PR TITLE
add missing include in ext_stream

### DIFF
--- a/hphp/runtime/ext/stream/ext_stream.cpp
+++ b/hphp/runtime/ext/stream/ext_stream.cpp
@@ -36,6 +36,7 @@
 #include <poll.h>
 #include <sys/types.h>
 #include <sys/socket.h>
+#include <sys/stat.h>
 #if defined(AF_UNIX)
 #include <sys/un.h>
 #include <algorithm>


### PR DESCRIPTION
We need to include sys/stat.h, or we might get errors such as:
error: aggregate 'stat s' has incomplete type and cannot be defined

Fixes the OSX build.
