### PR TITLE
Fix Redis::sRandMember()

### DIFF
--- a/hphp/system/php/redis/Redis.php
+++ b/hphp/system/php/redis/Redis.php
@@ -366,6 +366,20 @@ class Redis {
     return $this->processBooleanResponse();
   }
 
+  /* Sets ---------------------------------------------------------------- */
+
+  public function sRandMember($key, $count = null) {
+    $args = [$key];
+    if ($count !== null) {
+       $args[] = $count;
+    }
+    $this->processArrayCommand('SRANDMEMBER', $args);
+    if ($count !== null) {
+       return $this->processVectorResponse(true);
+    }
+    return $this->processStringResponse();
+  }
+
   /* zSets --------------------------------------------------------------- */
 
   public function zAdd($key, $score, $value/*, $scoreN, $valueN */) {
@@ -834,8 +848,6 @@ class Redis {
     'sgetmembers' => [ 'alias' => 'smembers' ],
     'smove' => [ 'format' => 'kkv', 'return' => '1' ],
     'spop' => [ 'format' => 'k', 'return' => 'Serialized' ],
-    'srandmember' => [ 'format' => 'kl', 'return' => 'Serialized',
-                       'default' => [ 1 => 1 ] ],
     'srem' => [ 'vararg' => self::VAR_KEY_FIRST_AND_SERIALIZE,
                 'return' => 'Long' ],
     'sremove' => [ 'alias' => 'srem' ],

--- a/hphp/test/slow/ext_redis/srandmember.php
+++ b/hphp/test/slow/ext_redis/srandmember.php
@@ -1,0 +1,12 @@
+<?php
+
+include (__DIR__ . '/redis.inc');
+
+$r = NewRedisTestInstance();
+$r->setOption(Redis::OPT_PREFIX, GetTestKeyName(__FILE__) . ':');
+$r->delete('foo');
+$r->sAdd('foo', 'bar');
+
+var_dump($r->srandmember('foo'));
+var_dump($r->srandmember('foo', 0));
+var_dump($r->srandmember('foo', 1));

--- a/hphp/test/slow/ext_redis/srandmember.php.expect
+++ b/hphp/test/slow/ext_redis/srandmember.php.expect
@@ -1,0 +1,7 @@
+string(3) "bar"
+array(0) {
+}
+array(1) {
+  [0] =>
+  string(3) "bar"
+}


### PR DESCRIPTION
Don't require a second parameter which is originally optional.
Also, it shouldn't always return an array.

Closes: #3213
