### PR TITLE
Allow typechecker to interpret WaitHandle result()

### DIFF
--- a/hphp/hack/hhi/classes.hhi
+++ b/hphp/hack/hhi/classes.hhi
@@ -45,6 +45,7 @@ abstract class WaitHandle<T> implements Awaitable<T> {
   public function isFailed(): bool {}
   public function getID(): int {}
   public function getName(): string {}
+  public function result() : T {}
   public function getExceptionIfFailed(): ?Exception {}
   public static function setOnIOWaitEnterCallback(?(function(): void) $callback) {}
   public static function setOnIOWaitExitCallback(?(function(): void) $callback) {}


### PR DESCRIPTION
Avoid problems with typechecker on hhvm 3.5 version
