### PR TITLE
Fix build broken on OS X

### DIFF
--- a/hphp/runtime/vm/jit/code-gen-helpers-x64.h
+++ b/hphp/runtime/vm/jit/code-gen-helpers-x64.h
@@ -108,16 +108,16 @@ void emitCheckSurpriseFlagsEnter(CodeBlock& mainCode, CodeBlock& coldCode,
  */
 template<typename T>
 inline void
-emitTLSLoad(X64Assembler& a, const ThreadLocalNoCheck<T>& datum, Reg64 reg) {
+emitTLSLoad(X64Assembler& a, const ThreadLocalNoCheck<T>& datum, Reg64 dest) {
   uintptr_t virtualAddress = uintptr_t(&datum.m_node.m_p) - tlsBase();
-  a.    fs().loadq(baseless(virtualAddress), reg);
+  a.    fs().loadq(baseless(virtualAddress), dest);
 }
 
 #else // USE_GCC_FAST_TLS
 
 template<typename T>
 inline void
-emitTLSLoad(X64Assembler& a, const ThreadLocalNoCheck<T>& datum, Reg64 reg) {
+emitTLSLoad(X64Assembler& a, const ThreadLocalNoCheck<T>& datum, Reg64 dest) {
   PhysRegSaver(a, kGPCallerSaved); // we don't know for sure what's alive
   a.    emitImmReg(datum.m_key, argNumToRegName[0]);
   const TCA addr = (TCA)pthread_getspecific;
@@ -127,8 +127,8 @@ emitTLSLoad(X64Assembler& a, const ThreadLocalNoCheck<T>& datum, Reg64 reg) {
     a.    movq(addr, reg::rax);
     a.    call(reg::rax);
   }
-  if (reg != reg::rax) {
-    a.    movq(reg::rax, reg);
+  if (dest != reg::rax) {
+    a.    movq(reg::rax, dest);
   }
 }
 


### PR DESCRIPTION
Typo fix, rename `dest` to `reg` to match GCC_FAST_TLS version

This closes issue #3145
