### PR TITLE
Moved UserFile casting error back to sock_array_to_fd_set().

### DIFF
--- a/hphp/runtime/base/user-file.cpp
+++ b/hphp/runtime/base/user-file.cpp
@@ -155,9 +155,6 @@ int UserFile::fd() const {
   Resource handle = const_cast<UserFile*>(this)->invokeCast(
     PHP_STREAM_AS_FD_FOR_SELECT);
   if (handle.isNull()) {
-    raise_warning(
-      "cannot represent a stream of type user-space as a file descriptor"
-    );
     return -1;
   }
   File *f = handle.getTyped<File>();

--- a/hphp/runtime/ext/sockets/ext_sockets.cpp
+++ b/hphp/runtime/ext/sockets/ext_sockets.cpp
@@ -237,6 +237,9 @@ static void sock_array_to_fd_set(const Array& sockets, pollfd *fds, int &nfds,
     File *sock = iter.second().toResource().getTyped<File>();
     int intfd = sock->fd();
     if (intfd < 0) {
+      raise_warning(
+        "cannot represent a stream of type user-space as a file descriptor"
+      );
       continue;
     }
     pollfd &fd = fds[nfds++];


### PR DESCRIPTION
Moved UserFile's fd casting error back to sock_array_fd_set() function
to fix two errors in vfsstream's framework test -
vfsStreamWrapperSetOptionTestCase::setBlockingDoesNotWork and
vfsStreamWrapperSetOptionTestCase::removeBlockingDoesNotWork,
which is introduced in commit 17e0756.
