### PR TITLE
Fix bundled PCRE build

### DIFF
--- a/CMake/HPHPFindLibs.cmake
+++ b/CMake/HPHPFindLibs.cmake
@@ -79,7 +79,7 @@ include_directories(${LIBMEMCACHED_INCLUDE_DIR})
 link_directories(${LIBMEMCACHED_LIBRARY_DIRS})
 
 # pcre checks
-find_package(PCRE REQUIRED)
+find_package(PCRE)
 include_directories(${PCRE_INCLUDE_DIR})
 
 # libevent checks


### PR DESCRIPTION
Do not pass the "REQUIRED" argument when finding PCRE, since we now have
a bundled PCRE which we can use in the absence of a system library. The
only effect of REQUIRED was to make FIND_PACKAGE_HANDLE_STANDARD_ARGS()
fail with an error.
