### PR TITLE
Revert work around for gcc compilation issue

### DIFF
--- a/hphp/runtime/ext/curl/ext_curl.cpp
+++ b/hphp/runtime/ext/curl/ext_curl.cpp
@@ -547,7 +547,7 @@ public:
                CURLFORM_END);
           } else {
             String val = var_val.toString();
-            const char* const postval = val.bufferSlice().ptr;
+            const char *postval = val.data();
 
             if (*postval == '@') {
               /* Given a string like:


### PR DESCRIPTION
Revert part of commit a7c76ea. The assertion inside bufferSize() failed.

Fixes guzzle test run failure.
