### PR TITLE
backport PHP bugfix #55504

### DIFF
--- a/hphp/runtime/server/http-protocol.cpp
+++ b/hphp/runtime/server/http-protocol.cpp
@@ -846,7 +846,7 @@ bool HttpProtocol::IsRfc1867(const string contentType, string &boundary) {
     }
   } else {
     /* search for the end of the boundary */
-    e = strchr(s, ',');
+    e = strpbrk(s, ",;");
   }
   if (e) {
     e[0] = '\0';


### PR DESCRIPTION
We didn't look for the end of the boundary correctly.

See:
- https://github.com/php/php-src/commit/994df9f1d1bfd5f6e6b81f32161acc2812d260a7#diff-eb2caada78cc7ed9dbeabe07d25eecf4
- https://bugs.php.net/bug.php?id=55504
