### PR TITLE
Fix #4380, making get code and get message final

### DIFF
--- a/hphp/system/php/lang/Exception.php
+++ b/hphp/system/php/lang/Exception.php
@@ -66,7 +66,7 @@ class Exception {
    *
    * @return     mixed   Returns the Exception message as a string.
    */
-  function getMessage() {
+  final function getMessage() {
     return $this->message;
   }
 
@@ -108,7 +108,7 @@ class Exception {
    *                     but possibly as other type in Exception descendants
    *                     (for example as string in PDOException).
    */
-  function getCode() {
+  final function getCode() {
     return $this->code;
   }
 

--- a/hphp/test/slow/exceptions/getcodefinal.php
+++ b/hphp/test/slow/exceptions/getcodefinal.php
@@ -1,0 +1,9 @@
+<?php
+class FooException extends Exception {
+  protected $code = 123;
+  public function getCode() {
+    return $this->code;
+  }
+}
+$e = new FooException();
+var_dump($e->getCode());

--- a/hphp/test/slow/exceptions/getcodefinal.php.expectf
+++ b/hphp/test/slow/exceptions/getcodefinal.php.expectf
@@ -1,0 +1,2 @@
+
+Fatal error: Cannot override final method Exception::getCode() in %s on line %s


### PR DESCRIPTION
In order to match with PHP getMessage() and  getCode() changed to final so they can not be overwritten.
