### PR TITLE
RequestInitDocument   404  friendly reminder

### DIFF
--- a/hphp/runtime/server/http-request-handler.cpp
+++ b/hphp/runtime/server/http-request-handler.cpp
@@ -465,7 +465,7 @@ bool HttpRequestHandler::executePHPRequest(Transport *transport,
     }
   } else {
     code = 404;
-    transport->sendString("Not Found", 404);
+    transport->sendString("RequestInitDocument Not Found", 404);
   }
 
   if (RuntimeOption::EnableDebugger) {


### PR DESCRIPTION
404  don't friendly reminder when RequestInitDocument   file don't exsists,we can't quickly positioning problem,so modify this function friendly reminder.
