### PR TITLE
Fix broken build due to missing lz4 library

### DIFF
--- a/hphp/hack/CMakeLists.txt
+++ b/hphp/hack/CMakeLists.txt
@@ -6,7 +6,8 @@ if (OCAMLC_FOUND)
   # and lz4 are all we need right now anyways.
   unset(extra_include_paths)
   unset(extra_lib_paths)
-  unset(extra_native_lib_paths)
+  unset(extra_native_libraries)
+  unset(extra_native_object_files)
   unset(extra_cc_flags)
   foreach(lib ${LIBELF_INCLUDE_DIRS})
     list(APPEND extra_include_paths ${lib})
@@ -26,9 +27,10 @@ if (OCAMLC_FOUND)
     list(APPEND extra_include_paths ${LZ4_INCLUDE_DIR})
     get_filename_component(pth ${LZ4_LIBRARY} PATH)
     list(APPEND extra_lib_paths ${pth})
+    list(APPEND extra_native_libraries lz4)
   else()
     list(APPEND extra_include_paths "${TP_DIR}/lz4")
-    list(APPEND extra_native_lib_paths "${TP_DIR}/lz4/liblz4.a")
+    list(APPEND extra_native_object_files "${TP_DIR}/lz4/liblz4.a")
   endif()
 
   # Xcode/Ninja generators undefined MAKE
@@ -44,7 +46,8 @@ if (OCAMLC_FOUND)
           $(MAKE) EXTRA_INCLUDE_PATHS="${extra_include_paths}"
           EXTRA_LIB_PATHS="${extra_lib_paths}"
           EXTRA_CC_FLAGS="${extra_cc_flags}"
-          EXTRA_NATIVE_LIB_PATHS="${extra_native_lib_paths}"
+          EXTRA_NATIVE_LIBRARIES="${extra_native_libraries}"
+          EXTRA_NATIVE_OBJECT_FILES="${extra_native_object_files}"
     WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/src"
   )
 

--- a/hphp/hack/src/Makefile
+++ b/hphp/hack/src/Makefile
@@ -8,6 +8,8 @@
 EXTRA_INCLUDE_PATHS=
 EXTRA_LIB_PATHS=
 EXTRA_CC_FLAGS=
+EXTRA_NATIVE_LIBRARIES=
+EXTRA_NATIVE_OBJECT_FILES=
 
 ################################################################################
 #                              OS-dependent stuff                              #
@@ -61,6 +63,7 @@ MODULES=\
   $(FSNOTIFY)
 
 NATIVE_OBJECT_FILES=\
+  $(EXTRA_NATIVE_OBJECT_FILES)\
   heap/hh_shared.o\
   utils/realpath.o\
   $(INOTIFY)/$(INOTIFY)_stubs.o\
@@ -74,6 +77,7 @@ OCAML_LIBRARIES=\
   str
 
 NATIVE_LIBRARIES=\
+  $(EXTRA_NATIVE_LIBRARIES)\
   $(ELF)\
   pthread
 
@@ -90,7 +94,7 @@ EXTRA_LIB_OPTS=$(foreach dir, $(EXTRA_LIB_PATHS),-cclib -L$(dir))
 FRAMEWORK_OPTS=$(foreach framework, $(FRAMEWORKS),-cclib -framework -cclib $(framework))
 
 LINKER_FLAGS=$(NATIVE_OBJECT_FILES) $(NATIVE_LIB_OPTS) $(EXTRA_LIB_OPTS) \
-	     $(FRAMEWORK_OPTS) $(SECTCREATE) $(EXTRA_NATIVE_LIB_PATHS)
+	     $(FRAMEWORK_OPTS) $(SECTCREATE)
 
 all: build-hhi-archive build-hack copy-hack-files
 


### PR DESCRIPTION
With non-bundled liblz4 a link error was observed, presumably due to
D1689677 e154a422f. Renamed EXTRA_NATIVE_LIB_PATHS to
EXTRA_NATIVE_OBJECT_FILES for consistency with other similarly named
variables, and introduced EXTRA_NATIVE_LIBRARIES to allow CMake to
request the -llz4 flag required by the non-bundled library.

Tested only in the non-bundled case.
