### PR TITLE
Fix bugs in the zend compat layer for initialization entries.

### DIFF
--- a/hphp/test/slow/ext_dso_test/dso_test.php
+++ b/hphp/test/slow/ext_dso_test/dso_test.php
@@ -17,7 +17,7 @@ var_dump(dso_test_null());
  * yet work; the value remains sticky at 1, and every access to
  * dso_test_long post-increments the value.
  */
-// ini_set("dso_test.direction", 0);
-// var_dump(dso_test_long());
-// var_dump(dso_test_long());
-// var_dump(dso_test_long());
+ini_set("dso_test.direction", 0);
+var_dump(dso_test_long());
+var_dump(dso_test_long());
+var_dump(dso_test_long());

--- a/hphp/test/slow/ext_dso_test/dso_test.php.expect
+++ b/hphp/test/slow/ext_dso_test/dso_test.php.expect
@@ -6,3 +6,6 @@ int(3)
 float(3.1415926535)
 bool(true)
 NULL
+int(2)
+int(1)
+int(0)


### PR DESCRIPTION
1. Fix a logic inversion bug with the return value from on_modify handler;
2. on_modify handler may be null, so protect against that;
3. the `modifiable` item is a bit set which may contain more than one element.

With these fixes, dso_test.php now sees that the direction flag
is correctly bound and implemented.
