### PR TITLE
Remove a warning from msg_receive function

### DIFF
--- a/hphp/runtime/ext/ipc/ext_ipc.cpp
+++ b/hphp/runtime/ext/ipc/ext_ipc.cpp
@@ -307,10 +307,7 @@ bool HHVM_FUNCTION(msg_receive,
 
   int result = msgrcv(q->id, buffer, maxsize, desiredmsgtype, realflags);
   if (result < 0) {
-    int err = errno;
-    raise_warning("Unable to receive message: %s",
-                    folly::errnoStr(err).c_str());
-    errorcode = err;
+    errorcode = errno;
     return false;
   }
 

--- a/hphp/test/slow/ext_ipc/message_queue.php
+++ b/hphp/test/slow/ext_ipc/message_queue.php
@@ -29,7 +29,7 @@ $ret = @msg_send($queue, 0, 'msg', false, false, $s_error_code);
 var_dump($ret);
 var_dump(22 === $s_error_code); // 22 - invalid argument
 
-$ret = @msg_receive($queue, 0, $type, 100, $msg, false, MSG_IPC_NOWAIT, $r_error_code);
+$ret = msg_receive($queue, 0, $type, 100, $msg, false, MSG_IPC_NOWAIT, $r_error_code);
 var_dump($ret);
 var_dump(MSG_ENOMSG === $r_error_code);
 


### PR DESCRIPTION
Remove a warning from `msg_receive` function for consistency with php:
https://github.com/php/php-src/blob/a770d29df74515197c76efdf1a64d9794c27b4af/ext/sysvmsg/sysvmsg.c#L377-L379
