### PR TITLE
Port fixes for EXIF bugs from PHP

### DIFF
--- a/hphp/runtime/ext/gd/ext_gd.cpp
+++ b/hphp/runtime/ext/gd/ext_gd.cpp
@@ -6206,14 +6206,18 @@ static int exif_process_IFD_TAG(image_info_type *ImageInfo, char *dir_entry,
     offset_val = php_ifd_get32u(dir_entry+8, ImageInfo->motorola_intel);
     /* If its bigger than 4 bytes, the dir entry contains an offset. */
     value_ptr = offset_base+offset_val;
-    if (offset_val+byte_count > IFDlength || value_ptr < dir_entry) {
+    if (byte_count > IFDlength ||
+        offset_val > IFDlength-byte_count ||
+        value_ptr < dir_entry ||
+        offset_val < (size_t)(dir_entry-offset_base)) {
       /*
       // It is important to check for IMAGE_FILETYPE_TIFF
       // JPEG does not use absolute pointers instead
       // its pointers are relative to the start
       // of the TIFF header in APP1 section.
       */
-      if (offset_val+byte_count>ImageInfo->FileSize ||
+      if (byte_count > ImageInfo->FileSize ||
+          offset_val>ImageInfo->FileSize-byte_count ||
           (ImageInfo->FileType!=IMAGE_FILETYPE_TIFF_II &&
            ImageInfo->FileType!=IMAGE_FILETYPE_TIFF_MM &&
            ImageInfo->FileType!=IMAGE_FILETYPE_JPEG)) {


### PR DESCRIPTION
Official fixes PHP bugs 60150 and 65873, plus extra line breaks. This is
just to be prudent, I haven't found an actual security vulnerability in
HHVM. In the case of 65873, reproduction depends on allocator details,
and HHVM's allocator is probably not vulnerable at present.

Submitted on behalf of a third-party: The PHP Group
Source: http://svn.php.net/viewvc/?view=revision&revision=319534
Source: https://github.com/php/php-src/commit/cbcf6e1880e35ed7cd052e127b037eee7cef61c9
License: version 3.01 of the PHP license

Closes: #1154
