### PR TITLE
Fix dwarf_producer_init check

### DIFF
--- a/CMake/FindLibDwarf.cmake
+++ b/CMake/FindLibDwarf.cmake
@@ -93,7 +93,8 @@ if (LIBDWARF_LIBRARIES AND LIBDWARF_INCLUDE_DIRS)
   ENDMACRO(CHECK_LIBDWARF_INIT)
 
   # Order is important, last one is used.
-  CHECK_LIBDWARF_INIT("dwarf_producer_init"   "0, dwarfCallback, nullptr, nullptr, nullptr"          0)
+  CHECK_LIBDWARF_INIT("dwarf_producer_init"  
+	"0, dwarfCallback, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr" 0)
   CHECK_LIBDWARF_INIT("dwarf_producer_init_c" "0, dwarfCallback, nullptr, nullptr, nullptr, nullptr" 1)
 endif()
 


### PR DESCRIPTION
dwarf_producer_init takes 10 arguments, but the checking code only
supplied 5, meaning that the `const char*` check would always fail,
producing the wrong information and preventing compilation.
