### PR TITLE
Update vfsstream framework test.

### DIFF
--- a/hphp/test/frameworks/frameworks.yaml
+++ b/hphp/test/frameworks/frameworks.yaml
@@ -639,7 +639,7 @@
     # unskips a couple of tests on HHVM
     url: https://github.com/mikey179/vfsStream.git
     branch: master
-    commit: 056b64e0341039eb83075ca53347f29d0bfdead0
+    commit: 2d5131709917b80a315a83c08a56516d867ba59f
     install_root: vfsstream
     test_root: vfsstream
     config_file: vfsstream/phpunit.xml.dist

--- a/hphp/test/frameworks/results/vfsstream.expect
+++ b/hphp/test/frameworks/results/vfsstream.expect
@@ -721,7 +721,7 @@ org\bovigo\vfs\vfsStreamWrapperTestCase::urlIsUpdatedAfterMove
 org\bovigo\vfs\vfsStreamWrapperTestCase::urlsAreCorrectlySet
 .
 org\bovigo\vfs\vfsStreamWrapperWithoutRootTestCase::canNotOpen
-F
+.
 org\bovigo\vfs\vfsStreamWrapperWithoutRootTestCase::canNotOpenDirectory
 .
 org\bovigo\vfs\vfsStreamWrapperWithoutRootTestCase::canNotRename


### PR DESCRIPTION
Update vfsstream framework test to include a fix for
vfsStreamWrapperWithoutRootTestCase::canNotOpen.
