### PR TITLE
set CURLOPT_CUSTOMREQUEST regardless of request size

### DIFF
--- a/hphp/runtime/base/http-client.cpp
+++ b/hphp/runtime/base/http-client.cpp
@@ -191,9 +191,9 @@ int HttpClient::request(const char* verb,
     curl_easy_setopt(cp, CURLOPT_POST,          1);
     curl_easy_setopt(cp, CURLOPT_POSTFIELDS,    data);
     curl_easy_setopt(cp, CURLOPT_POSTFIELDSIZE, size);
-    if (verb != nullptr) {
-      curl_easy_setopt(cp, CURLOPT_CUSTOMREQUEST, verb);
-    }
+  }
+  if (verb != nullptr) {
+    curl_easy_setopt(cp, CURLOPT_CUSTOMREQUEST, verb);
   }
 
   if (responseHeaders) {


### PR DESCRIPTION
When doing an URL request (ex. fopen/file_get_contents) with a context
that specifies a method but no content, we should still respect the
specified request method.

Not sure how to add a test for this since the deprecation of the
built-in webserver.

Closes #3234.
