### PR TITLE
[Runtime][HttpClient] Fix POST handling without data + Fix HEAD which should return no body

### DIFF
--- a/hphp/runtime/base/http-client.cpp
+++ b/hphp/runtime/base/http-client.cpp
@@ -191,8 +191,13 @@ int HttpClient::request(const char* verb,
     curl_easy_setopt(cp, CURLOPT_POST,          1);
     curl_easy_setopt(cp, CURLOPT_POSTFIELDS,    data);
     curl_easy_setopt(cp, CURLOPT_POSTFIELDSIZE, size);
-    if (verb != nullptr) {
-      curl_easy_setopt(cp, CURLOPT_CUSTOMREQUEST, verb);
+  }
+
+  if (verb != nullptr) {
+    curl_easy_setopt(cp, CURLOPT_CUSTOMREQUEST, verb);
+
+    if (strcasecmp(verb, "HEAD") == 0) {
+        curl_easy_setopt(cp, CURLOPT_NOBODY, 1);
     }
   }
 


### PR DESCRIPTION
This PR does two things:
- It fixes the POST handling when there is no data (#3234).
- It fixes the HEAD handling which should return no body.

After looking to the tests, I don't know how to do it :s
