### PR TITLE
Fix fribidi dependency includes

### DIFF
--- a/CMake/FindGLIB.cmake
+++ b/CMake/FindGLIB.cmake
@@ -1,0 +1,14 @@
+find_path(GLIB_INCLUDE_DIR
+          NAMES "glib.h"
+          PATHS "/usr/include" "/usr/local/include"
+          PATH_SUFFIXES "glib-2.0")
+find_path(GLIB_CONFIG_INCLUDE_DIR
+          NAMES "glibconfig.h"
+          PATHS "/usr/lib" "/usr/local/lib"
+          PATH_SUFFIXES "glib-2.0/include")
+include(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(GLIB DEFAULT_MSG
+                                  GLIB_INCLUDE_DIR
+                                  GLIB_CONFIG_INCLUDE_DIR)
+mark_as_advanced(GLIB_INCLUDE_DIR
+                 GLIB_CONFIG_INCLUDE_DIR)

--- a/hphp/runtime/ext/fribidi/config.cmake
+++ b/hphp/runtime/ext/fribidi/config.cmake
@@ -1,8 +1,12 @@
 find_package(fribidi 0.19.6)
-
-if (FRIBIDI_LIBRARY)
-  HHVM_EXTENSION(fribidi ext_fribidi.cpp)
-  HHVM_ADD_INCLUDES(fribidi ${FRIBIDI_INCLUDE_DIR})
-  HHVM_LINK_LIBRARIES(fribidi ${FRIBIDI_LIBRARY})
-  HHVM_SYSTEMLIB(fribidi ext_fribidi.php)
+if (FRIBIDI_FOUND)
+  find_package(GLIB)
+  if (GLIB_FOUND)
+    HHVM_EXTENSION(fribidi ext_fribidi.cpp)
+    HHVM_ADD_INCLUDES(fribidi ${FRIBIDI_INCLUDE_DIR}
+                              ${GLIB_INCLUDE_DIR}
+                              ${GLIB_CONFIG_INCLUDE_DIR})
+    HHVM_LINK_LIBRARIES(fribidi ${FRIBIDI_LIBRARY})
+    HHVM_SYSTEMLIB(fribidi ext_fribidi.php)
+  endif()
 endif()


### PR DESCRIPTION
Fribidi depends on glib, but we're not adding the header file include dirs into our paths.  This makes cmake find glib for us.  Without this, the build fails to find glib.h (on gentoo) and halts.
