### PR TITLE
Store static strings created by create_function() on a thread local map.

### DIFF
--- a/hphp/runtime/base/execution-context.cpp
+++ b/hphp/runtime/base/execution-context.cpp
@@ -118,11 +118,16 @@ template<> void ThreadLocalNoCheck<ExecutionContext>::destroy() {
 
 void ExecutionContext::cleanup() {
   manageAPCHandle();
-
-  // Discard all units that were created via create_function().
-  for (auto& v : m_createdFuncs) delete v;
+  clearCreatedFunctions();
 
   always_assert(m_activeSims.empty());
+}
+
+void ExecutionContext::clearCreatedFunctions() {
+  // Discard all units that were created via create_function().
+  for (auto& v : m_createdFuncs) delete v;
+  m_createdFuncs.clear();
+  clearThreadLocalStaticStringMap();
 }
 
 void ExecutionContext::sweep() {

--- a/hphp/runtime/base/execution-context.h
+++ b/hphp/runtime/base/execution-context.h
@@ -297,6 +297,7 @@ public:
     LeaveLast
   };
   void cleanup();
+  void clearCreatedFunctions();
 
   template <bool setMember, bool warn, bool define, bool unset, bool reffy,
             unsigned mdepth, VectorLeaveCode mleave, bool saveResult>

--- a/hphp/runtime/base/static-string-table.cpp
+++ b/hphp/runtime/base/static-string-table.cpp
@@ -122,8 +122,8 @@ StringData** precompute_chars() {
 
 StringData** precomputed_chars = precompute_chars();
 
-StringData* insertStaticString(StringData* sd) {
-  auto pair = s_stringDataMap->insert(
+StringData* insertStaticString(StringData* sd, StringDataMap* map) {
+  auto pair = map->insert(
     make_intern_key(sd),
     RDS::Link<TypedValue>(RDS::kInvalidHandle)
   );
@@ -139,22 +139,29 @@ StringData* insertStaticString(StringData* sd) {
   return const_cast<StringData*>(to_sdata(pair.first->first));
 }
 
-inline StringData* insertStaticStringSlice(StringSlice slice) {
-  return insertStaticString(StringData::MakeStatic(slice));
+inline StringData* insertStaticStringSlice(StringSlice slice,
+                                           StringDataMap* map) {
+  return insertStaticString(StringData::MakeStatic(slice), map);
 }
 
-void create_string_data_map() {
+void create_string_data_map(StringDataMap*& map) {
   StringDataMap::Config config;
   config.growthFactor = 1;
   MemoryStats::GetInstance()->ResetStaticStringSize();
 
-  s_stringDataMap =
-    new StringDataMap(RuntimeOption::EvalInitialStaticStringTableSize,
-                      config);
-  insertStaticString(StringData::MakeEmpty());
+  map = new StringDataMap(RuntimeOption::EvalInitialStaticStringTableSize,
+                          config);
+  insertStaticString(StringData::MakeEmpty(), map);
 }
 
 }
+
+struct StaticStringData {
+  static DECLARE_THREAD_LOCAL(StringDataMap*, s_localStringDataMap);
+};
+
+IMPLEMENT_THREAD_LOCAL(bool, StaticStringConfig::s_useLocalMap);
+IMPLEMENT_THREAD_LOCAL(StringDataMap*, StaticStringData::s_localStringDataMap);
 
 //////////////////////////////////////////////////////////////////////
 
@@ -165,7 +172,9 @@ size_t makeStaticStringCount() {
 
 StringData* makeStaticString(const StringData* str) {
   if (UNLIKELY(!s_stringDataMap)) {
-    create_string_data_map();
+    create_string_data_map(s_stringDataMap);
+    *StaticStringConfig::s_useLocalMap = false;
+    *StaticStringData::s_localStringDataMap = nullptr;
   }
   if (str->isStatic()) {
     assert(checkStaticStr(str));
@@ -175,18 +184,42 @@ StringData* makeStaticString(const StringData* str) {
   if (it != s_stringDataMap->end()) {
     return const_cast<StringData*>(to_sdata(it->first));
   }
-  return insertStaticStringSlice(str->slice());
+  if (UNLIKELY(*StaticStringConfig::s_useLocalMap)) {
+    StringDataMap*& localMap = *StaticStringData::s_localStringDataMap;
+    if (UNLIKELY(!localMap)) {
+      create_string_data_map(localMap);
+    }
+    auto const value = localMap->find(make_intern_key(str));
+    if (value != localMap->end()) {
+      return const_cast<StringData*>(to_sdata(value->first));
+    }
+    return insertStaticStringSlice(str->slice(), localMap);
+  }
+  return insertStaticStringSlice(str->slice(), s_stringDataMap);
 }
 
 StringData* makeStaticString(StringSlice slice) {
   if (UNLIKELY(!s_stringDataMap)) {
-    create_string_data_map();
+    create_string_data_map(s_stringDataMap);
+    *StaticStringConfig::s_useLocalMap = false;
+    *StaticStringData::s_localStringDataMap = nullptr;
   }
   auto const it = s_stringDataMap->find(make_intern_key(&slice));
   if (it != s_stringDataMap->end()) {
     return const_cast<StringData*>(to_sdata(it->first));
   }
-  return insertStaticStringSlice(slice);
+  if (UNLIKELY(*StaticStringConfig::s_useLocalMap)) {
+    StringDataMap*& localMap = *StaticStringData::s_localStringDataMap;
+    if (UNLIKELY(!localMap)) {
+      create_string_data_map(localMap);
+    }
+    auto const value = localMap->find(make_intern_key(&slice));
+    if (value != localMap->end()) {
+      return const_cast<StringData*>(to_sdata(value->first));
+    }
+    return insertStaticStringSlice(slice, localMap);
+  }
+  return insertStaticStringSlice(slice, s_stringDataMap);
 }
 
 StringData* lookupStaticString(const StringData *str) {
@@ -307,12 +340,40 @@ void refineStaticStringTableSize() {
   if (!oldStringTable) return;
 
   s_stringDataMap = nullptr;
-  create_string_data_map();
+  create_string_data_map(s_stringDataMap);
   SCOPE_EXIT { delete oldStringTable; };
 
   for (auto& kv : *oldStringTable) {
     s_stringDataMap->insert(kv.first, kv.second);
   }
+}
+
+void clearThreadLocalStaticStringMap() {
+  StringDataMap* localMap = *StaticStringData::s_localStringDataMap;
+  if (!localMap) return;
+
+  // Avoid clearing the map to improve performance if it's not used.
+  if (localMap->size() == 1 &&
+      to_sdata(localMap->begin()->first) == staticEmptyString())
+    return;
+
+  for (auto& kv : *localMap) {
+    const StringData* str = to_sdata(kv.first);
+    // Skip the empty string.
+    if (str == staticEmptyString())
+      continue;
+    const_cast<StringData*>(str)->destructStatic();
+  }
+  localMap->clear();
+  insertStaticString(StringData::MakeEmpty(), localMap);
+}
+
+void freeThreadLocalStaticStringMap() {
+  StringDataMap*& localMap = *StaticStringData::s_localStringDataMap;
+  if (!localMap) return;
+
+  delete localMap;
+  localMap = nullptr;
 }
 
 //////////////////////////////////////////////////////////////////////

--- a/hphp/runtime/base/static-string-table.h
+++ b/hphp/runtime/base/static-string-table.h
@@ -20,6 +20,7 @@
 #include "hphp/runtime/base/types.h"
 
 #include "hphp/util/slice.h"
+#include "hphp/util/thread-local.h"
 
 #include <string>
 
@@ -117,6 +118,19 @@ Array lookupDefinedConstants(bool categorize = false);
  * still be in a single-threaded environment.
  */
 void refineStaticStringTableSize();
+
+/*
+ * Store static strings that are created by php scripts on a thread local map,
+ * such as create_function().
+ *
+ * The memory of these strings will be freed when the script finishes.
+ */
+struct StaticStringConfig {
+  static DECLARE_THREAD_LOCAL(bool, s_useLocalMap);
+};
+
+void clearThreadLocalStaticStringMap();
+void freeThreadLocalStaticStringMap();
 
 //////////////////////////////////////////////////////////////////////
 

--- a/hphp/runtime/server/http-request-handler.cpp
+++ b/hphp/runtime/server/http-request-handler.cpp
@@ -58,6 +58,10 @@ HttpRequestHandler::HttpRequestHandler(int timeout)
                                  "requests_timed_out_on_queue",
                                  {ServiceData::StatsType::COUNT})) { }
 
+HttpRequestHandler::~HttpRequestHandler() {
+  freeThreadLocalStaticStringMap();
+}
+
 void HttpRequestHandler::sendStaticContent(Transport *transport,
                                            const char *data, int len,
                                            time_t mtime,

--- a/hphp/runtime/server/http-request-handler.h
+++ b/hphp/runtime/server/http-request-handler.h
@@ -42,6 +42,7 @@ public:
 
 public:
   explicit HttpRequestHandler(int timeout);
+  ~HttpRequestHandler();
 
   // implementing RequestHandler
   void setupRequest(Transport* transport) override;

--- a/hphp/runtime/vm/bytecode.cpp
+++ b/hphp/runtime/vm/bytecode.cpp
@@ -2581,7 +2581,9 @@ StrNR ExecutionContext::createFunction(const String& args,
           << "(" << args.data() << ") {"
           << code.data() << "}\n";
   std::string evalCode = codeStr.str();
+  *StaticStringConfig::s_useLocalMap = true;
   Unit* unit = compile_string(evalCode.data(), evalCode.size());
+  *StaticStringConfig::s_useLocalMap = false;
   // Move the function to a different name.
   std::ostringstream newNameStr;
   newNameStr << '\0' << "lambda_" << ++m_lambdaCounter;
@@ -7674,6 +7676,7 @@ void ExecutionContext::requestExit() {
   profileRequestEnd();
   EventHook::Disable();
   EnvConstants::requestExit();
+  clearCreatedFunctions();
 
   if (m_globalVarEnv) {
     smart_delete(m_globalVarEnv);

--- a/hphp/runtime/vm/bytecode.cpp
+++ b/hphp/runtime/vm/bytecode.cpp
@@ -2581,9 +2581,7 @@ StrNR ExecutionContext::createFunction(const String& args,
           << "(" << args.data() << ") {"
           << code.data() << "}\n";
   std::string evalCode = codeStr.str();
-  *StaticStringConfig::s_useLocalMap = true;
-  Unit* unit = compile_string(evalCode.data(), evalCode.size());
-  *StaticStringConfig::s_useLocalMap = false;
+  Unit* unit = compile_string(evalCode.data(), evalCode.size(), nullptr, true);
   // Move the function to a different name.
   std::ostringstream newNameStr;
   newNameStr << '\0' << "lambda_" << ++m_lambdaCounter;

--- a/hphp/runtime/vm/runtime.cpp
+++ b/hphp/runtime/vm/runtime.cpp
@@ -188,15 +188,16 @@ Unit* compile_string(const char* s,
                      size_t sz,
                      const char* fname /* = nullptr */,
                      bool useLocalStaticStringMap /* = false */) {
-  if (useLocalStaticStringMap)
-    *StaticStringConfig::s_useLocalMap = true;
-
   auto md5string = string_md5(s, sz);
   MD5 md5(md5string.c_str());
   Unit* u = Repo::get().loadUnit(fname ? fname : "", md5).release();
   if (u != nullptr) {
     return u;
   }
+
+  if (useLocalStaticStringMap)
+    *StaticStringConfig::s_useLocalMap = true;
+
   // NB: fname needs to be long-lived if generating a bytecode repo because it
   // can be cached via a Location ultimately contained by ErrorInfo for printing
   // code errors.

--- a/hphp/runtime/vm/runtime.cpp
+++ b/hphp/runtime/vm/runtime.cpp
@@ -186,7 +186,11 @@ Unit* build_native_class_unit(const HhbcExtClassInfo* builtinClasses,
 
 Unit* compile_string(const char* s,
                      size_t sz,
-                     const char* fname /* = nullptr */) {
+                     const char* fname /* = nullptr */,
+                     bool useLocalStaticStringMap /* = false */) {
+  if (useLocalStaticStringMap)
+    *StaticStringConfig::s_useLocalMap = true;
+
   auto md5string = string_md5(s, sz);
   MD5 md5(md5string.c_str());
   Unit* u = Repo::get().loadUnit(fname ? fname : "", md5).release();
@@ -196,7 +200,11 @@ Unit* compile_string(const char* s,
   // NB: fname needs to be long-lived if generating a bytecode repo because it
   // can be cached via a Location ultimately contained by ErrorInfo for printing
   // code errors.
-  return g_hphp_compiler_parse(s, sz, md5, fname);
+  auto unit = g_hphp_compiler_parse(s, sz, md5, fname);
+
+  if (useLocalStaticStringMap)
+    *StaticStringConfig::s_useLocalMap = false;
+  return unit;
 }
 
 Unit* compile_systemlib_string(const char* s, size_t sz,

--- a/hphp/runtime/vm/runtime.h
+++ b/hphp/runtime/vm/runtime.h
@@ -216,7 +216,10 @@ frame_free_args(TypedValue* args, int count) {
 
 Unit*
 compile_file(const char* s, size_t sz, const MD5& md5, const char* fname);
-Unit* compile_string(const char* s, size_t sz, const char* fname = nullptr);
+Unit* compile_string(const char* s,
+                     size_t sz,
+                     const char* fname = nullptr,
+                     bool useLocalStaticStringMap = false);
 Unit* compile_systemlib_string(const char* s, size_t sz, const char* fname);
 Unit* build_native_func_unit(const HhbcExtFuncInfo* builtinFuncs,
                                  ssize_t numBuiltinFuncs);


### PR DESCRIPTION
The memory of these static strings and compiled units are freed when the
script finishes. Part of #4250.