### PR TITLE
Preprocessor gcc performance regressions

### DIFF
--- a/CMake/HPHPCompiler.cmake
+++ b/CMake/HPHPCompiler.cmake
@@ -23,13 +23,16 @@ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
 # using GCC
 elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
   execute_process(COMMAND ${CMAKE_CXX_COMPILER} ${CMAKE_CXX_COMPILER_ARG1} -dumpversion OUTPUT_VARIABLE GCC_VERSION)
-  set(GNUCC49_OPT "")
-  if (NOT (GCC_VERSION VERSION_GREATER 4.8 OR GCC_VERSION VERSION_EQUAL 4.8))
-    message(FATAL_ERROR "${PROJECT_NAME} requires g++ 4.8 or greater.")
-  elseif(GCC_VERSION VERSION_GREATER 4.9 OR GCC_VERSION VERSION_EQUAL 4.9)
-    # fix problem with GCC 4.9, Changes in gcc Code Optimization Can Cause a Crash
-    # https://kb.isc.org/article/AA-01167
-    set(GNUCC49_OPT "-fno-delete-null-pointer-checks")
+  set(GNUCC_OPT "")
+  if(GCC_VERSION VERSION_GREATER 4.8 OR GCC_VERSION VERSION_EQUAL 4.8)
+    # FIXME: GCC 4.8+ regressions http://git.io/4r7VCQ
+    set(GNUCC_OPT "${GNUCC_OPT} -ftrack-macro-expansion=0 -fno-builtin-memcmp")
+    # Fix problem with GCC 4.9, https://kb.isc.org/article/AA-01167
+    if(GCC_VERSION VERSION_GREATER 4.9 OR GCC_VERSION VERSION_EQUAL 4.9)
+      set(GNUCC_OPT "${GNUCC_OPT} -fno-delete-null-pointer-checks")
+    endif()
+  else()
+     message(FATAL_ERROR "${PROJECT_NAME} requires g++ 4.8 or greater.")
   endif()
 
   # ARM64
@@ -50,8 +53,8 @@ elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
   set(CMAKE_CXX_FLAGS_RELEASE        "-O3 -DNDEBUG")
   set(CMAKE_C_FLAGS_RELWITHDEBINFO   "-O2 -g")
   set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O2 -g")
-  set(CMAKE_C_FLAGS                  "${CMAKE_C_FLAGS} ${GNUCC49_OPT} -w")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -std=gnu++11 -fno-gcse -fno-omit-frame-pointer -ftemplate-depth-180 -Woverloaded-virtual -Wno-deprecated -Wno-strict-aliasing -Wno-write-strings -Wno-invalid-offsetof -fno-operator-names -Wno-error=array-bounds -Wno-error=switch -Werror=format-security -Wno-unused-result -Wno-sign-compare -Wno-attributes -Wno-maybe-uninitialized -Wno-unused-local-typedefs -fno-canonical-system-headers -Wno-deprecated-declarations ${GNUCC49_OPT} ${GNUCC_PLAT_OPT}")
+  set(CMAKE_C_FLAGS   "${CMAKE_C_FLAGS} ${GNUCC_OPT} -w")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -std=gnu++11 -fno-gcse -fno-omit-frame-pointer -ftemplate-depth-180 -Woverloaded-virtual -Wno-deprecated -Wno-strict-aliasing -Wno-write-strings -Wno-invalid-offsetof -fno-operator-names -Wno-error=array-bounds -Wno-error=switch -Werror=format-security -Wno-unused-result -Wno-sign-compare -Wno-attributes -Wno-maybe-uninitialized -Wno-unused-local-typedefs -fno-canonical-system-headers -Wno-deprecated-declarations ${GNUCC_OPT} ${GNUCC_PLAT_OPT}")
   if(STATIC_CXX_LIB)
     set(CMAKE_EXE_LINKER_FLAGS "-static-libgcc -static-libstdc++")
   endif()
@@ -70,5 +73,7 @@ elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -no-ipo -fp-model precise -wd584 -wd1418 -wd1918 -wd383 -wd869 -wd981 -wd424 -wd1419 -wd444 -wd271 -wd2259 -wd1572 -wd1599 -wd82 -wd177 -wd593 -fno-omit-frame-pointer -ftemplate-depth-180 -Wall -Woverloaded-virtual -Wno-deprecated -w1 -Wno-strict-aliasing -Wno-write-strings -Wno-invalid-offsetof -fno-operator-names")
 # using Visual Studio C++
 elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
-  # TODO
+  message(FATAL_ERROR "${PROJECT_NAME} is not yet compatible with Visual Studio")
+else()
+  message("Warning: unknown/unsupported compiler, things may go wrong")
 endif()


### PR DESCRIPTION
Complicated constructs may present stark differences in expansion times between 4.7.x and 4.8.x/4.9.x
C++11 modes in `g++` as well as between `clang++` and `g++ 4.8.x`. In summary:
- Both `clang++` and earlier versions of `g++` prove far more performant to `g++ 4.8.x`, at times by several factors in **really** complex macro expansions.
- From gcc bugzilla entries http://gcc.gnu.org/bugzilla/show_bug.cgi?id=56746 and http://gcc.gnu.org/bugzilla/show_bug.cgi?id=53525 this is known to be a performance regression of the 4.8.x branch so far.
- Use of `g++ 4.8.x` with such constructs may result in out of memory errors, system lockup, memory fragmentation and other erratic behavior depending which worst - case scenario of said gcc preprocessor performance regression is met.
- The recommended fix for this kind of gcc performance regression is to pass during invocation of g++, the `-ftrack-macro-expansion=0` flag in order to bypass macro tracking which heavily contributes to this behavior.
- `-fno-builtin-memcmp`  [`regression gcc4.8/4.9`](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=43052)
- [`-pie -fPIC -Wl,-z,relro,-z,now -fstack-protector --param=ssp-buffer-size=4 -D_FORTIFY_SOURCE=2`](http://goo.gl/vVS2Gl), RedHat uses them by default, they better protected buffer/stack overflow exploits, factor productivity dropping 1-4% (to include additional flags to consume [grsecurity-kernel](https://grsecurity.net/) and patched [[1]](https://wiki.debian.org/Hardening), but it works without it); about [RELRO](https://isisblogs.poly.edu/2011/06/01/relro-relocation-read-only/)

Therefore, if g++ is detected as the compiler used during configuration with cmake, this flag should be passed **implicitly** in order to deal with such a `g++` performance regression.

As a result, the memory consumption falls from 3x to 1.5x, we can resume the build on 512mb low-end servers.
