### PR TITLE
Make HTTP status phrases optional with a fallback for known codes

### DIFF
--- a/hphp/runtime/ext/std/ext_std_network.cpp
+++ b/hphp/runtime/ext/std/ext_std_network.cpp
@@ -968,8 +968,7 @@ void HHVM_FUNCTION(header, const String& str, bool replace /* = true */,
       transport->addHeader(newHeader.empty() ? header : newHeader);
     }
     if (http_response_code) {
-      transport->setResponse(http_response_code,
-                             "explicit_header_response_code");
+      transport->setResponse(http_response_code);
     }
   }
 }
@@ -981,7 +980,7 @@ Variant HHVM_FUNCTION(http_response_code, int response_code /* = 0 */) {
   if (transport) {
     *s_response_code = transport->getResponseCode();
     if (response_code) {
-      transport->setResponse(response_code, "explicit_header_response_code");
+      transport->setResponse(response_code);
     }
   }
 

--- a/hphp/runtime/server/http-protocol.cpp
+++ b/hphp/runtime/server/http-protocol.cpp
@@ -872,6 +872,7 @@ void HttpProtocol::DecodeRfc1867(Transport *transport,
 }
 
 const char *HttpProtocol::GetReasonString(int code) {
+  // https://tools.ietf.org/html/rfc7231#section-6.1
   switch (code) {
   case 100: return "Continue";
   case 101: return "Switching Protocols";
@@ -882,7 +883,6 @@ const char *HttpProtocol::GetReasonString(int code) {
   case 204: return "No Content";
   case 205: return "Reset Content";
   case 206: return "Partial Content";
-  case 207: return "Multi-Status";
   case 300: return "Multiple Choices";
   case 301: return "Moved Permanently";
   case 302: return "Found";
@@ -898,24 +898,24 @@ const char *HttpProtocol::GetReasonString(int code) {
   case 405: return "Method Not Allowed";
   case 406: return "Not Acceptable";
   case 407: return "Proxy Authentication Required";
-  case 408: return "Request Time-out";
+  case 408: return "Request Timeout";
   case 409: return "Conflict";
   case 410: return "Gone";
   case 411: return "Length Required";
   case 412: return "Precondition Failed";
-  case 413: return "Request Entity Too Large";
-  case 414: return "Request-URI Too Large";
+  case 413: return "Payload Too Large";
+  case 414: return "URI Too Long";
   case 415: return "Unsupported Media Type";
-  case 416: return "Requested range not satisfiable";
+  case 416: return "Range Not Satisfiable";
   case 417: return "Expectation Failed";
   case 500: return "Internal Server Error";
   case 501: return "Not Implemented";
   case 502: return "Bad Gateway";
   case 503: return "Service Unavailable";
-  case 504: return "Gateway Time-out";
-  case 505: return "HTTP Version not supported";
+  case 504: return "Gateway Timeout";
+  case 505: return "HTTP Version Not Supported";
   }
-  return "Bad Response";
+  return "";
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/hphp/runtime/server/request-uri.cpp
+++ b/hphp/runtime/server/request-uri.cpp
@@ -165,7 +165,7 @@ bool RequestURI::rewriteURL(const VirtualHost *vhost, Transport *transport,
           m_rewrittenURL.substr(0, 8) != s_https) {
         PrependSlash(m_rewrittenURL);
       }
-      transport->redirect(m_rewrittenURL.c_str(), redirect, "rewriteURL");
+      transport->redirect(m_rewrittenURL.c_str(), redirect);
       return false;
     }
     splitURL(m_rewrittenURL, m_rewrittenURL, m_queryString);
@@ -195,7 +195,7 @@ bool RequestURI::rewriteURL(const VirtualHost *vhost, Transport *transport,
           m_rewrittenURL.substr(0, 8) != s_https) {
         PrependSlash(m_rewrittenURL);
       }
-      transport->redirect(m_rewrittenURL.c_str(), 301, "rewriteURL");
+      transport->redirect(m_rewrittenURL.c_str(), 301);
       return false;
     }
   }

--- a/hphp/runtime/server/transport.h
+++ b/hphp/runtime/server/transport.h
@@ -365,11 +365,7 @@ public:
   /**
    * Sending back a response.
    */
-  void setResponse(int code, const char *info) {
-    assert(code != 500 || (info && *info)); // must have a reason for a 500
-    m_responseCode = code;
-    m_responseCodeInfo = info ? info : "";
-  }
+  void setResponse(int code, const char *info = nullptr);
   const std::string &getResponseInfo() const { return m_responseCodeInfo; }
   bool headersSent() { return m_headerSent;}
   bool setHeaderCallback(const Variant& callback);
@@ -392,7 +388,7 @@ public:
     sendRaw((void*)data.c_str(), data.length(), code, compressed, chunked,
             codeInfo);
   }
-  void redirect(const char *location, int code, const char *info );
+  void redirect(const char *location, int code, const char *info = nullptr);
 
   // TODO: support rfc1867
   virtual bool isUploadedFile(const String& filename);


### PR DESCRIPTION
RFC 7231 defines status line as follows:
"The first line of a response message is the status-line, consisting
of the protocol version, a space, the status code, another
space, a possibly empty textual phrase describing the status code,
and ending with CRLF."
- This basically means response phrase is optional and may be omitted.
  In that case, fall back for default response phrase for known codes or
  empty string for others.
- Fix usage of explicit HTTP/\* header to set response phrase properly,
  if set.
- Also synchronize default phrases to match codes defined in RFC.

Closes #3907. Closes #3945. Partially reverts 93a6dc27c9.
