### PR TITLE
run usercode before ending the request

### DIFF
--- a/hphp/runtime/base/execution-context.cpp
+++ b/hphp/runtime/base/execution-context.cpp
@@ -434,6 +434,11 @@ bool ExecutionContext::removeShutdownFunction(const Variant& function,
   return ret;
 }
 
+bool ExecutionContext::hasShutdownFunctions(ShutdownType type) {
+  return !m_shutdowns.isNull() && m_shutdowns.exists(type) &&
+    m_shutdowns[type].toArray().size() >= 1;
+}
+
 Variant ExecutionContext::pushUserErrorHandler(const Variant& function,
                                                    int error_types) {
   Variant ret;

--- a/hphp/runtime/base/execution-context.h
+++ b/hphp/runtime/base/execution-context.h
@@ -239,6 +239,7 @@ public:
   void registerShutdownFunction(const Variant& function, Array arguments,
                                 ShutdownType type);
   bool removeShutdownFunction(const Variant& function, ShutdownType type);
+  bool hasShutdownFunctions(ShutdownType type);
   void onRequestShutdown();
   void onShutdownPreSend();
   void onShutdownPostSend();

--- a/hphp/runtime/base/program-functions.cpp
+++ b/hphp/runtime/base/program-functions.cpp
@@ -1755,17 +1755,23 @@ bool hphp_invoke(ExecutionContext *context, const std::string &cmd,
   return ret;
 }
 
-void hphp_context_exit() {
-  auto const context = g_context.getNoCheck();
-
+void hphp_context_shutdown() {
   // Run shutdown handlers. This may cause user code to run.
+  auto const context = g_context.getNoCheck();
   context->destructObjects();
   context->onRequestShutdown();
 
   // Extensions could have shutdown handlers
   Extension::RequestShutdownModules();
+}
+
+void hphp_context_exit(bool shutdown /* = true */) {
+  if (shutdown) {
+    hphp_context_shutdown();
+  }
 
   // Clean up a bunch of request state. No user code after this point.
+  auto const context = g_context.getNoCheck();
   context->requestExit();
   context->obProtect(false);
   context->obEndAll();

--- a/hphp/runtime/base/program-functions.h
+++ b/hphp/runtime/base/program-functions.h
@@ -91,7 +91,8 @@ bool hphp_invoke(ExecutionContext *context,
                  bool once,
                  bool warmupOnly,
                  bool richErrorMsg);
-void hphp_context_exit();
+void hphp_context_shutdown();
+void hphp_context_exit(bool shutdown = true);
 
 void hphp_thread_exit();
 void hphp_session_exit();


### PR DESCRIPTION
Currently, the following happens at the end of a request:
onSendEnd -> run postsend functions -> hphp_context_exit

However, hphp_context_exit can call destructors for objects that are 
alive at the end of request. This usercode should be allowed to send
output. This causes a circular reference issue because postsend
functions might need to access those objects.

When we don't have a postsend function, preserve Zend compatibility by
delaying the execution of onSendEnd.
