### PR TITLE
Updated fastroute tests to v0.2.0

### DIFF
--- a/hphp/test/frameworks/frameworks.yaml
+++ b/hphp/test/frameworks/frameworks.yaml
@@ -124,8 +124,8 @@
     sequential: true
   fastroute:
     url: https://github.com/nikic/FastRoute.git
-    branch: master
-    commit: 40c897afe69ed59582b30cb05f437e544ce46bdf
+    branch: v0.2.0
+    commit: 7dc9a43cb856debc22fe158a1144018e16f7a637
     install_root: fastroute
     test_root: fastroute
   guzzle:

--- a/hphp/test/frameworks/results/fastroute.expect
+++ b/hphp/test/frameworks/results/fastroute.expect
@@ -1,3 +1,51 @@
+FastRoute\Dispatcher\CharCountBasedTest::testDuplicateStaticRoute
+.
+FastRoute\Dispatcher\CharCountBasedTest::testDuplicateVariableNameError
+.
+FastRoute\Dispatcher\CharCountBasedTest::testDuplicateVariableRoute
+.
+FastRoute\Dispatcher\CharCountBasedTest::testFoundDispatches with data set #0
+.
+FastRoute\Dispatcher\CharCountBasedTest::testFoundDispatches with data set #1
+.
+FastRoute\Dispatcher\CharCountBasedTest::testFoundDispatches with data set #10
+.
+FastRoute\Dispatcher\CharCountBasedTest::testFoundDispatches with data set #2
+.
+FastRoute\Dispatcher\CharCountBasedTest::testFoundDispatches with data set #3
+.
+FastRoute\Dispatcher\CharCountBasedTest::testFoundDispatches with data set #4
+.
+FastRoute\Dispatcher\CharCountBasedTest::testFoundDispatches with data set #5
+.
+FastRoute\Dispatcher\CharCountBasedTest::testFoundDispatches with data set #6
+.
+FastRoute\Dispatcher\CharCountBasedTest::testFoundDispatches with data set #7
+.
+FastRoute\Dispatcher\CharCountBasedTest::testFoundDispatches with data set #8
+.
+FastRoute\Dispatcher\CharCountBasedTest::testFoundDispatches with data set #9
+.
+FastRoute\Dispatcher\CharCountBasedTest::testMethodNotAllowedDispatches with data set #0
+.
+FastRoute\Dispatcher\CharCountBasedTest::testMethodNotAllowedDispatches with data set #1
+.
+FastRoute\Dispatcher\CharCountBasedTest::testMethodNotAllowedDispatches with data set #2
+.
+FastRoute\Dispatcher\CharCountBasedTest::testNotFoundDispatches with data set #0
+.
+FastRoute\Dispatcher\CharCountBasedTest::testNotFoundDispatches with data set #1
+.
+FastRoute\Dispatcher\CharCountBasedTest::testNotFoundDispatches with data set #2
+.
+FastRoute\Dispatcher\CharCountBasedTest::testNotFoundDispatches with data set #3
+.
+FastRoute\Dispatcher\CharCountBasedTest::testNotFoundDispatches with data set #4
+.
+FastRoute\Dispatcher\CharCountBasedTest::testNotFoundDispatches with data set #5
+.
+FastRoute\Dispatcher\CharCountBasedTest::testShadowedStaticRoute
+.
 FastRoute\Dispatcher\GroupCountBasedTest::testDuplicateStaticRoute
 .
 FastRoute\Dispatcher\GroupCountBasedTest::testDuplicateVariableNameError
@@ -93,4 +141,52 @@ FastRoute\Dispatcher\GroupPosBasedTest::testNotFoundDispatches with data set #4
 FastRoute\Dispatcher\GroupPosBasedTest::testNotFoundDispatches with data set #5
 .
 FastRoute\Dispatcher\GroupPosBasedTest::testShadowedStaticRoute
+.
+FastRoute\Dispatcher\MarkBasedTest::testDuplicateStaticRoute
+.
+FastRoute\Dispatcher\MarkBasedTest::testDuplicateVariableNameError
+.
+FastRoute\Dispatcher\MarkBasedTest::testDuplicateVariableRoute
+.
+FastRoute\Dispatcher\MarkBasedTest::testFoundDispatches with data set #0
+.
+FastRoute\Dispatcher\MarkBasedTest::testFoundDispatches with data set #1
+.
+FastRoute\Dispatcher\MarkBasedTest::testFoundDispatches with data set #10
+.
+FastRoute\Dispatcher\MarkBasedTest::testFoundDispatches with data set #2
+E
+FastRoute\Dispatcher\MarkBasedTest::testFoundDispatches with data set #3
+E
+FastRoute\Dispatcher\MarkBasedTest::testFoundDispatches with data set #4
+E
+FastRoute\Dispatcher\MarkBasedTest::testFoundDispatches with data set #5
+E
+FastRoute\Dispatcher\MarkBasedTest::testFoundDispatches with data set #6
+E
+FastRoute\Dispatcher\MarkBasedTest::testFoundDispatches with data set #7
+E
+FastRoute\Dispatcher\MarkBasedTest::testFoundDispatches with data set #8
+E
+FastRoute\Dispatcher\MarkBasedTest::testFoundDispatches with data set #9
+.
+FastRoute\Dispatcher\MarkBasedTest::testMethodNotAllowedDispatches with data set #0
+.
+FastRoute\Dispatcher\MarkBasedTest::testMethodNotAllowedDispatches with data set #1
+.
+FastRoute\Dispatcher\MarkBasedTest::testMethodNotAllowedDispatches with data set #2
+E
+FastRoute\Dispatcher\MarkBasedTest::testNotFoundDispatches with data set #0
+.
+FastRoute\Dispatcher\MarkBasedTest::testNotFoundDispatches with data set #1
+.
+FastRoute\Dispatcher\MarkBasedTest::testNotFoundDispatches with data set #2
+.
+FastRoute\Dispatcher\MarkBasedTest::testNotFoundDispatches with data set #3
+.
+FastRoute\Dispatcher\MarkBasedTest::testNotFoundDispatches with data set #4
+.
+FastRoute\Dispatcher\MarkBasedTest::testNotFoundDispatches with data set #5
+.
+FastRoute\Dispatcher\MarkBasedTest::testShadowedStaticRoute
 .


### PR DESCRIPTION
This uncovers some issues:

```
1) FastRoute\Dispatcher\MarkBasedTest::testFoundDispatches with data set #2 ('GET', '/user/rdlowrey', Closure$FastRoute\Dispatcher\DispatcherTest::provideFoundDispatchCases;434883760#3, 'handler2', array('rdlowrey'))

RUN TEST FILE:  cd /root/hhvm/hphp/test/frameworks/framework_downloads/fastroute && /root/hhvm/hphp/test/frameworks/../../hhvm/hhvm -v Repo.Local.Mode=-- -v Repo.Central.Path=/tmp/framework-testqIDsQM --config /root/hhvm/hphp/test/frameworks/php.ini -c /root/hhvm/hphp/test/frameworks/.generated.php.ini /root/hhvm/hphp/test/frameworks/vendor/bin/phpunit --debug  -c /root/hhvm/hphp/test/frameworks/framework_downloads/fastroute/phpunit.xml --filter 'FastRoute\\Dispatcher\\MarkBasedTest::testFoundDispatches with data set #2'

array_keys() expects parameter 1 to be an array or collection

/root/hhvm/hphp/test/frameworks/framework_downloads/fastroute/src/Dispatcher/MarkBased.php:46
/root/hhvm/hphp/test/frameworks/framework_downloads/fastroute/src/Dispatcher/MarkBased.php:19
/root/hhvm/hphp/test/frameworks/framework_downloads/fastroute/test/Dispatcher/DispatcherTest.php:34

2) FastRoute\Dispatcher\MarkBasedTest::testFoundDispatches with data set #3 ('GET', '/user/12345', Closure$FastRoute\Dispatcher\DispatcherTest::provideFoundDispatchCases;434883760#3, 'handler1', array('12345'))

RUN TEST FILE:  cd /root/hhvm/hphp/test/frameworks/framework_downloads/fastroute && /root/hhvm/hphp/test/frameworks/../../hhvm/hhvm -v Repo.Local.Mode=-- -v Repo.Central.Path=/tmp/framework-testqIDsQM --config /root/hhvm/hphp/test/frameworks/php.ini -c /root/hhvm/hphp/test/frameworks/.generated.php.ini /root/hhvm/hphp/test/frameworks/vendor/bin/phpunit --debug  -c /root/hhvm/hphp/test/frameworks/framework_downloads/fastroute/phpunit.xml --filter 'FastRoute\\Dispatcher\\MarkBasedTest::testFoundDispatches with data set #3'

array_keys() expects parameter 1 to be an array or collection

/root/hhvm/hphp/test/frameworks/framework_downloads/fastroute/src/Dispatcher/MarkBased.php:46
/root/hhvm/hphp/test/frameworks/framework_downloads/fastroute/src/Dispatcher/MarkBased.php:19
/root/hhvm/hphp/test/frameworks/framework_downloads/fastroute/test/Dispatcher/DispatcherTest.php:34

3) FastRoute\Dispatcher\MarkBasedTest::testFoundDispatches with data set #4 ('GET', '/user/NaN', Closure$FastRoute\Dispatcher\DispatcherTest::provideFoundDispatchCases;434883760#3, 'handler2', array('NaN'))

RUN TEST FILE:  cd /root/hhvm/hphp/test/frameworks/framework_downloads/fastroute && /root/hhvm/hphp/test/frameworks/../../hhvm/hhvm -v Repo.Local.Mode=-- -v Repo.Central.Path=/tmp/framework-testqIDsQM --config /root/hhvm/hphp/test/frameworks/php.ini -c /root/hhvm/hphp/test/frameworks/.generated.php.ini /root/hhvm/hphp/test/frameworks/vendor/bin/phpunit --debug  -c /root/hhvm/hphp/test/frameworks/framework_downloads/fastroute/phpunit.xml --filter 'FastRoute\\Dispatcher\\MarkBasedTest::testFoundDispatches with data set #4'

array_keys() expects parameter 1 to be an array or collection

/root/hhvm/hphp/test/frameworks/framework_downloads/fastroute/src/Dispatcher/MarkBased.php:46
/root/hhvm/hphp/test/frameworks/framework_downloads/fastroute/src/Dispatcher/MarkBased.php:19
/root/hhvm/hphp/test/frameworks/framework_downloads/fastroute/test/Dispatcher/DispatcherTest.php:34

4) FastRoute\Dispatcher\MarkBasedTest::testFoundDispatches with data set #5 ('GET', '/user/rdlowrey/12345', Closure$FastRoute\Dispatcher\DispatcherTest::provideFoundDispatchCases;434883760#3, 'handler0', array('rdlowrey', '12345'))

RUN TEST FILE:  cd /root/hhvm/hphp/test/frameworks/framework_downloads/fastroute && /root/hhvm/hphp/test/frameworks/../../hhvm/hhvm -v Repo.Local.Mode=-- -v Repo.Central.Path=/tmp/framework-testqIDsQM --config /root/hhvm/hphp/test/frameworks/php.ini -c /root/hhvm/hphp/test/frameworks/.generated.php.ini /root/hhvm/hphp/test/frameworks/vendor/bin/phpunit --debug  -c /root/hhvm/hphp/test/frameworks/framework_downloads/fastroute/phpunit.xml --filter 'FastRoute\\Dispatcher\\MarkBasedTest::testFoundDispatches with data set #5'

array_keys() expects parameter 1 to be an array or collection

/root/hhvm/hphp/test/frameworks/framework_downloads/fastroute/src/Dispatcher/MarkBased.php:46
/root/hhvm/hphp/test/frameworks/framework_downloads/fastroute/src/Dispatcher/MarkBased.php:19
/root/hhvm/hphp/test/frameworks/framework_downloads/fastroute/test/Dispatcher/DispatcherTest.php:34

5) FastRoute\Dispatcher\MarkBasedTest::testFoundDispatches with data set #6 ('GET', '/user/12345.svg', Closure$FastRoute\Dispatcher\DispatcherTest::provideFoundDispatchCases;434883760#4, 'handler2', array('12345', 'svg'))

RUN TEST FILE:  cd /root/hhvm/hphp/test/frameworks/framework_downloads/fastroute && /root/hhvm/hphp/test/frameworks/../../hhvm/hhvm -v Repo.Local.Mode=-- -v Repo.Central.Path=/tmp/framework-testqIDsQM --config /root/hhvm/hphp/test/frameworks/php.ini -c /root/hhvm/hphp/test/frameworks/.generated.php.ini /root/hhvm/hphp/test/frameworks/vendor/bin/phpunit --debug  -c /root/hhvm/hphp/test/frameworks/framework_downloads/fastroute/phpunit.xml --filter 'FastRoute\\Dispatcher\\MarkBasedTest::testFoundDispatches with data set #6'

array_keys() expects parameter 1 to be an array or collection

/root/hhvm/hphp/test/frameworks/framework_downloads/fastroute/src/Dispatcher/MarkBased.php:46
/root/hhvm/hphp/test/frameworks/framework_downloads/fastroute/src/Dispatcher/MarkBased.php:19
/root/hhvm/hphp/test/frameworks/framework_downloads/fastroute/test/Dispatcher/DispatcherTest.php:34

6) FastRoute\Dispatcher\MarkBasedTest::testFoundDispatches with data set #7 ('HEAD', '/user/rdlowrey', Closure$FastRoute\Dispatcher\DispatcherTest::provideFoundDispatchCases;434883760#5, 'handler0', array('rdlowrey'))

RUN TEST FILE:  cd /root/hhvm/hphp/test/frameworks/framework_downloads/fastroute && /root/hhvm/hphp/test/frameworks/../../hhvm/hhvm -v Repo.Local.Mode=-- -v Repo.Central.Path=/tmp/framework-testqIDsQM --config /root/hhvm/hphp/test/frameworks/php.ini -c /root/hhvm/hphp/test/frameworks/.generated.php.ini /root/hhvm/hphp/test/frameworks/vendor/bin/phpunit --debug  -c /root/hhvm/hphp/test/frameworks/framework_downloads/fastroute/phpunit.xml --filter 'FastRoute\\Dispatcher\\MarkBasedTest::testFoundDispatches with data set #7'

array_keys() expects parameter 1 to be an array or collection

/root/hhvm/hphp/test/frameworks/framework_downloads/fastroute/src/Dispatcher/MarkBased.php:46
/root/hhvm/hphp/test/frameworks/framework_downloads/fastroute/src/Dispatcher/MarkBased.php:19
/root/hhvm/hphp/test/frameworks/framework_downloads/fastroute/test/Dispatcher/DispatcherTest.php:34

7) FastRoute\Dispatcher\MarkBasedTest::testFoundDispatches with data set #8 ('HEAD', '/user/rdlowrey/1234', Closure$FastRoute\Dispatcher\DispatcherTest::provideFoundDispatchCases;434883760#5, 'handler1', array('rdlowrey', '1234'))

RUN TEST FILE:  cd /root/hhvm/hphp/test/frameworks/framework_downloads/fastroute && /root/hhvm/hphp/test/frameworks/../../hhvm/hhvm -v Repo.Local.Mode=-- -v Repo.Central.Path=/tmp/framework-testqIDsQM --config /root/hhvm/hphp/test/frameworks/php.ini -c /root/hhvm/hphp/test/frameworks/.generated.php.ini /root/hhvm/hphp/test/frameworks/vendor/bin/phpunit --debug  -c /root/hhvm/hphp/test/frameworks/framework_downloads/fastroute/phpunit.xml --filter 'FastRoute\\Dispatcher\\MarkBasedTest::testFoundDispatches with data set #8'

array_keys() expects parameter 1 to be an array or collection

/root/hhvm/hphp/test/frameworks/framework_downloads/fastroute/src/Dispatcher/MarkBased.php:46
/root/hhvm/hphp/test/frameworks/framework_downloads/fastroute/src/Dispatcher/MarkBased.php:19
/root/hhvm/hphp/test/frameworks/framework_downloads/fastroute/test/Dispatcher/DispatcherTest.php:34

8) FastRoute\Dispatcher\MarkBasedTest::testMethodNotAllowedDispatches with data set #2 ('DELETE', '/user/rdlowrey/42', Closure$FastRoute\Dispatcher\DispatcherTest::provideMethodNotAllowedDispatchCases;434883760#3, array('GET', 'POST', 'PUT', 'PATCH'))

RUN TEST FILE:  cd /root/hhvm/hphp/test/frameworks/framework_downloads/fastroute && /root/hhvm/hphp/test/frameworks/../../hhvm/hhvm -v Repo.Local.Mode=-- -v Repo.Central.Path=/tmp/framework-testqIDsQM --config /root/hhvm/hphp/test/frameworks/php.ini -c /root/hhvm/hphp/test/frameworks/.generated.php.ini /root/hhvm/hphp/test/frameworks/vendor/bin/phpunit --debug  -c /root/hhvm/hphp/test/frameworks/framework_downloads/fastroute/phpunit.xml --filter 'FastRoute\\Dispatcher\\MarkBasedTest::testMethodNotAllowedDispatches with data set #2'

array_keys() expects parameter 1 to be an array or collection

/root/hhvm/hphp/test/frameworks/framework_downloads/fastroute/src/Dispatcher/MarkBased.php:46
/root/hhvm/hphp/test/frameworks/framework_downloads/fastroute/src/Dispatcher/MarkBased.php:19
/root/hhvm/hphp/test/frameworks/framework_downloads/fastroute/test/Dispatcher/DispatcherTest.php:57
```
