### PR TITLE
Enable the profiler in server mode.  Don't dump profiler data if it is n...

### DIFF
--- a/hphp/runtime/ext/ext_hotprofiler.h
+++ b/hphp/runtime/ext/ext_hotprofiler.h
@@ -298,7 +298,10 @@ public:
 
   /**
    * Will stop profiling if currently profiling, regardless of how it was
-   * started.
+   * started.  The Variant returned contains profile information.
+   * Some consumers of the return value may json_encode and then var_dump
+   * the returned value, and may choose to skip that step if the return value
+   * is a null Variant.
    */
   Variant stop();
 


### PR DESCRIPTION
...ull.

Some kinds of external profilers will want to run in server mode.

Some kinds of profilers don't have any meaningful data to report back to the
CLI, so if the profiler returns a null variant (presumably from a