### PR TITLE
let travis cache packages retrieved via apt-get to speedup built

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,9 @@ compiler:
 #  - clang-3.4
 #  - clang-3.5
 
+cache:
+  - apt
+
 services:
   - memcached
   - redis-server


### PR DESCRIPTION
see http://docs.travis-ci.com/user/caching/#Caching-Ubuntu-packages
