### PR TITLE
Improved the Zend compatibility for ReflectionClass

### DIFF
--- a/hphp/runtime/ext/reflection/ext_reflection_hni.php
+++ b/hphp/runtime/ext/reflection/ext_reflection_hni.php
@@ -1321,7 +1321,7 @@ class ReflectionClass implements Reflector, Serializable {
    *
    * @return     bool   Returns TRUE on success or FALSE on failure.
    */
-  final public function inNamespace(): bool {
+  public function inNamespace(): bool {
     return strrpos($this->getName(), '\\') !== false;
   }
 
@@ -1333,7 +1333,7 @@ class ReflectionClass implements Reflector, Serializable {
    *
    * @return     string   The namespace name.
    */
-  final public function getNamespaceName(): string {
+  public function getNamespaceName(): string {
     $name = $this->getName();
     $pos = strrpos($name, '\\');
     return ($pos === false) ? '' : substr($name, 0, $pos);
@@ -1347,7 +1347,7 @@ class ReflectionClass implements Reflector, Serializable {
    *
    * @return     string  The short name of the function.
    */
-  final public function getShortName(): string {
+  public function getShortName(): string {
     $name = $this->getName();
     $pos = strrpos($name, '\\');
     return ($pos === false) ? $name : substr($name, $pos + 1);


### PR DESCRIPTION
`inNamespace()`, `getNamespaceName()`, and `getShortName()` should not be `final`. This was causing issues in phpspec which mocks these methods.

This was done for ReflectionFunctionAbstract in #3070 but ReflectionClass was missed
