### PR TITLE
Remove Redis::SERIALIZER_IGBINARY constant

### DIFF
--- a/hphp/system/php/redis/Redis.php
+++ b/hphp/system/php/redis/Redis.php
@@ -46,7 +46,6 @@ class Redis {
   /* Type of serialization to use with values stored in redis */
   const SERIALIZER_NONE     = 0;
   const SERIALIZER_PHP      = 1;
-  const SERIALIZER_IGBINARY = 2;
 
   /* Options used by lInsert and similar methods */
   const AFTER  = 'after';
@@ -97,9 +96,8 @@ class Redis {
         return true;
 
       case self::OPT_SERIALIZER:
-        if (($value !== self::SERIALIZER_NONE) AND
-            ($value !== self::SERIALIZER_PHP) AND
-            ($value !== self::SERIALIZER_IGBINARY)) {
+        if (($value !== self::SERIALIZER_NONE) &&
+            ($value !== self::SERIALIZER_PHP)) {
           throw new RedisException("Invalid serializer option: $value");
         }
         $this->serializer = (int)$value;
@@ -1129,7 +1127,6 @@ class Redis {
         return $str;
       case self::SERIALIZER_PHP:
         return serialize($str);
-      case self::SERIALIZER_IGBINARY:
       default:
         throw new RedisException("Not Implemented");
     }
@@ -1141,7 +1138,6 @@ class Redis {
         return $str;
       case self::SERIALIZER_PHP:
         return unserialize($str);
-      case self::SERIALIZER_IGBINARY:
       default:
         throw new RedisException("Not Implemented");
     }


### PR DESCRIPTION
In the original phpredis extension `Redis::SERIALIZER_IGBINARY` constant is only defined when phpredis is compiled with `--enable-redis-igbinary` flag: https://github.com/phpredis/phpredis/blob/2336477e10f7e6e7bb10fecc5988e807b2a8c1e3/redis.c#L537. That allows to do the simple `if (defined(Redis::SERIALIZER_IGBINARY))` check to ensure that the igbinary serializer is available.