### PR TITLE
detect proper libdwarf types

### DIFF
--- a/CMake/FindLibDwarf.cmake
+++ b/CMake/FindLibDwarf.cmake
@@ -58,35 +58,31 @@ if (LIBDWARF_LIBRARIES AND LIBDWARF_INCLUDE_DIRS)
   # way to test for them. The following checks should detect the changes and
   # pass that information on accordingly.
   INCLUDE(CheckCSourceCompiles)
-  CHECK_C_SOURCE_COMPILES("#include <libdwarf.h>
-  int dwarfCallback(const char * a, int b, Dwarf_Unsigned c,
-  Dwarf_Unsigned d, Dwarf_Unsigned e, Dwarf_Unsigned f,
-  Dwarf_Unsigned * g, Dwarf_Ptr h, int * i) {}
-int main() {
-  dwarf_producer_init_c(0, dwarfCallback, 0, 0, 0, 0);
-  return 0;
-}" DW_INIT_C)
+  INCLUDE(CheckFunctionExists)
 
-  if (NOT DW_INIT_C)
-	CHECK_C_SOURCE_COMPILES("#include <libdwarf.h>
-  int dwarfCallback(const char * a, int b, Dwarf_Unsigned c,
-  Dwarf_Unsigned d, Dwarf_Unsigned e, Dwarf_Unsigned f,
-  Dwarf_Unsigned * g, Dwarf_Ptr h, int * i) {}
-  int main() {
-	dwarf_producer_init(0, dwarfCallback, 0, 0, 0, 0, 0, 0, 0, 0);
-    return 0;
-  }" DW_INIT)
-	if (DW_INIT)
-	  set(LIBDWARF_CONST_NAME 1)
-	  set(LIBDWARF_USE_INIT_C 0)
-	else()
-	  set(LIBDWARF_CONST_NAME 0)
-	  set(LIBDWARF_USE_INIT_C 1)
-	endif()
-  else()
-	set(LIBDWARF_CONST_NAME 1)
-	set(LIBDWARF_USE_INIT_C 1)
-  endif()
+  MACRO(CHECK_LIBDWARF_INIT init params var)
+    # Check for the existence of this particular init function.
+    CHECK_FUNCTION_EXISTS(${init} INIT_EXISTS)
+    if (INIT_EXISTS)
+      set(LIBDWARF_USE_INIT_C ${var})
+
+      # Check to see if we can use a const name.
+      CHECK_C_SOURCE_COMPILES("#include <libdwarf.h>
+      int dwarfCallback(const char * a, int b, Dwarf_Unsigned c,
+      Dwarf_Unsigned d, Dwarf_Unsigned e, Dwarf_Unsigned f,
+      Dwarf_Unsigned * g, Dwarf_Ptr h, int * i) {}
+      int main() { ${init}(${params}); return 0; }" DW_CONST)
+      if (DW_CONST)
+        set(LIBDWARF_CONST_NAME 1)
+      else()
+        set(LIBDWARF_CONST_NAME 0)
+      endif()
+    endif()
+  ENDMACRO(CHECK_LIBDWARF_INIT)
+
+  # Order is important, last one is used.
+  CHECK_LIBDWARF_INIT("dwarf_producer_init"   "0, dwarfCallback, 0, 0, 0, 0, 0, 0, 0, 0"  "0")
+  CHECK_LIBDWARF_INIT("dwarf_producer_init_c" "0, dwarfCallback, 0, 0, 0, 0"              "1")
 endif()
 
 if(LIBDWARF_CONST_NAME)


### PR DESCRIPTION
Current master is broken by libdwarf once again. Other than checking for
a particular init function we should also check if we're allowed to use
a const char\* for name separately.

Combined them into a macro for future changes.
