### PR TITLE
Implement AlwaysEscapeLog runtime option

### DIFF
--- a/hphp/runtime/base/runtime-option.cpp
+++ b/hphp/runtime/base/runtime-option.cpp
@@ -89,9 +89,9 @@ bool RuntimeOption::IntsOverflowToInts = false;
 std::string RuntimeOption::LogFile;
 std::string RuntimeOption::LogFileSymLink;
 int RuntimeOption::LogHeaderMangle = 0;
-bool RuntimeOption::AlwaysEscapeLog = false;
 bool RuntimeOption::AlwaysLogUnhandledExceptions =
   RuntimeOption::EnableHipHopSyntax;
+bool RuntimeOption::AlwaysEscapeLog = true;
 bool RuntimeOption::NoSilencer = false;
 int RuntimeOption::ErrorUpgradeLevel = 0;
 bool RuntimeOption::CallUserHandlerOnFatals = false;
@@ -800,7 +800,7 @@ void RuntimeOption::Load(IniSetting::Map& ini, Hdf& config,
     }
     Config::Bind(LogFileFlusher::DropCacheChunkSize, ini,
                  logger["DropCacheChunkSize"], 1 << 20);
-    Config::Bind(AlwaysEscapeLog, ini, logger["AlwaysEscapeLog"], false);
+    Config::Bind(AlwaysEscapeLog, ini, logger["AlwaysEscapeLog"], true);
     Config::Bind(RuntimeOption::LogHeaderMangle, ini, logger["HeaderMangle"],
                  0);
 

--- a/hphp/runtime/base/runtime-option.cpp
+++ b/hphp/runtime/base/runtime-option.cpp
@@ -800,7 +800,7 @@ void RuntimeOption::Load(IniSetting::Map& ini, Hdf& config,
     }
     Config::Bind(LogFileFlusher::DropCacheChunkSize, ini,
                  logger["DropCacheChunkSize"], 1 << 20);
-    Config::Bind(AlwaysEscapeLog, ini, logger["AlwaysEscapeLog"], true);
+    Config::Bind(Logger::AlwaysEscapeLog, ini, logger["AlwaysEscapeLog"], true);
     Config::Bind(RuntimeOption::LogHeaderMangle, ini, logger["HeaderMangle"],
                  0);
 

--- a/hphp/util/logger.cpp
+++ b/hphp/util/logger.cpp
@@ -46,6 +46,7 @@ IMPLEMENT_LOGLEVEL(Verbose);
 
 ///////////////////////////////////////////////////////////////////////////////
 
+bool Logger::AlwaysEscapeLog = true;
 bool Logger::UseSyslog = false;
 bool Logger::UseLogFile = true;
 bool Logger::UseRequestLog = false;
@@ -139,7 +140,7 @@ void Logger::log(LogLevelType level, const std::string &msg,
                  const StackTrace *stackTrace,
                  bool escape /* = false */, bool escapeMore /* = false */) {
 
-  if (RuntimeOption::AlwaysEscapeLog && Logger::Escape) {
+  if (Logger::AlwaysEscapeLog && Logger::Escape) {
     escape = true;
   }
   assert(!escapeMore || escape);

--- a/hphp/util/logger.cpp
+++ b/hphp/util/logger.cpp
@@ -22,6 +22,7 @@
 #include "hphp/util/exception.h"
 #include "hphp/util/text-color.h"
 #include "hphp/util/string-vsnprintf.h"
+#include "hphp/runtime/base/runtime-option.h"
 
 #define IMPLEMENT_LOGLEVEL(LOGLEVEL)                                    \
   void Logger::LOGLEVEL(const char *fmt, ...) {                         \
@@ -139,7 +140,7 @@ void Logger::log(LogLevelType level, const std::string &msg,
                  const StackTrace *stackTrace,
                  bool escape /* = false */, bool escapeMore /* = false */) {
 
-  if (Logger::Escape) {
+  if (RuntimeOption::AlwaysEscapeLog && Logger::Escape) {
     escape = true;
   }
   assert(!escapeMore || escape);

--- a/hphp/util/logger.cpp
+++ b/hphp/util/logger.cpp
@@ -22,7 +22,6 @@
 #include "hphp/util/exception.h"
 #include "hphp/util/text-color.h"
 #include "hphp/util/string-vsnprintf.h"
-#include "hphp/runtime/base/runtime-option.h"
 
 #define IMPLEMENT_LOGLEVEL(LOGLEVEL)                                    \
   void Logger::LOGLEVEL(const char *fmt, ...) {                         \

--- a/hphp/util/logger.h
+++ b/hphp/util/logger.h
@@ -24,7 +24,6 @@
 #include "hphp/util/thread-local.h"
 #include "hphp/util/cronolog.h"
 #include "hphp/util/log-file-flusher.h"
-#include "hphp/runtime/base/runtime-option.h"
 
 namespace HPHP {
 ///////////////////////////////////////////////////////////////////////////////
@@ -44,6 +43,7 @@ public:
 
   Logger(): m_standardOut(stderr) {}
 
+  static bool AlwaysEscapeLog;
   static bool UseSyslog;
   static bool UseLogFile;
   static bool UseRequestLog;

--- a/hphp/util/logger.h
+++ b/hphp/util/logger.h
@@ -24,6 +24,7 @@
 #include "hphp/util/thread-local.h"
 #include "hphp/util/cronolog.h"
 #include "hphp/util/log-file-flusher.h"
+#include "hphp/runtime/base/runtime-option.h"
 
 namespace HPHP {
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Previously, AlwaysEscapeLog was never checked effectively making the default "true", despite the fact that it was listed as "false" in runtime-option.cpp. After checking AlwaysEscapeLog I changed the default behavior to true, to match how it behaved by default before this patch.

It's important to note that if AlwaysEscapeLog is set to false this implementation will cause logs to *never* be escaped. If that was not the intended behavior of this option, I can amend it to match what it should do.

fixes #4437