### PR TITLE
Content-Type should only be set once when handling admin server requests

### DIFF
--- a/hphp/runtime/server/admin-request-handler.cpp
+++ b/hphp/runtime/server/admin-request-handler.cpp
@@ -628,7 +628,7 @@ static bool send_report(Transport *transport, Writer::Format format,
   std::string out;
   ServerStats::Report(out, format, from, to, agg, keys, url, code, prefix);
 
-  transport->addHeader("Content-Type", mime);
+  transport->replaceHeader("Content-Type", mime);
   transport->sendString(out);
   return true;
 }
@@ -638,7 +638,7 @@ static bool send_status(Transport *transport, Writer::Format format,
   string out;
   ServerStats::ReportStatus(out, format);
 
-  transport->addHeader("Content-Type", mime);
+  transport->replaceHeader("Content-Type", mime);
   transport->sendString(out);
   return true;
 }
@@ -749,19 +749,19 @@ bool AdminRequestHandler::handleMemoryRequest(const std::string &cmd,
   std::string out;
   if (cmd == "memory.xml") {
       MemoryStats::GetInstance()->ReportMemory(out, Writer::Format::XML);
-      transport->addHeader("Content-Type","application/xml");
+      transport->replaceHeader("Content-Type","application/xml");
       transport->sendString(out);
       return true;
   }
   if (cmd == "memory.json") {
       MemoryStats::GetInstance()->ReportMemory(out, Writer::Format::JSON);
-      transport->addHeader("Content-Type","application/json");
+      transport->replaceHeader("Content-Type","application/json");
       transport->sendString(out);
       return true;
   }
   if (cmd == "memory.html" || cmd == "memory.htm") {
       MemoryStats::GetInstance()->ReportMemory(out, Writer::Format::XML);
-      transport->addHeader("Content-Type","application/html");
+      transport->replaceHeader("Content-Type","application/html");
       transport->sendString(out);
       return true;
   }
@@ -837,7 +837,7 @@ bool AdminRequestHandler::handleStatsRequest(const std::string &cmd,
           200) {
         xsl = response.data();
         if (!xsl.empty()) {
-          transport->addHeader("Content-Type", "application/xml");
+          transport->replaceHeader("Content-Type", "application/xml");
           transport->sendString(xsl);
           return true;
         }


### PR DESCRIPTION
Instead of setting multiple Content-Types, change the Content-Type to what is being returned.

This caused problems when fronting the admin server with Apache. For some commands it was fine (eg check-load) but for commands that returned html, xml or json Apache would return a 500 error and complain about 

```
FastCGI: comm with server "/hhvm-admin" aborted: error parsing headers: duplicate header 'Content-Type'
```

After using the fcgi CLI protocol to see what hhvm was sending back I noticed that HHVM would sometimes send back two content types: always text/plain followed by the actual content type, say application/json. After poking through the code I noticed that it seems to do just that: when an admin server request received it would set the Content-Type to text/plain and if the command returned some other content type it would set _another_ Content-Type header to the real Content-Type.

This patch changes that behavior to change the existing text/plain header to the real Content-Type instead of adding multiple Content-Type headers.
