### PR TITLE
Fix PCRE cache, and related code cleanup

### DIFF
--- a/hphp/runtime/base/program-functions.cpp
+++ b/hphp/runtime/base/program-functions.cpp
@@ -124,7 +124,6 @@ void timezone_init();
 
 void pcre_init();
 void pcre_reinit();
-void pcre_session_exit();
 
 ///////////////////////////////////////////////////////////////////////////////
 // helpers
@@ -1893,9 +1892,6 @@ void hphp_session_exit() {
 
   {
     ServerStatsHelper ssh("rollback");
-
-    // Clean up pcre state at the end of the request.
-    pcre_session_exit();
 
     hphp_memory_cleanup();
     // Do any post-sweep cleanup necessary for global variables

--- a/hphp/runtime/ext/pcre/ext_pcre.cpp
+++ b/hphp/runtime/ext/pcre/ext_pcre.cpp
@@ -172,7 +172,7 @@ String HHVM_FUNCTION(sql_regcase, const String& str) {
 
 const StaticString s_PCRE_VERSION("PCRE_VERSION");
 
-extern IMPLEMENT_THREAD_LOCAL(PCREglobals, s_pcre_globals);
+extern IMPLEMENT_THREAD_LOCAL(PCREglobals, tl_pcre_globals);
 
 class PcreExtension : public Extension {
 public:
@@ -234,11 +234,11 @@ public:
     IniSetting::Bind(this, IniSetting::PHP_INI_ALL,
                      "pcre.backtrack_limit",
                      std::to_string(RuntimeOption::PregBacktraceLimit).c_str(),
-                     &s_pcre_globals->m_preg_backtrace_limit);
+                     &tl_pcre_globals->m_preg_backtrace_limit);
     IniSetting::Bind(this, IniSetting::PHP_INI_ALL,
                      "pcre.recursion_limit",
                      std::to_string(RuntimeOption::PregRecursionLimit).c_str(),
-                     &s_pcre_globals->m_preg_recursion_limit);
+                     &tl_pcre_globals->m_preg_recursion_limit);
   }
 
 } s_pcre_extension;


### PR DESCRIPTION
When the PCRE cache fills up, memory is leaked since the static string created by insert_cached_pcre() cannot be freed. Also, queueing cached
regexes for deletion on request termination is not good policy -- it is effectively a memory leak for long-running scripts.

Also, when the PCRE cache is full, new regexes need to be recompiled on
every call to preg_match() etc. so the performance of an app using
dynamically-generated regex strings will degrade once the limit is
reached.

So:
- Introduce a thread-local PCRE cache with LRU eviction, used alongside
  the existing cache.
- Do not place an entry in the shared cache unless the input text is a
  static string. This prevents pollution of the shared cache with
  regexes derived from user input.
- If the shared cache is full, or if the regex text is non-static, store
  the pcre object in the local cache.
- Use reference counting for local cache entries so that recursive code
  which requires more than 1024 regexes to be active at a given time
  will not crash. But for entries in the shared cache, do not update the
  reference count, to avoid degrading performance due bus activity.
- Retain the thread-local cache beyond the end of the request. This is
  basically the same as the way Zend manages its PCRE cache, and should
  reduce startup overhead.
- Remove m_overflow and associated functions.
- Make the "bump" regex a static string so that its regex will be
  shared.

Also:
- Use tl_ prefix for thread-local variables, per convention.
- Fix a race condition in get_subpat_names() which would have caused
  occasional incorrect match results and memory leakage. Build the array
  in a temporary variable and then atomically swap it in to the shared
  entry, instead of overwriting the shared pointer and then
  progressively building the array while the cache is in a broken state.
- Note that "const pcre_cache_entry_" becomes non-const
  pcre_cache_entry_ptr in a few places, since "const SmartPtr" would be
  equivalent to "pcre_cache_entry const_". There's no equivalent for
  a non-const SmartPtr which wraps a const.
