### PR TITLE
Fixed xpath's php:functionString

### DIFF
--- a/hphp/runtime/ext/domdocument/ext_domdocument.cpp
+++ b/hphp/runtime/ext/domdocument/ext_domdocument.cpp
@@ -1261,6 +1261,7 @@ static Variant php_xpath_eval(DOMXPath* domxpath, const String& expr,
   }
   ctxp->namespaces = ns;
   ctxp->nsNr = nsnbr;
+  CallerFrame cf;
   xpathobjp = xmlXPathEvalExpression((xmlChar*)expr.data(), ctxp);
   ctxp->node = nullptr;
   if (ns != nullptr) {
@@ -5490,7 +5491,7 @@ static void dom_xpath_ext_function_php(xmlXPathParserContextPtr ctxt,
       arg = String((char *)xmlXPathCastToString(obj), CopyString);
     }
     xmlXPathFreeObject(obj);
-    args.set(i, arg);
+    args.prepend(arg);
   }
 
   obj = valuePop(ctxt);


### PR DESCRIPTION
Added CallerFrame before dom_xpath_ext_function_php's call to xmlXPathEvalExpression in case libxml2 needs to call back into HHVM. 
The xpath query might contain `php:functionString` which triggers a call to any arbitrary php function.

Also fixed a bug where the arguments in an xpath php:functionString were reversed. For example, if the xpath was `/foo[php:functionString('preg_match', '{$regex}', @bar)]`, preg_match was being called as `preg_match($bar, $regex)` instead of `preg_match($regex, $bar)`.
