### PR TITLE
Fix test/slow/ext_gd/imageweb.php

### DIFF
--- a/hphp/test/slow/ext_gd/imagewebp.php
+++ b/hphp/test/slow/ext_gd/imagewebp.php
@@ -9,22 +9,20 @@ imagestring($im, 2, 9, 9,
             'I\'ve got 99 problems but WebP ain\'t one.', $text_color);
 
 // Save the image
-imagewebp($im, $filename, 99);
+imagewebp($im, $filename);
 
 imagedestroy($im);
 
-// We could check the MD5-hash here but maybe libvpx will get some
-// improvements in the future that would change the output file.
-// We just check if the file is a valid WebP-File and has
-// approximately the right size.
-echo floor(filesize($filename)/100)*100, "\n";
+$size = filesize($filename) - 7; //Subtract FourCC + length header
 $fp = fopen($filename, 'r');
 
 // read 14 Bytes from the WebP-File, that contains the header
-$data = fread($fp, 14);
+$header = fread($fp, 14);
+$header = unpack("A4fourcc/L1length/A4chunkheader", $header);
 
-// remove non-ASCII chars
-echo preg_replace('/[[:^print:]]/', '?', $data);
+if ($header["fourcc"] != "RIFF") echo "Invalid FourCC in created image file\n";
+if ($header["length"] != $size) echo "The length specified in the image header is different from the actual size: (${header['length']} != ${size})\n";
 
 fclose($fp);
 unlink($filename);
+echo "OK!\n";

--- a/hphp/test/slow/ext_gd/imagewebp.php.expect
+++ b/hphp/test/slow/ext_gd/imagewebp.php.expect
@@ -1,2 +1,1 @@
-2500
-RIFF????WEBPVP
+OK!


### PR DESCRIPTION
@rrh made me aware that the test was not passing any more with a more recent version of libvpx.
This commit corrects the test and should be robust enough for any future update.

Instead of just printing the header and the file size, it now checks if the header is valid and the specified length matches the real length of the file.

Fixes #3927
