### PR TITLE
Add support for registering and using an externally supplied Profiler,

### DIFF
--- a/hphp/runtime/ext/ext_hotprofiler.cpp
+++ b/hphp/runtime/ext/ext_hotprofiler.cpp
@@ -1318,14 +1318,14 @@ bool ProfilerFactory::start(ProfilerKind kind,
     } else {
       throw_invalid_argument(
         "ProfilerFactory::setExternalProfiler() not yet called");
-      /* Control reaches here if !RuntimeOption::ThrowInvalidArguments. */
+      return false;
     }
     break;
   default:
     throw_invalid_argument("level: %d", kind);
     return false;
   }
-  if (m_profiler && m_profiler->m_successful) {
+  if (m_profiler->m_successful) {
     // This will be disabled automatically when the thread completes the request
     HPHP::EventHook::Enable();
     ThreadInfo::s_threadInfo->m_profiler = m_profiler;
@@ -1448,7 +1448,7 @@ void f_xhprof_enable(int flags/* = 0 */,
     flags = 0;  /* flags are not used by MemoProfiler::MemoProfiler */
     s_profiler_factory->start(ProfilerKind::Memo, flags);
   } else if (flags & External) {
-    flags = TrackBuiltins | TrackCPU | TrackMemory;
+    flags = TrackBuiltins;
     for (ArrayIter iter(args); iter; ++iter) {
       if (iter.first().toInt32() == 0) {
          flags = iter.second().toInt32();

--- a/hphp/runtime/ext/ext_hotprofiler.h
+++ b/hphp/runtime/ext/ext_hotprofiler.h
@@ -305,6 +305,9 @@ public:
     delete(m_external_profiler);
     m_external_profiler = p;
   }
+  Profiler *getExternalProfiler() {
+    return m_external_profiler;
+  }
 
 private:
   Profiler *m_profiler;


### PR DESCRIPTION
as for example from a 3rd party DSO.

While I'm at it, plumb in instantiation of the pre-existing experimental
MemoProfiler.

This PR replaces https://github.com/facebook/hhvm/pull/3082. This PR
is simpler than that proposed before, since the old work is supplanted
in large part by recent work for debugger hooks.  There were too many
git branch conflicts to warrant preserving the commentary of 3082,
most of which is no longer relevant.
