### PR TITLE
Implement a proper hack-mode for Emacs

### DIFF
--- a/hphp/hack/editor-plugins/emacs/hack-mode.el
+++ b/hphp/hack/editor-plugins/emacs/hack-mode.el
@@ -124,7 +124,7 @@
 
 (defconst hack-types
   (eval-when-compile
-    (regexp-opt '("array" "bool" "char" "float" "int" "mixed" "object" "string" "void")))
+    (regexp-opt '("array" "bool" "char" "float" "int" "mixed" "string" "void")))
   "Hack types.")
 
 (defconst hack-special-methods
@@ -325,10 +325,6 @@
   (setq case-fold-search t)
   
   (setq-local compile-command (concat hack-client-binary "--from emacs"))
-  
-  (define-key hack-mode-map (kbd "M-RET") 'recompile)
-  (define-key hack-mode-map (kbd "M-<up>") 'next-error)
-  (define-key hack-mode-map (kbd "M-<down>") 'previous-error)
   
   (add-hook 'completion-at-point-functions 'hack-completion nil t) 
 


### PR DESCRIPTION
This mostly supercedes the existing `hack-for-hiphop.el` "integration" that already exists. This is my first time doing anything major with Emacs, so it ~~might~~ certainly needs some more work. A few issues I can think of immediately are that it doesn't highlight XHP expressions and it likely won't indent them properly. Indentation is hard though, so I'm leaving that until later.
## Features
- Highlighting of various Hack-specific constructs, including Hack-specific keywords.
- Better integration with the typechecker by _not_ setting global keybindings unlike the current integration, instead creating mode-specific bindings.
- Integration with the completion service provided by the typechecker. Includes integration with the `auto-complete` Emacs extension for intellisense-style autocompletion.
- Doesn't depend on an existing `php-mode` of which there are atleast 3 different ones of various completeness and complexity.
