### PR TITLE
Added Twital test suite

### DIFF
--- a/hphp/test/frameworks/frameworks.yaml
+++ b/hphp/test/frameworks/frameworks.yaml
@@ -645,3 +645,9 @@
     commit: 45e0f801d896258022c6a70a7738b991cb19aafe
     install_root: html5php
     test_root: html5php      
+  twital:
+    url: https://github.com/goetas/twital.git
+    branch: master
+    commit: 9f5d2f66bea26fc590ec003f2488568b34bafe72
+    install_root: twital
+    test_root: twital 


### PR DESCRIPTION
Twital is a small "plugin" for Twig that adds some sugar syntax, which makes its templates similar to PHPTal or AngularJS.

Twital is a very young project, I'm very interested to maintain it always up to date with the latest PHP trends
