### PR TITLE
Clean up CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,18 +1,18 @@
-# Contributing to HipHop
+# Contributing to HHVM
 
-We'd love to have your help in making HipHop better. If you run into problems, please open an [issue](http://github.com/facebook/hiphop-php/issues), or better yet, fork us and send a pull request.
+We'd love to have your help in making HHVM better. Before jumping into the code, please familiarize yourself with our [coding conventions](hphp/doc/coding-conventions.md). We're also working on a [Hacker's Guide to HHVM](hphp/doc/hackers-guide). It's still very incomplete, but if there's a specific topic you'd like to see addressed sooner rather than later, let us know. For documentation and any other problems, please open an [issue](http://github.com/facebook/hhvm/issues), or better yet, [fork us and send a pull request](https://github.com/facebook/hhvm/pulls). Join us on Freenode in [#hhvm](http://webchat.freenode.net/?channels=hhvm) for general discussion, or [#hhvm-dev](http://webchat.freenode.net/?channels=hhvm-dev) for development-oriented discussion.
 
-If you want to help but don't know where to start, try fixing some of the [Zend tests that don't pass](hphp/test/zend/bad). You can run them with [hphp/test/run](hphp/test/run). When they work, move them to [zend/good](hphp/test/zend/good) and send a pull request.
+If you want to help but don't know where to start, try fixing some of the [PHP5 tests that don't pass](hphp/test/zend/bad). You can run them with [hphp/test/run](hphp/test/run). When they work, move them to [zend/good](hphp/test/zend/good) and send a pull request.
 
-All the open issues tagged [PHP5 incompatibility](https://github.com/facebook/hiphop-php/issues?labels=php5+incompatibility&page=1&state=open) are real issues reported by the community in existing PHP code and [frameworks](https://github.com/facebook/hiphop-php/wiki/OSS-PHP-Frameworks-Unit-Testing:-General) that could use some attention.
+All the open issues tagged [PHP5 incompatibility](https://github.com/facebook/hhvm/issues?labels=php5+incompatibility&page=1&state=open) are real issues reported by the community in existing PHP code and [frameworks](https://github.com/facebook/hhvm/wiki/OSS-PHP-Frameworks-Unit-Testing:-General) that could use some attention.
 
 ## Submitting Pull Requests
 
-Before changes can be accepted a [Contributor Licensing Agreement](http://code.facebook.com/cla) ([pdf](https://github.com/facebook/hiphop-php/raw/master/hphp/doc/FB_Individual_CLA.pdf) - print, sign, scan, link) must be signed.
+Before changes can be accepted a [Contributor Licensing Agreement](http://code.facebook.com/cla) must be completed. You will be prompted to accept the CLA when you submit your first pull request. If you prefer a hard copy, you can print the [pdf](https://github.com/facebook/hhvm/raw/master/hphp/doc/FB_Individual_CLA.pdf), sign it, scan it, and send it to <cla@fb.com>.
 
-Please add appropriate test cases as you make changes; see [here](hphp/test) for more information. Travis-CI is integrated with this GitHub project and will provide test results automatically on all pulls.
+Please add appropriate test cases as you make changes; see [here](hphp/test/README.md) for more information. Travis-CI is integrated with this GitHub project and will provide test results automatically on all pull requests.
 
-## Additional Resources
+## Quick Links
 
- * IRC:[#hhvm on freenode](http://webchat.freenode.net/?channels=hhvm)
+ * IRC: [#hhvm](http://webchat.freenode.net/?channels=hhvm) and [#hhvm-dev](http://webchat.freenode.net/?channels=hhvm-dev) on Freenode.
  * [Issue tracker](http://github.com/facebook/hiphop-php/issues)

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ You can install a [prebuilt package](https://github.com/facebook/hhvm/wiki/Prebu
 
 You can run standalone programs just by passing them to hhvm: `hhvm my_script.php`.
 
-If you want to host a website: 
+If you want to host a website:
 * Install your favorite webserver
 * Install our [package](https://github.com/facebook/hhvm/wiki/Prebuilt%20Packages%20for%20HHVM)
 * Start your webserver
@@ -35,20 +35,7 @@ If you want to host a website:
 
 ## Contributing
 
-We'd love to have your help in making HHVM better.
-
-You must sign a [Contributor License Agreement](http://code.facebook.com/cla) before your changes can be accepted.
-
-You will be prompted to accept the CLA when you submit your pull request.
-
-If you prefer to submit a paper copy, then you can print the [pdf](https://github.com/facebook/hhvm/raw/master/hphp/doc/FB_Individual_CLA.pdf) and send it to <cla@fb.com>.
-
-If you run into problems, please open an [issue](http://github.com/facebook/hhvm/issues), or better yet, [fork us and send a pull request](https://github.com/facebook/hhvm/pulls). Join us on [#hhvm on freenode](http://webchat.freenode.net/?channels=hhvm).
-
-If you want to help but don't know where to start, try fixing some of the [PHP5 tests that don't pass](hphp/test/zend/bad). You can run them with [hphp/test/run](hphp/test/run). When they work, move them to [zend/good](hphp/test/zend/good) and send a pull request.
-
-All the open issues tagged [php5 incompatibility](https://github.com/facebook/hhvm/issues?labels=php5+incompatibility&page=1&state=open) are real issues reported by the community in existing PHP code and [frameworks](https://github.com/facebook/hhvm/wiki/OSS-PHP-Frameworks-Unit-Testing:-General) that could use some attention. Please add appropriate test cases as you make changes; see [here](hphp/test) for more information. Travis-CI is integrated with this GitHub project and will provide test results automatically on all pulls.
-
+We'd love to have your help in making HHVM better. If you're interested, please read our [guide to contributing](CONTRIBUTING.md).
 
 ## License
 


### PR DESCRIPTION
CONTRIBUTING.md was mostly a duplicate of a section in README.md. I
deduped the content, cutting the README.md section down to a link to
CONTRIBUTING.md. I also reordered and cleaned up some of the text in
CONTRIBUTING.md.

Test Plan: Read it, clicked the links.
