### PR TITLE
Call gzclearerr() in gzseek().

### DIFF
--- a/hphp/runtime/ext/zlib/zip-file.cpp
+++ b/hphp/runtime/ext/zlib/zip-file.cpp
@@ -142,6 +142,7 @@ bool ZipFile::seek(int64_t offset, int whence /* = SEEK_SET */) {
   setWritePosition(0);
   setReadPosition(0);
   setEof(false);
+  gzclearerr(m_gzFile);
   flush();
   off_t result = gzseek(m_gzFile, offset, whence);
   setPosition(result);


### PR DESCRIPTION
This clears gzeof so data can be read. This only occurs when the user read
a gz file to the end, seek and read again with buffer size >= 8192.

Part of #4136.
Fixed test/zend/good/ext/zlib/tests/gzreadgzwriteplain.php.