### PR TITLE
Fixes HHVM-3.1 build.

### DIFF
--- a/hphp/runtime/server/fastcgi/fastcgi-transport.cpp
+++ b/hphp/runtime/server/fastcgi/fastcgi-transport.cpp
@@ -386,6 +386,7 @@ void FastCGITransport::onHeadersComplete() {
   m_httpVersion = getRawHeader(s_httpVersion);
   m_serverObject = getRawHeader(s_scriptName);
   m_pathTranslated = getRawHeader(s_pathTranslated);
+  m_scriptFilename = getRawHeader(s_scriptFilename);
   m_documentRoot = getRawHeader(s_documentRoot);
   if (!m_documentRoot.empty() &&
       m_documentRoot[m_documentRoot.length() - 1] != '/') {

--- a/hphp/runtime/server/fastcgi/fastcgi-transport.h
+++ b/hphp/runtime/server/fastcgi/fastcgi-transport.h
@@ -115,6 +115,7 @@ private:
   std::unique_ptr<folly::IOBuf> m_currBody;
   std::unordered_map<std::string, std::string> m_requestHeaders;
   std::string m_pathTranslated;
+  std::string m_scriptFilename;
   std::string m_requestURI;
   std::string m_documentRoot;
   std::string m_remoteHost;


### PR DESCRIPTION
This fixes the `'m_scriptFilename' was not declared in this scope` build error
caused by facebook/hhvm@740f281.
