### PR TITLE
Add TYPO3 Unit tests to the OSS framework parity check

### DIFF
--- a/hphp/test/frameworks/framework_class_overrides/TYPO3.php
+++ b/hphp/test/frameworks/framework_class_overrides/TYPO3.php
@@ -1,0 +1,136 @@
+<?hh
+require_once __DIR__.'/../Framework.php';
+
+class Typo3 extends Framework {
+  protected $additionalFolders = array('typo3temp', 'uploads',
+                                       'typo3conf', 'typo3conf/ext');
+
+  public function __construct(string $name) {
+    $typo3path = Options::$frameworks_root . '/typo3';
+    $env_vars = Map { "TYPO3_PATH_WEB" =>  $typo3path };
+    $tc = get_runtime_build().' '.__DIR__.
+      '/../framework_downloads/typo3/bin/phpunit';
+    parent::__construct($name, $tc, $env_vars, null,
+                        false, TestFindModes::TOKEN);
+  }
+
+  protected function install(): void {
+    parent::install();
+    // comment out 2 methods from interfaces which couses troubles
+    // because of https://github.com/facebook/hhvm/issues/2527
+    $filePath = $this->getInstallRoot() .
+                '/typo3/sysext/core/Resources/PHP/TYPO3.Flow/Classes/'.
+                'TYPO3/Flow/Package/PackageManagerInterface.php';
+    file_put_contents($filePath,
+                      str_replace('public function initialize(',
+                                  '//public function initialize(',
+                                  file_get_contents($filePath)));
+    $filePath = $this->getInstallRoot() .
+                '/typo3/sysext/core/Resources/PHP/TYPO3.Flow/Classes/'.
+                'TYPO3/Flow/Package/PackageInterface.php';
+    file_put_contents($filePath,
+                      str_replace('public function boot(',
+                                  '//public function boot(',
+                                  file_get_contents($filePath)));
+
+    verbose("Creating a phpunit xml configuration file for running the TYPO3 tests.\n");
+	$phpunit_xml = <<<XML
+<?xml version="1.0"?>
+<phpunit backupGlobals="true" backupStaticAttributes="false" bootstrap="UnitTestsBootstrap.php" colors="false" convertErrorsToExceptions="true" convertWarningsToExceptions="true" forceCoversAnnotation="false" processIsolation="false" stopOnError="false" stopOnFailure="false" stopOnIncomplete="false" stopOnSkipped="false" strict="false" verbose="false">
+	<testsuites>
+		<testsuite name="Core tests">
+			<directory>../../../../typo3/sysext/core/Tests/Unit/</directory>
+		</testsuite>
+		<testsuite name="Core modules">
+			<directory>../../../../typo3/sysext/backend/Tests/Unit/</directory>
+			<directory>../../../../typo3/sysext/belog/Tests/Unit/</directory>
+			<directory>../../../../typo3/sysext/beuser/Tests/Unit/</directory>
+			<directory>../../../../typo3/sysext/dbal/Tests/Unit/</directory>
+
+			<directory>../../../../typo3/sysext/documentation/Tests/Unit/</directory>
+			<directory>../../../../typo3/sysext/extbase/Tests/Unit/</directory>
+			<directory>../../../../typo3/sysext/extensionmanager/Tests/Unit/</directory>
+			<directory>../../../../typo3/sysext/felogin/Tests/Unit/</directory>
+			<directory>../../../../typo3/sysext/fluid/Tests/Unit/</directory>
+
+			<!--For some reason hhvm fatals with this folder, but runs OK if we list all test files separately-->
+			<!--<directory>../../../../typo3/sysext/form/Tests/Unit/</directory>-->
+			<directory>../../../../typo3/sysext/frontend/Tests/Unit/</directory>
+			<directory>../../../../typo3/sysext/impexp/Tests/Unit/</directory>
+			<directory>../../../../typo3/sysext/indexed_search/Tests/Unit/</directory>
+			<directory>../../../../typo3/sysext/install/Tests/Unit/</directory>
+			<directory>../../../../typo3/sysext/lang/Tests/Unit/</directory>
+
+			<directory>../../../../typo3/sysext/lowlevel/Tests/Unit/</directory>
+			<directory>../../../../typo3/sysext/recordlist/Tests/Unit/</directory>
+			<directory>../../../../typo3/sysext/rsauth/Tests/Unit/</directory>
+			<directory>../../../../typo3/sysext/saltedpassword/Tests/Unit/</directory>
+			<directory>../../../../typo3/sysext/scheduler/Tests/Unit/</directory>
+			<directory>../../../../typo3/sysext/sv/Tests/Unit/</directory>
+			<directory>../../../../typo3/sysext/workspaces/Tests/Unit/</directory>
+		</testsuite>
+		<testsuite name="Core legacy tests">
+			<directory>../../../../typo3/sysext/core/Tests/Legacy/</directory>
+		</testsuite>
+		<testsuite name="Suite integrity tests">
+			<directory>../../../../typo3/sysext/core/Tests/Integrity/</directory>
+		</testsuite>
+		<testsuite name="Form extension">
+			<file>../../../../typo3/sysext/form/Tests/Unit/Domain/Factory/TypoScriptFactoryTest.php</file>
+			<file>../../../../typo3/sysext/form/Tests/Unit/Filter/AlphanumericFilterTest.php</file>
+			<file>../../../../typo3/sysext/form/Tests/Unit/Filter/StripNewLinesFilterTest.php</file>
+			<file>../../../../typo3/sysext/form/Tests/Unit/Filter/RegExpFilterTest.php</file>
+			<file>../../../../typo3/sysext/form/Tests/Unit/Filter/DigitFilterTest.php</file>
+			<file>../../../../typo3/sysext/form/Tests/Unit/Filter/TrimFilterTest.php</file>
+			<file>../../../../typo3/sysext/form/Tests/Unit/Filter/TitleCaseFilterTest.php</file>
+			<file>../../../../typo3/sysext/form/Tests/Unit/Filter/AlphabeticFilterTest.php</file>
+			<file>../../../../typo3/sysext/form/Tests/Unit/Filter/CurrencyFilterTest.php</file>
+			<file>../../../../typo3/sysext/form/Tests/Unit/Filter/UpperCaseFilterTest.php</file>
+			<file>../../../../typo3/sysext/form/Tests/Unit/Filter/LowerCaseFilterTest.php</file>
+			<file>../../../../typo3/sysext/form/Tests/Unit/Filter/IntegerFilterTest.php</file>
+			<file>../../../../typo3/sysext/form/Tests/Unit/Filter/RemoveXssFilterTest.php</file>
+			<file>../../../../typo3/sysext/form/Tests/Unit/PostProcess/MailPostProcessorTest.php</file>
+			<file>../../../../typo3/sysext/form/Tests/Unit/PostProcess/PostProcessorTest.php</file>
+			<file>../../../../typo3/sysext/form/Tests/Unit/Validation/InArrayValidatorTest.php</file>
+			<file>../../../../typo3/sysext/form/Tests/Unit/Validation/AlphabeticValidatorTest.php</file>
+			<file>../../../../typo3/sysext/form/Tests/Unit/Validation/UriValidatorTest.php</file>
+			<file>../../../../typo3/sysext/form/Tests/Unit/Validation/IntegerValidatorTest.php</file>
+			<file>../../../../typo3/sysext/form/Tests/Unit/Validation/FloatValidatorTest.php</file>
+			<file>../../../../typo3/sysext/form/Tests/Unit/Validation/DateValidatorTest.php</file>
+			<file>../../../../typo3/sysext/form/Tests/Unit/Validation/EmailValidatorTest.php</file>
+			<file>../../../../typo3/sysext/form/Tests/Unit/Validation/RequiredValidatorTest.php</file>
+			<file>../../../../typo3/sysext/form/Tests/Unit/Validation/AlphanumericValidatorTest.php</file>
+			<file>../../../../typo3/sysext/form/Tests/Unit/Validation/IpValidatorTest.php</file>
+			<file>../../../../typo3/sysext/form/Tests/Unit/Validation/FileMinimumSizeValidatorTest.php</file>
+			<file>../../../../typo3/sysext/form/Tests/Unit/Validation/DigitValidatorTest.php</file>
+			<file>../../../../typo3/sysext/form/Tests/Unit/Validation/FileAllowedTypesValidatorTest.php</file>
+			<file>../../../../typo3/sysext/form/Tests/Unit/Validation/EqualsValidatorTest.php</file>
+			<file>../../../../typo3/sysext/form/Tests/Unit/Validation/FileMaximumSizeValidatorTest.php</file>
+			<file>../../../../typo3/sysext/form/Tests/Unit/Validation/LengthValidatorTest.php</file>
+			<file>../../../../typo3/sysext/form/Tests/Unit/Validation/BetweenValidatorTest.php</file>
+			<file>../../../../typo3/sysext/form/Tests/Unit/Validation/GreaterThanValidatorTest.php</file>
+			<file>../../../../typo3/sysext/form/Tests/Unit/Validation/RegExpValidatorTest.php</file>
+			<file>../../../../typo3/sysext/form/Tests/Unit/Validation/LessThanValidatorTest.php</file>
+			<file>../../../../typo3/sysext/form/Tests/Unit/View/Mail/Html/Element/AbstractElementViewTest.php</file>
+		</testsuite>
+	</testsuites>
+</phpunit>
+XML;
+
+    file_put_contents($this->getTestPath()."/HHVMUnitTests.xml", $phpunit_xml);
+
+
+  }
+
+  protected function isInstalled(): bool {
+    foreach($this->additionalFolders as $folder) {
+      if(!file_exists($this->getInstallRoot() . '/' . $folder)) {
+        if(file_exists($this->getInstallRoot())) {
+          remove_dir_recursive($this->getInstallRoot());
+        }
+        return false;
+      }
+    }
+    return parent::isInstalled();
+  }
+}

--- a/hphp/test/frameworks/frameworks.yaml
+++ b/hphp/test/frameworks/frameworks.yaml
@@ -622,6 +622,14 @@
     clowns:
 	  # Dependent on system language settings.
       - twig/test/Twig/Tests/CompilerTest.php
+  typo3:
+    url: git://github.com/TYPO3/TYPO3.CMS.git
+    branch: master
+    commit: 1338779992cfd4cb88434e283b78d27ab9250c2b
+    install_root: typo3
+    test_root: typo3/typo3/sysext/core/Build
+    config_file: typo3/typo3/sysext/core/Build/HHVMUnitTests.xml
+    bootstrap_file: typo3/typo3/sysext/core/Build/UnitTestsBootstrap.php
   vfsstream:
     # We're using Graham's fork to unskip a couple of tests
     # The latest stable is v1.3.0 - the fork is slightly ahead


### PR DESCRIPTION
Third try to include TYPO3 tests in HHVM parity check :)
fixes: https://github.com/facebook/hhvm/issues/2103

This patch was tested on Centos 6.4 with HHVM compiled from sources 730e11dc2f69a3d40270dbd60f547428df0a480d

The problem was that TYPO3 unit tests were working on Ubuntu, but not on Centos.
I've spend some time debugging on Centos and found out that the whole
test suit runs properly (without fatals). The master process receives the 
`Tests: 6701, Assertions: 8610, Failures: 69, Errors: 33, Skipped: 146.`
 but for some reason doesn't recognize it.

This patch contains a workaround so all TYPO3 unit test suite runs, and returns valid stats:

```
[vagrant@vagrant-centos64 hphp]$ hhvm  test/frameworks/run.php --csv --csvheader typo3
date,               typo3
2014/08/24-14:06:53,98.42
```

However there is probably still sth wrong with the test runner.

A little explanation  of the workaround:

A custom phpunit xml configuration file is created,
because for some reason test runner returned "SUMMARY: typo3=FATAL" 
with default TYPO3 phpunit configuration, which contained sth like this:

```
<testsuite name="Core tests">
    <directory>../../../../typo3/sysext/*/Tests/Unit/</directory>
</testsuite>
```

I've tried to run unit tests of all core extensions one after another (separate <directory> entries in the xml) and managed to narrow down the issue to the extension "Form"

So I've broken down the configuration for each extension folder
instead of using wildcard.
However HHVM still couldnt return the stats,  when running just test  for "Form" extension alone

```
<directory>../../../../typo3/sysext/form/Tests/Unit/</directory>
```

However if you list all Form unit tests separately, it works.
So as a workaround all Form tests are listed in the phpunit xml
configuration file.
