### PR TITLE
Mark extension test runner as executable

### DIFF
--- a/hphp/tools/hphpize/hphpize.in
+++ b/hphp/tools/hphpize/hphpize.in
@@ -13,6 +13,7 @@ else
   HHVM_LIB="$HHVM_INSTALL_PREFIX/$HHVM_INSTALL_LIBDIR/hhvm"
   cp "$HHVM_LIB/hphpize/hphpize.cmake" CMakeLists.txt
   cp "$HHVM_LIB/hphpize/run" run-test
+  chmod +x run-test
 fi
 
 echo "** hphpize complete, now run \`cmake . && make\` to build, \`make test\` to test"


### PR DESCRIPTION
This is the last change needed for the "make test" command to work for me, hopefully.
