### PR TITLE
Admin server: add /jemalloc-proc-status command

### DIFF
--- a/hphp/runtime/server/admin-request-handler.cpp
+++ b/hphp/runtime/server/admin-request-handler.cpp
@@ -265,6 +265,8 @@ void AdminRequestHandler::handleRequest(Transport *transport) {
               "/jemalloc-prof-dump:\n"
               "                  dump heap profile\n"
               "    file          optional, filesystem path\n"
+              "/jemalloc-prof-status:\n"
+              "                  report heap profiling status\n"
               "/jemalloc-prof-request:\n"
               "                  dump thread-local heap profile in\n"
               "                  the next request that runs\n"
@@ -607,6 +609,24 @@ void AdminRequestHandler::handleRequest(Transport *transport) {
           transport->sendString(estr.str());
         } else {
           transport->sendString("OK\n");
+        }
+        break;
+      }
+      if (cmd == "jemalloc-prof-status") {
+        bool active = false;
+        size_t activeSize = sizeof(active);
+        int err = 0;
+        err = mallctl("opt.prof", &active, &activeSize, nullptr, 0);
+        if (active && err == 0) {
+            err = mallctl("prof.active", &active, &activeSize, nullptr, 0);
+        }
+        if (err != 0) {
+          std::ostringstream estr;
+          estr << "Error " << err << " in mallctl(...)"
+            << endl;
+          transport->sendString(estr.str());
+        } else {
+          transport->sendString(active ? "ACTIVE\n" : "DISABLED\n");
         }
         break;
       }


### PR DESCRIPTION
Turning on jemalloc's heap profiling can substantially impact speed and
stability. If it can be toggled on and off at runtime, its state ought to be
queryable at runtime too. Sample use-case: alerting for servers that have heap
profiling turned on.
