### PR TITLE
Runtime: raise strict warning when non static method is called statically

### DIFF
--- a/hphp/runtime/base/strings.h
+++ b/hphp/runtime/base/strings.h
@@ -42,6 +42,8 @@ const char* const CANT_ACCESS_PARENT_WHEN_NO_PARENT =
   "Cannot access parent:: when current class scope has no parent";
 const char* const CANT_ACCESS_STATIC =
   "Cannot access static:: when no class scope is active";
+const char* const METHOD_SHOULD_NOT_BE_CALLED_STATICALLY =
+  "Non-static method %s::%s() should not be called statically";
 const char* const UNDEFINED_INDEX =
   "Undefined index: %s";
 const char* const CANNOT_USE_SCALAR_AS_ARRAY =

--- a/hphp/runtime/vm/bytecode.cpp
+++ b/hphp/runtime/vm/bytecode.cpp
@@ -1120,6 +1120,11 @@ ExecutionContext::lookupClsMethod(const Func*& f,
   if (obj && !(f->attrs() & AttrStatic) && obj->instanceof(cls)) {
     return LookupResult::MethodFoundWithThis;
   }
+  if (!obj && !(f->attrs() & AttrStatic)) {
+    raise_strict_warning(Strings::METHOD_SHOULD_NOT_BE_CALLED_STATICALLY,
+      cls->name()->data(),
+      f->name()->data());
+  }
   return LookupResult::MethodFoundNoThis;
 }
 

--- a/hphp/test/slow/static_statement/1411.php
+++ b/hphp/test/slow/static_statement/1411.php
@@ -1,0 +1,15 @@
+<?php
+
+error_reporting(-1);
+
+class Foo {
+  function get() {
+    return "bar";
+  }
+}
+
+echo Foo::get();
+
+function no_called() {
+    Foo::get();
+}

--- a/hphp/test/slow/static_statement/1411.php.expectf
+++ b/hphp/test/slow/static_statement/1411.php.expectf
@@ -1,0 +1,3 @@
+
+Strict Warning: Non-static method Foo::get() should not be called statically in %s on line 11
+bar


### PR DESCRIPTION
Aims to close #3193
