### PR TITLE
Testfiles are supposed to end with a newline

### DIFF
--- a/hphp/test/tools/import_zend_test.py
+++ b/hphp/test/tools/import_zend_test.py
@@ -967,7 +967,9 @@ def walk(filename, dest_subdir):
         file(full_dest_filename+'.ini', 'w').write(exp)
 
     if 'SKIPIF' in sections:
-        skipif = sections['SKIPIF']
+        skipif = sections['SKIPIF'].strip()
+        if skipif[:2] != '<?':
+          skipif = '<?php' + skipif
 
         if '/ext/standard/tests/strings/fprintf_' in full_dest_filename:
             skipif = skipif.replace('dump.txt', dest_filename + '.txt')


### PR DESCRIPTION
Zends temporary *.php files all end with a newline. That mismatch results in some bad test being moved to good and vice versa if the test uses **FILE**.

Run zends `./run-test.php --keep-php` to view the test files.

Fixes #3174
