### PR TITLE
ReflectionProperty::setValue throws an ReflectionException if unaccessible

### DIFF
--- a/hphp/runtime/ext/reflection/ext_reflection-classes.php
+++ b/hphp/runtime/ext/reflection/ext_reflection-classes.php
@@ -745,7 +745,7 @@ class ReflectionProperty implements Reflector {
       return null;
     }
     // Can be removed once we support ParamCoerceMode in PHP
-    if (gettype($obj) != "object") {
+    if (!is_object($obj)) {
       trigger_error('ReflectionProperty::getValue() expects parameter 1'
          . ' to be object, ' . gettype($obj) . ' given', E_USER_WARNING);
       return null;
@@ -777,6 +777,12 @@ class ReflectionProperty implements Reflector {
       $value = $obj;
       $obj = null;
     }
+    if (!$this->isAccessible()) {
+      throw new ReflectionException(
+        "Cannot access non-public member " . $this->class .
+        "::" . $this->getName()
+      );
+    }
     if ($this->isStatic()) {
       hphp_set_static_property(
         $this->info['class'],
@@ -792,7 +798,7 @@ class ReflectionProperty implements Reflector {
         return null;
       }
       // Can be removed once we support ParamCoerceMode in PHP
-      if (gettype($obj) != "object") {
+      if (!is_object($obj)) {
         trigger_error('ReflectionProperty::setValue() expects parameter 1'
           . ' to be object, ' . gettype($obj) . ' given', E_USER_WARNING);
         return null;
@@ -853,6 +859,10 @@ class ReflectionProperty implements Reflector {
       return self::stripHHPrefix($this->info['type']);
     }
     return '';
+  }
+
+  private function isAccessible() {
+    return ($this->isPublic() || $this->forceAccessible);
   }
 }
 

--- a/hphp/test/slow/reflection/ReflectionProperty_setValue_exception.php
+++ b/hphp/test/slow/reflection/ReflectionProperty_setValue_exception.php
@@ -1,0 +1,24 @@
+<?php
+
+class cls {
+  private $priv = 42;
+  private static $s_priv = 21;
+}
+
+$prop = new ReflectionProperty('cls', 'priv');
+$s_prop = new ReflectionProperty('cls', 's_priv');
+
+// Non-static
+try {
+  $obj = new cls();
+  $prop->setValue($obj, 1);
+} catch (ReflectionException $e) {
+  echo $e->getMessage() . "\n";
+}
+
+// Static
+try {
+  $s_prop->setValue(1);
+} catch (ReflectionException $e) {
+  echo $e->getMessage() . "\n";
+}

--- a/hphp/test/slow/reflection/ReflectionProperty_setValue_exception.php.expect
+++ b/hphp/test/slow/reflection/ReflectionProperty_setValue_exception.php.expect
@@ -1,0 +1,2 @@
+Cannot access non-public member cls::priv
+Cannot access non-public member cls::s_priv


### PR DESCRIPTION
Also changed `gettype() != 'object'` to `!is_object()`

Fixes #3128
