### PR TITLE
Fix cpu_set_t compilation on Mac OS 10.9 / GCC 4.8

### DIFF
--- a/hphp/runtime/ext/ext_hotprofiler.h
+++ b/hphp/runtime/ext/ext_hotprofiler.h
@@ -20,6 +20,36 @@
 
 #include "hphp/runtime/ext/ext_fb.h"
 
+#ifdef __FreeBSD__
+#include <sys/param.h>
+#include <sys/cpuset.h>
+#define cpu_set_t cpuset_t
+#define SET_AFFINITY(pid, size, mask) \
+           cpuset_setaffinity(CPU_LEVEL_WHICH, CPU_WHICH_TID, -1, size, mask)
+#define GET_AFFINITY(pid, size, mask) \
+           cpuset_getaffinity(CPU_LEVEL_WHICH, CPU_WHICH_TID, -1, size, mask)
+#elif defined(__APPLE__)
+#include <mach/mach_init.h>
+#include <mach/thread_policy.h>
+#include <mach/thread_act.h>
+
+#define cpu_set_t thread_affinity_policy_data_t
+#define CPU_SET(cpu_id, new_mask) \
+        (*(new_mask)).affinity_tag = (cpu_id + 1)
+#define CPU_ZERO(new_mask)                 \
+        (*(new_mask)).affinity_tag = THREAD_AFFINITY_TAG_NULL
+#define GET_AFFINITY(pid, size, mask) \
+         (*(mask)).affinity_tag = THREAD_AFFINITY_TAG_NULL
+#define SET_AFFINITY(pid, size, mask)       \
+        thread_policy_set(mach_thread_self(), THREAD_AFFINITY_POLICY, \
+                          (int *)mask, THREAD_AFFINITY_POLICY_COUNT)
+#else
+#include <sched.h>
+#define SET_AFFINITY(pid, size, mask) sched_setaffinity(0, size, mask)
+#define GET_AFFINITY(pid, size, mask) sched_getaffinity(0, size, mask)
+#endif
+
+
 namespace HPHP {
 
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Fix cpu_set_t type undefined error.

OS: Mac OS 10.9
Compiler: macports-gcc-4.8
Rev: HHVM-3.2.0
