### PR TITLE
add option to statically link libstdc++

### DIFF
--- a/CMake/HPHPCompiler.cmake
+++ b/CMake/HPHPCompiler.cmake
@@ -52,7 +52,7 @@ elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
   set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O2 -g")
   set(CMAKE_C_FLAGS                  "${GNUCC49_OPT} -w")
   set(CMAKE_CXX_FLAGS "-Wall -std=gnu++11 -fno-gcse -fno-omit-frame-pointer -ftemplate-depth-180 -Woverloaded-virtual -Wno-deprecated -Wno-strict-aliasing -Wno-write-strings -Wno-invalid-offsetof -fno-operator-names -Wno-error=array-bounds -Wno-error=switch -Werror=format-security -Wno-unused-result -Wno-sign-compare -Wno-attributes -Wno-maybe-uninitialized -Wno-unused-local-typedefs -fno-canonical-system-headers -Wno-deprecated-declarations ${GNUCC49_OPT} ${GNUCC_PLAT_OPT}")
-  if(APPLE) # Make OSX builds more portable
+  if(APPLE OR STATIC_CXX_LIB)
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -static-libgcc")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -static-libgcc -static-libstdc++")
   endif()

--- a/CMake/Options.cmake
+++ b/CMake/Options.cmake
@@ -3,6 +3,7 @@
 option(ALWAYS_ASSERT "Enabled asserts in a release build" OFF)
 option(DEBUG_MEMORY_LEAK "Allow easier debugging of memory leaks" OFF)
 option(DEBUG_APC_LEAK "Allow easier debugging of apc leaks" OFF)
+option(STATIC_CXX_LIB "Statically link libstd++ and libgcc." OFF)
 
 option(HOTPROFILER "Enable support for the hot-profiler" OFF)
 option(EXECUTION_PROFILER "Enable the execution profiler" OFF)


### PR DESCRIPTION
Ubuntu 12.04 doesn't have 4.8 out of the box, but our packages
currently depend on libstdc++6 >= 4.8. Although GCC's ABI policy
guarantees forward compatibility, it's scary to have to upgrade
libstdc++ system-wide.

Add a build option (off by default) to statically link it. Next step
will be to update the packaging scripts for 12.04.
