### PR TITLE
Mock date/time functions in Isolation.php

### DIFF
--- a/hphp/test/frameworks/Isolation.php
+++ b/hphp/test/frameworks/Isolation.php
@@ -134,10 +134,8 @@ function tempnam_ISOLATION_WRAPPER() {
 fb_rename_function('tempnam', 'ORIG_tempnam');
 fb_rename_function('tempnam_ISOLATION_WRAPPER', 'tempnam');
 
-static $time = null;
-
 function time_ISOLATION_WRAPPER() {
-  global $time;
+  static $time;
   $org_time = ORIG_time();
   if ($time === null) {
     $time = $org_time;
@@ -154,7 +152,7 @@ fb_rename_function('time', 'ORIG_time');
 fb_rename_function('time_ISOLATION_WRAPPER', 'time');
 
 function microtime_ISOLATION_WRAPPER(bool $get_as_float = false) {
-  global $time;
+  static $time;
   list($msec, $sec) = explode(" ", ORIG_microtime());
   if ($time === null) {
     $time = $sec;

--- a/hphp/test/frameworks/frameworks.yaml
+++ b/hphp/test/frameworks/frameworks.yaml
@@ -71,7 +71,8 @@
       # Assumes that calculating the current time in seconds twice will give
       # the same result. Not true if you're unlucky.
       - codeigniter/tests/codeigniter/helpers/date_helper_test.php
-      # Flakey test case. Already made a PR at https://github.com/bcit-ci/CodeIgniter/pull/3399.
+      # Flakey test case. Already made a PR 
+      # at https://github.com/bcit-ci/CodeIgniter/pull/3399.
       - codeigniter/tests/codeigniter/libraries/Session_test.php
   composer:
     url: https://github.com/composer/composer.git
@@ -525,7 +526,7 @@
       - phpbb3/tests/lock/flock_test.php
       # race condition - https://github.com/phpbb/phpbb/pull/3006
       - phpbb3/tests/wrapper/gmgetdate_test.php
-      # This flakey test is caused by assuming time functions never return the
+      # This flakey test is caused by assuming time functions always return the
       # same value. Made PR https://github.com/phpbb/phpbb/pull/3222 to fix.
       - phpbb3/tests/passwords/manager_test.php
       - phpbb3/tests/random/gen_rand_string_test.php


### PR DESCRIPTION
Mock date/time functions (e.g. time() ) so they never return the same value when calling multiple times.
By doing so, more flakey test cases can be found.
