### PR TITLE
Add a new class SystemProfiler and a default null singleton instance.

### DIFF
--- a/hphp/runtime/base/execution-context.cpp
+++ b/hphp/runtime/base/execution-context.cpp
@@ -44,6 +44,7 @@
 #include "hphp/runtime/debugger/debugger.h"
 #include "hphp/runtime/base/unit-cache.h"
 #include "hphp/runtime/ext/ext_string.h"
+#include "hphp/runtime/ext/ext_system_profiler.h"
 #include "hphp/runtime/ext/std/ext_std_output.h"
 #include "hphp/runtime/vm/jit/translator-inline.h"
 #include "hphp/runtime/vm/jit/translator.h"
@@ -651,6 +652,9 @@ void ExecutionContext::handleError(const std::string& msg,
   bool handled = false;
   if (callUserHandler) {
     handled = callUserErrorHandler(ee, errnum, false);
+  }
+  if (g_system_profiler) {
+    g_system_profiler->errorCallBack(errnum, ee, msg);
   }
   if (mode == ErrorThrowMode::Always ||
       (mode == ErrorThrowMode::IfUnhandled && !handled)) {

--- a/hphp/runtime/base/unit-cache.cpp
+++ b/hphp/runtime/base/unit-cache.cpp
@@ -37,6 +37,7 @@
 #include "hphp/runtime/base/file-stream-wrapper.h"
 #include "hphp/runtime/base/profile-dump.h"
 #include "hphp/runtime/base/rds.h"
+#include "hphp/runtime/ext/ext_system_profiler.h"
 #include "hphp/runtime/server/source-root-info.h"
 #include "hphp/runtime/vm/debugger-hook.h"
 #include "hphp/runtime/vm/repo.h"
@@ -455,6 +456,9 @@ Unit* lookupUnit(StringData* path, const char* currentDir, bool* initial_opt) {
       rpath.get()->incRefCount();
     }
     DEBUGGER_ATTACHED_ONLY(phpDebuggerFileLoadHook(cunit.unit));
+    if (g_system_profiler) {
+      g_system_profiler->fileLoadCallBack(path->toCppString());
+    }
   }
 
   return cunit.unit;

--- a/hphp/runtime/ext/ext_hotprofiler.h
+++ b/hphp/runtime/ext/ext_hotprofiler.h
@@ -115,9 +115,17 @@ enum Flag {
   MeasureXhprofDisable  = 0x20,
   Unused                = 0x40,
   TrackMalloc           = 0x80,
+
   // Allows profiling of multiple threads at the same time with TraceProfiler.
   // Requires a lot of memory.
   IHaveInfiniteMemory   = 0x100,
+
+  // A very slow profiler of function arguments and results
+  // to look for memoization opportunities.
+  Memo                  = 0x200,
+
+  // A hot profiler gotten through ProfilerHooks::getHotProfiler()
+  External              = 0x400,
 };
 
 /**
@@ -244,6 +252,7 @@ enum class ProfilerKind {
   Trace        = 3,
   Memo         = 4,
   XDebug       = 5,
+  External     = 7,
   Sample       = 620002, // Rockfort's zip code
 };
 

--- a/hphp/runtime/ext/ext_system_profiler.cpp
+++ b/hphp/runtime/ext/ext_system_profiler.cpp
@@ -1,0 +1,24 @@
+/*
+   +----------------------------------------------------------------------+
+   | HipHop for PHP                                                       |
+   +----------------------------------------------------------------------+
+   | Copyright (c) 2010-2014 Facebook, Inc. (http://www.facebook.com)     |
+   | Copyright (c) 1997-2010 The PHP Group                                |
+   +----------------------------------------------------------------------+
+   | This source file is subject to version 3.01 of the PHP license,      |
+   | that is bundled with this package in the file LICENSE, and is        |
+   | available through the world-wide-web at the following url:           |
+   | http://www.php.net/license/3_01.txt                                  |
+   | If you did not receive a copy of the PHP license and are unable to   |
+   | obtain it through the world-wide-web, please send a note to          |
+   | license@php.net so we can mail you a copy immediately.               |
+   +----------------------------------------------------------------------+
+*/
+
+#include "hphp/runtime/ext/ext_system_profiler.h"
+
+namespace HPHP {
+
+SystemProfiler *g_system_profiler = 0;
+
+}

--- a/hphp/runtime/ext/ext_system_profiler.h
+++ b/hphp/runtime/ext/ext_system_profiler.h
@@ -1,0 +1,65 @@
+/*
+   +----------------------------------------------------------------------+
+   | HipHop for PHP                                                       |
+   +----------------------------------------------------------------------+
+   | Copyright (c) 2010-2014 Facebook, Inc. (http://www.facebook.com)     |
+   | Copyright (c) 1997-2010 The PHP Group                                |
+   +----------------------------------------------------------------------+
+   | This source file is subject to version 3.01 of the PHP license,      |
+   | that is bundled with this package in the file LICENSE, and is        |
+   | available through the world-wide-web at the following url:           |
+   | http://www.php.net/license/3_01.txt                                  |
+   | If you did not receive a copy of the PHP license and are unable to   |
+   | obtain it through the world-wide-web, please send a note to          |
+   | license@php.net so we can mail you a copy immediately.               |
+   +----------------------------------------------------------------------+
+*/
+
+#ifndef incl_HPHP_EXT_SYSTEM_PROFILER_H_
+#define incl_HPHP_EXT_SYSTEM_PROFILER_H_
+
+#include <string>
+
+#include "hphp/runtime/base/exceptions.h"
+#include "hphp/runtime/ext/ext_hotprofiler.h"
+
+namespace HPHP {
+
+///////////////////////////////////////////////////////////////////////////////
+// classes
+
+/*
+ * Events interesting to a system profiler.
+ *
+ * A system profiler should instantiate one instance of this class,
+ * and bind the global g_system_profiler to point to that instance.
+ * That binding can be done in a dynamic shared object.
+ */
+
+class SystemProfiler {
+public:
+  SystemProfiler() { }
+  virtual ~SystemProfiler() { }
+
+  /*
+   * Called when a PHP execution error is handled.
+   */
+  virtual void errorCallBack(int errnum,
+                             const ExtendedException &ee,
+                             const std::string &msg) = 0;
+  /*
+   * Called when PHP loads a file.
+   */
+  virtual void fileLoadCallBack(const std::string &name) = 0;
+
+  /*
+   * Called once to get the hotprofiler.
+   */
+  virtual Profiler *getHotProfiler() = 0;
+};
+
+extern SystemProfiler *g_system_profiler;
+
+}
+
+#endif // incl_HPHP_EXT_SYSTEM_PROFILER_H_


### PR DESCRIPTION
This class implements hookpoints of interest to a system profiler,
currently hooking file load and PHP errors.  This list may grow.

The new class also supplies a HotProfiler.

The instance of a SystemProfiler may be made and bound during the initialization
phase of a 3rd party DSO.

While I'm at it, plumb in instantiation of the pre-existing experimental MemoProfiler.
