### PR TITLE
Replace mempcpy by mempcpy to fix #3589 : mempcpy is not available on Mac OS

### DIFF
--- a/hphp/runtime/server/server-stats.cpp
+++ b/hphp/runtime/server/server-stats.cpp
@@ -847,7 +847,7 @@ void ServerStats::logBytes(int64_t bytes) {
 static void safe_copy(char *dest, const char *src, int max) {
   int len = strlen(src) + 1;
   dest[--max] = '\0';
-  mempcpy(dest, src, len > max ? max : len);
+  memcpy(dest, src, len > max ? max : len);
 }
 
 void ServerStats::startRequest(const char *url, const char *clientIP,


### PR DESCRIPTION
`mempcpy` is not available on Mac OS and the only difference between `memcpy` and `mempcpy` is the return value. As long as the return value is not used we can use memcpy (which is available in Mac OS)

THis PR will also fix htps://github.com/mcuadros/homebrew-hhvm/issues/97
