### PR TITLE
Extend zend_call_function to handle method invocation.

### DIFF
--- a/hphp/runtime/base/object-data.cpp
+++ b/hphp/runtime/base/object-data.cpp
@@ -1901,6 +1901,12 @@ RefData* ObjectData::zGetProp(Class* ctx, const StringData* key,
                               bool& visible, bool& accessible,
                               bool& unset) {
   auto tv = getProp(ctx, key, visible, accessible, unset);
+  if (tv == 0) {
+    /*
+     * Protect against unknown object properties.
+     */
+    return nullptr;
+  }
   if (tv->m_type != KindOfRef) {
     tvBox(tv);
   }

--- a/hphp/runtime/ext_zend_compat/php-src/Zend/zend_execute_API.cpp
+++ b/hphp/runtime/ext_zend_compat/php-src/Zend/zend_execute_API.cpp
@@ -158,11 +158,22 @@ namespace {
 
 int zend_call_function(zend_fcall_info *fci, zend_fcall_info_cache *fci_cache TSRMLS_DC) /* {{{ */
 {
-  assert(fci->object_ptr == nullptr);
-
   // mostly from vm_call_user_func
   HPHP::ObjectData* obj = nullptr;
   HPHP::Class* cls = nullptr;
+
+  if (fci->object_ptr != nullptr) {
+    HPHP::TypedValue *tv = fci->object_ptr->tv();
+    if (tv->m_type == HPHP::KindOfObject) {
+      obj = tv->m_data.pobj;
+      if (obj != 0) {
+        cls = obj->getVMClass();
+      }
+    } else {
+      assert(!"zend_call_function not given an object");
+    }
+  }
+
   HPHP::CallerFrame cf;
   HPHP::StringData* invName = nullptr;
   const HPHP::Func* f = HPHP::vm_decode_function(


### PR DESCRIPTION
Add a null pointer guard in the zend property getter,
as for example when the object doesn't have the given property.
