### PR TITLE
Improved Zend compatibility in the reflection API.

### DIFF
--- a/hphp/runtime/ext/reflection/ext_reflection_hni.php
+++ b/hphp/runtime/ext/reflection/ext_reflection_hni.php
@@ -236,9 +236,13 @@ abstract class ReflectionFunctionAbstract implements Reflector {
     return hphp_array_idx($this->getAttributes(), $name, null);
   }
 
-  abstract public function getAttributesRecursive(): array;
+  public function getAttributesRecursive(): array {
+    return $this->getAttributes();
+  }
 
-  abstract public function getAttributeRecursive($name);
+  public function getAttributeRecursive($name) {
+    return $this->getAttribute($name);
+  }
 
   <<__Native>>
   public function getNumberOfParameters(): int;
@@ -612,14 +616,6 @@ class ReflectionFunction extends ReflectionFunctionAbstract {
       return new ReflectionClass($cls);
     }
     return null;
-  }
-
-  public function getAttributesRecursive(): array {
-    return $this->getAttributes();
-  }
-
-  public function getAttributeRecursive($name) {
-    return $this->getAttribute($name);
   }
 }
 

--- a/hphp/test/slow/reflection/extend_reflection_function_abstract.php
+++ b/hphp/test/slow/reflection/extend_reflection_function_abstract.php
@@ -1,0 +1,9 @@
+<?php
+
+class MyReflectionFunction extends ReflectionFunctionAbstract {
+  public function __toString() {
+    return "MyReflectionFunction";
+  }
+}
+
+echo new MyReflectionFunction;

--- a/hphp/test/slow/reflection/extend_reflection_function_abstract.php.expect
+++ b/hphp/test/slow/reflection/extend_reflection_function_abstract.php.expect
@@ -1,0 +1,1 @@
+MyReflectionFunction


### PR DESCRIPTION
Make sure `ReflectionFunctionAbstract` can be extended by implementing only `__toString()`.

NOTE: This was part of #3070, but was accidentally left behind.
