### PR TITLE
Custom path to the installed folder

### DIFF
--- a/CMake/HPHPSetup.cmake
+++ b/CMake/HPHPSetup.cmake
@@ -13,6 +13,8 @@ set(HHVM_WHOLE_ARCHIVE_LIBRARIES
     hphp_runtime_ext
    )
 
+add_definitions(-DINSTALL_PREFIX="${CMAKE_INSTALL_PREFIX}")
+
 if (ENABLE_ZEND_COMPAT)
   add_definitions("-DENABLE_ZEND_COMPAT=1")
   list(APPEND HHVM_WHOLE_ARCHIVE_LIBRARIES hphp_ext_zend_compat)

--- a/hphp/runtime/base/emulate-zend.cpp
+++ b/hphp/runtime/base/emulate-zend.cpp
@@ -235,12 +235,12 @@ int emulate_zend(int argc, char** argv) {
 
     // If the -c option is specified without a -n, php behavior is to
     // load the default ini/hdf
-    auto default_config_file = "/etc/hhvm/php.ini";
+    auto default_config_file = INSTALL_PREFIX "/etc/hhvm/php.ini";
     if (access(default_config_file, R_OK) != -1) {
       newargv.push_back("-c");
       newargv.push_back(default_config_file);
     }
-    default_config_file = "/etc/hhvm/config.hdf";
+    default_config_file = INSTALL_PREFIX "/etc/hhvm/config.hdf";
     if (access(default_config_file, R_OK) != -1) {
       newargv.push_back("-c");
       newargv.push_back(default_config_file);

--- a/hphp/runtime/base/program-functions.cpp
+++ b/hphp/runtime/base/program-functions.cpp
@@ -1191,12 +1191,12 @@ static int execute_program_impl(int argc, char** argv) {
       return -1;
     }
     if (po.config.empty() && !vm.count("no-config")) {
-      auto default_config_file = "/etc/hhvm/php.ini";
+      auto default_config_file = INSTALL_PREFIX "/etc/hhvm/php.ini";
       if (access(default_config_file, R_OK) != -1) {
         Logger::Verbose("Using default config file: %s", default_config_file);
         po.config.push_back(default_config_file);
       }
-      default_config_file = "/etc/hhvm/config.hdf";
+      default_config_file = INSTALL_PREFIX "/etc/hhvm/config.hdf";
       if (access(default_config_file, R_OK) != -1) {
         Logger::Verbose("Using default config file: %s", default_config_file);
         po.config.push_back(default_config_file);

--- a/hphp/util/compilation-flags.h
+++ b/hphp/util/compilation-flags.h
@@ -16,6 +16,15 @@
 #ifndef incl_HPHP_COMPILATION_FLAGS_H_
 #define incl_HPHP_COMPILATION_FLAGS_H_
 
+#ifndef INSTALL_PREFIX
+# if defined(__APPLE__) || defined(__FreeBSD__) || \
+     defined(__OpenBSD__) || defined(__NetBSD__)
+#  define INSTALL_PREFIX "/usr/local"
+# else
+#  define INSTALL_PREFIX ""
+# endif
+#endif
+
 namespace HPHP {
 
 //////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Makes it possible selection of configuration folder hhvm, the default folder configuration nailed to the `/etc/hhvm/` but it's only for Linux justified.

ref: facebook/hhvm#3197
