### PR TITLE
In mysql_escape_string() use ReserveString instead of AttachString

### DIFF
--- a/hphp/runtime/ext/mysql/ext_mysql.cpp
+++ b/hphp/runtime/ext/mysql/ext_mysql.cpp
@@ -107,21 +107,26 @@ bool f_mysql_set_timeout(int query_timeout_ms /* = -1 */,
 }
 
 String f_mysql_escape_string(const String& unescaped_string) {
-  char *new_str = (char *)malloc(unescaped_string.size() * 2 + 1);
-  int new_len = mysql_escape_string(new_str, unescaped_string.data(),
+  String new_str((size_t)unescaped_string.size() * 2 + 1, ReserveString);
+  unsigned long new_len = mysql_escape_string(new_str.bufferSlice().begin(),
+                                    unescaped_string.data(),
                                     unescaped_string.size());
-  return String(new_str, new_len, AttachString);
+  new_str.shrink(new_len);
+  return new_str;
 }
 
 Variant f_mysql_real_escape_string(const String& unescaped_string,
                                    const Variant& link_identifier /* = null */) {
   MYSQL *conn = MySQL::GetConn(link_identifier);
   if (conn) {
-    char *new_str = (char *)malloc(unescaped_string.size() * 2 + 1);
-    int new_len = mysql_real_escape_string(conn, new_str,
-                                           unescaped_string.data(),
-                                           unescaped_string.size());
-    return String(new_str, new_len, AttachString);
+    String new_str((size_t)unescaped_string.size() * 2 + 1, ReserveString);
+    unsigned long new_len = mysql_real_escape_string(conn,
+                                      new_str.bufferSlice().begin(),
+                                      unescaped_string.data(),
+                                      unescaped_string.size());
+
+    new_str.shrink(new_len);
+    return new_str;
   }
   return false;
 }

--- a/hphp/test/zend/good/ext/mysql/tests/skipif.inc
+++ b/hphp/test/zend/good/ext/mysql/tests/skipif.inc
@@ -1,0 +1,6 @@
+<?php
+if (!extension_loaded("mysql")) {
+  die('skip mysql extension not available');
+}
+require_once('connect.inc');
+?>


### PR DESCRIPTION
- Use ReserveString instead of AttachString in mysql_escape_string()
  and mysql_real_escape_string(). AttachString should really be
  deprecated, since it doesn't actually attach, it just copies.
- Don't truncate the return value of the underlying C API call -- use
  unsigned long.
- Upgrade string size to size_t before doing arithmetic. Overflow is
  probably not possible in this case, but it's a good habit to get into.
- Added missing skipif.inc from PHP, so that the relevant tests would
  run.

Submitted on behalf of a third-party: The PHP Group
Source: PHP 5.7.0-dev
License: version 3.01 of the PHP license
