### PR TITLE
Fixes issue with gdb segfaulting when reading debug symbols

### DIFF
--- a/CMake/HPHPCompiler.cmake
+++ b/CMake/HPHPCompiler.cmake
@@ -74,8 +74,8 @@ elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
   endif()
 
   # No optimizations for debug builds.
-  set(CMAKE_C_FLAGS_DEBUG    "-O0 -ggdb")
-  set(CMAKE_CXX_FLAGS_DEBUG  "-O0 -ggdb")
+  set(CMAKE_C_FLAGS_DEBUG    "-Og")
+  set(CMAKE_CXX_FLAGS_DEBUG  "-Og")
 
   # Generic GCC flags and Optional flags
   set(CMAKE_C_FLAGS_MINSIZEREL       "-Os -DNDEBUG")


### PR DESCRIPTION
Changing the gcc debug optimization level to -gO (enables some optimizations
that do not interfere with debugging). gdb no longer segfaults.
