### PR TITLE
Align definition of HPHP::smart::Allocator:destroy() with the C++11 one

### DIFF
--- a/hphp/runtime/base/smart-containers.h
+++ b/hphp/runtime/base/smart-containers.h
@@ -96,8 +96,9 @@ struct Allocator {
     ::new ((void*)p) U(std::forward<Args>(args)...);
   }
 
-  void destroy(pointer p) {
-    p->~T();
+  template<class U>
+  void destroy(U* p) {
+    p->~U();
   }
 
   void deallocate(pointer p, size_type num) {


### PR DESCRIPTION
As requested on https://reviews.facebook.net/D19731#inline-159849
