### PR TITLE
Fix http headers parsing + Remove unused code + Fix indentation

### DIFF
--- a/hphp/runtime/base/http-client.cpp
+++ b/hphp/runtime/base/http-client.cpp
@@ -171,14 +171,12 @@ int HttpClient::request(const char* verb,
     }
   }
 
-  std::vector<String> headers; // holding those temporary strings
   curl_slist *slist = nullptr;
   if (requestHeaders) {
     for (HeaderMap::const_iterator iter = requestHeaders->begin();
          iter != requestHeaders->end(); ++iter) {
       for (unsigned int i = 0; i < iter->second.size(); i++) {
         String header = iter->first + ": " + iter->second[i];
-        headers.push_back(header);
         slist = curl_slist_append(slist, header.data());
       }
     }
@@ -197,7 +195,7 @@ int HttpClient::request(const char* verb,
     curl_easy_setopt(cp, CURLOPT_CUSTOMREQUEST, verb);
 
     if (strcasecmp(verb, "HEAD") == 0) {
-        curl_easy_setopt(cp, CURLOPT_NOBODY, 1);
+      curl_easy_setopt(cp, CURLOPT_NOBODY, 1);
     }
   }
 

--- a/hphp/runtime/base/http-stream-wrapper.cpp
+++ b/hphp/runtime/base/http-stream-wrapper.cpp
@@ -76,7 +76,7 @@ File* HttpStreamWrapper::open(const String& filename, const String& mode,
 
       for (ArrayIter it(lines); it; ++it) {
         Array parts = StringUtil::Explode(
-          it.second().toString(), ": ").toArray();
+          it.second().toString(), ":").toArray();
         headers.set(parts.rvalAt(0), parts.rvalAt(1));
       }
     }


### PR DESCRIPTION
This PR does three things:
- Remove an unused variable in the http-client
- Fix indentation of one of my previous commit
- Fix the http headers parsing (Fixes #3241)

Regarding the fix about the http header parsing, the [RFC-2616](http://tools.ietf.org/html/rfc2616#section-4.2) specifies that the field value **MAY** be preceded by any amount of LWS, though a single SP is preferred. So, an header value not preceded by a space is valid.
