### PR TITLE
Changed CRYPT_BLOWFISH to 1 because apparently it is available

### DIFF
--- a/hphp/system/idl/constants.idl.json
+++ b/hphp/system/idl/constants.idl.json
@@ -208,7 +208,7 @@
         },
         {
             "name": "CRYPT_BLOWFISH",
-            "value": 0
+            "value": 1
         },
         {
             "name": "CRYPT_EXT_DES",


### PR DESCRIPTION
CRYPT_BLOWFISH is set to 0 in HHVM. PHP's documentation states that it is set to 1 where blowfish is available in `crypt`.

Blowfish support is available in HHVM since 4a23fdc0dc804c9a5fa8bc84f9016c1d44597afb so the constant should be set to 1.

Fixes #3274
