### PR TITLE
Add log when memory usage reached the MaxRSS

### DIFF
--- a/hphp/runtime/server/http-server.cpp
+++ b/hphp/runtime/server/http-server.cpp
@@ -516,7 +516,7 @@ void HttpServer::dropCache() {
 
 void HttpServer::checkMemory() {
   int64_t used = Process::GetProcessRSS(Process::GetProcessId()) * 1024 * 1024;
-  if (RuntimeOption::MaxRSS > 0 && used_mem > RuntimeOption::MaxRSS) {
+  if (RuntimeOption::MaxRSS > 0 && used > RuntimeOption::MaxRSS) {
     Logger::Error("ResourceLimit.MaxRSS %ld reached %ld used, exiting",
                   RuntimeOption::MaxRSS, used);
     stop();


### PR DESCRIPTION
Our online system use linux container, now and then it may be killed because of memory leaks.
This log could be useful at this scenario.
