### PR TITLE
Fatal if a class implements IteratorAggregate and Iterator

### DIFF
--- a/hphp/runtime/vm/class.cpp
+++ b/hphp/runtime/vm/class.cpp
@@ -2318,6 +2318,14 @@ void Class::setInitializers() {
   m_callsCustomInstanceInit = method && method->isBuiltin();
 }
 
+void Class::checkInterfaceConstraints() {
+  if (UNLIKELY(m_interfaces.contains(String("Iterator").get()) &&
+      m_interfaces.contains(String("IteratorAggregate").get()))) {
+    raise_error("Class %s cannot implement both IteratorAggregate and Iterator"
+                " at the same time", name()->data());
+  }
+}
+
 // Checks if interface methods are OK:
 //  - there's no requirement if this is a trait, interface, or abstract class
 //  - a non-abstract class must implement all methods from interfaces it
@@ -2451,6 +2459,7 @@ void Class::setInterfaces() {
   }
 
   m_interfaces.create(interfacesBuilder);
+  checkInterfaceConstraints();
   checkInterfaceMethods();
 }
 

--- a/hphp/runtime/vm/class.h
+++ b/hphp/runtime/vm/class.h
@@ -937,6 +937,7 @@ private:
                      const StringData* newMethName);
 
   void checkInterfaceMethods();
+  void checkInterfaceConstraints();
   void methodOverrideCheck(const Func* parentMethod, const Func* method);
 
   static bool compatibleTraitPropInit(TypedValue& tv1, TypedValue& tv2);

--- a/hphp/test/slow/ext_class/iteratoraggregate_iterator_both.php
+++ b/hphp/test/slow/ext_class/iteratoraggregate_iterator_both.php
@@ -1,0 +1,3 @@
+<?php
+
+class ThisShouldFatal implements Iterator, IteratorAggregate {}

--- a/hphp/test/slow/ext_class/iteratoraggregate_iterator_both.php.expectf
+++ b/hphp/test/slow/ext_class/iteratoraggregate_iterator_both.php.expectf
@@ -1,0 +1,2 @@
+
+Fatal error: Class ThisShouldFatal cannot implement both IteratorAggregate and Iterator at the same time in %s/ext_class/iteratoraggregate_iterator_both.php on line %s

--- a/hphp/test/slow/ext_class/iteratoraggregate_iterator_both_indirect.php
+++ b/hphp/test/slow/ext_class/iteratoraggregate_iterator_both_indirect.php
@@ -1,0 +1,6 @@
+<?php
+class IA implements IteratorAggregate {
+  public function getIterator(){}
+}
+
+class Fatal extends IA implements Iterator {}

--- a/hphp/test/slow/ext_class/iteratoraggregate_iterator_both_indirect.php.expectf
+++ b/hphp/test/slow/ext_class/iteratoraggregate_iterator_both_indirect.php.expectf
@@ -1,0 +1,2 @@
+
+Fatal error: Class Fatal cannot implement both Iterator and IteratorAggregate at the same time in %s/ext_class/iteratoraggregate_iterator_both_indirect.php on line %s

--- a/hphp/test/slow/ext_class/iteratoraggregate_iterator_both_indirect.php.expectf
+++ b/hphp/test/slow/ext_class/iteratoraggregate_iterator_both_indirect.php.expectf
@@ -1,2 +1,2 @@
 
-Fatal error: Class Fatal cannot implement both Iterator and IteratorAggregate at the same time in %s/ext_class/iteratoraggregate_iterator_both_indirect.php on line %s
+Fatal error: Class Fatal cannot implement both IteratorAggregate and Iterator at the same time in %s/ext_class/iteratoraggregate_iterator_both_indirect.php on line %s


### PR DESCRIPTION
It doesn't make sense to implement both IteratorAggregate and Iterator.
Which of those two are supposed to be iterated? PHP fatals on this, we should too.

Part of #3536
This might cause issue for people using `extends PDOStatement implements IteratorAggregate`
But since it wouldn't do what you expect it to do anyway (See #3536 why PdoStatement is broken), we should tell them

Test Plan:
`test/run test/slow/ext_class`