### PR TITLE
Fix casting to wrong type.

### DIFF
--- a/hphp/runtime/ext/gd/libgd/gd_webp.cpp
+++ b/hphp/runtime/ext/gd/libgd/gd_webp.cpp
@@ -72,7 +72,7 @@ gdImagePtr gdImageCreateFromWebpCtx (gdIOCtx * infile)
 	gdImagePtr im;
 
 	do {
-		temp = (unsigned uint8*) gdRealloc(filedata, size+GD_WEBP_ALLOC_STEP);
+		temp = (unsigned char*) gdRealloc(filedata, size+GD_WEBP_ALLOC_STEP);
 		if (temp) {
 			filedata = temp;
 			read = temp + size;


### PR DESCRIPTION
hhvm/hphp/runtime/ext/gd/libgd/gd_webp.cpp:75:10: error: cast from pointer to smaller type 'unsigned int' loses information
                temp = (unsigned uint8*) gdRealloc(filedata, size+GD_WEBP_ALLOC_STEP);
                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
