### PR TITLE
Add a system profiler and hook some actions of interest to New Relic

### DIFF
--- a/hphp/runtime/base/execution-context.cpp
+++ b/hphp/runtime/base/execution-context.cpp
@@ -45,6 +45,7 @@
 #include "hphp/runtime/base/type-conversions.h"
 #include "hphp/runtime/debugger/debugger.h"
 #include "hphp/runtime/base/unit-cache.h"
+#include "hphp/runtime/ext/ext_system_profiler.h"
 #include "hphp/runtime/ext/std/ext_std_output.h"
 #include "hphp/runtime/ext/string/ext_string.h"
 #include "hphp/runtime/vm/jit/translator-inline.h"
@@ -712,6 +713,10 @@ void ExecutionContext::handleError(const std::string& msg,
 
   if (!handled) {
     recordLastError(ee, errnum);
+  }
+
+  if (g_system_profiler) {
+    g_system_profiler->errorCallBack(ee, errnum, msg);
   }
 
   if (mode == ErrorThrowMode::Always ||

--- a/hphp/runtime/base/unit-cache.cpp
+++ b/hphp/runtime/base/unit-cache.cpp
@@ -30,6 +30,7 @@
 #include "hphp/util/rank.h"
 #include "hphp/util/mutex.h"
 #include "hphp/util/process.h"
+#include "hphp/runtime/ext/ext_system_profiler.h"
 #include "hphp/runtime/base/runtime-option.h"
 #include "hphp/runtime/base/zend-string.h"
 #include "hphp/runtime/base/string-util.h"
@@ -473,6 +474,9 @@ Unit* lookupUnit(StringData* path, const char* currentDir, bool* initial_opt) {
     spath.get()->incRefCount();
     if (!cunit.unit->filepath()->same(spath.get())) {
       eContext->m_evaledFiles[cunit.unit->filepath()] = cunit.unit;
+    }
+    if (g_system_profiler) {
+      g_system_profiler->fileLoadCallBack(path->toCppString());
     }
     DEBUGGER_ATTACHED_ONLY(phpDebuggerFileLoadHook(cunit.unit));
   }

--- a/hphp/runtime/ext/ext_hotprofiler.cpp
+++ b/hphp/runtime/ext/ext_hotprofiler.cpp
@@ -31,6 +31,7 @@
 #include "hphp/util/cycles.h"
 #include "hphp/runtime/base/variable-serializer.h"
 #include "hphp/runtime/ext/std/ext_std_function.h"
+#include "hphp/runtime/ext/ext_system_profiler.h"
 #include "hphp/runtime/ext/xdebug/xdebug_profiler.h"
 #include "hphp/runtime/base/request-event-handler.h"
 
@@ -1351,7 +1352,9 @@ bool ProfilerFactory::start(ProfilerKind kind,
     m_profiler = new XDebugProfiler();
     break;
   case ProfilerKind::External:
-    if (m_external_profiler) {
+    if (g_system_profiler) {
+      m_profiler = g_system_profiler->getHotProfiler();
+    } else if (m_external_profiler) {
       m_profiler = m_external_profiler;
     } else {
       throw_invalid_argument(
@@ -1363,7 +1366,7 @@ bool ProfilerFactory::start(ProfilerKind kind,
     throw_invalid_argument("level: %d", kind);
     return false;
   }
-  if (m_profiler->m_successful) {
+  if (m_profiler && m_profiler->m_successful) {
     // This will be disabled automatically when the thread completes the request
     HPHP::EventHook::Enable();
     ThreadInfo::s_threadInfo->m_profiler = m_profiler;
@@ -1486,7 +1489,6 @@ void f_xhprof_enable(int flags/* = 0 */,
     flags = 0;  /* flags are not used by MemoProfiler::MemoProfiler */
     s_profiler_factory->start(ProfilerKind::Memo, flags);
   } else if (flags & External) {
-    flags = NoTrackBuiltins;
     for (ArrayIter iter(args); iter; ++iter) {
       if (iter.first().toInt32() == 0) {
          flags = iter.second().toInt32();

--- a/hphp/runtime/ext/ext_hotprofiler.h
+++ b/hphp/runtime/ext/ext_hotprofiler.h
@@ -314,7 +314,6 @@ public:
    * Registers a Profiler to use when ProfilerKind::External is used.
    */
   void setExternalProfiler(Profiler *p) {
-    delete(m_external_profiler);
     m_external_profiler = p;
   }
   Profiler *getExternalProfiler() {

--- a/hphp/runtime/ext/ext_system_profiler.cpp
+++ b/hphp/runtime/ext/ext_system_profiler.cpp
@@ -19,6 +19,6 @@
 
 namespace HPHP {
 
-SystemProfiler *g_system_profiler = 0;
+SystemProfiler *g_system_profiler = nullptr;
 
 }

--- a/hphp/runtime/ext/ext_system_profiler.cpp
+++ b/hphp/runtime/ext/ext_system_profiler.cpp
@@ -1,0 +1,24 @@
+/*
+   +----------------------------------------------------------------------+
+   | HipHop for PHP                                                       |
+   +----------------------------------------------------------------------+
+   | Copyright (c) 2010-2014 Facebook, Inc. (http://www.facebook.com)     |
+   | Copyright (c) 1997-2010 The PHP Group                                |
+   +----------------------------------------------------------------------+
+   | This source file is subject to version 3.01 of the PHP license,      |
+   | that is bundled with this package in the file LICENSE, and is        |
+   | available through the world-wide-web at the following url:           |
+   | http://www.php.net/license/3_01.txt                                  |
+   | If you did not receive a copy of the PHP license and are unable to   |
+   | obtain it through the world-wide-web, please send a note to          |
+   | license@php.net so we can mail you a copy immediately.               |
+   +----------------------------------------------------------------------+
+*/
+
+#include "hphp/runtime/ext/ext_system_profiler.h"
+
+namespace HPHP {
+
+SystemProfiler *g_system_profiler = 0;
+
+}

--- a/hphp/runtime/ext/ext_system_profiler.h
+++ b/hphp/runtime/ext/ext_system_profiler.h
@@ -1,0 +1,65 @@
+/*
+   +----------------------------------------------------------------------+
+   | HipHop for PHP                                                       |
+   +----------------------------------------------------------------------+
+   | Copyright (c) 2010-2014 Facebook, Inc. (http://www.facebook.com)     |
+   | Copyright (c) 1997-2010 The PHP Group                                |
+   +----------------------------------------------------------------------+
+   | This source file is subject to version 3.01 of the PHP license,      |
+   | that is bundled with this package in the file LICENSE, and is        |
+   | available through the world-wide-web at the following url:           |
+   | http://www.php.net/license/3_01.txt                                  |
+   | If you did not receive a copy of the PHP license and are unable to   |
+   | obtain it through the world-wide-web, please send a note to          |
+   | license@php.net so we can mail you a copy immediately.               |
+   +----------------------------------------------------------------------+
+*/
+
+#ifndef incl_HPHP_EXT_SYSTEM_PROFILER_H_
+#define incl_HPHP_EXT_SYSTEM_PROFILER_H_
+
+#include <string>
+
+#include "hphp/runtime/base/exceptions.h"
+#include "hphp/runtime/ext/ext_hotprofiler.h"
+
+namespace HPHP {
+
+///////////////////////////////////////////////////////////////////////////////
+// classes
+
+/*
+ * Events interesting to a system profiler.
+ *
+ * A system profiler should instantiate one instance of this class,
+ * and bind the global g_system_profiler to point to that instance.
+ * That binding can be done in a dynamic shared object.
+ */
+
+class SystemProfiler {
+public:
+  SystemProfiler() { }
+  virtual ~SystemProfiler() { }
+
+  /*
+   * Called when a PHP execution error is handled.
+   */
+  virtual void errorCallBack(const ExtendedException &ee,
+                             int errnum,
+                             const std::string &msg) = 0;
+  /*
+   * Called when PHP loads a file.
+   */
+  virtual void fileLoadCallBack(const std::string &name) = 0;
+
+  /*
+   * Called once to get the hotprofiler.
+   */
+  virtual Profiler *getHotProfiler() = 0;
+};
+
+extern SystemProfiler *g_system_profiler;
+
+}
+
+#endif // incl_HPHP_EXT_SYSTEM_PROFILER_H_


### PR DESCRIPTION

This PR re-does an earlier PR which was abandoned in the summer 2014:
  https://github.com/facebook/hhvm/pull/3082
At the time, PR 3082 was abandoned in favor of local development using
a subclass of the recently developed DebugHookHandler. However, using
DebugHookHandler proved to be too intrusive, heavy weight and expensive,
and I find that this mechanism is sufficient, albeit it is yet another
mechanism.

Don't have ProfilerFactory::setExternalProfiler delete a pre-existing
external profiler, as that is not the sole ownership point.

Don't assume that the External profiler wants to ignore builtin functions.