### PR TITLE
Make access log %h behave more like Apache

### DIFF
--- a/hphp/runtime/server/access-log.cpp
+++ b/hphp/runtime/server/access-log.cpp
@@ -296,7 +296,12 @@ bool AccessLog::genField(std::ostringstream &out, const char* &format,
     }
     break;
   case 'h':
-    out << transport->getRemoteHost();
+    { 
+       std::string host = transport->getRemoteHost();
+       if(host.empty())
+         host = transport->getRemoteAddr();
+       out << host;
+    }
     break;
   case 'i':
     if (arg.empty()) return false;


### PR DESCRIPTION
The access log format appears to be Apache like -- but doesn't behave like Apache when hostname lookups are off, it logs a blank.   It should log IP address in this case just like Apache, this accomplishes that.
