### PR TITLE
fix ubuntu 12.04 compilation error on clientCheck.ml

### DIFF
--- a/hphp/hack/src/client/clientCheck.ml
+++ b/hphp/hack/src/client/clientCheck.ml
@@ -263,11 +263,9 @@ let rec main args retries =
         Unix.sleep(3);
         main args (retries-1)
       end else begin
-        Printf.fprintf stderr begin
-          if args.autostart
-          then "The server will be ready in a few seconds (a couple of minutes if your files are cold)!\n"
-          else "Error: no hh_server running. Either start hh_server yourself or run hh_client without --autostart-server false\n%!"
-        end;
+        if args.autostart
+        then Printf.fprintf stderr "The server will be ready in a few seconds (a couple of minutes if your files are cold)!\n"
+        else Printf.fprintf stderr "Error: no hh_server running. Either start hh_server yourself or run hh_client without --autostart-server false\n%!";
         flush stderr;
         exit 6;
       end


### PR DESCRIPTION
```
Linking CXX static library libhphp_analysis.a
[ 39%] Built target hphp_analysis
File "clientCheck.ml", line 266, characters 30-314:
Error: This expression has type string but an expression was expected of type
         ('a, out_channel, unit) format =
           ('a, out_channel, unit, unit, unit, unit) format6
make[5]: *** [clientCheck.cmx] Error 2
make[4]: *** [rec.opt] Error 1
make[3]: *** [opt] Error 2
make[2]: *** [hphp/hack/CMakeFiles/hack] Error 2
make[1]: *** [hphp/hack/CMakeFiles/hack.dir/all] Error 2
make: *** [all] Error 2
```
