### PR TITLE
Fix for Redis EVAL / EVALSHA

### DIFF
--- a/hphp/system/php/redis/Redis.php
+++ b/hphp/system/php/redis/Redis.php
@@ -597,7 +597,8 @@ class Redis {
     array_unshift($args, $numKeys);
     array_unshift($args, $script);
     $this->processArrayCommand($cmd, $args);
-    return $this->processVariantResponse();
+    $response = $this->processVariantResponse();
+    return ($response !== NULL) ? $response : false;
   }
 
   public function evaluate($script, array $args = [], $numKeys = 0) {

--- a/hphp/test/slow/ext_redis/evalevalSha.php
+++ b/hphp/test/slow/ext_redis/evalevalSha.php
@@ -11,6 +11,7 @@ $r->setOption(Redis::OPT_PREFIX, $prefix);
 foreach (['eval', 'evaluate'] as $method) {
     echo $method . "\n";
     var_dump($r->$method('return 42')); // Return integer -> 42
+    var_dump($r->$method('return false')); // Return false
     // Return results as array()
     var_dump($r->$method('return {1,2,{3,4,{"a","b"}}}'));
     // Script with parameters -> OK

--- a/hphp/test/slow/ext_redis/evalevalSha.php.expect
+++ b/hphp/test/slow/ext_redis/evalevalSha.php.expect
@@ -1,5 +1,6 @@
 eval
 int(42)
+bool(false)
 array(3) {
   [0]=>
   int(1)
@@ -33,6 +34,7 @@ array(4) {
 }
 evaluate
 int(42)
+bool(false)
 array(3) {
   [0]=>
   int(1)
@@ -67,12 +69,12 @@ array(4) {
 evalSha
 int(42)
 string(2) "OK"
-NULL
+bool(false)
 string(6) "string"
 evaluateSha
 int(42)
 string(2) "OK"
-NULL
+bool(false)
 string(6) "string"
 script
 string(40) "1fa00e76656cc152ad327c13fe365858fd7be306"


### PR DESCRIPTION
phpredis casts nil responses to bool(false), whereas HHVM returns NULL for both
false and nil return values. For example:

```
<?php
$redis = new Redis();
$redis->connect( '127.0.0.1' );
var_dump( $redis->evaluate( 'return' ) );
var_dump( $redis->evaluate( 'return false' ) );
```

With Zend / phpredis, the output is:

```
bool(false)
bool(false)
```

With HHVM, it's:

```
NULL
NULL
```

This patch adds a fix and a test.
