### PR TITLE
Allow debugger to attach to more classes of requests

### DIFF
--- a/hphp/runtime/server/source-root-info.cpp
+++ b/hphp/runtime/server/source-root-info.cpp
@@ -40,6 +40,8 @@ SourceRootInfo::SourceRootInfo(Transport* transport)
 
   auto documentRoot = transport->getDocumentRoot();
   if (!documentRoot.empty()) {
+    m_user = "__builtin";
+    m_sandbox = "default";
     // The transport take precedence over the config file
     m_path = documentRoot;
     *s_path.getCheck() = documentRoot;


### PR DESCRIPTION
Specifically any request sent with a document root never had
its sandbox setup.  This patch feels like a bit of a hack, but with
just these two lines i can attach to and debug live fcgi request
that i could not without it.
