### PR TITLE
Update HHVM_API_VERSION

### DIFF
--- a/hphp/runtime/ext/extension.h
+++ b/hphp/runtime/ext/extension.h
@@ -113,7 +113,7 @@ private:
   std::string m_dsoName;
 };
 
-#define HHVM_API_VERSION 20131007L
+#define HHVM_API_VERSION 20140702L
 
 #ifdef HHVM_BUILD_DSO
 #define HHVM_GET_MODULE(name) \


### PR DESCRIPTION
Since 3.0 `Extension` class has been updated, so we need
to update HHVM_API_VERSION, or HHVM could load extensions
compiled against HHVM2.2 and crash.

Closes #3032
