### PR TITLE
Fixes for Redis extension and associated test suite

### DIFF
--- a/hphp/system/php/redis/Redis.php
+++ b/hphp/system/php/redis/Redis.php
@@ -369,7 +369,7 @@ class Redis {
   /* Sets ---------------------------------------------------------------- */
 
   public function sRandMember($key, $count = null) {
-    $args = [$key];
+    $args = [$this->prefix($key)];
     if ($count !== null) {
        $args[] = $count;
     }
@@ -1220,8 +1220,11 @@ class Redis {
   protected function processSerializedResponse() {
     if ($this->mode === self::ATOMIC) {
       $resp = $this->sockReadData($type);
+      if ($resp === null) {
+        return false;
+      }
       return (($type === self::TYPE_LINE) OR ($type === self::TYPE_BULK))
-             ? $this->unserialize($resp) : null;
+             ? $this->unserialize($resp) : false;
     }
     $this->multiHandler[] = [ 'cb' => [$this,'processSerializedResponse'] ];
     if (($this->mode === self::MULTI) && !$this->processQueuedResponse()) {
@@ -1307,7 +1310,7 @@ class Redis {
       if ($unser AND (($lineNo % $unser) == 0)) {
         $val = $this->unserialize($val);
       }
-      $ret[] = $val;
+      $ret[] = $val !== null ? $val : false;
     }
     return $ret;
   }
@@ -1370,7 +1373,7 @@ class Redis {
       if ($unser_val) {
         $val = $this->unserialize($val);
       }
-      $ret[$key] = $val;
+      $ret[$key] = $val !== null ? $val : false;
     }
     return $ret;
   }

--- a/hphp/test/slow/ext_redis/hmsetget.php.expect
+++ b/hphp/test/slow/ext_redis/hmsetget.php.expect
@@ -27,7 +27,7 @@ array(3) {
 string(3) "bar"
 string(5) "boom1"
 string(5) "boom2"
-NULL
+bool(false)
 array(4) {
   ["foo"]=>
   string(3) "bar"
@@ -36,5 +36,5 @@ array(4) {
   ["baz2"]=>
   string(5) "boom2"
   ["nofield"]=>
-  NULL
+  bool(false)
 }

--- a/hphp/test/slow/ext_redis/hsetget.php.expect
+++ b/hphp/test/slow/ext_redis/hsetget.php.expect
@@ -20,4 +20,4 @@ array(2) {
 }
 string(3) "bar"
 string(4) "boom"
-NULL
+bool(false)

--- a/hphp/test/slow/ext_redis/info.php.expect
+++ b/hphp/test/slow/ext_redis/info.php.expect
@@ -4,3 +4,5 @@ bool(true)
 bool(true)
 bool(true)
 string(17) "hhvm-redis-client"
+bool(true)
+bool(true)

--- a/hphp/test/slow/ext_redis/list.php.expect
+++ b/hphp/test/slow/ext_redis/list.php.expect
@@ -13,5 +13,3 @@ int(2)
 string(11) "easy as 123"
 string(5) "apple"
 string(11) "easy as 123"
-bool(true)
-bool(true)

--- a/hphp/test/slow/ext_redis/redis.inc
+++ b/hphp/test/slow/ext_redis/redis.inc
@@ -21,7 +21,7 @@ function NewRedisTestInstance($status = false) {
 }
 
 function GetTestKeyName($test, $rand = false) {
-  $name = 'REDIS_TEST:' . preg_replace('/[^a-zA-Z0-9]/', '-', $test);
-  if ($rand) $name .= ':' . rand(0,1000000);
-  return $name;
+  static $ts;
+  $ts = $ts ?: time();
+  return 'REDIS_TEST:' . md5( $test . $ts . ( $rand ? '' : rand(0,1000000) ) );
 }

--- a/hphp/test/slow/ext_redis/setExtended.php.expect
+++ b/hphp/test/slow/ext_redis/setExtended.php.expect
@@ -5,11 +5,11 @@ bool(false)
 bool(true)
 bool(false)
 bool(true)
-NULL
+bool(false)
 bool(true)
 bool(true)
-NULL
+bool(false)
 bool(true)
 string(2) "10"
-NULL
+bool(false)
 Redis Exception: Invalid set options: nx and xx may not be specified at the same time

--- a/hphp/test/slow/ext_redis/srandmember.php.expect
+++ b/hphp/test/slow/ext_redis/srandmember.php.expect
@@ -2,6 +2,6 @@ string(3) "bar"
 array(0) {
 }
 array(1) {
-  [0] =>
+  [0]=>
   string(3) "bar"
 }

--- a/hphp/test/slow/ext_redis/watch.php
+++ b/hphp/test/slow/ext_redis/watch.php
@@ -16,7 +16,7 @@ var_dump($r1->set($key1, $value)); //true
 var_dump($r1->watch($key1)); //true
 $checkValue = $r1->get($key1);
 var_dump($checkValue); //6379
-if ($checkValue !== null && $checkValue == $value) {
+if ($checkValue !== false && $checkValue == $value) {
   var_dump($r1->multi()->del($key1)->exec()); //[1]
 }
 
@@ -25,6 +25,6 @@ var_dump($r1->watch($key1));
 $checkValue = $r1->get($key1);
 var_dump($r2->set($key1, 'different value'));
 var_dump($checkValue);
-if ($checkValue !== null && $checkValue == $value) {
+if ($checkValue !== false && $checkValue == $value) {
   var_dump($r1->multi()->del($key1)->exec());
 }

--- a/hphp/test/slow/ext_redis/watch.php.expect
+++ b/hphp/test/slow/ext_redis/watch.php.expect
@@ -11,5 +11,5 @@ bool(true)
 string(4) "6379"
 array(1) {
   [0]=>
-  int(0)
+  int(1)
 }


### PR DESCRIPTION
- Fix a couple of tests that were broken by 91b1918 adding two lines to the
  wrong expect file (list.php.expect instead of info.php.expect).
- Fixed hphp/test/slow/ext_redis/watch.php.expect to expect the correct
  behavior. (Tested by verifying with Zend + phpredis.)
- Make the key prefix set by the test suite include the md5 of the file path
  plus UNIX timestamp representing the test suite initialization. This makes
  the tests not break when the path exceeds the redis key length limit and it
  makes repeated test runs not conflict with one another.
- Make Redis::sRandMember apply the key prefix (if one exists).
- Make Redis::get() and Redis::h{m}get() return false rather than null for
  missing keys or fields, matching the behavior of phpredis.

Minimal test case for the false / null behavior:

```
<?php
$redis = new Redis;
$redis->connect("localhost");
var_dump($redis->get("nonexistent-key"));
$redis->hMset('ice_cream', array('flavor' => 'vanilla'));
var_dump($redis->hMget('ice_cream', array('flavor', 'nonexistent-field')));
```

Output with phpredis:

```
bool(false)
array(2) {
  ["flavor"]=>
  string(7) "vanilla"
  ["nonexistent-field"]=>
  bool(false)
}
```

Output with HHVM:

```
NULL
array(2) {
  ["flavor"]=>
  string(7) "vanilla"
  ["nonexistent-field"]=>
  NULL
}
```

Fixes https://bugzilla.wikimedia.org/show_bug.cgi?id=68841
