### PR TITLE
Fixed soap memory leak

### DIFF
--- a/hphp/runtime/ext/soap/soap.cpp
+++ b/hphp/runtime/ext/soap/soap.cpp
@@ -60,7 +60,7 @@ sdl *SoapData::get_sdl(const char *uri, long cache_wsdl,
   if (sdl) {
     // holding it for the entire request life time, so soapserver and
     // soapclient can use sdl* without being deleted
-    m_sdls.push_back(sdl);
+    m_sdls.insert(sdl);
     return sdl.get();
   }
   return NULL;
@@ -70,7 +70,7 @@ encodeMap *SoapData::register_typemap(encodeMapPtr typemap) {
   if (typemap) {
     // holding it for the entire request life time, so soapserver and
     // soapclient can use encodeMap* without being deleted
-    m_typemaps.push_back(typemap);
+    m_typemaps.insert(typemap);
     return typemap.get();
   }
   return NULL;
@@ -78,7 +78,7 @@ encodeMap *SoapData::register_typemap(encodeMapPtr typemap) {
 
 void SoapData::register_encoding(xmlCharEncodingHandlerPtr encoding) {
   if (encoding) {
-    m_encodings.push_back(encoding);
+    m_encodings.insert(encoding);
   }
 }
 
@@ -130,8 +130,8 @@ void SoapData::reset() {
   m_sdls.clear();
   m_typemaps.clear();
 
-  for (unsigned int i = 0; i < m_encodings.size(); i++) {
-    xmlCharEncCloseFunc(m_encodings[i]);
+  for (auto itr = m_encodings.begin(); itr != m_encodings.end(); ++itr) {
+    xmlCharEncCloseFunc(*itr);
   }
   m_encodings.clear();
 }

--- a/hphp/runtime/ext/soap/soap.h
+++ b/hphp/runtime/ext/soap/soap.h
@@ -131,9 +131,9 @@ public:
   virtual void requestShutdown() { reset();}
 
 private:
-  std::vector<sdlPtr> m_sdls;
-  std::vector<encodeMapPtr> m_typemaps;
-  std::vector<xmlCharEncodingHandlerPtr> m_encodings;
+  hphp_hash_set<sdlPtr> m_sdls;
+  hphp_hash_set<encodeMapPtr> m_typemaps;
+  hphp_hash_set<xmlCharEncodingHandlerPtr> m_encodings;
 
   sdlPtr get_sdl_impl(const char *uri, long cache_wsdl, HttpClient *http);
   void reset();


### PR DESCRIPTION
Uses unordered_sets instead of vectors for SoapData collections m_sdls, m_typemaps, and m_encodings. This way when the same pointer is added to the collection multiple times, the collection doesn't unnecessarily consume memory.

Closes #2828.
