### PR TITLE
EZC: fix crash due to EG(exception) being transmitted between requests

### DIFF
--- a/hphp/runtime/ext_zend_compat/hhvm/zend-object-store.h
+++ b/hphp/runtime/ext_zend_compat/hhvm/zend-object-store.h
@@ -36,8 +36,14 @@ class ZendObjectStore final : public RequestEventHandler {
       : m_free_list_head(0)
     {}
 
-    virtual void requestInit() {};
+    virtual void requestInit() {}
     virtual void requestShutdown();
+
+    // Defer shutdown until after other requestShutdown hooks are done
+    // freeing their objects.
+    virtual int priority() const {
+      return 10;
+    }
 
     zend_object_handle insertObject(void *object,
         zend_objects_store_dtor_t dtor,

--- a/hphp/runtime/ext_zend_compat/php-src/Zend/zend_globals.cpp
+++ b/hphp/runtime/ext_zend_compat/php-src/Zend/zend_globals.cpp
@@ -1,28 +1,61 @@
 #include "zend.h"
 #include "zend_globals.h"
+#include "zend_exceptions.h"
 
 #include "hphp/runtime/base/externals.h"
 #include "hphp/util/thread-local.h"
 #include "hphp/runtime/base/execution-context.h"
 #include "hphp/runtime/base/thread-info.h"
 #include "hphp/runtime/base/request-injection-data.h"
+#include "hphp/runtime/base/request-local.h"
+#include "hphp/runtime/base/request-event-handler.h"
 
 ZEND_API zend_compiler_globals compiler_globals;
 
-static IMPLEMENT_THREAD_LOCAL(_zend_executor_globals, s_zend_executor_globals);
+namespace HPHP {
+
+class ZendExecutorGlobals : public RequestEventHandler {
+  public:
+    virtual void requestInit() {
+      m_data.exception = nullptr;
+      m_data.prev_exception = nullptr;
+    }
+
+    virtual void requestShutdown() {
+      zval * tmp;
+      if (m_data.exception) {
+        tmp = m_data.exception;
+        m_data.exception = nullptr;
+        zval_ptr_dtor(&tmp);
+      }
+      if (m_data.prev_exception) {
+        tmp = m_data.prev_exception;
+        m_data.prev_exception = nullptr;
+        zval_ptr_dtor(&tmp);
+      }
+    }
+
+    virtual ~ZendExecutorGlobals() {}
+
+    _zend_executor_globals m_data;
+};
+
+IMPLEMENT_STATIC_REQUEST_LOCAL(ZendExecutorGlobals, s_zend_executor_globals);
+
+} // namespace HPHP
 
 #define G(TYPE, MEMBER)                                   \
   std::add_lvalue_reference<TYPE>::type EG_ ## MEMBER() { \
-    return s_zend_executor_globals.get()->MEMBER;         \
+    return HPHP::s_zend_executor_globals.get()->m_data.MEMBER;         \
   }
 EG_DEFAULT
 #undef G
 
 HashTable& EG_regular_list() {
-  return *s_zend_executor_globals.get()->regular_list;
+  return *HPHP::s_zend_executor_globals.get()->m_data.regular_list;
 }
 HashTable& EG_persistent_list() {
-  return *s_zend_executor_globals.get()->persistent_list;
+  return *HPHP::s_zend_executor_globals.get()->m_data.persistent_list;
 }
 
 HashTable& EG_symbol_table() {


### PR DESCRIPTION
When an exception was thrown from EZC, EG(exception) was left holding a
reference to the smart-allocated exception object, even after the end of
the request. At the end of the request, the object storage was freed by
resetAllocator(), then when zend_wrap_func() was entered in the next
request, EG(exception) would be freed again, causing a crash.

Fixed by installing request event handlers. The requestInit() handler is
analogous to Zend's init_executor().
