### PR TITLE
Fix segfault with exceptions in object dtors and track_errors

### DIFF
--- a/hphp/runtime/base/execution-context.cpp
+++ b/hphp/runtime/base/execution-context.cpp
@@ -724,12 +724,13 @@ void ExecutionContext::handleError(const std::string& msg,
     throw exn;
   }
   if (!handled) {
-    if (ThreadInfo::s_threadInfo->m_reqInjectionData.hasTrackErrors()) {
+    VMRegAnchor _;
+    auto fp = vmfp();
+
+    if (ThreadInfo::s_threadInfo->m_reqInjectionData.hasTrackErrors() && fp) {
       // Set $php_errormsg in the parent scope
       Variant varFrom(ee.getMessage());
       const auto tvFrom(varFrom.asTypedValue());
-      VMRegAnchor _;
-      auto fp = vmfp();
       if (fp->func()->isBuiltin()) {
         fp = getPrevVMStateUNSAFE(fp);
       }

--- a/hphp/test/slow/exceptions/dtor_track_errors_crash.php
+++ b/hphp/test/slow/exceptions/dtor_track_errors_crash.php
@@ -1,0 +1,10 @@
+<?php
+ini_set('track_errors', 1);
+
+class Foo {
+  public function __destruct() {
+    throw new Exception("FOO");
+  }
+}
+
+$f = new Foo();

--- a/hphp/test/slow/exceptions/dtor_track_errors_crash.php.expectf
+++ b/hphp/test/slow/exceptions/dtor_track_errors_crash.php.expectf
@@ -1,0 +1,4 @@
+%SDestructor threw an object exception: exception 'Exception' with message 'FOO'%S
+%S
+%S
+%S


### PR DESCRIPTION
This fixes the issue tracked in #4577 where throwing an exception
from an object destructor when the 'track_errors' ini setting is
on causes HHVM to segfault, due to accessing the frame pointer after
it has been destroyed.