### PR TITLE
fix OCaml for ninja-build generator

### DIFF
--- a/hphp/hack/CMakeLists.txt
+++ b/hphp/hack/CMakeLists.txt
@@ -19,6 +19,11 @@ if (OCAMLC_FOUND)
     list(APPEND hackcflags -ccopt -L${pth} -cclib -l${libname})
   endforeach()
 
+  # Xcode/Ninja generators undefined MAKE
+  if(NOT MAKE) 
+    set(MAKE make)
+  endif()
+
   add_custom_target(
     hack
     ALL


### PR DESCRIPTION
``` bash
$ cmake -G Ninja .
$ ninja -j4
```

![2014-07-08 01 49 51](https://cloud.githubusercontent.com/assets/3759759/3503335/b535d782-062e-11e4-87b7-ff98c4df1bca.png)
