### PR TITLE
import_zend_test.py now executes CLEAN sections properly

### DIFF
--- a/hphp/test/tools/import_zend_test.py
+++ b/hphp/test/tools/import_zend_test.py
@@ -1148,7 +1148,7 @@ def walk(filename, dest_subdir):
             test += '\n'
         if not sections['CLEAN'].startswith('<?'):
             sections['CLEAN'] = '<?php\n' + sections['CLEAN']
-        disable_errors = "<?php error_reporting(0); ?>\n";
+        disable_errors = "<?php error_reporting(0); ?>\n"
         test += disable_errors + sections['CLEAN']
 
     # If you put an exception in here, please send a pull request upstream to


### PR DESCRIPTION
php-src is inconsistent with test's CLEAN section. Sometimes it starts with php open tags sometimes it doesn't.
e.g. https://github.com/facebook/hhvm/blob/master/hphp/test/zend/bad/ext/gd/tests/imagegd_nullbyte_injection.php

Also, php-src doesn't execute the CLEAN section when the test is executed. So all errors will be ignored. set error_reporting to 0 when the CLEAN section begins to ignore all errors as well.

Talked to ptarjan on IRC because my reimport will do stupid things and maybe a really nice oncall will do me the favor and reimport the whole thing? :)

Also PHP 5.6.1 is out, I don't know if it makes sense to start the import of the new version without importing 5.6.0 again.

From what I see from my import this should fix a bunch of bad tests :)
