### PR TITLE
fix Redis lrem can remove type is string or float

### DIFF
--- a/hphp/system/php/redis/Redis.php
+++ b/hphp/system/php/redis/Redis.php
@@ -822,7 +822,7 @@ class Redis {
     'lpushx' => [ 'format' => 'kl', 'return' => 'Long' ],
     'lrange' => [ 'format' => 'kll', 'return' => 'Vector', 'retargs' => [1] ],
     'lgetrange' => [ 'alias' => 'lrange' ],
-    'lrem' => [ 'format' => 'kvl', 'return' => 'Long' ],
+    'lrem' => [ 'format' => 'kvs', 'return' => 'Long' ],
     'lremove' => [ 'alias' => 'lrem' ],
     'lset' => [ 'format' => 'klv', 'return' => 'Boolean' ],
     'ltrim' => [ 'format' => 'kll', 'return' => 'Boolean' ],


### PR DESCRIPTION
Fix Redis lrem don't remove in addition to Long value,

Specific content see:

https://github.com/facebook/hhvm/issues/3452
