### PR TITLE
Case sensitivity/caching issue for autoloaded parent classes

### DIFF
--- a/hphp/runtime/vm/class.cpp
+++ b/hphp/runtime/vm/class.cpp
@@ -309,8 +309,13 @@ const Func* Class::getDeclaredCtor() const {
 Class::Avail Class::avail(Class*& parent, bool tryAutoload /*=false*/) const {
   if (Class *ourParent = m_parent.get()) {
     if (!parent) {
-      PreClass *ppcls = ourParent->m_preClass.get();
-      parent = Unit::getClass(ppcls->namedEntity(), ppcls->name(), tryAutoload);
+      if (!tryAutoload) {
+          PreClass *ppcls = ourParent->m_preClass.get();
+          parent = Unit::getClass(ppcls->namedEntity(), ppcls->name(), tryAutoload);
+      } else {
+          const StringData* parent_name_code = m_preClass->parent();
+          parent = Unit::getClass(Unit::GetNamedEntity(parent_name_code), parent_name_code, tryAutoload);
+      }
       if (!parent) {
         parent = ourParent;
         return Avail::Fail;


### PR DESCRIPTION
when class extends parent class,but code parent class differences class real name(lowercase class name is same),this problem appears in web mode.
first access hhvm no problem,but seconde access (beacause first access class have cached),and throw fatal:
error 1:
HipHop Fatal error: File not found: /mnt/huzhiguang/data/hhvm/class/autoload/TeSt_Base.php in /mnt/huzhiguang/data/hhvm/class/autoload/test1.php on line 5

error 2:

[Tue Jul  1 14:25:43 2014] [hphp] [28065:7f868e9ff700:12:000001] HipHop Fatal error: unknown class Opsystem_Base in /home/work/orp001/app/testapp/actions/A1.php on lin
e 8

replay problem issuse:
https://github.com/facebook/hhvm/issues/3146
