### PR TITLE
Fix #4486, Set the sokcet timeout to never by -1

### DIFF
--- a/hphp/runtime/ext/sockets/ext_sockets.cpp
+++ b/hphp/runtime/ext/sockets/ext_sockets.cpp
@@ -720,6 +720,10 @@ bool HHVM_FUNCTION(socket_set_option,
         tv.tv_sec += tv.tv_usec / 1000000;
         tv.tv_usec %= 1000000;
       }
+      if (tv.tv_sec < 0) {
+        tv.tv_sec = ThreadInfo::s_threadInfo.getNoCheck()->
+        m_reqInjectionData.getSocketDefaultTimeout();
+      }
       optlen = sizeof(tv);
       opt_ptr = &tv;
       sock->setTimeout(tv);


### PR DESCRIPTION
Fixing the stream timeout option. -1 now means never timeout in this function.