### PR TITLE
Fix build when using json-c parser instead of the bundled parser

### DIFF
--- a/hphp/runtime/ext/json/jsonc_parser.cpp
+++ b/hphp/runtime/ext/json/jsonc_parser.cpp
@@ -99,7 +99,7 @@ Variant json_type_array_to_variant(json_object *new_obj, const bool assoc,
   Variant var, tmpvar;
   nb = json_object_array_length(new_obj);
   if (collections) {
-    var = newres<c_Vector>();
+    var = newobj<c_Vector>();
   } else {
     var = Array::Create();
   }
@@ -123,7 +123,7 @@ Variant json_type_object_to_variant(json_object *new_obj, const bool assoc,
     Variant       var, tmpvar;
 
   if (collections) {
-    var = newres<c_Map>();
+    var = newobj<c_Map>();
   } else if (assoc) {
     var = Array::Create();
   } else {


### PR DESCRIPTION
Without this fix, the build fails if USE_JSONC is set.
