### PR TITLE
fix fgets bug & redis sockReadLine bug

### DIFF
--- a/hphp/system/php/redis/Redis.php
+++ b/hphp/system/php/redis/Redis.php
@@ -974,21 +974,15 @@ class Redis {
   }
 
   protected function sockReadLine() {
-   if (!$this->checkConnection()) {
-     return false;
-   }
+    $line = '';
+    do {
+      if (!$this->checkConnection()) {
+        return false;
+      }
+      $line .= fgets($this->connection);
+    } while (substr($line, -2) !== "\r\n");
 
-   $line = '';
-   while(1) {
-     $c = fgetc($this->connection);
-     $line .= $c;
-     if (substr($line, -2) == "\r\n") {
-       $line = substr($line, 0, -2);
-       return $line;
-     }
-   }
-
-   return false;
+    return substr($line, 0, -2);
   }
 
   protected function sockReadData(&$type) {

--- a/hphp/test/zend/good/ext/standard/tests/file/fgets_socket_variation1.php
+++ b/hphp/test/zend/good/ext/standard/tests/file/fgets_socket_variation1.php
@@ -20,7 +20,6 @@ if (!$client) {
 /* Accept that connection */
 $socket = stream_socket_accept($server);
 
-
 echo "Write some data:\n";
 fwrite($socket, "line1\nline2\nline3\n");
 


### PR DESCRIPTION
doc for `fgets` from php.net::

```
Reading ends when length - 1 bytes have been read, or a newline (which is included in the return value), or an EOF (whichever comes first). If no length is specified, it will keep reading from the stream until it reaches the end of the line.
```

3 situation when fgets return:
1. read got '\n'
2. eof
3. read length-1 bytes

**but in the code, there is one more situation** ::

```
     m_writepos = filteredReadToBuffer();
     m_readpos = 0;
     if (bufferedLen() == 0) {
       break;                              /////////////////////////  if read got 0 bytes
     }
```

Socket::readImpl (hphp/runtime/base/socket.cpp) may return 0 bytes if `poll` got timeouted.

so fgets may return a string not endwith '\n'
