### PR TITLE
Redis readtime implement bug maybe hangding

### DIFF
--- a/hphp/system/php/redis/Redis.php
+++ b/hphp/system/php/redis/Redis.php
@@ -670,7 +670,7 @@ class Redis {
   }
 
   public function getTimeout() {
-    return $this->getReadTimeout();
+    return $this->timeout_connect;
   }
 
   public function getReadTimeout() {
@@ -1602,7 +1602,7 @@ class Redis {
       return false;
     }
     stream_set_blocking($conn, true);
-    stream_set_timeout($conn, $this->timeout_seconds, $this->timeout_useconds);
+    $this->setOption(Redis::OPT_READ_TIMEOUT,$timeout);
 
     return true;
   }


### PR DESCRIPTION
(1)gettimeout problem
Redis function getTimeout's timeout should be connect timeout  rather than read timeout..

reference:

https://github.com/nicolasff/phpredis/blob/master/redis.c 

6926 lines of this file

(2)redis connect readtime problem 

Developer  are used to set timeout(connecttimeout and readtime) in function connect,rather than setting setOption OPT_READ_TIMEOUT again,some developer forget set readtime maybe hhvm hangding when read data time out.

reference:
https://github.com/nicolasff/phpredis/blob/94e064940c488805485ad61a470ec9b34784f71f/library.c

1187 lines of this file

but hhvm implement functiom connect don't set readtimeout
