### PR TITLE
Update vfsstream framework test to include a minor fix.

### DIFF
--- a/hphp/test/frameworks/frameworks.yaml
+++ b/hphp/test/frameworks/frameworks.yaml
@@ -628,11 +628,11 @@
 	  # Dependent on system language settings.
       - twig/test/Twig/Tests/CompilerTest.php
   vfsstream:
-    # It's slightly ahead of stable release v1.4.0 to include a commit which
-    # unskips a couple of tests on HHVM
-    url: https://github.com/mikey179/vfsStream.git
-    branch: master
-    commit: 056b64e0341039eb83075ca53347f29d0bfdead0
+    # It's using a fork of vfsstream which is slightly 
+    # ahead of stable release v1.4.0
+    url: https://github.com/kevinxucs/vfsStream.git
+    branch: hhvm-v1.4.0
+    commit: de553dcb5a9b068f3e80b738dc47328197cae18a
     install_root: vfsstream
     test_root: vfsstream
     config_file: vfsstream/phpunit.xml.dist

--- a/hphp/test/frameworks/results/vfsstream.expect
+++ b/hphp/test/frameworks/results/vfsstream.expect
@@ -721,7 +721,7 @@ org\bovigo\vfs\vfsStreamWrapperTestCase::urlIsUpdatedAfterMove
 org\bovigo\vfs\vfsStreamWrapperTestCase::urlsAreCorrectlySet
 .
 org\bovigo\vfs\vfsStreamWrapperWithoutRootTestCase::canNotOpen
-F
+.
 org\bovigo\vfs\vfsStreamWrapperWithoutRootTestCase::canNotOpenDirectory
 .
 org\bovigo\vfs\vfsStreamWrapperWithoutRootTestCase::canNotRename


### PR DESCRIPTION
Update vfsstream framework test to use my own fork which includes a
minor fix for test case vfsStreamWrapperWithoutRootTestCase::canNotOpen.

vfsstream framework test back to 100%.
