### PR TITLE
explicitly use int64_t for seconds in xdebug

### DIFF
--- a/hphp/runtime/ext/xdebug/ext_xdebug.cpp
+++ b/hphp/runtime/ext/xdebug/ext_xdebug.cpp
@@ -161,7 +161,7 @@ static String format_filename(String* dir,
       }
       // Timestamp (seconds)
       case 't': {
-        time_t sec = time(nullptr);
+        int64_t sec = (int64_t)time(nullptr);
         if (sec != -1) {
           buf.append(sec);
         }


### PR DESCRIPTION
There is no HPHP::StringBuffer::append(time_t). This broke the build on OSX.
