### PR TITLE
Free MySQLStmt, MySQLStmtVariables and the buffer when mysqli_stmt destructs

### DIFF
--- a/hphp/runtime/ext/mysql/ext_mysqli.cpp
+++ b/hphp/runtime/ext/mysql/ext_mysqli.cpp
@@ -634,6 +634,18 @@ static Variant HHVM_METHOD(mysqli_stmt, send_long_data, int64_t param_nr,
   return getStmt(this_)->send_long_data(param_nr, data);
 }
 
+static void HHVM_METHOD(mysqli_stmt, __destruct) {
+  auto res = this_->o_realProp(
+    s_stmt,
+    ObjectData::RealPropUnchecked,
+    s_mysqli_stmt.get()
+  );
+  if (res->isInitialized() && res->isResource()) {
+    auto stmt = res->asResRef().getTyped<MySQLStmt>(false, false);
+    delete stmt;
+  }
+}
+
 //////////////////////////////////////////////////////////////////////////////
 // class mysqli_warning
 
@@ -743,6 +755,7 @@ class mysqliExtension final : public Extension {
     HHVM_ME(mysqli_stmt, reset);
     HHVM_ME(mysqli_stmt, result_metadata);
     HHVM_ME(mysqli_stmt, send_long_data);
+    HHVM_ME(mysqli_stmt, __destruct);
 
     HHVM_FE(mysqli_get_client_version);
     //HHVM_FE(mysqli_get_client_stats);

--- a/hphp/runtime/ext/mysql/ext_mysqli.php
+++ b/hphp/runtime/ext/mysql/ext_mysqli.php
@@ -1334,6 +1334,9 @@ class mysqli_stmt {
     }
   }
 
+  <<__Native>>
+  public function __destruct(): void;
+
   public function __clone(): void {
     throw new Exception(
       'Trying to clone an uncloneable object of class mysqli_stmt'

--- a/hphp/runtime/ext/mysql/mysql_common.cpp
+++ b/hphp/runtime/ext/mysql/mysql_common.cpp
@@ -809,6 +809,13 @@ MySQLStmtVariables::MySQLStmtVariables(std::vector<Variant*> arr): m_arr(arr) {
 }
 
 MySQLStmtVariables::~MySQLStmtVariables() {
+  for (int i = 0; i < m_arr.size(); i++) {
+    MYSQL_BIND *b = &m_vars[i];
+    if (b->buffer_length > 0) {
+      free(b->buffer);
+    }
+  }
+
   free(m_vars);
   free(m_null);
   free(m_length);


### PR DESCRIPTION
This fixes memory leak of mysqli_stmt.

Part 4 of #4505.