### PR TITLE
backport PHP bugfix #43540

### DIFF
--- a/hphp/runtime/server/upload.cpp
+++ b/hphp/runtime/server/upload.cpp
@@ -800,7 +800,7 @@ void rfc1867PostHandler(Transport* transport,
         new_val_len = value_len;
         if (php_rfc1867_callback != nullptr) {
           multipart_event_formdata event_formdata;
-          size_t newlength = 0;
+          size_t newlength = new_val_len;
 
           event_formdata.post_bytes_processed = mbuff->read_post_bytes;
           event_formdata.name = param;


### PR DESCRIPTION
We need to properly set newlength.

See:
- https://github.com/php/php-src/commit/898ff10dc0f799ecf997cb3c64a96f2751884187
- https://bugs.php.net/bug.php?id=43540
