### PR TITLE
added missing fclose() to free the handle after a test run

### DIFF
--- a/hphp/test/run
+++ b/hphp/test/run
@@ -1047,6 +1047,7 @@ function run_and_lock_test($options, $test) {
   if (!flock($lock, LOCK_EX)) return false;
   $result = run_test($options, $test);
   if (!flock($lock, LOCK_UN)) return false;
+  fclose($lock);
   return $result;
 }
 


### PR DESCRIPTION
this prevents that the file handle leaks.
