### PR TITLE
Refactor ZArrVal::cowCheck to expose its guts as new function forceAsPro...

### DIFF
--- a/hphp/runtime/base/array-data.h
+++ b/hphp/runtime/base/array-data.h
@@ -203,6 +203,7 @@ public:
   bool isApcArray() const { return m_kind == kApcKind; }
   bool isGlobalsArray() const { return m_kind == kGlobalsKind; }
   bool isProxyArray() const { return m_kind == kProxyKind; }
+  bool isEmptyArray() const { return m_kind == kEmptyKind; }
 
   /*
    * Returns whether or not this array contains "vector-like" data.

--- a/hphp/runtime/ext_zend_compat/php-src/Zend/zend_operators.h
+++ b/hphp/runtime/ext_zend_compat/php-src/Zend/zend_operators.h
@@ -472,17 +472,25 @@ public:
   void cowCheck() {
     ArrayData * ad = m_tv->m_data.parr;
     if (ad->isStatic() || ad->hasMultipleRefs()) {
-      ad = ad->copy();
-      ad->incRefCount();
-      // copy() causes an array to be unproxied, so we normally need
-      // to reproxy it
-      if (!ad->isProxyArray()) {
-        ad = ProxyArray::Make(ad);
-        ad->incRefCount();
-      }
-      m_tv->m_data.parr->decRefCount();
-      m_tv->m_data.parr = ad;
+      forceAsProxyArray ();
     }
+  }
+  inline void forceAsProxyArray () {
+    ArrayData * ad = m_tv->m_data.parr;
+    if (ad->isEmptyArray()) {
+      assert(!"can't forceAsProxyArray an empty array");
+    } else {
+      ad = ad->copy();
+    }
+    ad->incRefCount();
+    // copy() causes an array to be unproxied, so we normally need
+    // to reproxy it
+    if (!ad->isProxyArray()) {
+      ad = ProxyArray::Make(ad);
+      ad->incRefCount();
+    }
+    m_tv->m_data.parr->decRefCount();
+    m_tv->m_data.parr = ad;
   }
   /* implicit */ operator HashTable*() {
     cowCheck();


### PR DESCRIPTION
...xyArray.

Add helper member function is ArrayData::isEmptyArray.

Having the new function forceAsProxyArray simplifies the task of making
some zend extensions port more easily to HHVM.