### PR TITLE
Clean up some tracing and asserts

### DIFF
--- a/hphp/runtime/vm/bytecode.cpp
+++ b/hphp/runtime/vm/bytecode.cpp
@@ -2101,7 +2101,11 @@ void ExecutionContext::invokeFunc(TypedValue* retval,
 
   pushVMState(originalSP);
   SCOPE_EXIT {
-    assert(vmStack().top() == reentrySP);
+    assert_flog(
+      vmStack().top() == reentrySP,
+      "vmsp after reentry: {} doesn't match original vmsp: {}",
+      vmStack().top(), reentrySP
+    );
     popVMState();
   };
 

--- a/hphp/runtime/vm/jit/arg-group.h
+++ b/hphp/runtime/vm/jit/arg-group.h
@@ -61,6 +61,7 @@ public:
              // mangling before call depending on TypedValue's layout.
     Imm,     // 64-bit Immediate
     Addr,    // Address (register plus 32-bit displacement)
+    IpRel,   // ip-relative address
     None,    // Nothing: register will contain garbage
   };
 
@@ -68,7 +69,10 @@ public:
   PhysReg srcReg() const { return m_srcReg; }
   Kind kind() const { return m_kind; }
   void setDstReg(PhysReg reg) { m_dstReg = reg; }
-  Immed64 imm() const { assert(m_kind == Kind::Imm); return m_imm64; }
+  Immed64 imm() const {
+    assert(m_kind == Kind::Imm || m_kind == Kind::IpRel);
+    return m_imm64;
+  }
   Immed disp() const { assert(m_kind == Kind::Addr); return m_disp32; }
   bool isZeroExtend() const { return m_zeroExtend; }
   bool done() const { return m_done; }
@@ -196,6 +200,12 @@ struct ArgGroup {
 
   ArgGroup& memberKeyS(int i) {
     return memberKeyImpl(i, false);
+  }
+
+  template<typename T>
+  ArgGroup& ipRel(const T* ptr) {
+    push_gp(ArgDesc(ArgDesc::Kind::IpRel, (uintptr_t)ptr));
+    return *this;
   }
 
 private:

--- a/hphp/runtime/vm/jit/back-end-arm.cpp
+++ b/hphp/runtime/vm/jit/back-end-arm.cpp
@@ -232,7 +232,7 @@ struct BackEnd : public JIT::BackEnd {
     a.    Str   (rAsm, rAsm2[disp]);
   }
 
-  void emitTraceCall(CodeBlock& cb, int64_t pcOff) override {
+  void emitTraceCall(CodeBlock& cb, Offset pcOff) override {
     // TODO(2967396) implement properly
   }
 

--- a/hphp/runtime/vm/jit/back-end-x64.cpp
+++ b/hphp/runtime/vm/jit/back-end-x64.cpp
@@ -193,7 +193,7 @@ struct BackEnd : public JIT::BackEnd {
     a.    popf  ();
   }
 
-  void emitTraceCall(CodeBlock& cb, int64_t pcOff) override {
+  void emitTraceCall(CodeBlock& cb, Offset pcOff) override {
     X64::emitTraceCall(cb, pcOff);
   }
 

--- a/hphp/runtime/vm/jit/back-end.h
+++ b/hphp/runtime/vm/jit/back-end.h
@@ -120,7 +120,7 @@ class BackEnd {
   virtual TCA emitCallArrayPrologue(Func* func, DVFuncletsVec& dvs) = 0;
   virtual void funcPrologueSmashGuard(TCA prologue, const Func* func) = 0;
   virtual void emitIncStat(CodeBlock& cb, intptr_t disp, int n) = 0;
-  virtual void emitTraceCall(CodeBlock& cb, int64_t pcOff) = 0;
+  virtual void emitTraceCall(CodeBlock& cb, Offset pcOff) = 0;
   virtual void emitFwdJmp(CodeBlock& cb, Block* target,
                           CodegenState& state) = 0;
   virtual void patchJumps(CodeBlock& cb, CodegenState& state, Block* block) = 0;

--- a/hphp/runtime/vm/jit/code-gen-helpers-x64.cpp
+++ b/hphp/runtime/vm/jit/code-gen-helpers-x64.cpp
@@ -315,7 +315,7 @@ void emitRB(X64Assembler& a,
   a.    call((TCA)Trace::ringbufferMsg);
 }
 
-void emitTraceCall(CodeBlock& cb, int64_t pcOff) {
+void emitTraceCall(CodeBlock& cb, Offset pcOff) {
   Asm a { cb };
   // call to a trace function
   a.    lea    (rip[(int64_t)a.frontier()], rcx);

--- a/hphp/runtime/vm/jit/code-gen-helpers-x64.h
+++ b/hphp/runtime/vm/jit/code-gen-helpers-x64.h
@@ -74,7 +74,7 @@ void emitJmpOrJcc(Asm& as, ConditionCode cc, TCA dest);
 
 void emitRB(Asm& a, Trace::RingBufferType t, const char* msgm);
 
-void emitTraceCall(CodeBlock& cb, int64_t pcOff);
+void emitTraceCall(CodeBlock& cb, Offset pcOff);
 
 /*
  * Tests the surprise flags for the current thread. Should be used

--- a/hphp/runtime/vm/jit/translator-runtime.h
+++ b/hphp/runtime/vm/jit/translator-runtime.h
@@ -190,8 +190,8 @@ void lookupClsMethodHelper(Class* cls,
                            ActRec* ar,
                            ActRec* fp);
 
-void checkFrame(ActRec* fp, Cell* sp, bool checkLocals);
-void traceCallback(ActRec* fp, Cell* sp, int64_t pcOff, void* rip);
+void checkFrame(ActRec* fp, Cell* sp, bool fullCheck, Offset bcOff);
+void traceCallback(ActRec* fp, Cell* sp, Offset pcOff, void* rip);
 
 void loadArrayFunctionContext(ArrayData*, ActRec* preLiveAR, ActRec* fp);
 void fpushCufHelperArray(ArrayData*, ActRec* preLiveAR, ActRec* fp);

--- a/hphp/util/trace.h
+++ b/hphp/util/trace.h
@@ -332,6 +332,8 @@ inline void itraceImpl(const char* fmtRaw, Args&&... args) {
   Trace::ftraceRelease(fmt, std::forward<Args>(args)...);
 }
 #define ITRACE(level, ...) ONTRACE((level), Trace::itraceImpl(__VA_ARGS__));
+#define ITRACE_MOD(mod, level, ...)                             \
+  ONTRACE_MOD(mod, level, Trace::itraceImpl(__VA_ARGS__));
 
 void trace(const char *, ...) ATTRIBUTE_PRINTF(1,2);
 void trace(const std::string&);


### PR DESCRIPTION
I added all of this while debugging various issues and figured it'd be
generally useful.
- Convert unwind.cpp to use ITRACE.
- Assert that spoff is correct on tracelet entry.
- Use visitStackElems to verify stack contents in checkFrame.
- Fix RBTrace codegen for code relocation by using rip-relative lea

Test Plan: ran with TRACE=vmentry:1,unwind:1, saw expected results. automated
tests.
