### PR TITLE
Build against bundled sqlite if version is bad

### DIFF
--- a/CMake/FindLibSQLite.cmake
+++ b/CMake/FindLibSQLite.cmake
@@ -8,25 +8,24 @@
 find_package(PkgConfig)
 pkg_check_modules(PC_SQLITE3 QUIET sqlite3)
 
-if (PC_SQLITE3_FOUND AND (PC_SQLITE3_VERSION VERSION_LESS "3.8.6" AND
-                          NOT (PC_SQLITE3_VERSION VERSION_LESS "3.8.4")))
+if (PC_SQLITE3_FOUND AND NOT (PC_SQLITE3_VERSION VERSION_LESS "3.8.0"))
   set(LIBSQLITE3_FOUND 0)
   set(LIBSQLITE3_INCLUDE_DIR "LIBSQLITE3_INCLUDE_DIR-NOTFOUND")
   set(LIBSQLITE3_LIBRARY "LIBSQLITE3_LIBRARY-NOTFOUND")
+  message(STATUS "Found non-working version of libsqlite3")
 else()
   find_path(LIBSQLITE3_INCLUDE_DIR
             NAMES sqlite3.h
             HINTS ${PC_SQLITE3_INCLUDE_DIRS})
 
-    find_library(LIBSQLITE3_LIBRARY
-                 NAMES sqlite3)
-endif (PC_SQLITE3_FOUND AND (PC_SQLITE3_VERSION VERSION_LESS "3.8.6" AND
-                             NOT (PC_SQLITE3_VERSION VERSION_LESS "3.8.4")))
+  find_library(LIBSQLITE3_LIBRARY
+            NAMES sqlite3)
+  include(FindPackageHandleStandardArgs)
+  FIND_PACKAGE_HANDLE_STANDARD_ARGS(LIBSQLITE3 DEFAULT_MSG
+                                    LIBSQLITE3_LIBRARY
+                                    LIBSQLITE3_INCLUDE_DIR)
 
-include(FindPackageHandleStandardArgs)
-FIND_PACKAGE_HANDLE_STANDARD_ARGS(
-    LIBSQLITE3 DEFAULT_MSG
-    LIBSQLITE3_LIBRARY LIBSQLITE3_INCLUDE_DIR)
+endif (PC_SQLITE3_FOUND AND NOT (PC_SQLITE3_VERSION VERSION_LESS "3.8.0"))
 
 if (NOT LIBSQLITE3_FOUND)
   message(STATUS "Using third-party bundled libsqlite3")


### PR DESCRIPTION
Running hhvm against sqlite 3.8.2 fails with:
'COMMIT;' --> (5) cannot commit transaction - SQL statements in progress

Without this patch the cmake scripts will use the bundled copy of sqlite
if 3.8.4 <= version < 3.8.6.  With this patch the range is now
3.8.2 <= version < 3.8.6 so hhvm will not try to run against sqlite 3.8.2.

Closes #3994
