### PR TITLE
Raise warning when put_contents on non-regular file with exclusive lock.

### DIFF
--- a/hphp/runtime/ext/std/ext_std_file.cpp
+++ b/hphp/runtime/ext/std/ext_std_file.cpp
@@ -577,8 +577,18 @@ Variant HHVM_FUNCTION(file_put_contents,
     return false;
   }
 
-  if ((flags & LOCK_EX) && !f->lock(LOCK_EX)) {
-    return false;
+  if (flags & LOCK_EX) {
+    // Check to make sure we are dealing with a regular file
+    if (!dynamic_cast<PlainFile*>(f)) {
+      raise_warning(
+        "%s(): Exclusive locks may only be set for regular files",
+        __FUNCTION__ + 2);
+      return false;
+    }
+
+    if (!f->lock(LOCK_EX)) {
+      return false;
+    }
   }
 
   int numbytes = 0;

--- a/hphp/test/frameworks/results/vfsstream.expect
+++ b/hphp/test/frameworks/results/vfsstream.expect
@@ -219,7 +219,7 @@ org\bovigo\vfs\vfsStreamDirectoryTestCase::rename
 org\bovigo\vfs\vfsStreamDirectoryTestCase::renameToInvalidNameThrowsvfsStreamException
 .
 org\bovigo\vfs\vfsStreamExLockTestCase::filePutContentsLockShouldReportError
-F
+.
 org\bovigo\vfs\vfsStreamExLockTestCase::flockSouldPass
 .
 org\bovigo\vfs\vfsStreamFileTestCase::content

--- a/hphp/test/slow/ext_file/file_put_contents.php
+++ b/hphp/test/slow/ext_file/file_put_contents.php
@@ -6,3 +6,10 @@ file_put_contents($tempfile, 'testing file_put_contents');
 var_dump(file_get_contents($tempfile));
 
 unlink($tempfile);
+
+$tempfile2 = tempnam('/tmp', 'vmextfiletest');
+
+file_put_contents('File://' . $tempfile2, 'testing file_put_contents with File:// url and LOCK_EX', LOCK_EX);
+var_dump(file_get_contents($tempfile2));
+
+unlink($tempfile2);

--- a/hphp/test/slow/ext_file/file_put_contents.php.expect
+++ b/hphp/test/slow/ext_file/file_put_contents.php.expect
@@ -1,1 +1,2 @@
 string(25) "testing file_put_contents"
+string(54) "testing file_put_contents with File:// url and LOCK_EX"


### PR DESCRIPTION
In file_put_contents(), raise warning if attempting to add an exclusive lock on non-regular file.

Passing vfsstream's filePutContentsLockShouldReportError test case.
