### PR TITLE
Fix CRLF handling when they are split over input chunk buffers

### DIFF
--- a/hphp/runtime/base/file.cpp
+++ b/hphp/runtime/base/file.cpp
@@ -560,22 +560,24 @@ String File::readLine(int64_t maxlen /* = 0 */) {
       bool done = false;
 
       char *readptr = m_buffer + m_readpos;
-      const char *eol;
+      const char *eol = 0;
       const char *cr;
       const char *lf;
       cr = (const char *)memchr(readptr, '\r', avail);
       lf = (const char *)memchr(readptr, '\n', avail);
-      if (cr && lf != cr + 1 && !(lf && lf < cr)) {
+      if (eol && (readptr != lf)) {
+        break;
+      } else if (cr && lf != cr + 1 && !(lf && lf < cr)) {
         /* mac */
         eol = cr;
       } else if ((cr && lf && cr == lf - 1) || (lf)) {
-        /* dos or unix endings */
+        /* dos or unix endings. Possible LF for CR at end of previous buffer */
         eol = lf;
       } else {
         eol = cr;
       }
 
-      if (eol) {
+      if (eol && ((eol != cr) || (eol != (m_buffer + CHUNK_SIZE - 1)))) {
         cpysz = eol - readptr + 1;
         done = true;
       } else {


### PR DESCRIPTION
This has been identified before in a couple of issues "readLine improperly handles crlf" (#1658) and "Respect auto_detect_line_endings ini setting" (#2897).

In both cases it was not a direct report of the problem (one moved it to HHVM Redis, the other to `auto_detect_line_endings` configuration). We have also run into this issue (using `Predis`), but we also see it in general file handling due to inconsistent line counts between PHP/HHVM.

The problem stems from HHVM having a bug in file handling when reading CR/LF terminated lines, in this case when using `fgets()`.

It appears this function chunks in 8K reads, looking for CR and/or LF combinations. However, there is an edge case where the 8K chunk can split the CR/LF character combination, such that it delivers the line ending in CR, then delivers the next line as the single LF. For us, this breaks `Predis`, but also causes incorrect line counts.

To reproduce, create a file of "L\r\n" lines only using the following file writer code. The line length must be odd to cause the CR/LF to cross the HHVM read chunk boundary:

``` PHP
<?php

for($i = 0; $i < 4000; $i++) {
    echo "L\r\n";
}
```

To see the error, run the file reader code:

``` PHP
<?php

$c = 0;

while(($r = fgets(STDIN)) !== false) {
    if(substr($r, -2) != "\r\n") {
        echo 'Fail: line count=' . $c . PHP_EOL;
        exit(0);
    }
    $c++;
}

echo 'Success: line count=' . $c . PHP_EOL;
```

A sample run using PHP and HHVM:

```
[vantage@system hhvm]$ php fw.php >fcrlf
[vantage@system hhvm]$ php fr.php <fcrlf
Success: line count=4000
[vantage@system hhvm]$ hhvm --version
HipHop VM 3.3.1 (rel)
Compiler: heads/HHVM-3.3-0-g70b1468524cfe6009e8bc05397ccb39416bc9126
Repo schema: 2122fff12bba8fabfa50b88ee6ce227c3f179f66
Extension API: 20140829
[vantage@system hhvm]$ hhvm fr.php <fcrlf
Fail: line count=2730
[vantage@system hhvm]$
```
