### PR TITLE
libdwarf, libpam, libelf, bootstrap cmake fixes

### DIFF
--- a/CMake/FindLibDwarf.cmake
+++ b/CMake/FindLibDwarf.cmake
@@ -52,11 +52,54 @@ FIND_PACKAGE_HANDLE_STANDARD_ARGS(LibDwarf DEFAULT_MSG
 
 if (LIBDWARF_LIBRARIES AND LIBDWARF_INCLUDE_DIRS)
   set(CMAKE_REQUIRED_INCLUDES ${LIBDWARF_INCLUDE_DIRS})
-  set(CMAKE_REQUIRED_LIBRARIES ${LIBDWARF_LIBRARIES})
-  include(CheckSymbolExists)
-  CHECK_SYMBOL_EXISTS(dwarf_encode_leb128 "libdwarf.h" LIBDWARF_HAVE_ENCODE_LEB128)
+  set(CMAKE_REQUIRED_LIBRARIES ${LIBDWARF_LIBRARIES} ${LIBELF_LIBRARIES})
+  
+  # libdwarf makes breaking changes occasionally and doesn't provide an easy
+  # way to test for them. The following checks should detect the changes and
+  # pass that information on accordingly.
+  INCLUDE(CheckCSourceCompiles)
+  CHECK_C_SOURCE_COMPILES("#include <libdwarf.h>
+  int dwarfCallback(const char * a, int b, Dwarf_Unsigned c,
+  Dwarf_Unsigned d, Dwarf_Unsigned e, Dwarf_Unsigned f,
+  Dwarf_Unsigned * g, Dwarf_Ptr h, int * i) {}
+int main() {
+  dwarf_producer_init_c(0, dwarfCallback, 0, 0, 0, 0);
+  return 0;
+}" DW_INIT_C)
+
+  if (NOT DW_INIT_C)
+	CHECK_C_SOURCE_COMPILES("#include <libdwarf.h>
+  int dwarfCallback(const char * a, int b, Dwarf_Unsigned c,
+  Dwarf_Unsigned d, Dwarf_Unsigned e, Dwarf_Unsigned f,
+  Dwarf_Unsigned * g, Dwarf_Ptr h, int * i) {}
+  int main() {
+	dwarf_producer_init(0, dwarfCallback, 0, 0, 0, 0, 0, 0, 0, 0);
+    return 0;
+  }" DW_INIT)
+	if (DW_INIT)
+	  set(LIBDWARF_CONST_NAME 1)
+	  set(LIBDWARF_USE_INIT_C 0)
+	else()
+	  set(LIBDWARF_CONST_NAME 0)
+	  set(LIBDWARF_USE_INIT_C 1)
+	endif()
+  else()
+	set(LIBDWARF_CONST_NAME 1)
+	set(LIBDWARF_USE_INIT_C 1)
+  endif()
+endif()
+
+if(LIBDWARF_CONST_NAME)
+  message(STATUS "libdwarf uses const char* type")
+else()
+  message(STATUS "libdwarf uses char* type")
+endif()
+if(LIBDWARF_USE_INIT_C)
+  message(STATUS "libdwarf has dwarf_producer_init_c")
+else()
+  message(STATUS "libdwarf does not have dwarf_producer_init_c, using dwarf_producer_init")
 endif()
 
 mark_as_advanced(LIBDW_INCLUDE_DIR DWARF_INCLUDE_DIR)
 mark_as_advanced(LIBDWARF_INCLUDE_DIRS LIBDWARF_LIBRARIES)
-mark_as_advanced(LIBDWARF_HAVE_ENCODE_LEB128)
+mark_as_advanced(LIBDWARF_CONST_NAME LIBDWARF_USE_INIT_C)

--- a/CMake/HPHPFindLibs.cmake
+++ b/CMake/HPHPFindLibs.cmake
@@ -303,8 +303,11 @@ endif()
 
 find_package(LibDwarf REQUIRED)
 include_directories(${LIBDWARF_INCLUDE_DIRS})
-if (LIBDWARF_HAVE_ENCODE_LEB128)
-  add_definitions("-DHAVE_LIBDWARF_20130729")
+if (LIBDWARF_CONST_NAME)
+  add_definitions("-DLIBDWARF_CONST_NAME")
+endif()
+if (LIBDWARF_USE_INIT_C)
+  add_definitions("-DLIBDWARF_USE_INIT_C")
 endif()
 
 find_package(LibElf REQUIRED)
@@ -313,13 +316,9 @@ if (ELF_GETSHDRSTRNDX)
   add_definitions("-DHAVE_ELF_GETSHDRSTRNDX")
 endif()
 
-# For some reason imap-uw is using libpam on OSX, so we need to include it as
-# an indirect dependency
-if (APPLE)
-  find_package(Libpam)
-  if (PAM_INCLUDE_PATH)
-    include_directories(${PAM_INCLUDE_PATH})
-  endif()
+find_package(Libpam)
+if (PAM_INCLUDE_PATH)
+  include_directories(${PAM_INCLUDE_PATH})
 endif()
 
 FIND_LIBRARY(CRYPT_LIB NAMES xcrypt crypt crypto)

--- a/hphp/runtime/vm/debug/dwarf.h
+++ b/hphp/runtime/vm/debug/dwarf.h
@@ -52,7 +52,7 @@ typedef enum {
 const int DWARF_CODE_ALIGN = 1;
 const int DWARF_DATA_ALIGN = 8;
 
-#ifdef HAVE_LIBDWARF_20130729
+#ifdef LIBDWARF_CONST_NAME
 #define LIBDWARF_CALLBACK_NAME_TYPE const char*
 #else
 #define LIBDWARF_CALLBACK_NAME_TYPE char*

--- a/hphp/runtime/vm/debug/elfwriter.cpp
+++ b/hphp/runtime/vm/debug/elfwriter.cpp
@@ -95,6 +95,7 @@ void ElfWriter::initStrtab() {
   addSectionString("");
 }
 
+#if defined(LIBDWARF_USE_INIT_C) || defined(FACEBOOK)
 bool ElfWriter::initDwarfProducer() {
   Dwarf_Error error = 0;
   /* m_dwarfProducer is the handle used for interaction for libdwarf */
@@ -116,6 +117,27 @@ bool ElfWriter::initDwarfProducer() {
   }
   return true;
 }
+#else
+bool ElfWriter::initDwarfProducer() {
+  Dwarf_Error error = 0;
+  auto ret = dwarf_producer_init(
+	  DW_DLC_WRITE | DW_DLC_SIZE_64 | DW_DLC_SYMBOLIC_RELOCATIONS,
+	  g_dwarfCallback,
+	  nullptr,
+	  nullptr,
+	  reinterpret_cast<Dwarf_Ptr>(this),
+	  "x86_64",
+	  "V2",
+	  nullptr,
+	  &m_dwarfProducer,
+	  &error);
+  if (ret != DW_DLV_OK) {
+    logError("Unable to create dwarf producer");
+    return false;
+  }
+  return true;
+}
+#endif
 
 Dwarf_P_Die ElfWriter::addFunctionInfo(FunctionInfo* f, Dwarf_P_Die type) {
   Dwarf_Error error = 0;

--- a/hphp/tools/bootstrap/CMakeLists.txt
+++ b/hphp/tools/bootstrap/CMakeLists.txt
@@ -1,11 +1,15 @@
+if (NOT DOUBLE_CONVERSION_LIBRARY)
+  set(DOUBLE_CONVERSION_LIBRARY double-conversion)
+endif()
+
 add_executable(gen-ext-hhvm "gen-ext-hhvm.cpp" "idl.cpp")
-target_link_libraries(gen-ext-hhvm folly ${LIBGLOG_LIBRARY} double-conversion
+target_link_libraries(gen-ext-hhvm folly ${LIBGLOG_LIBRARY} ${DOUBLE_CONVERSION_LIBRARY}
                       ${LIBPTHREAD_LIBRARIES} ${DL_LIB})
 
 add_executable(gen-infotabs "gen-infotabs.cpp" "idl.cpp")
-target_link_libraries(gen-infotabs folly ${LIBGLOG_LIBRARY} double-conversion
+target_link_libraries(gen-infotabs folly ${LIBGLOG_LIBRARY} ${DOUBLE_CONVERSION_LIBRARY}
                       ${LIBPTHREAD_LIBRARIES} ${DL_LIB})
 
 add_executable(gen-class-map "gen-class-map.cpp" "idl.cpp")
-target_link_libraries(gen-class-map folly ${LIBGLOG_LIBRARY} double-conversion
+target_link_libraries(gen-class-map folly ${LIBGLOG_LIBRARY} ${DOUBLE_CONVERSION_LIBRARY}
                       ${LIBPTHREAD_LIBRARIES} ${DL_LIB})


### PR DESCRIPTION
First: libdwarf. libdwarf seems to have no problem making breaking
changes and provides no easy way to even test the version you're
building against. I have added two tests in `FindLibDwarf.cmake` to
detect a change to function type signature and to detect the removal
of `dwarf_producer_init_c`. Hopefully this will work on all systems.

The recent change to use more system libraries broke the build of the
`gen-*` bootstrap utilities, as the targets were not updated to use
the system `double-conversion` library and instead attempted to use
the (unbuilt) local one.

Commit 83cbca11c1 made linking to libpam happen only on OSX. This
breaks the build on ArchLinux and openSUSE at least. I reverted this
change given that detecting whether or not you need to link to it is
quite difficult.
