### PR TITLE
Fix Symfony's it's not safe to rely on system timezone setting errors

### DIFF
--- a/hphp/test/frameworks/framework_class_overrides/Symfony.php
+++ b/hphp/test/frameworks/framework_class_overrides/Symfony.php
@@ -7,4 +7,17 @@ class Symfony extends Framework {
     parent::__construct($name, null, $env_vars, null, true,
                         TestFindModes::TOKEN);
   }
+
+  <<Override>>
+  protected function extraPreComposer() {
+    // Add a default timezone, because Symfony requires a 
+    // default timezone in the default php.ini
+    verbose("Adding default timezone to autoload.php.dist");
+    $default_timezone_string = 
+      "date_default_timezone_set('America/Los_Angeles');";
+    $file = Options::$frameworks_root."/symfony/autoload.php.dist";
+    $contents = explode("\n", file_get_contents($file));
+    $contents[1] = $default_timezone_string;
+    file_put_contents($file, join("\n", $contents));
+  }
 }


### PR DESCRIPTION
Symfony requires a date.timezone setting in the standard php.ini
We can't do that so this modification adds a call to date_default_timezone_set
