### PR TITLE
Don't use -Og for debug build, and add -ggdb

### DIFF
--- a/CMake/HPHPCompiler.cmake
+++ b/CMake/HPHPCompiler.cmake
@@ -40,8 +40,8 @@ elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
   endif()
 
   # Use -Og with Debug builds in gcc >= 4.8
-  set(CMAKE_C_FLAGS_DEBUG    "-Og -g")
-  set(CMAKE_CXX_FLAGS_DEBUG  "-Og -g")
+  set(CMAKE_C_FLAGS_DEBUG    "-O0 -ggdb")
+  set(CMAKE_CXX_FLAGS_DEBUG  "-O0 -ggdb")
 
   # Generic GCC flags and Optional flags
   set(CMAKE_C_FLAGS_MINSIZEREL       "-Os -DNDEBUG")


### PR DESCRIPTION
-Og is great in theory but in practice it produces binaries that aren't very
debuggable. Go back to -O0. -ggdb produces more expressive debug information.

Test Plan: Built, debugged the resulting binary with significantly less pain
