### PR TITLE
Remove kernel version assertions

### DIFF
--- a/hphp/util/kernel-version.cpp
+++ b/hphp/util/kernel-version.cpp
@@ -30,12 +30,9 @@ void KernelVersion::parse(const char* s) {
   release[0] = 0;
   char build[128];
   build[0] = 0;
-  DEBUG_ONLY auto ret =
-    sscanf(s,
-           "%d.%d%1[.-]%127[A-Za-z0-9]-%127[A-Za-z0-9]_fbk%d_",
-           &m_major, &m_minor, dashdot, release, build, &m_fbk);
-  assert(ret == 2 || ret == 5 || ret == 6);
-  assert(m_major > 0 && m_minor > 0);
+  sscanf(s,
+         "%d.%d%1[.-]%127[A-Za-z0-9]-%127[A-Za-z0-9]_fbk%d_",
+         &m_major, &m_minor, dashdot, release, build, &m_fbk);
   m_release_str = release[0] == 0 ? "" : (const char*) release;
   m_build_str = build[0] == 0 ? "" : (const char*) build;
   // Populate the int-based release and build, if we have all digits in them


### PR DESCRIPTION
It doesn't make any sense to assert on the contents of a string that
some user typed into their custom kernel configuration file. Assertions
are for developers, not for users.

Anyway, why would you assert that the minor version is non-zero? Some day there will be a 4.0.
