### PR TITLE
Refactor steam_metadata() related code in UserFile.

### DIFF
--- a/hphp/runtime/base/file.h
+++ b/hphp/runtime/base/file.h
@@ -25,6 +25,13 @@
 #include "hphp/runtime/base/type-string.h"
 #include "hphp/runtime/base/type-variant.h"
 
+#define PHP_STREAM_META_TOUCH       1
+#define PHP_STREAM_META_OWNER_NAME  2
+#define PHP_STREAM_META_OWNER       3
+#define PHP_STREAM_META_GROUP_NAME  4
+#define PHP_STREAM_META_GROUP       5
+#define PHP_STREAM_META_ACCESS      6
+
 struct stat;
 
 namespace HPHP {

--- a/hphp/runtime/base/user-file.cpp
+++ b/hphp/runtime/base/user-file.cpp
@@ -25,7 +25,6 @@
 
 #include "hphp/runtime/base/comparisons.h"
 #include "hphp/runtime/base/complex-types.h"
-#include "hphp/runtime/base/array-init.h"
 #include "hphp/runtime/base/runtime-error.h"
 #include "hphp/runtime/vm/jit/translator-inline.h"
 
@@ -497,81 +496,19 @@ bool UserFile::rmdir(const String& filename, int options) {
   return false;
 }
 
-bool UserFile::invokeMetadata(const Array& args, const char* funcName) {
+bool UserFile::invokeMetadata(const Array& args) {
   bool invoked = false;
   Variant ret = invoke(m_StreamMetadata, s_stream_metadata, args, invoked);
   if (!invoked) {
-    raise_warning("%s(): %s::stream_metadata is not implemented!",
-                  funcName, m_cls->name()->data());
+    raise_warning("%s::stream_metadata is not implemented!",
+                  m_cls->name()->data());
     return false;
-  } else if (ret.toBoolean() == true) {
+  }
+  if (ret.toBoolean() == true) {
     return true;
   }
+
   return false;
-}
-
-bool UserFile::touch(const String& path, int64_t mtime, int64_t atime) {
-  if (atime == 0) {
-    atime = mtime;
-  }
-
-  return invokeMetadata(
-    PackedArrayInit(3)
-      .append(path)
-      .append(1) // STREAM_META_TOUCH
-      .append(atime ? make_packed_array(mtime, atime) : Array::Create())
-      .toArray(),
-    "touch");
-}
-
-bool UserFile::chmod(const String& path, int64_t mode) {
-  return invokeMetadata(
-    PackedArrayInit(3)
-      .append(path)
-      .append(6) // STREAM_META_ACCESS
-      .append(mode)
-      .toArray(),
-    "chmod");
-}
-
-bool UserFile::chown(const String& path, int64_t uid) {
-  return invokeMetadata(
-    PackedArrayInit(3)
-      .append(path)
-      .append(3) // STREAM_META_OWNER
-      .append(uid)
-      .toArray(),
-    "chown");
-}
-
-bool UserFile::chown(const String& path, const String& uid) {
-  return invokeMetadata(
-    PackedArrayInit(3)
-      .append(path)
-      .append(2) // STREAM_META_OWNER_NAME
-      .append(uid)
-      .toArray(),
-    "chown");
-}
-
-bool UserFile::chgrp(const String& path, int64_t gid) {
-  return invokeMetadata(
-    PackedArrayInit(3)
-      .append(path)
-      .append(5) // STREAM_META_GROUP
-      .append(gid)
-      .toArray(),
-      "chgrp");
-}
-
-bool UserFile::chgrp(const String& path, const String& gid) {
-  return invokeMetadata(
-    PackedArrayInit(3)
-      .append(path)
-      .append(4) // STREAM_META_GROUP_NAME
-      .append(gid)
-      .toArray(),
-    "chgrp");
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/hphp/runtime/base/user-stream-wrapper.cpp
+++ b/hphp/runtime/base/user-stream-wrapper.cpp
@@ -92,42 +92,5 @@ Directory* UserStreamWrapper::opendir(const String& path) {
   return dir;
 }
 
-bool UserStreamWrapper::touch(const String& path,
-                              int64_t mtime, int64_t atime) {
-  auto file = newres<UserFile>(m_cls);
-  Resource wrapper(file);
-  return file->touch(path, mtime, atime);
-}
-
-bool UserStreamWrapper::chmod(const String& path, int64_t mode) {
-  auto file = newres<UserFile>(m_cls);
-  Resource wrapper(file);
-  return file->chmod(path, mode);
-}
-
-bool UserStreamWrapper::chown(const String& path, int64_t uid) {
-  auto file = newres<UserFile>(m_cls);
-  Resource wrapper(file);
-  return file->chown(path, uid);
-}
-
-bool UserStreamWrapper::chown(const String& path, const String& uid) {
-  auto file = newres<UserFile>(m_cls);
-  Resource wrapper(file);
-  return file->chown(path, uid);
-}
-
-bool UserStreamWrapper::chgrp(const String& path, int64_t gid) {
-  auto file = newres<UserFile>(m_cls);
-  Resource wrapper(file);
-  return file->chgrp(path, gid);
-}
-
-bool UserStreamWrapper::chgrp(const String& path, const String& gid) {
-  auto file = newres<UserFile>(m_cls);
-  Resource wrapper(file);
-  return file->chgrp(path, gid);
-}
-
 ///////////////////////////////////////////////////////////////////////////////
 }

--- a/hphp/runtime/base/user-stream-wrapper.h
+++ b/hphp/runtime/base/user-stream-wrapper.h
@@ -38,12 +38,13 @@ struct UserStreamWrapper final : Stream::Wrapper {
   int mkdir(const String& path, int mode, int options) override;
   int rmdir(const String& path, int options) override;
   Directory* opendir(const String& path) override;
-  bool touch(const String& path, int64_t mtime, int64_t atime);
-  bool chmod(const String& path, int64_t mode);
-  bool chown(const String& path, int64_t uid);
-  bool chown(const String& path, const String& uid);
-  bool chgrp(const String& path, int64_t gid);
-  bool chgrp(const String& path, const String& gid);
+
+  template<typename ValueT>
+  bool metadata(const String& path, int option, ValueT value) {
+    auto file = newres<UserFile>(m_cls);
+    Resource wrapper(file);
+    return file->metadata(path, option, value);
+  }
 
 private:
   String m_name;

--- a/hphp/runtime/ext/stream/ext_stream.cpp
+++ b/hphp/runtime/ext/stream/ext_stream.cpp
@@ -48,13 +48,6 @@
 #define PHP_STREAM_BUFFER_FULL  2   /* fully buffered */
 #define PHP_STREAM_COPY_ALL     (-1)
 
-#define PHP_STREAM_META_TOUCH       1
-#define PHP_STREAM_META_OWNER_NAME  2
-#define PHP_STREAM_META_OWNER       3
-#define PHP_STREAM_META_GROUP_NAME  4
-#define PHP_STREAM_META_GROUP       5
-#define PHP_STREAM_META_ACCESS      6
-
 namespace HPHP {
 
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Refactor steam_metadata() related code in UserFile so that only the overloaded metadata(path, option, value) is exposed instead of multiple functions (i.e. touch(), chmod(), chown(), chgrp()), which simplies the code.
