### PR TITLE
Change mkdir() / rmdir() / unlink() raise warning behavior.

### DIFF
--- a/hphp/runtime/base/file-stream-wrapper.cpp
+++ b/hphp/runtime/base/file-stream-wrapper.cpp
@@ -101,9 +101,12 @@ int FileStreamWrapper::rename(const String& oldname, const String& newname) {
 }
 
 int FileStreamWrapper::mkdir(const String& path, int mode, int options) {
-  if (options & k_STREAM_MKDIR_RECURSIVE)
-    return mkdir_recursive(path, mode);
-  return ::mkdir(File::TranslatePath(path).data(), mode);
+  if (options & k_STREAM_MKDIR_RECURSIVE) {
+    ERROR_RAISE_WARNING(mkdir_recursive(path, mode));
+    return ret;
+  }
+  ERROR_RAISE_WARNING(::mkdir(File::TranslatePath(path).data(), mode));
+  return ret;
 }
 
 int FileStreamWrapper::mkdir_recursive(const String& path, int mode) {

--- a/hphp/runtime/base/file-stream-wrapper.h
+++ b/hphp/runtime/base/file-stream-wrapper.h
@@ -25,6 +25,17 @@
 #include "hphp/runtime/base/file.h"
 #include "hphp/runtime/base/mem-file.h"
 #include "hphp/runtime/base/stream-wrapper.h"
+#include "folly/String.h"
+
+#define ERROR_RAISE_WARNING(exp)        \
+  int ret = (exp);                      \
+  if (ret != 0) {                       \
+    raise_warning(                      \
+      "%s(): %s",                       \
+      __FUNCTION__,                     \
+      folly::errnoStr(errno).c_str()    \
+    );                                  \
+  }                                     \
 
 namespace HPHP {
 ///////////////////////////////////////////////////////////////////////////////
@@ -46,12 +57,22 @@ class FileStreamWrapper : public Stream::Wrapper {
     return ::lstat(File::TranslatePath(path).data(), buf);
   }
   virtual int unlink(const String& path) {
-    return ::unlink(File::TranslatePath(path).data());
+    int ret = ::unlink(File::TranslatePath(path).data());
+    if (ret != 0) {
+      raise_warning(
+        "%s(%s): %s",
+        __FUNCTION__,
+        path.c_str(),
+        folly::errnoStr(errno).c_str()
+      );
+    }
+    return ret;
   }
   virtual int rename(const String& oldname, const String& newname);
   virtual int mkdir(const String& path, int mode, int options);
   virtual int rmdir(const String& path, int options) {
-    return ::rmdir(File::TranslatePath(path).data());
+    ERROR_RAISE_WARNING(::rmdir(File::TranslatePath(path).data()));
+    return ret;
   }
 
   virtual Directory* opendir(const String& path);

--- a/hphp/runtime/ext/std/ext_std_file.cpp
+++ b/hphp/runtime/ext/std/ext_std_file.cpp
@@ -1520,19 +1520,6 @@ bool HHVM_FUNCTION(unlink,
   CHECK_PATH_FALSE(filename, 1);
   Stream::Wrapper* w = Stream::getWrapperFromURI(filename);
   if (!w) return false;
-  auto fsw = dynamic_cast<FileStreamWrapper*>(w);
-  if (fsw != nullptr) {
-    if (w->unlink(filename) != 0) {
-      raise_warning(
-        "%s(%s): %s",
-         __FUNCTION__ + 2,
-         filename.c_str(),
-         folly::errnoStr(errno).c_str()
-      );
-      return false;
-    }
-    return true;
-  }
   CHECK_SYSTEM_SILENT(w->unlink(filename));
   return true;
 }
@@ -1736,11 +1723,6 @@ bool HHVM_FUNCTION(mkdir,
   Stream::Wrapper* w = Stream::getWrapperFromURI(pathname);
   if (!w) return false;
   int options = recursive ? k_STREAM_MKDIR_RECURSIVE : 0;
-  auto fsw = dynamic_cast<FileStreamWrapper*>(w);
-  if (fsw != nullptr) {
-    CHECK_SYSTEM(fsw->mkdir(pathname, mode, options));
-    return true;
-  }
   CHECK_SYSTEM_SILENT(w->mkdir(pathname, mode, options));
   return true;
 }
@@ -1751,11 +1733,6 @@ bool HHVM_FUNCTION(rmdir,
   Stream::Wrapper* w = Stream::getWrapperFromURI(dirname);
   if (!w) return false;
   int options = 0;
-  auto fsw = dynamic_cast<FileStreamWrapper*>(w);
-  if (fsw != nullptr) {
-    CHECK_SYSTEM(w->rmdir(dirname, options));
-    return true;
-  }
   CHECK_SYSTEM_SILENT(w->rmdir(dirname, options));
   return true;
 }


### PR DESCRIPTION
According to PHP5, mkdir() / rmdir() / unlink() raises warning only if dealing with plain files.

Fixed vfsstream framework test regressions.
