### PR TITLE
Specify ssl cipher list for curl with OpenSSL only

### DIFF
--- a/hphp/runtime/base/http-client.cpp
+++ b/hphp/runtime/base/http-client.cpp
@@ -138,7 +138,13 @@ int HttpClient::request(const char* verb,
   curl_easy_setopt(cp, CURLOPT_NOSIGNAL, 1); // for multithreading mode
   curl_easy_setopt(cp, CURLOPT_SSL_VERIFYPEER,    0);
   curl_easy_setopt(cp, CURLOPT_SSL_CTX_FUNCTION, curl_tls_workarounds_cb);
-  curl_easy_setopt(cp, CURLOPT_SSL_CIPHER_LIST, "ALL");
+
+  /*
+   * cipher list varies according to SSL library, and "ALL" is for OpenSSL
+   */
+  curl_version_info_data *cver = curl_version_info(CURLVERSION_NOW);
+  if (cver && cver->ssl_version && strstr(cver->ssl_version, "OpenSSL"))
+		  curl_easy_setopt(cp, CURLOPT_SSL_CIPHER_LIST, "ALL");
 
   curl_easy_setopt(cp, CURLOPT_TIMEOUT,           m_timeout);
   if (m_maxRedirect > 1) {


### PR DESCRIPTION
Since libcurl can be linked against multiple SSL libraries, it is necessary to use some light instropection when setting CURLOPT_SSL_CIPHER_LIST. This is an issue for some distributions (e.g. Fedora) where libcurl was changed to use Mozilla's NSS library. I'm not sure what cipher list would be desired for NSS, but the default seems adequate for now.
