### PR TITLE
set memcache's option use ini_set has some error

### DIFF
--- a/hphp/runtime/ext/ext_memcache.cpp
+++ b/hphp/runtime/ext/ext_memcache.cpp
@@ -76,7 +76,7 @@ static bool ini_on_update_hash_strategy(const std::string& value) {
   } else if (!strncasecmp(value.data(), "consistent", sizeof("consistent"))) {
     MEMCACHEG(hash_strategy) = "consistent";
   }
-  return false;
+  return true;
 }
 
 static bool ini_on_update_hash_function(const std::string& value) {
@@ -85,7 +85,7 @@ static bool ini_on_update_hash_function(const std::string& value) {
   } else if (!strncasecmp(value.data(), "fnv", sizeof("fnv"))) {
     MEMCACHEG(hash_function) = "fnv";
   }
-  return false;
+  return true;
 }
 
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
1. when use init_set('memcache.hash_function', $funciton_value )  will override the memcache.hash_strategy's value
2. cause 1's problem,when inited the thread, the memcache.hash_function's value will also override the memcache.hash_strategy's value;
3. when use init_set a option's value, if success the update_callback return true,  then ini_set will return the option's old value, otherwise init_set will return false; 

//use the code to test,like
<?php 
var_dump(ini_get( 'memcache.hash_function')); // crc32
var_dump(ini_get( 'memcache.hash_strategy')); // crc32, it shoud be standard
var_dump(ini_set( 'memcache.hash_strategy', 'consistent' )); // false,if success shoud be return the old value
var_dump(ini_get( 'memcache.hash_strategy'));    // consistent, it's right now
var_dump(ini_set( 'memcache.hash_function', 'crc32' ));    // false,if success shoud be return the old value
var_dump(ini_get( 'memcache.hash_function'));  // crc32, set the memcache.hash_function
var_dump(ini_get( 'memcache.hash_strategy'));  // crc32, the hash_strategy is overrided by the memcache.hash_function

?>
