### PR TITLE
FastCGI socket owner, group and mode change support

### DIFF
--- a/hphp/runtime/base/ini-setting.cpp
+++ b/hphp/runtime/base/ini-setting.cpp
@@ -54,14 +54,22 @@ int64_t convert_bytes_to_long(const std::string& value) {
   if (value.size() == 0) {
     return 0;
   }
-  int64_t newInt = strtoll(value.data(), nullptr, 10);
-  char lastChar = value.data()[value.size() - 1];
-  if (lastChar == 'K' || lastChar == 'k') {
-    newInt <<= 10;
-  } else if (lastChar == 'M' || lastChar == 'm') {
-    newInt <<= 20;
-  } else if (lastChar == 'G' || lastChar == 'g') {
-    newInt <<= 30;
+  int base = 10;
+  const char* value_cstr = value.c_str();
+  if (value_cstr[0] == '0') {
+    value_cstr++;
+    base = 8;
+  }
+  int64_t newInt = strtoll(value_cstr, nullptr, base);
+  if (base == 10) {
+    const char& lastChar = value.back();
+    if (lastChar == 'K' || lastChar == 'k') {
+      newInt <<= 10;
+    } else if (lastChar == 'M' || lastChar == 'm') {
+      newInt <<= 20;
+    } else if (lastChar == 'G' || lastChar == 'g') {
+      newInt <<= 30;
+    }
   }
   return newInt;
 }

--- a/hphp/runtime/base/runtime-option.cpp
+++ b/hphp/runtime/base/runtime-option.cpp
@@ -130,6 +130,9 @@ std::string RuntimeOption::DefaultServerNameSuffix;
 std::string RuntimeOption::ServerType = "libevent";
 std::string RuntimeOption::ServerIP;
 std::string RuntimeOption::ServerFileSocket;
+std::string RuntimeOption::ServerFileSocketOwner;
+std::string RuntimeOption::ServerFileSocketGroup;
+mode_t RuntimeOption::ServerFileSocketMode;
 std::string RuntimeOption::ServerPrimaryIPv4;
 std::string RuntimeOption::ServerPrimaryIPv6;
 int RuntimeOption::ServerPort = 80;
@@ -1043,6 +1046,9 @@ void RuntimeOption::Load(IniSetting::Map& ini, Hdf& config,
     Config::Bind(ServerType, ini, server["Type"], ServerType);
     Config::Bind(ServerIP, ini, server["IP"]);
     Config::Bind(ServerFileSocket, ini, server["FileSocket"]);
+    Config::Bind(ServerFileSocketOwner, ini, server["FileSocketOwner"]);
+    Config::Bind(ServerFileSocketGroup, ini, server["FileSocketGroup"]);
+    Config::Bind(ServerFileSocketMode, ini, server["FileSocketMode"], 0650);
     ServerPrimaryIPv4 = GetPrimaryIPv4();
     ServerPrimaryIPv6 = GetPrimaryIPv6();
 #ifdef FACEBOOK

--- a/hphp/runtime/base/runtime-option.h
+++ b/hphp/runtime/base/runtime-option.h
@@ -109,6 +109,9 @@ public:
   static std::string ServerType;
   static std::string ServerIP;
   static std::string ServerFileSocket;
+  static std::string ServerFileSocketOwner;
+  static std::string ServerFileSocketGroup;
+  static mode_t ServerFileSocketMode;
   static std::string ServerPrimaryIPv4;
   static std::string ServerPrimaryIPv6;
   static int ServerPort;

--- a/hphp/runtime/server/fastcgi/fastcgi-server.cpp
+++ b/hphp/runtime/server/fastcgi/fastcgi-server.cpp
@@ -242,7 +242,10 @@ void FastCGIServer::start() {
   }
   if (m_socketConfig.bindAddress.getFamily() == AF_UNIX) {
     auto path = m_socketConfig.bindAddress.getPath();
-    chmod(path.c_str(), 0760);
+    if (chmod(path.c_str(), 0760) != 0) {
+      Logger::Warning("chmod %s failed: %s",
+        path.c_str(), folly::errnoStr(errno).c_str());
+    }
   }
   m_acceptor.reset(new FastCGIAcceptor(m_socketConfig, this));
   m_acceptor->init(m_socket.get(), m_worker.getEventBase());

--- a/hphp/runtime/server/fastcgi/fastcgi-server.cpp
+++ b/hphp/runtime/server/fastcgi/fastcgi-server.cpp
@@ -25,6 +25,9 @@
 #include "thrift/lib/cpp/async/TAsyncTransport.h" // @nolint
 #include "proxygen/lib/services/Acceptor.h" // @nolint
 
+#include <grp.h>
+#include <pwd.h>
+
 namespace HPHP {
 
 using folly::IOBuf;
@@ -242,9 +245,42 @@ void FastCGIServer::start() {
   }
   if (m_socketConfig.bindAddress.getFamily() == AF_UNIX) {
     auto path = m_socketConfig.bindAddress.getPath();
-    if (chmod(path.c_str(), 0760) != 0) {
-      Logger::Warning("chmod %s failed: %s",
-        path.c_str(), folly::errnoStr(errno).c_str());
+    if ((RuntimeOption::ServerFileSocketOwner != "") ||
+        (RuntimeOption::ServerFileSocketGroup != "")) {
+      uid_t sock_uid = -1;
+      if (RuntimeOption::ServerFileSocketOwner != "") {
+        auto pw = getpwnam(RuntimeOption::ServerFileSocketOwner.c_str());
+        if (pw == nullptr) {
+          Logger::Warning("Bad ServerFileSocketOwner %s: %s",
+            RuntimeOption::ServerFileSocketOwner.c_str(),
+             folly::errnoStr(errno).c_str());
+        }
+        else {
+          sock_uid = pw->pw_uid;
+        }
+      }
+      gid_t sock_gid = -1;
+      if (RuntimeOption::ServerFileSocketGroup != "") {
+        auto gr = getgrnam(RuntimeOption::ServerFileSocketGroup.c_str());
+        if (gr == nullptr) {
+          Logger::Warning("Bad ServerFileSocketGroup %s: %s",
+            RuntimeOption::ServerFileSocketGroup.c_str(),
+            folly::errnoStr(errno).c_str());
+        }
+        else {
+          sock_gid = gr->gr_gid;
+        }
+      }
+      if (chown(path.c_str(), sock_uid, sock_gid) != 0) {
+        Logger::Warning("chown ServerFileSocket %s %d:%d failed: %s",
+          path.c_str(), sock_uid, sock_gid, folly::errnoStr(errno).c_str());
+      }
+    }
+    Logger::Debug("chmod %o", RuntimeOption::ServerFileSocketMode);
+    if (chmod(path.c_str(), RuntimeOption::ServerFileSocketMode) != 0) {
+      Logger::Warning("chmod ServerFileSocket %s %o failed: %s",
+        path.c_str(), RuntimeOption::ServerFileSocketMode,
+        folly::errnoStr(errno).c_str());
     }
   }
   m_acceptor.reset(new FastCGIAcceptor(m_socketConfig, this));

--- a/hphp/runtime/server/fastcgi/fastcgi-server.cpp
+++ b/hphp/runtime/server/fastcgi/fastcgi-server.cpp
@@ -276,7 +276,6 @@ void FastCGIServer::start() {
           path.c_str(), sock_uid, sock_gid, folly::errnoStr(errno).c_str());
       }
     }
-    Logger::Debug("chmod %o", RuntimeOption::ServerFileSocketMode);
     if (chmod(path.c_str(), RuntimeOption::ServerFileSocketMode) != 0) {
       Logger::Warning("chmod ServerFileSocket %s %o failed: %s",
         path.c_str(), RuntimeOption::ServerFileSocketMode,


### PR DESCRIPTION
Adds three new hdf / ini settings: `Server.FileSocketOwner` / `hhvm.server.file_socket_owner`, `Server.FileSocketGroup` / `hhvm.server.file_socket_group`, `Server.FileSocketMode` / `hhvm.server.file_socket_mode` which allows to change owner, group and permissions for UNIX socket file used by FastCGI server. Should work similar as php-fpm `listen.owner`, `listen.group`, `listen.mode`. This allows running hhvm and front-end webserver (e.g. nginx) under different users through UNIX sockets.

Also added is support of specifying octal values for integer settings in php.ini.

P.S. php-fpm defaults to mode 0660, HHVM defaults to 0650. Shouldn't we also change that?