### PR TITLE
Lock the session file when opening it

### DIFF
--- a/hphp/runtime/ext/session/ext_session.cpp
+++ b/hphp/runtime/ext/session/ext_session.cpp
@@ -21,6 +21,7 @@
 #include <sys/types.h>
 #include <sys/time.h>
 #include <sys/stat.h>
+#include <sys/file.h>
 #include <fcntl.h>
 #include <dirent.h>
 #include <vector>


### PR DESCRIPTION
This seems to be a copy+paste mistake from https://github.com/php/php-src/blob/master/ext/session/mod_files.c#L157-L168.
