### PR TITLE
Fix segfault when calling hash_final twice

### DIFF
--- a/hphp/runtime/ext/ext_hash.cpp
+++ b/hphp/runtime/ext/ext_hash.cpp
@@ -327,9 +327,16 @@ bool HHVM_FUNCTION(hash_update, const Resource& context, const String& data) {
   return true;
 }
 
-String HHVM_FUNCTION(hash_final, const Resource& context,
+Variant HHVM_FUNCTION(hash_final, const Resource& context,
                                  bool raw_output /* = false */) {
   HashContext *hash = context.getTyped<HashContext>();
+
+  if (hash->context == nullptr) {
+    raise_warning(
+      "hash_final(): supplied resource is not a valid Hash Context resource"
+    );
+    return false;
+  }
 
   String raw = String(hash->ops->digest_size, ReserveString);
   char *digest = raw.bufferSlice().ptr;

--- a/hphp/runtime/ext/ext_hash.h
+++ b/hphp/runtime/ext/ext_hash.h
@@ -32,7 +32,8 @@ Variant HHVM_FUNCTION(hash_init, const String& algo, int64_t options = 0,
                                  const String& key = null_string);
 Variant HHVM_FUNCTION(hash_file, const String& algo, const String& filename,
                                  bool raw_output = false);
-String HHVM_FUNCTION(hash_final, const Resource& context, bool raw_output = false);
+Variant HHVM_FUNCTION(hash_final, const Resource& context,
+		                  bool raw_output = false);
 bool HHVM_FUNCTION(hash_update, const Resource& context, const String& data);
 Resource HHVM_FUNCTION(hash_copy, const Resource& context);
 bool HHVM_FUNCTION(hash_equals, const Variant& known, const Variant& user);

--- a/hphp/system/php/hash/hash.php
+++ b/hphp/system/php/hash/hash.php
@@ -60,7 +60,7 @@ function hash_file(string $algo, string $filename,
  *                  of the message digest is returned.
  */
 <<__Native>>
-function hash_final(resource $context, bool $raw_output = false): string;
+function hash_final(resource $context, bool $raw_output = false): mixed;
 
 /**
  * hash() - http://php.net/function.hash

--- a/hphp/test/slow/ext_hash/hash_final_invalid.php
+++ b/hphp/test/slow/ext_hash/hash_final_invalid.php
@@ -1,0 +1,5 @@
+<?php
+
+$ctx = hash_init('sha256' );
+var_dump(hash_final($ctx));
+var_dump(hash_final($ctx));

--- a/hphp/test/slow/ext_hash/hash_final_invalid.php.expectf
+++ b/hphp/test/slow/ext_hash/hash_final_invalid.php.expectf
@@ -1,0 +1,4 @@
+string(%d) "%s"
+
+Warning: hash_final(): supplied resource is not a valid Hash Context resource in %s/hash_final_invalid.php on line 5
+bool(false)


### PR DESCRIPTION
context is freed in hash_final. The second call tries to use the freed variable.

Fixes #3741
