### PR TITLE
http streams: only split headers into two pieces

### DIFF
--- a/hphp/runtime/base/http-stream-wrapper.cpp
+++ b/hphp/runtime/base/http-stream-wrapper.cpp
@@ -76,7 +76,7 @@ File* HttpStreamWrapper::open(const String& filename, const String& mode,
 
       for (ArrayIter it(lines); it; ++it) {
         Array parts = StringUtil::Explode(
-          it.second().toString(), ":").toArray();
+          it.second().toString(), ":", 2).toArray();
         headers.set(parts.rvalAt(0), parts.rvalAt(1));
       }
     }


### PR DESCRIPTION
Limit header explosions to two pieces to avoid truncating header data containing colons.
