### PR TITLE
implement custom propEmpty logic for SimpleXML

### DIFF
--- a/hphp/runtime/base/object-data.cpp
+++ b/hphp/runtime/base/object-data.cpp
@@ -1420,7 +1420,7 @@ bool ObjectData::propIsset(Class* ctx, const StringData* key) {
   return tv.m_data.num;
 }
 
-bool ObjectData::propEmpty(Class* ctx, const StringData* key) {
+bool ObjectData::propEmptyImpl(Class* ctx, const StringData* key) {
   bool visible, accessible, unset;
   auto propVal = getProp(ctx, key, visible, accessible, unset);
   if (visible && accessible && !unset) {
@@ -1443,6 +1443,15 @@ bool ObjectData::propEmpty(Class* ctx, const StringData* key) {
     }
   }
   return false;
+}
+
+bool ObjectData::propEmpty(Class* ctx, const StringData* key) {
+  if (UNLIKELY(getAttribute(HasPropEmpty))) {
+    if (instanceof(c_SimpleXMLElement::classof())) {
+      return c_SimpleXMLElement::PropEmpty(this, key);
+    }
+  }
+  return propEmptyImpl(ctx, key);
 }
 
 void ObjectData::setProp(Class* ctx,

--- a/hphp/runtime/base/object-data.h
+++ b/hphp/runtime/base/object-data.h
@@ -62,6 +62,7 @@ class ObjectData {
     IsCppBuiltin  = 0x1000, // has custom C++ subclass
     IsCollection  = 0x2000, // it's a collection (and the specific type is
                             // stored in o_subclass_u8)
+    HasPropEmpty  = 0x4000, // has custom propEmpty logic
     InstanceDtor  = 0x1400, // HasNativeData | IsCppBuiltin
   };
 
@@ -396,6 +397,7 @@ class ObjectData {
   template <bool warn, bool define>
   void propImpl(TypedValue*& retval, TypedValue& tvRef, Class* ctx,
                 const StringData* key);
+  bool propEmptyImpl(Class* ctx, const StringData* key);
   bool invokeSet(TypedValue* retval, const StringData* key, TypedValue* val);
   bool invokeGet(TypedValue* retval, const StringData* key);
   bool invokeGetProp(TypedValue*& retval, TypedValue& tvRef,

--- a/hphp/runtime/ext/ext_simplexml.cpp
+++ b/hphp/runtime/ext/ext_simplexml.cpp
@@ -1203,7 +1203,8 @@ c_SimpleXMLElement::c_SimpleXMLElement(Class* cb) :
                        ObjectData::UseIsset|
                        ObjectData::UseUnset|
                        ObjectData::CallToImpl|
-                       ObjectData::HasClone>(cb),
+                       ObjectData::HasClone|
+                       ObjectData::HasPropEmpty>(cb),
       document(nullptr), node(nullptr), xpath(nullptr) {
   iter.name     = nullptr;
   iter.nsprefix = nullptr;
@@ -1608,6 +1609,11 @@ bool c_SimpleXMLElement::t___isset(Variant name) {
 
 Variant c_SimpleXMLElement::t___set(Variant name, Variant value) {
   return sxe_prop_dim_write(this, name, value, true, false, nullptr);
+}
+
+bool c_SimpleXMLElement::PropEmpty(ObjectData* obj, const StringData* key) {
+  return !sxe_prop_dim_exists(static_cast<c_SimpleXMLElement*>(obj),
+    Variant(key->toCppString()), true, true, false);
 }
 
 c_SimpleXMLElement* c_SimpleXMLElement::Clone(ObjectData* obj) {

--- a/hphp/runtime/ext/ext_simplexml.h
+++ b/hphp/runtime/ext/ext_simplexml.h
@@ -53,7 +53,8 @@ class c_SimpleXMLElement :
                                 ObjectData::UseIsset|
                                 ObjectData::UseUnset|
                                 ObjectData::CallToImpl|
-                                ObjectData::HasClone>,
+                                ObjectData::HasClone|
+                                ObjectData::HasPropEmpty>,
       public Sweepable {
  public:
   DECLARE_CLASS(SimpleXMLElement)
@@ -92,6 +93,7 @@ class c_SimpleXMLElement :
   public: Variant t___unset(Variant name);
 
  public:
+  static bool    PropEmpty(ObjectData* obj, const StringData* key);
   static c_SimpleXMLElement* Clone(ObjectData* obj);
   static bool    ToBool(const ObjectData* obj) noexcept;
   static int64_t ToInt64(const ObjectData* obj) noexcept;

--- a/hphp/test/slow/simple_xml/prop_empty.php
+++ b/hphp/test/slow/simple_xml/prop_empty.php
@@ -1,0 +1,17 @@
+<?php
+$xml = new SimpleXMLElement(<<<EOF
+<foo>
+    <bar />
+    <baz hello="" />
+    <bak hello="world" />
+    <bat><bar /></bat>
+    <baq><bar hello="world" /></baq>
+</foo>
+EOF
+);
+
+var_dump(empty($xml->bar));
+var_dump(empty($xml->baz));
+var_dump(empty($xml->bak));
+var_dump(empty($xml->bat));
+var_dump(empty($xml->baq));

--- a/hphp/test/slow/simple_xml/prop_empty.php.expect
+++ b/hphp/test/slow/simple_xml/prop_empty.php.expect
@@ -1,0 +1,5 @@
+bool(true)
+bool(true)
+bool(true)
+bool(false)
+bool(false)


### PR DESCRIPTION
The PHP documentation for empty() says the following:
"That means empty() is essentially the concise equivalent to
!isset($var) || $var == false."

Surprise surprise, SimpleXML doesn't work that way:

``` php
$xml = new SimpleXMLElement('<foo><bar/></foo>');
var_dump(isset($xml->bar));  // true
var_dump((bool)($xml->bar)); // true
var_dump(empty($xml->bar));  // true, wat?!
```

To solve this, we do the same thing as ObjectData::clone by
defining an HasPropEmpty attribute and checking for it in
ObjectData::propEmpty.
