### PR TITLE
Fix breakage of DSO loading on all platforms

### DIFF
--- a/CMake/FindLibDL.cmake
+++ b/CMake/FindLibDL.cmake
@@ -18,10 +18,15 @@ FIND_PACKAGE_HANDLE_STANDARD_ARGS(LibDL DEFAULT_MSG
 SET(CMAKE_REQUIRED_LIBRARIES dl)
 INCLUDE(CheckCSourceRuns)
 CHECK_C_SOURCE_RUNS("#include <dlfcn.h>
+#include <stdlib.h>
 void testfunc() {}
 int main() {
   testfunc();
-  return dlsym(0, \"_testfunc\") != (void*)0;
+  if (dlsym(0, \"_testfunc\") != (void*)0) {
+    return EXIT_SUCCESS;
+  } else {
+    return EXIT_FAILURE;
+  }
 }" LIBDL_NEEDS_UNDERSCORE)
 
 mark_as_advanced(LIBDL_INCLUDE_DIRS LIBDL_LIBRARIES LIBDL_NEEDS_UNDERSCORE)


### PR DESCRIPTION
bc00a9937 fixed a spelling error, but failed to fix the accidentally inverted logic, meaning that instead of underscores being unconditionally omitted, they would instead be added when they are not needed, and omitted when they are needed.

Exit statuses are hard. Used EXIT_SUCCESS/EXIT_FAILURE in the hopes of making the code readable.
