### PR TITLE
Updated the function definition of mysqli_begin_transaction()

### DIFF
--- a/hphp/runtime/ext/mysql/ext_mysqli.php
+++ b/hphp/runtime/ext/mysql/ext_mysqli.php
@@ -1704,8 +1704,8 @@ function mysqli_autocommit(mysqli $link, bool $mode): bool {
  * @return bool -
  */
 function mysqli_begin_transaction(mysqli $link,
-                                  int $flags,
-                                  string $name): bool {
+                                  int $flags = 0,
+                                  ?string $name = null): bool {
   return $link->begin_transaction($flags, $name);
 }
 


### PR DESCRIPTION
Set default values for the flags[0] and name[null] parameter to ensure compatibility with php
Original defition: http://lxr.php.net/xref/PHP_5_6/ext/mysqli/mysqli_nonapi.c#1116

Covers #4553 