### PR TITLE
Fix the default ini value for "arg_separator.input" to be "&"

### DIFF
--- a/hphp/runtime/base/request-injection-data.cpp
+++ b/hphp/runtime/base/request-injection-data.cpp
@@ -87,6 +87,9 @@ void RequestInjectionData::threadInit() {
                    "arg_separator.output", "&",
                    &m_argSeparatorOutput);
   IniSetting::Bind(IniSetting::CORE, IniSetting::PHP_INI_ALL,
+                   "arg_separator.input", "&",
+                   &m_argSeparatorInput);
+  IniSetting::Bind(IniSetting::CORE, IniSetting::PHP_INI_ALL,
                    "default_charset", RuntimeOption::DefaultCharsetName.c_str(),
                    &m_defaultCharset);
   IniSetting::Bind(IniSetting::CORE, IniSetting::PHP_INI_ALL,

--- a/hphp/runtime/base/request-injection-data.h
+++ b/hphp/runtime/base/request-injection-data.h
@@ -90,6 +90,7 @@ struct RequestInjectionData {
   // Things corresponding to user setable INI settings
   std::string m_maxMemory;
   std::string m_argSeparatorOutput;
+  std::string m_argSeparatorInput;
   std::string m_defaultCharset;
   std::string m_defaultMimeType;
   std::vector<std::string> m_include_paths;

--- a/hphp/test/slow/ext_options/arg_separator_input_default.php
+++ b/hphp/test/slow/ext_options/arg_separator_input_default.php
@@ -1,0 +1,4 @@
+<?php
+
+var_dump(ini_get("arg_separator.output"));
+var_dump(ini_get("arg_separator.input"));

--- a/hphp/test/slow/ext_options/arg_separator_input_default.php.expect
+++ b/hphp/test/slow/ext_options/arg_separator_input_default.php.expect
@@ -1,0 +1,2 @@
+string(1) "&"
+string(1) "&"


### PR DESCRIPTION
This fixes #3256
