### PR TITLE
Fix for wrong PATH_INFO and PATH_TRANSLATED (maybe)

### DIFF
--- a/hphp/runtime/server/fastcgi/fastcgi-transport.cpp
+++ b/hphp/runtime/server/fastcgi/fastcgi-transport.cpp
@@ -68,6 +68,10 @@ const std::string FastCGITransport::getPathInfo() {
   return m_pathInfo;
 }
 
+bool FastCGITransport::isPathInfoSet() {
+  return m_pathInfoSet;
+}
+
 const std::string FastCGITransport::getDocumentRoot() {
   return m_documentRoot;
 }
@@ -411,6 +415,9 @@ void FastCGITransport::onHeadersComplete() {
   m_serverObject = getRawHeader(s_scriptName);
   m_scriptFilename = getRawHeader(s_scriptFilename);
   m_pathTranslated = getRawHeader(s_pathTranslated);
+  if (getRawHeaderPtr(s_pathInfo) != nullptr) {
+    m_pathInfoSet = true;
+  }
   m_pathInfo = getRawHeader(s_pathInfo);
   m_documentRoot = getRawHeader(s_documentRoot);
   if (!m_documentRoot.empty() &&

--- a/hphp/runtime/server/fastcgi/fastcgi-transport.h
+++ b/hphp/runtime/server/fastcgi/fastcgi-transport.h
@@ -57,6 +57,7 @@ public:
   virtual const std::string getScriptFilename() override;
   virtual const std::string getPathTranslated() override;
   virtual const std::string getPathInfo() override;
+  virtual bool isPathInfoSet() override;
   virtual const std::string getDocumentRoot() override;
   virtual const char *getServerName() override;
   virtual const char *getServerAddr() override;
@@ -123,6 +124,7 @@ private:
   std::unordered_map<std::string, std::string> m_requestHeaders;
   std::string m_scriptFilename;
   std::string m_pathTranslated;
+  bool m_pathInfoSet = false;
   std::string m_requestURI;
   std::string m_documentRoot;
   std::string m_remoteHost;

--- a/hphp/runtime/server/request-uri.cpp
+++ b/hphp/runtime/server/request-uri.cpp
@@ -80,11 +80,20 @@ bool RequestURI::process(const VirtualHost *vhost, Transport *transport,
     if (!resolveURL(vhost, pathTranslation, sourceRoot)) {
       return false;
     }
-    if (!m_origPathInfo.empty() &&
-        m_origPathInfo.charAt(0) != '/') {
-      m_origPathInfo = "/" + m_origPathInfo;
+    if (m_origPathInfo.empty()) {
+      // PATH_INFO wasn't filled by resolveURL() because m_originalURL
+      // didn't contain it. We set it now, based on PATH_TRANSLATED.
+      m_origPathInfo = transport->getPathTranslated();
+      if (!m_origPathInfo.empty() &&
+          m_origPathInfo.charAt(0) != '/') {
+        m_origPathInfo = "/" + m_origPathInfo;
+      }
     }
-    m_pathInfo = transport->getPathInfo();
+    if (transport->isPathInfoSet()) {
+      m_pathInfo =transport->getPathInfo();
+    } else {
+      m_pathInfo = m_origPathInfo;
+    }
     return true;
   }
 

--- a/hphp/runtime/server/transport.h
+++ b/hphp/runtime/server/transport.h
@@ -127,6 +127,7 @@ public:
   virtual const std::string getScriptFilename() { return ""; }
   virtual const std::string getPathTranslated() { return ""; }
   virtual const std::string getPathInfo() { return ""; }
+  virtual bool isPathInfoSet() {return false; }
 
   /**
    * Server Headers


### PR DESCRIPTION
This might be a fix for #4048. If I didn't miss anything, the fastcgi variable PATH_INFO was not even read before.

This works for my setup (nginx + standard hhvm.conf) but I am not sure if just using the variables fastcgi provides is always the right way.

Any feedback is appreciated.
