### PR TITLE
Fix a crash when using sqliteCreateFunction

### DIFF
--- a/hphp/runtime/ext/pdo_sqlite.cpp
+++ b/hphp/runtime/ext/pdo_sqlite.cpp
@@ -375,6 +375,7 @@ bool PDOSqliteStatement::executer() {
 }
 
 bool PDOSqliteStatement::fetcher(PDOFetchOrientation ori, long offset) {
+  SYNC_VM_REGS_SCOPED();
   if (!m_stmt) {
     return false;
   }

--- a/hphp/test/slow/ext_sqlite3/createfunction.php
+++ b/hphp/test/slow/ext_sqlite3/createfunction.php
@@ -1,0 +1,14 @@
+<?php
+$db = new PDO('sqlite::memory:');
+$db->sqliteCreateFunction('length', 'strlen', 1);
+
+$db->exec("DROP TABLE IF EXISTS test_table;");
+$db->exec("CREATE TABLE test_table (test_field TEXT);");
+$db->exec("INSERT INTO test_table VALUES('text1');");
+$db->exec("INSERT INTO test_table VALUES('text2');");
+
+$q = "SELECT * FROM test_table WHERE LENGTH(test_field) < 75";
+$sth = $db->prepare($q);
+$r = $sth->execute();
+$rows = $sth->fetchall();
+var_dump($rows);

--- a/hphp/test/slow/ext_sqlite3/createfunction.php.expectf
+++ b/hphp/test/slow/ext_sqlite3/createfunction.php.expectf
@@ -1,0 +1,16 @@
+array(2) {
+  [0]=>
+  array(2) {
+    ["test_field"]=>
+    string(5) "text1"
+    [0]=>
+    string(5) "text1"
+  }
+  [1]=>
+  array(2) {
+    ["test_field"]=>
+    string(5) "text2"
+    [0]=>
+    string(5) "text2"
+  }
+}


### PR DESCRIPTION
The segfault is reproduced by the test.
Without this fix, drupal 7 when configured to use sqlite is unusable.
The crash occurs for instance when clearing the cache.
