### PR TITLE
OCaml 4 deprecation fix for Hack

### DIFF
--- a/hphp/hack/src/dfind/dfindServer.ml
+++ b/hphp/hack/src/dfind/dfindServer.ml
@@ -162,7 +162,7 @@ let process_client_msg env oc = function
 (*****************************************************************************)
 
 let server_socket, client_socket =
-  let tmp = Tmp.temp_dir_name in
+  let tmp = Filename.get_temp_dir_name () in
   let user = Sys.getenv "USER" in
   let sock_name = tmp ^ "/dfind_"^user^".sock" in
   begin fun () -> (* Server side *)
@@ -204,7 +204,7 @@ let server_socket, client_socket =
 (*****************************************************************************)
 
 let get_pid_file () =
-  let tmp = Tmp.temp_dir_name in
+  let tmp = Filename.get_temp_dir_name () in
   let user = Sys.getenv "USER" in
   let fn = tmp ^ "/dfind_"^user^".pid" in
   fn

--- a/hphp/hack/src/parsing/searchService.ml
+++ b/hphp/hack/src/parsing/searchService.ml
@@ -143,9 +143,9 @@ module WorkerApi = struct
       first_char := false
     end str;
     let i = ref (List.length !result) in
-    let filtered_str = String.create !i in
+    let filtered_str = Bytes.create !i in
     List.iter begin fun c ->
-      String.set filtered_str (!i - 1) c;
+      Bytes.set filtered_str (!i - 1) c;
       decr i
     end !result;
     filtered_str

--- a/hphp/hack/src/utils/tmp.ml
+++ b/hphp/hack/src/utils/tmp.ml
@@ -14,7 +14,7 @@
 (*****************************************************************************)
 
 let temp_dir_name =
-  let dir = Filename.temp_dir_name in
+  let dir = Filename.get_temp_dir_name () in
   if dir.[String.length dir - 1] <> '/' then dir ^ "/" else dir
 
 let get_dir ?user:(user=None) () =


### PR DESCRIPTION
Bump OCaml requirement to version 4.02.0
- Tmp.temp_dir_name is deprecated in OCaml4, use Filename.get_temp_base_name instead of it.
- String.create is deprecated, use Bytes.create instead.
- String.set is deprecated, use Bytes.set instead.
