### PR TITLE
Hooked stream_metadata(..) with chown(..).

### DIFF
--- a/hphp/runtime/base/user-file.cpp
+++ b/hphp/runtime/base/user-file.cpp
@@ -518,5 +518,39 @@ bool UserFile::touch(const String& path, int64_t mtime, int64_t atime) {
   return false;
 }
 
+bool UserFile::chown(const String& path, const Variant& user) {
+  bool invoked = false;
+  Variant ret;
+  PackedArrayInit init(3);
+  init.append(path);
+  if (user.isString()) {
+    init
+      .append(2) // STREAM_META_OWNER_NAME
+      .append(user.toString());
+    ret = invoke(
+      m_StreamMetadata,
+      s_stream_metadata,
+      init.toArray(),
+      invoked
+    );
+  } else {
+    init
+      .append(3) // STREAM_META_OWNER
+      .append(user.toInt32());
+    ret = invoke(
+      m_StreamMetadata,
+      s_stream_metadata,
+      init.toArray(),
+      invoked
+    );
+  }
+  if (invoked && ret.toBoolean() == true) {
+    return true;
+  }
+
+  raise_warning("\"%s::chown\" call failed", m_cls->name()->data());
+  return false;
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 }

--- a/hphp/runtime/base/user-file.h
+++ b/hphp/runtime/base/user-file.h
@@ -62,6 +62,7 @@ public:
   bool mkdir(const String& path, int mode, int options);
   bool rmdir(const String& path, int options);
   bool touch(const String& path, int64_t mtime, int64_t atime);
+  bool chown(const String& path, const Variant& user);
 
 private:
   int urlStat(const String& path, struct stat* stat_sb, int flags = 0);

--- a/hphp/runtime/base/user-stream-wrapper.cpp
+++ b/hphp/runtime/base/user-stream-wrapper.cpp
@@ -92,11 +92,20 @@ Directory* UserStreamWrapper::opendir(const String& path) {
   return dir;
 }
 
+///////////////////////////////////////////////////////////////////////////////
+// non-generic functions
+
 bool UserStreamWrapper::touch(const String& path,
                               int64_t mtime, int64_t atime) {
   auto file = NEWOBJ(UserFile)(m_cls);
   Resource wrapper(file);
   return file->touch(path, mtime, atime);
+}
+
+bool UserStreamWrapper::chown(const String& path, const Variant& user) {
+  auto file = NEWOBJ(UserFile)(m_cls);
+  Resource wrapper(file);
+  return file->chown(path, user);
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/hphp/runtime/base/user-stream-wrapper.h
+++ b/hphp/runtime/base/user-stream-wrapper.h
@@ -39,6 +39,7 @@ struct UserStreamWrapper final : Stream::Wrapper {
   int rmdir(const String& path, int options) override;
   Directory* opendir(const String& path) override;
   bool touch(const String& path, int64_t mtime, int64_t atime);
+  bool chown(const String& path, const Variant& user);
 
 private:
   String m_name;

--- a/hphp/runtime/ext/ext_file.cpp
+++ b/hphp/runtime/ext/ext_file.cpp
@@ -1124,6 +1124,13 @@ static int get_uid(const Variant& user) {
 
 bool f_chown(const String& filename, const Variant& user) {
   CHECK_PATH_FALSE(filename, 1);
+
+  Stream::Wrapper* w = Stream::getWrapperFromURI(filename);
+  auto usw = dynamic_cast<UserStreamWrapper*>(w);
+  if (usw != nullptr) {
+    return usw->chown(filename, user);
+  }
+
   int uid = get_uid(user);
   if (uid == 0) return false;
   CHECK_SYSTEM(chown(File::TranslatePath(filename).data(), uid, (gid_t)-1));

--- a/hphp/test/frameworks/results/vfsstream.expect
+++ b/hphp/test/frameworks/results/vfsstream.expect
@@ -629,7 +629,7 @@ org\bovigo\vfs\vfsStreamWrapperTestCase::chmod
 org\bovigo\vfs\vfsStreamWrapperTestCase::chmodModifiesPermissions
 F
 org\bovigo\vfs\vfsStreamWrapperTestCase::chownChangesUser
-F
+.
 org\bovigo\vfs\vfsStreamWrapperTestCase::chownDoesNotWorkOnVfsStreamUrls
 .
 org\bovigo\vfs\vfsStreamWrapperTestCase::directoriesAndNonExistingFilesAreNeverExecutable


### PR DESCRIPTION
Part of #3687. So far, only chown(..) in user-stream-wrapper has been hooked with stream_metadata(..) function. Similar to commit 1f55a08.

Also passes vfsStream's chownChangesUser test case.
