### PR TITLE
partial revert of 56fe9861a1e2b34f64d460e737dcd7cfb902ec5b

### DIFF
--- a/CMake/HPHPCompiler.cmake
+++ b/CMake/HPHPCompiler.cmake
@@ -74,8 +74,8 @@ elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
   endif()
 
   # No optimizations for debug builds.
-  set(CMAKE_C_FLAGS_DEBUG    "-Og")
-  set(CMAKE_CXX_FLAGS_DEBUG  "-Og")
+  set(CMAKE_C_FLAGS_DEBUG    "-Og -ggdb")
+  set(CMAKE_CXX_FLAGS_DEBUG  "-Og -ggdb")
 
   # Generic GCC flags and Optional flags
   set(CMAKE_C_FLAGS_MINSIZEREL       "-Os -DNDEBUG")


### PR DESCRIPTION
`-Og` does not imply `-ggdb` 