### PR TITLE
Cloning exceptions should raise a fatal error

### DIFF
--- a/hphp/system/php/lang/Exception.php
+++ b/hphp/system/php/lang/Exception.php
@@ -24,7 +24,7 @@ class Exception {
    * special logic to call the __init__ method before
    * calling __construct just to make sure $this->trace is always populated.
    */
-  final function __init__() {
+  final public function __init__() {
     if (isset($this->trace)) {
       return;
     }
@@ -52,7 +52,7 @@ class Exception {
    * @previous   mixed   The previous exception used for the exception
    *                     chaining.
    */
-  function __construct($message = '', $code = 0, Exception $previous = null) {
+  public function __construct($message = '', $code = 0, Exception $previous = null) {
     $this->message = $message;
     $this->code = $code;
     $this->previous = $previous;
@@ -66,7 +66,7 @@ class Exception {
    *
    * @return     mixed   Returns the Exception message as a string.
    */
-  function getMessage() {
+  public function getMessage() {
     return $this->message;
   }
 
@@ -80,15 +80,15 @@ class Exception {
    * @return     mixed   Returns the previous Exception if available or NULL
    *                     otherwise.
    */
-  final function getPrevious() {
+  final public function getPrevious() {
     return $this->previous;
   }
 
-  final function setPrevious(Exception $previous) {
+  final public function setPrevious(Exception $previous) {
     $this->previous = $previous;
   }
 
-  final function setPreviousChain(Exception $previous) {
+  final public function setPreviousChain(Exception $previous) {
     $cur = $this;
     $next = $cur->getPrevious();
     while ($next instanceof Exception) {
@@ -108,7 +108,7 @@ class Exception {
    *                     but possibly as other type in Exception descendants
    *                     (for example as string in PDOException).
    */
-  function getCode() {
+  public function getCode() {
     return $this->code;
   }
 
@@ -121,7 +121,7 @@ class Exception {
    * @return     mixed   Returns the filename in which the exception was
    *                     created.
    */
-  final function getFile() {
+  final public function getFile() {
     if (!$this->__check_init(__METHOD__)) {
       return null;
     }
@@ -137,7 +137,7 @@ class Exception {
    * @return     mixed   Returns the line number where the exception was
    *                     created.
    */
-  final function getLine() {
+  final public function getLine() {
     if (!$this->__check_init(__METHOD__)) {
       return null;
     }
@@ -152,7 +152,7 @@ class Exception {
    *
    * @return     mixed   Returns the Exception stack trace as an array.
    */
-  final function getTrace() {
+  final public function getTrace() {
     if (!$this->__check_init(__METHOD__)) {
       return null;
     }
@@ -167,7 +167,7 @@ class Exception {
    *
    * @return     mixed   Returns the Exception stack trace as a string.
    */
-  final function getTraceAsString() {
+  final public function getTraceAsString() {
     if (!$this->__check_init(__METHOD__)) {
       return null;
     }
@@ -196,7 +196,7 @@ class Exception {
    *
    * @return     mixed   Returns the string representation of the exception.
    */
-  function __toString() {
+  public function __toString() {
     $res = "";
     $lst = array();
     $ex = $this;
@@ -242,5 +242,10 @@ class Exception {
 
   public static function setTraceOptions($opts) {
     self::$traceOpts = (int)$opts;
+  }
+
+  final private function __clone() {
+    trigger_error("Trying to clone an uncloneable object of class Exception",
+                  E_USER_ERROR);
   }
 }

--- a/hphp/system/php/lang/Exception.php
+++ b/hphp/system/php/lang/Exception.php
@@ -245,7 +245,7 @@ class Exception {
   }
 
   final private function __clone() {
-    trigger_error("Trying to clone an uncloneable object of class Exception",
-                  E_USER_ERROR);
+    trigger_error("Trying to clone an uncloneable object of class " .
+                  get_class($this), E_USER_ERROR);
   }
 }

--- a/hphp/system/php/lang/Exception.php
+++ b/hphp/system/php/lang/Exception.php
@@ -52,7 +52,8 @@ class Exception {
    * @previous   mixed   The previous exception used for the exception
    *                     chaining.
    */
-  public function __construct($message = '', $code = 0, Exception $previous = null) {
+  public function __construct($message = '', $code = 0,
+                              Exception $previous = null) {
     $this->message = $message;
     $this->code = $code;
     $this->previous = $previous;

--- a/hphp/test/quick/exceptions_clone.php
+++ b/hphp/test/quick/exceptions_clone.php
@@ -1,0 +1,3 @@
+<?php
+
+var_dump(clone new Exception("Class Exeption should not clonable"));

--- a/hphp/test/quick/exceptions_clone.php.expectf
+++ b/hphp/test/quick/exceptions_clone.php.expectf
@@ -1,0 +1,1 @@
+Fatal error: Trying to clone an uncloneable object of class Exception


### PR DESCRIPTION
Closes #4491

There should be more fix afterwards

```php
<?php

class A {
   private function __clone() {

   }
}

clone new A();

```

This should raise calling private method error