### PR TITLE
EZC: fix 'Z' type in zend_parse_parameters()

### DIFF
--- a/hphp/runtime/ext_zend_compat/hhvm/zend-execution-stack.h
+++ b/hphp/runtime/ext_zend_compat/hhvm/zend-execution-stack.h
@@ -35,7 +35,7 @@ struct ZendStackEntry {
 };
 
 struct ZendExecutionStack final : RequestEventHandler {
-  static zval* getArg(int i);
+  static zval** getArg(int i);
   static int numArgs();
 
   static void push(void* z);


### PR DESCRIPTION
For both 'Z' and vararg '_' types in zend_parse_parameters(), a zval_*
needs to be returned to the caller. I previously thought that temporary
storage would be needed for this, but in fact you can just point to the
TypedValue pref member.
