### PR TITLE
Apply OCaml deprecation fix from HHVM-3.3 branch

### DIFF
--- a/hphp/hack/src/Makefile.common
+++ b/hphp/hack/src/Makefile.common
@@ -29,7 +29,7 @@ OPTOBJS?= $(SRC:.ml=.cmx)
 # don't want to add an extra layer of complexity. In fact, we are not
 # even sure it would work with -thread ...
 OCAMLDTYPES?=-dtypes
-OCAMLCFLAGS?=-g $(OCAMLDTYPES) $(OCAMLCFLAGS_EXTRA) -w -21 -warn-error +a
+OCAMLCFLAGS?=-g $(OCAMLDTYPES) $(OCAMLCFLAGS_EXTRA) -w -21
 
 # This flag is also used in subdirectories so don't change its name here.
 OPTFLAGS?= $(OCAMLCFLAGS)

--- a/hphp/hack/src/typing/typing_decl.ml
+++ b/hphp/hack/src/typing/typing_decl.ml
@@ -608,7 +608,7 @@ and type_typedef_naming_and_decl nenv tdef =
     | Ast.Alias x -> false
     | Ast.NewType x -> true
   in
-  let params, tcstr, concrete_type =
+  let (params, tcstr, concrete_type) =
     Naming.typedef nenv tdef in
   let decl = is_abstract, params, concrete_type in
   let filename = Pos.filename pos in


### PR DESCRIPTION
Hi @jwatzman,

I've sent #3835 to fix the deprecation for OCaml4, but I guess you don't want to break OCaml3 users.

This pull request is applying OCaml deprecation fix from HHVM-3.3 branch to let HHVM-3.2 works for OCaml.

Fix external build?

Summary: One external report that this unused variable was causing an
error in the build. Our internal build went fine, so this might be a
change in default warnings between 3.12 and 4.01? In any event, easy
enough to fix, and also remove warn-error in the external build for now.

Reviewed By: @gabelevi

Differential Revision: D1512305

Conflicts:
    hphp/hack/src/typing/typing_decl.ml
