### PR TITLE
unset another cached variable for dwarf detection

### DIFF
--- a/CMake/FindLibDwarf.cmake
+++ b/CMake/FindLibDwarf.cmake
@@ -62,6 +62,7 @@ if (LIBDWARF_LIBRARIES AND LIBDWARF_INCLUDE_DIRS)
 
   MACRO(CHECK_LIBDWARF_INIT init params var)
     # Check for the existence of this particular init function.
+    unset(INIT_EXISTS CACHE)
     CHECK_FUNCTION_EXISTS(${init} INIT_EXISTS)
     if (INIT_EXISTS)
       set(LIBDWARF_USE_INIT_C ${var})


### PR DESCRIPTION
We're not actually broken right now because of the way we fall-back to
dwarf_producer_init_c, but a function exists check is still being
skipped due to CMake caching. That could potentially confuse things
if/when another init function were to be added in the future.
