### PR TITLE
Updated reactphp framework tests to 0.4.1

### DIFF
--- a/hphp/test/frameworks/frameworks.yaml
+++ b/hphp/test/frameworks/frameworks.yaml
@@ -547,8 +547,8 @@
     test_root: ratchet
   reactphp:
     url: https://github.com/reactphp/react.git
-    branch: v0.4.0
-    commit: 3a5d12166b38d059a96c232d809332e7f3e60d9d
+    branch: v0.4.1
+    commit: 17044db0ab6a9c145fb1ac40822c5c17d045dc36
     install_root: reactphp
     test_root: reactphp
     flakey:

--- a/hphp/test/frameworks/results/reactphp.expect
+++ b/hphp/test/frameworks/results/reactphp.expect
@@ -494,6 +494,8 @@ React\Tests\Socket\ServerTest::testConnectionWithManyClients
 .
 React\Tests\Socket\ServerTest::testData
 .
+React\Tests\Socket\ServerTest::testDataSentFromPy
+.
 React\Tests\Socket\ServerTest::testDataWithNoData
 .
 React\Tests\Socket\ServerTest::testDisconnect
@@ -521,6 +523,8 @@ React\Tests\Stream\BufferTest::testWriteDetectsWhenOtherSideIsClosed
 React\Tests\Stream\BufferTest::testWriteReturnsFalseWhenBufferIsFull
 .
 React\Tests\Stream\BufferTest::testWritingToClosedBufferShouldNotWriteToStream
+.
+React\Tests\Stream\BufferTest::testWritingToClosedStream
 .
 React\Tests\Stream\BufferedSinkTest::closeTwiceShouldBeFine
 .


### PR DESCRIPTION
We're still at `100%` passing tests.

Just a heads up that when 0.5.0 is released, we will have trouble testing it in this way since most of the code has been removed from the repo and moved into separate component repos so the test suite in the main repo no longer hits most of the code.
