### PR TITLE
Fix #3053: renamed toString to __toStringHelper in the reflection extension

### DIFF
--- a/hphp/runtime/ext/reflection/ext_reflection_hni.php
+++ b/hphp/runtime/ext/reflection/ext_reflection_hni.php
@@ -340,7 +340,7 @@ abstract class ReflectionFunctionAbstract implements Reflector {
   }
 
   // Implementation of __toString
-  final protected function toString(
+  final protected function __toStringHelper(
     $type,
     array $preAttrs = [],
     array $funcAttrs = [],
@@ -509,7 +509,7 @@ class ReflectionFunction extends ReflectionFunctionAbstract {
    * @return     string  A representation of this ReflectionFunction.
    */
   public function __toString(): string {
-    return $this->toString($this->isClosure() ? 'Closure' : 'Function');
+    return $this->__toStringHelper($this->isClosure() ? 'Closure' : 'Function');
   }
 
   /**
@@ -759,7 +759,7 @@ class ReflectionMethod extends ReflectionFunctionAbstract {
       $funcAttrs[] = 'public';
     }
 
-    return $this->toString('Method', $preAttrs, $funcAttrs);
+    return $this->__toStringHelper('Method', $preAttrs, $funcAttrs);
   }
 
   /**


### PR DESCRIPTION
I tried to fix #3053 by renaming `toString()` (which caused conflicts with user libs) to `__toStringHelper()` (which hopefully should create much less conflicts.

First time contributing, so I'm hoping that I did everything correctly :)
