### PR TITLE
Add support for stream wrapper in include_path.

### DIFF
--- a/hphp/runtime/base/builtin-functions.cpp
+++ b/hphp/runtime/base/builtin-functions.cpp
@@ -818,8 +818,9 @@ String resolve_include(const String& file, const char* currentDir,
     for (int i = 0; i < (int)path_count; i++) {
       String path("");
       String includePath(includePaths[i]);
+      bool is_stream_wrapper = (includePath.find("://") > 0);
 
-      if (includePath[0] != '/') {
+      if (!is_stream_wrapper && includePath[0] != '/') {
         path += (g_context->getCwd() + "/");
       }
 
@@ -830,7 +831,13 @@ String resolve_include(const String& file, const char* currentDir,
       }
 
       path += file;
-      String can_path = FileUtil::canonicalize(path);
+
+      String can_path;
+      if (!is_stream_wrapper) {
+        can_path = FileUtil::canonicalize(path);
+      } else {
+        can_path = String(path.c_str());
+      }
 
       if (tryFile(can_path, ctx)) {
         return can_path;

--- a/hphp/runtime/base/request-injection-data.cpp
+++ b/hphp/runtime/base/request-injection-data.cpp
@@ -102,11 +102,35 @@ void RequestInjectionData::threadInit() {
                    "include_path", getDefaultIncludePath().c_str(),
                    IniSetting::SetAndGet<std::string>(
                      [this](const std::string& value) {
-                       auto paths = HHVM_FN(explode)(":", value);
                        m_include_paths.clear();
-                       for (ArrayIter iter(paths); iter; ++iter) {
-                         m_include_paths.push_back(
-                           iter.second().toString().toCppString());
+                       int pos = value.find(':');
+                       if (pos < 0) {
+                         m_include_paths.push_back(value);
+                       } else {
+                         int pos0 = 0;
+                         do {
+                           // Check for stream wrapper
+                           if (value.length() > pos + 2 &&
+                               value[pos + 1] == '/' &&
+                               value[pos + 2] == '/') {
+                             // .:// or ..:// is not stream wrapper
+                             if (((pos - pos0) >= 1 && value[pos - 1] != '.') ||
+                                 ((pos - pos0) >= 2 && value[pos - 2] != '.') ||
+                                 (pos - pos0) > 2) {
+                               pos += 3;
+                               continue;
+                             }
+                           }
+                           m_include_paths.push_back(
+                             value.substr(pos0, pos - pos0));
+                           pos++;
+                           pos0 = pos;
+                         } while ((pos = value.find(':', pos)) >= 0);
+
+                         if (pos0 <= value.length()) {
+                           m_include_paths.push_back(
+                             value.substr(pos0));
+                         }
                        }
                        return true;
                      },

--- a/hphp/test/frameworks/results/vfsstream.expect
+++ b/hphp/test/frameworks/results/vfsstream.expect
@@ -259,7 +259,7 @@ org\bovigo\vfs\vfsStreamFileTestCase::writeEmptyFile
 org\bovigo\vfs\vfsStreamGlobTestCase::globDoesNotWorkWithVfsStreamUrls
 .
 org\bovigo\vfs\vfsStreamResolveIncludePathTestCase::knownFileCanBeResolved
-F
+.
 org\bovigo\vfs\vfsStreamResolveIncludePathTestCase::unknownFileCanNotBeResolvedYieldsFalse
 .
 org\bovigo\vfs\vfsStreamTestCase::copyFromEmptyFolder


### PR DESCRIPTION
set_include_path now supports parsing of stream wrapper path (e.g. proto://path).

Passing vfsstream knownFileCanBeResolved test.
