### PR TITLE
Fix a crash in nested file functions

### DIFF
--- a/hphp/runtime/base/execution-context.cpp
+++ b/hphp/runtime/base/execution-context.cpp
@@ -700,7 +700,7 @@ void ExecutionContext::handleError(const std::string& msg,
         }
         tvDup(*tvFrom, *tvTo);
       } else if (fp->hasVarEnv()) {
-        g_context->setVar(s_php_errormsg.get(), tvFrom);
+        fp->getVarEnv()->set(s_php_errormsg.get(), tvFrom);
       }
     }
 

--- a/hphp/runtime/base/url-file.cpp
+++ b/hphp/runtime/base/url-file.cpp
@@ -124,8 +124,8 @@ bool UrlFile::open(const String& input_url, const String& mode) {
     }
     tvDup(*tvFrom, *tvTo);
   } else if (fp->hasVarEnv()) {
-    g_context->setVar(s_http_response_header.get(),
-                      Variant(m_responseHeaders).asTypedValue());
+    fp->getVarEnv()->set(s_http_response_header.get(),
+                         Variant(m_responseHeaders).asTypedValue());
   }
 
   /*


### PR DESCRIPTION
Summary: UrlFile functions correctly chased through multiple actrecs
to find the callsite. ExecutionContext::setVar only went one deep.

The result was that the example crashed because it tried to set a
variable in a frame that didn't have a VarEnv.

Reviewed By: @swtaarrs

Differential Revision: D1614350
