### PR TITLE
Replaced uses of StringData::bufferSlice() with mutableData()

### DIFF
--- a/hphp/runtime/base/builtin-functions.cpp
+++ b/hphp/runtime/base/builtin-functions.cpp
@@ -660,10 +660,10 @@ String concat3(const String& s1, const String& s2, const String& s3) {
   StringSlice r3 = s3.slice();
   int len = r1.len + r2.len + r3.len;
   StringData* str = StringData::Make(len);
-  auto const r = str->bufferSlice();
-  memcpy(r.ptr,                   r1.ptr, r1.len);
-  memcpy(r.ptr + r1.len,          r2.ptr, r2.len);
-  memcpy(r.ptr + r1.len + r2.len, r3.ptr, r3.len);
+  auto const r = str->mutableData();
+  memcpy(r,                   r1.ptr, r1.len);
+  memcpy(r + r1.len,          r2.ptr, r2.len);
+  memcpy(r + r1.len + r2.len, r3.ptr, r3.len);
   str->setSize(len);
   return str;
 }
@@ -676,11 +676,11 @@ String concat4(const String& s1, const String& s2, const String& s3,
   StringSlice r4 = s4.slice();
   int len = r1.len + r2.len + r3.len + r4.len;
   StringData* str = StringData::Make(len);
-  auto const r = str->bufferSlice();
-  memcpy(r.ptr,                            r1.ptr, r1.len);
-  memcpy(r.ptr + r1.len,                   r2.ptr, r2.len);
-  memcpy(r.ptr + r1.len + r2.len,          r3.ptr, r3.len);
-  memcpy(r.ptr + r1.len + r2.len + r3.len, r4.ptr, r4.len);
+  auto const r = str->mutableData();
+  memcpy(r,                            r1.ptr, r1.len);
+  memcpy(r + r1.len,                   r2.ptr, r2.len);
+  memcpy(r + r1.len + r2.len,          r3.ptr, r3.len);
+  memcpy(r + r1.len + r2.len + r3.len, r4.ptr, r4.len);
   str->setSize(len);
   return str;
 }

--- a/hphp/runtime/base/file-util.cpp
+++ b/hphp/runtime/base/file-util.cpp
@@ -401,7 +401,7 @@ String FileUtil::relativePath(const std::string& fromDir,
   }
 
   String ret(maxlen, ReserveString);
-  char* path = ret.bufferSlice().ptr;
+  char* path = ret.mutableData();
 
   const char* from_dir = fromDir.c_str();
   const char* to_file = toFile.c_str();
@@ -490,7 +490,7 @@ String FileUtil::canonicalize(const char *addpath, size_t addlen,
     addpath = "";
 
   String ret(maxlen-1, ReserveString);
-  char *path = ret.bufferSlice().ptr;
+  char *path = ret.mutableData();
 
   if (addpath[0] == '/' && collapse_slashes) {
     /* Ignore the given root path, strip off leading

--- a/hphp/runtime/base/file.cpp
+++ b/hphp/runtime/base/file.cpp
@@ -284,7 +284,7 @@ String File::read(int64_t length) {
 
   auto const allocSize = length;
   String s = String(allocSize, ReserveString);
-  char *ret = s.bufferSlice().ptr;
+  char *ret = s.mutableData();
   int64_t copied = 0;
   int64_t avail = bufferedLen();
 
@@ -702,7 +702,7 @@ Variant File::readRecord(const String& delimiter, int64_t maxlen /* = 0 */) {
 
   if (toread >= 0) {
     String s = String(toread, ReserveString);
-    char *buf = s.bufferSlice().ptr;
+    char *buf = s.mutableData();
     if (toread) {
       memcpy(buf, m_data->m_buffer + m_data->m_readpos, toread);
     }

--- a/hphp/runtime/base/php-stream-wrapper.cpp
+++ b/hphp/runtime/base/php-stream-wrapper.cpp
@@ -85,7 +85,7 @@ static SmartPtr<File> phpStreamOpenFilter(const char* sFilter,
   }
 
   String duppath(sFilter, CopyString);
-  char *path = duppath.bufferSlice().ptr;
+  char *path = duppath.mutableData();
   char *p = strstr(path, "/resource=");
   if (!p) {
     raise_recoverable_error("No URL resource specified");

--- a/hphp/runtime/base/string-data-inl.h
+++ b/hphp/runtime/base/string-data-inl.h
@@ -113,7 +113,11 @@ inline const char* StringData::data() const {
   return m_data;
 }
 
-inline char* StringData::mutableData() const { return m_data; }
+inline char* StringData::mutableData() const {
+  assert(!isImmutable());
+  return m_data;
+}
+
 inline int StringData::size() const { return m_len; }
 inline bool StringData::empty() const { return size() == 0; }
 inline uint32_t StringData::capacity() const {

--- a/hphp/runtime/base/string-data.cpp
+++ b/hphp/runtime/base/string-data.cpp
@@ -490,14 +490,13 @@ StringData* StringData::append(StringSlice range) {
 
   auto const target = UNLIKELY(isShared()) ? escalate(newLen)
                                            : reserve(newLen);
-  auto const mslice = target->bufferSlice();
 
   /*
    * memcpy is safe even if it's a self append---the regions will be
    * disjoint, since s can't point past the start of our source
    * pointer, and len is smaller than the old length.
    */
-  memcpy(mslice.ptr + m_len, s, len);
+  memcpy(target->mutableData() + m_len, s, len);
 
   target->setSize(newLen);
   assert(target->checkSane());
@@ -530,14 +529,13 @@ StringData* StringData::append(StringSlice r1, StringSlice r2) {
 
   auto const target = UNLIKELY(isShared()) ? escalate(newLen)
                                            : reserve(newLen);
-  auto const mslice = target->bufferSlice();
 
   /*
    * memcpy is safe even if it's a self append---the regions will be
    * disjoint, since rN.ptr can't point past the start of our source
    * pointer, and rN.len is smaller than the old length.
    */
-  void* p = mslice.ptr;
+  void* p = target->mutableData();
   p = memcpy((char*)p + m_len,  r1.ptr, r1.len);
       memcpy((char*)p + r1.len, r2.ptr, r2.len);
 
@@ -575,14 +573,13 @@ StringData* StringData::append(StringSlice r1,
 
   auto const target = UNLIKELY(isShared()) ? escalate(newLen)
                                            : reserve(newLen);
-  auto const mslice = target->bufferSlice();
 
   /*
    * memcpy is safe even if it's a self append---the regions will be
    * disjoint, since rN.ptr can't point past the start of our source
    * pointer, and rN.len is smaller than the old length.
    */
-  void* p = mslice.ptr;
+  void* p = target->mutableData();
   p = memcpy((char*)p + m_len,  r1.ptr, r1.len);
   p = memcpy((char*)p + r1.len, r2.ptr, r2.len);
       memcpy((char*)p + r2.len, r3.ptr, r3.len);

--- a/hphp/runtime/base/string-util.cpp
+++ b/hphp/runtime/base/string-util.cpp
@@ -134,7 +134,7 @@ String StringUtil::Implode(const Variant& items, const String& delim) {
   assert(i == size);
 
   String s = String(len, ReserveString);
-  char *buffer = s.bufferSlice().ptr;
+  char *buffer = s.mutableData();
   const char *sdelim = delim.data();
   char *p = buffer;
   for (int i = 0; i < size; i++) {
@@ -422,7 +422,7 @@ String StringUtil::Translate(const String& input, const String& from,
 
   int len = input.size();
   String retstr(len, ReserveString);
-  char *ret = retstr.bufferSlice().ptr;
+  char *ret = retstr.mutableData();
   memcpy(ret, input.data(), len);
   auto trlen = std::min(from.size(), to.size());
   string_translate(ret, len, from.data(), to.data(), trlen);
@@ -456,7 +456,7 @@ String StringUtil::MD5(const char *data, uint32_t size,
   if (raw) return String((char*)md5.digest, rawLen, CopyString);
   auto const hexLen = rawLen * 2;
   String hex(hexLen, ReserveString);
-  string_bin2hex((char*)md5.digest, rawLen, hex.bufferSlice().ptr);
+  string_bin2hex((char*)md5.digest, rawLen, hex.mutableData());
   hex.setSize(hexLen);
   return hex;
 }

--- a/hphp/runtime/base/thrift-buffer.h
+++ b/hphp/runtime/base/thrift-buffer.h
@@ -200,7 +200,7 @@ public:
     read(size);
     if (size > 0 && size + 1 > 0) {
       data = String(size, ReserveString);
-      char *buf = data.bufferSlice().ptr;
+      char *buf = data.mutableData();
       read(buf, size);
       data.setSize(size);
     } else if (size) {

--- a/hphp/runtime/base/type-string.cpp
+++ b/hphp/runtime/base/type-string.cpp
@@ -547,9 +547,8 @@ void String::unserialize(VariableUnserializer *uns,
   uns->expectChar(delimiter0);
 
   StringData *px = StringData::Make(int(size));
-  auto const buf = px->bufferSlice();
-  assert(size <= buf.len);
-  uns->read(buf.ptr, size);
+  assert(size <= px->capacity());
+  uns->read(px->mutableData(), size);
   px->setSize(size);
   if (m_px) decRefStr(m_px);
   m_px = px;

--- a/hphp/runtime/base/type-string.h
+++ b/hphp/runtime/base/type-string.h
@@ -215,6 +215,11 @@ public:
   const char *data() const {
     return m_px ? m_px->data() : "";
   }
+
+  char *mutableData() const {
+    return m_px->mutableData();
+  }
+
 public:
   const String& setSize(int len) {
     assert(m_px);

--- a/hphp/runtime/base/zend-pack.cpp
+++ b/hphp/runtime/base/zend-pack.cpp
@@ -341,7 +341,7 @@ Variant ZendPack::pack(const String& fmt, const Array& argv) {
   }
 
   String s = String(outputsize, ReserveString);
-  char *output = s.bufferSlice().ptr;
+  char *output = s.mutableData();
   outputpos = 0;
   currentarg = 0;
 
@@ -752,7 +752,7 @@ Variant ZendPack::unpack(const String& fmt, const String& data) {
           }
 
           String s = String(len, ReserveString);
-          buf = s.bufferSlice().ptr;
+          buf = s.mutableData();
 
           for (ipos = opos = 0; opos < len; opos++) {
             char c = (input[inputpos + ipos] >> nibbleshift) & 0xf;

--- a/hphp/runtime/base/zend-string.cpp
+++ b/hphp/runtime/base/zend-string.cpp
@@ -292,7 +292,7 @@ int string_natural_cmp(char const *a, size_t a_len,
 void string_to_case(String& s, int (*tocase)(int)) {
   assert(!s.isNull());
   assert(tocase);
-  auto data = s.bufferSlice().ptr;
+  auto data = s.mutableData();
   auto len = s.size();
   for (int i = 0; i < len; i++) {
     data[i] = tocase(data[i]);
@@ -324,7 +324,7 @@ String string_pad(const char *input, int len, int pad_length,
   }
 
   String ret(pad_length, ReserveString);
-  char *result = ret.bufferSlice().ptr;
+  char *result = ret.mutableData();
 
   /* We need to figure out the left/right padding lengths. */
   int left_pad, right_pad;
@@ -512,7 +512,7 @@ String string_replace(const char *s, int len, int start, int length,
   }
 
   String retString(len + len_repl - length, ReserveString);
-  char *ret = retString.bufferSlice().ptr;
+  char *ret = retString.mutableData();
 
   int ret_len = 0;
   if (start) {
@@ -589,7 +589,7 @@ String string_replace(const char *input, int len,
   }
 
   String retString(reserve, ReserveString);
-  char *ret = retString.bufferSlice().ptr;
+  char *ret = retString.mutableData();
   char *p = ret;
   int pos = 0; // last position in input that hasn't been copied over yet
   int n;
@@ -634,7 +634,7 @@ String string_chunk_split(const char *src, int srclen, const char *end,
     ),
     ReserveString
   );
-  char *dest = ret.bufferSlice().ptr;
+  char *dest = ret.mutableData();
 
   const char *p; char *q;
   const char *pMax = src + srclen - chunklen + 1;
@@ -756,7 +756,7 @@ String string_strip_tags(const char *s, const int len,
   assert(allow);
 
   String retString(s, len, CopyString);
-  rbuf = retString.bufferSlice().ptr;
+  rbuf = retString.mutableData();
   String allowString;
 
   c = *s;
@@ -768,7 +768,7 @@ String string_strip_tags(const char *s, const int len,
     assert(allow);
 
     allowString = String(allow_len, ReserveString);
-    char *atmp = allowString.bufferSlice().ptr;
+    char *atmp = allowString.mutableData();
     for (const char *tmp = allow; *tmp; tmp++, atmp++) {
       *atmp = tolower((int)*(const unsigned char *)tmp);
     }
@@ -1006,7 +1006,7 @@ String string_addslashes(const char *str, int length) {
   }
 
   String retString((length << 1) + 1, ReserveString);
-  char *new_str = retString.bufferSlice().ptr;
+  char *new_str = retString.mutableData();
   const char *source = str;
   const char *end = source + length;
   char *target = new_str;
@@ -1065,7 +1065,7 @@ String string_quoted_printable_encode(const char *input, int len) {
       1),
     ReserveString
   );
-  d = buffer = ret.bufferSlice().ptr;
+  d = buffer = ret.mutableData();
 
   while (length--) {
     if (((c = *str++) == '\015') && (*str == '\012') && length > 0) {
@@ -1114,7 +1114,7 @@ String string_quoted_printable_decode(const char *input, int len, bool is_q) {
   int i = 0, j = 0, k;
   const char *str_in = input;
   String ret(len, ReserveString);
-  char *str_out = ret.bufferSlice().ptr;
+  char *str_out = ret.mutableData();
   while (i < len && str_in[i]) {
     switch (str_in[i]) {
     case '=':
@@ -1285,7 +1285,7 @@ String string_uuencode(const char *src, int src_len) {
 
   /* encoded length is ~ 38% greater than the original */
   String ret((int)ceil(src_len * 1.38) + 45, ReserveString);
-  p = dest = ret.bufferSlice().ptr;
+  p = dest = ret.mutableData();
   s = src;
   e = src + src_len;
 
@@ -1345,7 +1345,7 @@ String string_uudecode(const char *src, int src_len) {
   char *p, *dest;
 
   String ret(ceil(src_len * 0.75), ReserveString);
-  p = dest = ret.bufferSlice().ptr;
+  p = dest = ret.mutableData();
   s = src;
   e = src + src_len;
 
@@ -1442,7 +1442,7 @@ static String php_base64_encode(const unsigned char *str, int length) {
   }
 
   String ret(((length + 2) / 3) * 4, ReserveString);
-  p = result = (unsigned char *)ret.bufferSlice().ptr;
+  p = result = (unsigned char *)ret.mutableData();
 
   while (length > 2) { /* keep going until we have less than 24 bits */
     *p++ = base64_table[current[0] >> 2];
@@ -1477,7 +1477,7 @@ static String php_base64_decode(const char *str, int length, bool strict) {
   /* this sucks for threaded environments */
 
   String retString(length, ReserveString);
-  unsigned char* result = (unsigned char*)retString.bufferSlice().ptr;
+  unsigned char* result = (unsigned char*)retString.mutableData();
 
   /* run through the whole string, converting as we go */
   while ((ch = *current++) != '\0' && length-- > 0) {
@@ -1557,7 +1557,7 @@ String string_escape_shell_arg(const char *str) {
   l = strlen(str);
 
   String ret(safe_address(l, 4, 3), ReserveString); /* worst case */
-  cmd = ret.bufferSlice().ptr;
+  cmd = ret.mutableData();
 
   cmd[y++] = '\'';
 
@@ -1584,7 +1584,7 @@ String string_escape_shell_cmd(const char *str) {
 
   l = strlen(str);
   String ret(safe_address(l, 2, 1), ReserveString);
-  cmd = ret.bufferSlice().ptr;
+  cmd = ret.mutableData();
 
   for (x = 0, y = 0; x < l; x++) {
     switch (str[x]) {
@@ -1747,7 +1747,7 @@ String string_money_format(const char *format, double value) {
   int format_len = strlen(format);
   int str_len = safe_address(format_len, 1, 1024);
   String ret(str_len, ReserveString);
-  char *str = ret.bufferSlice().ptr;
+  char *str = ret.mutableData();
   if ((str_len = strfmon(str, str_len, format, value)) < 0) {
     return String();
   }
@@ -1778,7 +1778,7 @@ String string_number_format(double d, int dec,
 
   // departure from PHP: we got rid of dependencies on spprintf() here.
   String tmpstr(63, ReserveString);
-  tmpbuf = tmpstr.bufferSlice().ptr;
+  tmpbuf = tmpstr.mutableData();
   tmplen = snprintf(tmpbuf, 64, "%.*F", dec, d);
   if (tmpbuf == nullptr || !isdigit((int)tmpbuf[0])) {
     tmpstr.setSize(tmplen);
@@ -1787,7 +1787,7 @@ String string_number_format(double d, int dec,
   if (tmplen >= 64) {
     // Uncommon, asked for more than 64 chars worth of precision
     tmpstr = String(tmplen, ReserveString);
-    tmpbuf = tmpstr.bufferSlice().ptr;
+    tmpbuf = tmpstr.mutableData();
     tmplen = snprintf(tmpbuf, tmplen + 1, "%.*F", dec, d);
     if (tmpbuf == nullptr || !isdigit((int)tmpbuf[0])) {
       tmpstr.setSize(tmplen);
@@ -1830,7 +1830,7 @@ String string_number_format(double d, int dec,
     reslen++;
   }
   String resstr(reslen, ReserveString);
-  resbuf = resstr.bufferSlice().ptr;
+  resbuf = resstr.mutableData();
 
   s = tmpbuf+tmplen-1;
   t = resbuf+reslen-1;
@@ -1891,7 +1891,7 @@ String string_soundex(const String& str) {
   assert(!str.empty());
   int _small, code, last;
   String retString(4, ReserveString);
-  char* soundex = retString.bufferSlice().ptr;
+  char* soundex = retString.mutableData();
 
   static char soundex_table[26] = {
     0,              /* A */
@@ -2522,7 +2522,7 @@ String string_convert_cyrillic_string(const String& input, char from, char to) {
   unsigned char tmp;
   const unsigned char *uinput = (unsigned char *)input.slice().ptr;
   String retString(input.size(), ReserveString);
-  unsigned char *str = (unsigned char *)retString.bufferSlice().ptr;
+  unsigned char *str = (unsigned char *)retString.mutableData();
 
   from_table = nullptr;
   to_table   = nullptr;
@@ -2660,7 +2660,7 @@ String string_convert_hebrew_string(const String& inStr,
   } while (block_end < str_len-1);
 
   String brokenStr(str_len, ReserveString);
-  broken_str = brokenStr.bufferSlice().ptr;
+  broken_str = brokenStr.mutableData();
   begin=end=str_len-1;
   target = broken_str;
 

--- a/hphp/runtime/base/zend-url.cpp
+++ b/hphp/runtime/base/zend-url.cpp
@@ -30,7 +30,7 @@ static void replace_controlchars(String& output, const char *str, int len) {
   unsigned char *s = (unsigned char *)str;
   unsigned char *e = (unsigned char *)str + len;
   output = String(str, len, CopyString);
-  char *outbuf = output.bufferSlice().ptr;
+  char *outbuf = output.mutableData();
   while (s < e) {
     if (iscntrl(*s)) {
       *outbuf='_';
@@ -319,7 +319,7 @@ String url_encode(const char *s, int len) {
 
   from = (unsigned char const *)s;
   end = (unsigned char const *)s + len;
-  start = to = (unsigned char *)retString.bufferSlice().ptr;
+  start = to = (unsigned char *)retString.mutableData();
 
   while (from < end) {
     c = *from++;
@@ -344,7 +344,7 @@ String url_encode(const char *s, int len) {
 
 String url_decode(const char *s, int len) {
   String retString(s, len, CopyString);
-  char *str = retString.bufferSlice().ptr;
+  char *str = retString.mutableData();
   char *dest = str;
   char *data = str;
 
@@ -423,7 +423,7 @@ int url_decode_ex(char *value, int len) {
 String url_raw_encode(const char *s, int len) {
   String retString(safe_address(len, 3, 1), ReserveString);
   register int x, y;
-  unsigned char *str = (unsigned char *)retString.bufferSlice().ptr;
+  unsigned char *str = (unsigned char *)retString.mutableData();
 
   for (x = 0, y = 0; len--; x++, y++) {
     str[y] = (unsigned char) s[x];
@@ -442,7 +442,7 @@ String url_raw_encode(const char *s, int len) {
 
 String url_raw_decode(const char *s, int len) {
   String retString(s, len, CopyString);
-  char *str = retString.bufferSlice().ptr;
+  char *str = retString.mutableData();
   char *dest = str;
   char *data = str;
 

--- a/hphp/runtime/ext/VariantController.h
+++ b/hphp/runtime/ext/VariantController.h
@@ -139,7 +139,7 @@ struct VariantController {
     return empty_string();
   }
   static char* getMutablePtr(StringType& s) {
-    return s.bufferSlice().ptr;
+    return s.mutableData();
   }
   static void shrinkString(String& s, size_t length) {
     s.shrink(length);

--- a/hphp/runtime/ext/bz2/ext_bz2.cpp
+++ b/hphp/runtime/ext/bz2/ext_bz2.cpp
@@ -178,7 +178,7 @@ Variant HHVM_FUNCTION(bzdecompress, const String& source, int small /* = 0 */) {
   // base
   bzs.avail_out = source_len * 2;
   String ret(bzs.avail_out, ReserveString);
-  bzs.next_out = ret.bufferSlice().ptr;
+  bzs.next_out = ret.mutableData();
 
   while ((error = BZ2_bzDecompress(&bzs)) == BZ_OK && bzs.avail_in > 0) {
     /* compression is better then 2:1, need to allocate more memory */

--- a/hphp/runtime/ext/ext_collections.cpp
+++ b/hphp/runtime/ext/ext_collections.cpp
@@ -68,7 +68,7 @@ static void throwIntOOB(int64_t key, bool isVector = false)
 void throwIntOOB(int64_t key, bool isVector /* = false */) {
   static const size_t reserveSize = 50;
   String msg(reserveSize, ReserveString);
-  char* buf = msg.bufferSlice().ptr;
+  char* buf = msg.mutableData();
   int sz = sprintf(buf, "Integer key %" PRId64 " is %s", key,
                    isVector ? "out of bounds" : "not defined");
   assert(sz <= reserveSize);
@@ -1546,7 +1546,7 @@ void HashCollection::throwTooLarge() {
   assert(getClassName().size() == 6);
   static const size_t reserveSize = 130;
   String msg(reserveSize, ReserveString);
-  char* buf = msg.bufferSlice().ptr;
+  char* buf = msg.mutableData();
   int sz = sprintf(
     buf,
     "%s object has reached its maximum capacity of %u element "
@@ -1565,7 +1565,7 @@ void HashCollection::throwReserveTooLarge() {
   assert(getClassName().size() == 6);
   static const size_t reserveSize = 80;
   String msg(reserveSize, ReserveString);
-  char* buf = msg.bufferSlice().ptr;
+  char* buf = msg.mutableData();
   int sz = sprintf(
     buf,
     "%s does not support reserving room for more than %u elements",

--- a/hphp/runtime/ext/ext_fb.cpp
+++ b/hphp/runtime/ext/ext_fb.cpp
@@ -132,7 +132,7 @@ Variant f_fb_serialize(const Variant& thing) {
       HPHP::serialize::FBSerializer<VariantController>::serializedSize(thing);
     String s(len, ReserveString);
     HPHP::serialize::FBSerializer<VariantController>::serialize(
-      thing, s.bufferSlice().ptr);
+      thing, s.mutableData());
     s.setSize(len);
     return s;
   } catch (const HPHP::serialize::SerializeError&) {
@@ -519,7 +519,7 @@ String fb_compact_serialize(const Variant& thing,
     int64_t val = thing.toInt64();
     if (val >= 0 && (uint64_t)val <= kInt7Mask) {
       String s(2, ReserveString);
-      *(uint16_t*)(s.bufferSlice().ptr) = (uint16_t)htons(kInt13Prefix | val);
+      *(uint16_t*)(s.mutableData()) = (uint16_t)htons(kInt13Prefix | val);
       s.setSize(2);
       return s;
     }
@@ -818,7 +818,7 @@ bool f_fb_utf8ize(VRefParam input) {
     return false; // Too long.
   }
   String dstStr(dstMaxLenBytes, ReserveString);
-  char *dstBuf = dstStr.bufferSlice().ptr;
+  char *dstBuf = dstStr.mutableData();
 
   // Copy valid bytes found so far as one solid block.
   memcpy(dstBuf, srcBuf, srcPosBytes);
@@ -921,7 +921,7 @@ static String fb_utf8_substr_simple(const String& str, int32_t firstCodePoint,
     return empty_string(); // Too long.
   }
   String dstStr(dstMaxLenBytes, ReserveString);
-  char* dstBuf = dstStr.bufferSlice().ptr;
+  char* dstBuf = dstStr.mutableData();
   int32_t dstPosBytes = 0;
 
   // Iterate through src's codepoints; srcPosBytes is incremented by U8_NEXT.

--- a/hphp/runtime/ext/ext_hash.cpp
+++ b/hphp/runtime/ext/ext_hash.cpp
@@ -229,7 +229,7 @@ static Variant php_hash_do_hash(const String& algo, const String& data,
   }
 
   String raw = String(ops->digest_size, ReserveString);
-  char *digest = raw.bufferSlice().ptr;
+  char *digest = raw.mutableData();
   ops->hash_final((unsigned char *)digest, context);
   free(context);
 
@@ -339,7 +339,7 @@ Variant HHVM_FUNCTION(hash_final, const Resource& context,
   }
 
   String raw = String(hash->ops->digest_size, ReserveString);
-  char *digest = raw.bufferSlice().ptr;
+  char *digest = raw.mutableData();
   hash->ops->hash_final((unsigned char *)digest, hash->context);
   if (hash->options & k_HASH_HMAC) {
     finalize_hmac_key(hash->key, hash->ops, hash->context, digest);

--- a/hphp/runtime/ext/icu/ext_icu_misc.cpp
+++ b/hphp/runtime/ext/icu/ext_icu_misc.cpp
@@ -103,11 +103,11 @@ static Variant doIdnTranslateUTS46(const String& domain, int64_t options,
   auto capacity = result.capacity() + 1;
   if (toUtf8) {
     len = uidna_nameToUnicodeUTF8(idna, domain.c_str(), domain.size(),
-                                  result.bufferSlice().ptr, capacity,
+                                  result.mutableData(), capacity,
                                   &info, &error);
   } else {
     len = uidna_nameToASCII_UTF8(idna, domain.c_str(), domain.size(),
-                                 result.bufferSlice().ptr, capacity,
+                                 result.mutableData(), capacity,
                                  &info, &error);
   }
   if (len > capacity) {

--- a/hphp/runtime/ext/icu/ext_icu_uconverter.cpp
+++ b/hphp/runtime/ext/icu/ext_icu_uconverter.cpp
@@ -386,7 +386,7 @@ static Variant HHVM_METHOD(UConverter, convert,
   }
 
   String destStr(dest_len, ReserveString);
-  char *dest = (char*) destStr.bufferSlice().ptr;
+  char *dest = (char*) destStr.mutableData();
   error = U_ZERO_ERROR;
   dest_len = ucnv_fromUChars(toCnv, dest, dest_len,
                              tmp.getBuffer(), tmp.length(), &error);

--- a/hphp/runtime/ext/mcrypt/ext_mcrypt.cpp
+++ b/hphp/runtime/ext/mcrypt/ext_mcrypt.cpp
@@ -155,13 +155,13 @@ static Variant php_mcrypt_do_crypt(const String& cipher, const String& key,
     block_size = mcrypt_enc_get_block_size(td);
     data_size = (((data.size() - 1) / block_size) + 1) * block_size;
     s = String(data_size, ReserveString);
-    data_s = (char*)s.bufferSlice().ptr;
+    data_s = (char*)s.mutableData();
     memset(data_s, 0, data_size);
     memcpy(data_s, data.data(), data.size());
   } else { /* It's not a block algorithm */
     data_size = data.size();
     s = String(data_size, ReserveString);
-    data_s = (char*)s.bufferSlice().ptr;
+    data_s = (char*)s.mutableData();
     memcpy(data_s, data.data(), data.size());
   }
 
@@ -208,13 +208,13 @@ static Variant mcrypt_generic(const Resource& td, const String& data,
     block_size = mcrypt_enc_get_block_size(pm->m_td);
     data_size = (((data.size() - 1) / block_size) + 1) * block_size;
     s = String(data_size, ReserveString);
-    data_s = (unsigned char *)s.bufferSlice().ptr;
+    data_s = (unsigned char *)s.mutableData();
     memset(data_s, 0, data_size);
     memcpy(data_s, data.data(), data.size());
   } else { /* It's not a block algorithm */
     data_size = data.size();
     s = String(data_size, ReserveString);
-    data_s = (unsigned char *)s.bufferSlice().ptr;
+    data_s = (unsigned char *)s.mutableData();
     memcpy(data_s, data.data(), data.size());
   }
 

--- a/hphp/runtime/ext/mysql/ext_mysql.cpp
+++ b/hphp/runtime/ext/mysql/ext_mysql.cpp
@@ -125,7 +125,7 @@ static bool HHVM_FUNCTION(mysql_set_timeout, int query_timeout_ms /* = -1 */,
 static String HHVM_FUNCTION(mysql_escape_string,
                             const String& unescaped_string) {
   String new_str((size_t)unescaped_string.size() * 2 + 1, ReserveString);
-  unsigned long new_len = mysql_escape_string(new_str.bufferSlice().begin(),
+  unsigned long new_len = mysql_escape_string(new_str.mutableData(),
                                     unescaped_string.data(),
                                     unescaped_string.size());
   new_str.shrink(new_len);
@@ -139,7 +139,7 @@ static Variant HHVM_FUNCTION(mysql_real_escape_string,
   if (conn) {
     String new_str((size_t)unescaped_string.size() * 2 + 1, ReserveString);
     unsigned long new_len = mysql_real_escape_string(conn,
-                                      new_str.bufferSlice().begin(),
+                                      new_str.mutableData(),
                                       unescaped_string.data(),
                                       unescaped_string.size());
 

--- a/hphp/runtime/ext/openssl/ext_openssl.cpp
+++ b/hphp/runtime/ext/openssl/ext_openssl.cpp
@@ -1215,7 +1215,7 @@ bool HHVM_FUNCTION(openssl_open, const String& sealed_data, VRefParam open_data,
   EVP_PKEY *pkey = okey->m_key;
 
   String s = String(sealed_data.size(), ReserveString);
-  unsigned char *buf = (unsigned char *)s.bufferSlice().ptr;
+  unsigned char *buf = (unsigned char *)s.mutableData();
 
   EVP_CIPHER_CTX ctx;
   int len1, len2;
@@ -1920,7 +1920,7 @@ bool HHVM_FUNCTION(openssl_private_decrypt, const String& data,
   EVP_PKEY *pkey = okey->m_key;
   int cryptedlen = EVP_PKEY_size(pkey);
   String s = String(cryptedlen, ReserveString);
-  unsigned char *cryptedbuf = (unsigned char *)s.bufferSlice().ptr;
+  unsigned char *cryptedbuf = (unsigned char *)s.mutableData();
 
   int successful = 0;
   switch (pkey->type) {
@@ -1960,7 +1960,7 @@ bool HHVM_FUNCTION(openssl_private_encrypt, const String& data,
   EVP_PKEY *pkey = okey->m_key;
   int cryptedlen = EVP_PKEY_size(pkey);
   String s = String(cryptedlen, ReserveString);
-  unsigned char *cryptedbuf = (unsigned char *)s.bufferSlice().ptr;
+  unsigned char *cryptedbuf = (unsigned char *)s.mutableData();
 
   int successful = 0;
   switch (pkey->type) {
@@ -1996,7 +1996,7 @@ bool HHVM_FUNCTION(openssl_public_decrypt, const String& data,
   EVP_PKEY *pkey = okey->m_key;
   int cryptedlen = EVP_PKEY_size(pkey);
   String s = String(cryptedlen, ReserveString);
-  unsigned char *cryptedbuf = (unsigned char *)s.bufferSlice().ptr;
+  unsigned char *cryptedbuf = (unsigned char *)s.mutableData();
 
   int successful = 0;
   switch (pkey->type) {
@@ -2036,7 +2036,7 @@ bool HHVM_FUNCTION(openssl_public_encrypt, const String& data,
   EVP_PKEY *pkey = okey->m_key;
   int cryptedlen = EVP_PKEY_size(pkey);
   String s = String(cryptedlen, ReserveString);
-  unsigned char *cryptedbuf = (unsigned char *)s.bufferSlice().ptr;
+  unsigned char *cryptedbuf = (unsigned char *)s.mutableData();
 
   int successful = 0;
   switch (pkey->type) {
@@ -2124,7 +2124,7 @@ Variant HHVM_FUNCTION(openssl_seal, const String& data, VRefParam sealed_data,
   int len1, len2;
 
   s = String(data.size() + EVP_CIPHER_CTX_block_size(&ctx), ReserveString);
-  buf = (unsigned char *)s.bufferSlice().ptr;
+  buf = (unsigned char *)s.mutableData();
   if (!EVP_SealInit(&ctx, cipher_type, eks, eksl, nullptr, pkeys, nkeys) ||
       !EVP_SealUpdate(&ctx, buf, &len1, (unsigned char *)data.data(),
                       data.size())) {
@@ -2201,7 +2201,7 @@ bool HHVM_FUNCTION(openssl_sign, const String& data, VRefParam signature,
   EVP_PKEY *pkey = okey->m_key;
   int siglen = EVP_PKEY_size(pkey);
   String s = String(siglen, ReserveString);
-  unsigned char *sigbuf = (unsigned char *)s.bufferSlice().ptr;
+  unsigned char *sigbuf = (unsigned char *)s.mutableData();
 
   EVP_MD_CTX md_ctx;
   EVP_SignInit(&md_ctx, mdtype);
@@ -2625,7 +2625,7 @@ Variant HHVM_FUNCTION(openssl_random_pseudo_bytes, int length,
   unsigned char *buffer = NULL;
 
   String s = String(length, ReserveString);
-  buffer = (unsigned char *)s.bufferSlice().ptr;
+  buffer = (unsigned char *)s.mutableData();
 
   crypto_strong = false;
 
@@ -2665,7 +2665,7 @@ static String php_openssl_validate_iv(String piv, int iv_required_len) {
   }
 
   String s = String(iv_required_len, ReserveString);
-  iv_new = s.bufferSlice().ptr;
+  iv_new = s.mutableData();
   memset(iv_new, 0, iv_required_len);
 
   if (piv.size() <= 0) {
@@ -2710,7 +2710,7 @@ Variant HHVM_FUNCTION(openssl_encrypt, const String& data, const String& method,
    */
   if (keylen > password.size()) {
     String s = String(keylen, ReserveString);
-    char *keybuf = s.bufferSlice().ptr;
+    char *keybuf = s.mutableData();
     memset(keybuf, 0, keylen);
     memcpy(keybuf, password.data(), password.size());
     key = s.setSize(keylen);
@@ -2728,7 +2728,7 @@ Variant HHVM_FUNCTION(openssl_encrypt, const String& data, const String& method,
 
   int outlen = data.size() + EVP_CIPHER_block_size(cipher_type);
   String rv = String(outlen, ReserveString);
-  unsigned char *outbuf = (unsigned char*)rv.bufferSlice().ptr;
+  unsigned char *outbuf = (unsigned char*)rv.mutableData();
 
   EVP_CIPHER_CTX cipher_ctx;
 
@@ -2791,7 +2791,7 @@ Variant HHVM_FUNCTION(openssl_decrypt, const String& data, const String& method,
    */
    if (keylen > password.size()) {
     String s = String(keylen, ReserveString);
-    char *keybuf = s.bufferSlice().ptr;
+    char *keybuf = s.mutableData();
     memset(keybuf, 0, keylen);
     memcpy(keybuf, password.data(), password.size());
     key = s.setSize(keylen);
@@ -2804,7 +2804,7 @@ Variant HHVM_FUNCTION(openssl_decrypt, const String& data, const String& method,
 
   int outlen = decoded_data.size() + EVP_CIPHER_block_size(cipher_type);
   String rv = String(outlen, ReserveString);
-  unsigned char *outbuf = (unsigned char*)rv.bufferSlice().ptr;
+  unsigned char *outbuf = (unsigned char*)rv.mutableData();
 
   EVP_CIPHER_CTX cipher_ctx;
   EVP_DecryptInit(&cipher_ctx, cipher_type, NULL, NULL);
@@ -2842,7 +2842,7 @@ Variant HHVM_FUNCTION(openssl_digest, const String& data, const String& method,
   }
   int siglen = EVP_MD_size(mdtype);
   String rv = String(siglen, ReserveString);
-  unsigned char *sigbuf = (unsigned char *)rv.bufferSlice().ptr;
+  unsigned char *sigbuf = (unsigned char *)rv.mutableData();
   EVP_MD_CTX md_ctx;
 
   EVP_DigestInit(&md_ctx, mdtype);

--- a/hphp/runtime/ext/pdo/ext_pdo.cpp
+++ b/hphp/runtime/ext/pdo/ext_pdo.cpp
@@ -2648,7 +2648,7 @@ safe:
 rewrite:
     /* allocate output buffer */
     out = String(newbuffer_len, ReserveString);
-    newbuffer = out.bufferSlice().ptr;
+    newbuffer = out.mutableData();
 
     /* and build the query */
     plc = placeholders;

--- a/hphp/runtime/ext/pdo_mysql.cpp
+++ b/hphp/runtime/ext/pdo_mysql.cpp
@@ -566,7 +566,7 @@ int64_t PDOMySqlConnection::doer(const String& sql) {
 bool PDOMySqlConnection::quoter(const String& input, String &quoted,
                                 PDOParamType paramtype) {
   String s(2 * input.size() + 3, ReserveString);
-  char *buf = s.bufferSlice().ptr;
+  char *buf = s.mutableData();
   int len = mysql_real_escape_string(m_server, buf + 1,
                                      input.data(), input.size());
   len++;

--- a/hphp/runtime/ext/pdo_sqlite.cpp
+++ b/hphp/runtime/ext/pdo_sqlite.cpp
@@ -205,7 +205,7 @@ bool PDOSqliteConnection::quoter(const String& input, String &quoted,
                                  PDOParamType paramtype) {
   int len = 2 * input.size() + 3;
   String s(len, ReserveString);
-  char *buf = s.bufferSlice().ptr;
+  char *buf = s.mutableData();
   sqlite3_snprintf(len, buf, "'%q'", input.data());
   quoted = s.setSize(strlen(buf));
   return true;

--- a/hphp/runtime/ext/posix/ext_posix.cpp
+++ b/hphp/runtime/ext/posix/ext_posix.cpp
@@ -161,7 +161,7 @@ bool HHVM_FUNCTION(posix_access,
 
 String HHVM_FUNCTION(posix_ctermid) {
   String s = String(L_ctermid, ReserveString);
-  char *buffer = s.bufferSlice().ptr;
+  char *buffer = s.mutableData();
   ctermid(buffer);
   s.setSize(strlen(buffer));
   return s;
@@ -177,7 +177,7 @@ int64_t HHVM_FUNCTION(posix_errno) {
 
 String HHVM_FUNCTION(posix_getcwd) {
   String s = String(PATH_MAX, ReserveString);
-  char *buffer = s.bufferSlice().ptr;
+  char *buffer = s.mutableData();
   if (getcwd(buffer, PATH_MAX) == NULL) {
     return "/";
   }
@@ -560,7 +560,7 @@ Variant HHVM_FUNCTION(posix_ttyname,
   }
 
   String ttyname(ttyname_maxlen, ReserveString);
-  char *p = ttyname.bufferSlice().ptr;
+  char *p = ttyname.mutableData();
   if (ttyname_r(php_posix_get_fd(fd), p, ttyname_maxlen)) {
     return false;
   }

--- a/hphp/runtime/ext/session/ext_session.cpp
+++ b/hphp/runtime/ext/session/ext_session.cpp
@@ -594,7 +594,7 @@ public:
     }
 
     String s = String(m_st_size, ReserveString);
-    char *val = s.bufferSlice().ptr;
+    char *val = s.mutableData();
 
 #if defined(HAVE_PREAD)
     long n = pread(m_fd, val, m_st_size, 0);

--- a/hphp/runtime/ext/std/ext_std_misc.cpp
+++ b/hphp/runtime/ext/std/ext_std_misc.cpp
@@ -413,7 +413,7 @@ String HHVM_FUNCTION(uniqid, const String& prefix /* = null_string */,
   int usec = (int)(tv.tv_usec % 0x100000);
 
   String uniqid(prefix.size() + 64, ReserveString);
-  auto ptr = uniqid.bufferSlice().ptr;
+  auto ptr = uniqid.mutableData();
   // StringData::capacity() returns the buffer size without the null
   // terminator. snprintf expects a the buffer capacity including room
   // for the null terminator, writes the null termintor, and returns

--- a/hphp/runtime/ext/std/ext_std_network.cpp
+++ b/hphp/runtime/ext/std/ext_std_network.cpp
@@ -499,7 +499,7 @@ static unsigned char *php_parserr(unsigned char *cp, unsigned char* end,
     int l1 = 0, l2 = 0;
 
     String s = String(dlen, ReserveString);
-    tp = (unsigned char *)s.bufferSlice().ptr;
+    tp = (unsigned char *)s.mutableData();
 
     while (l1 < dlen) {
       n = cp[l1];

--- a/hphp/runtime/ext/std/ext_std_string.cpp
+++ b/hphp/runtime/ext/std/ext_std_string.cpp
@@ -54,8 +54,7 @@ Variant HHVM_FUNCTION(wordwrap, const String& str, int64_t linewidth /* = 75 */,
     auto new_sd = StringData::Make(str.get(), CopyString);
     new_sd->invalidateHash();
     Variant ret = new_sd;
-    auto const bs = new_sd->bufferSlice();
-    char* newtext = bs.begin();
+    char* newtext = new_sd->mutableData();
     auto bc = brkstr[0];
     size_t current = 0, laststart = 0, lastspace = 0;
     for (; current < textlen; current++) {

--- a/hphp/runtime/ext/string/ext_string.cpp
+++ b/hphp/runtime/ext/string/ext_string.cpp
@@ -62,12 +62,11 @@ String stringForEach(uint32_t len, const String& str, Op action) {
   String ret = mutate ? str : String(len, ReserveString);
 
   StringSlice srcSlice = str.slice();
-  auto const dstSlice = ret.bufferSlice();
 
   const char* src = srcSlice.begin();
   const char* end = srcSlice.end();
 
-  char* dst = dstSlice.begin();
+  char* dst = ret.mutableData();
 
   for (; src != end; ++src, ++dst) {
     *dst = action(*src);
@@ -476,7 +475,7 @@ String stringTrim(String& str, const String& charlist) {
   if (str.get()->hasExactlyOneRef()) {
     int slen = end - start + 1;
     if (start) {
-      char* sdata = str.bufferSlice().ptr;
+      char* sdata = str.mutableData();
       for (int idx = 0; start < len;) sdata[idx++] = sdata[start++];
     }
     return String(str.get()->shrink(slen));
@@ -850,7 +849,7 @@ String HHVM_FUNCTION(str_repeat,
   if (input.size() == 1) {
     String ret(multiplier, ReserveString);
 
-    memset(ret.bufferSlice().ptr, *input.data(), multiplier);
+    memset(ret.mutableData(), *input.data(), multiplier);
     ret.setSize(multiplier);
     return ret;
   }
@@ -1734,7 +1733,7 @@ String HHVM_FUNCTION(sha1,
 bool strtr_slow(const Array& arr, StringBuffer& result, String& key,
                 const char*s, int& pos, int minlen, int maxlen) {
 
-  memcpy(key.bufferSlice().ptr, s + pos, maxlen);
+  memcpy(key.mutableData(), s + pos, maxlen);
   for (int len = maxlen; len >= minlen; len--) {
     key.setSize(len);
     auto const& var = arr->get(key.toKey());

--- a/hphp/runtime/ext/thrift/binary.cpp
+++ b/hphp/runtime/ext/thrift/binary.cpp
@@ -174,7 +174,7 @@ Variant binary_deserialize(int8_t thrift_typeID, PHPInputTransport& transport,
       uint32_t size = transport.readU32();
       if (size && (size + 1)) {
         String s = String(size, ReserveString);
-        char* strbuf = s.bufferSlice().ptr;
+        char* strbuf = s.mutableData();
         transport.readBytes(strbuf, size);
         s.setSize(size);
         return s;

--- a/hphp/runtime/ext/thrift/compact.cpp
+++ b/hphp/runtime/ext/thrift/compact.cpp
@@ -992,7 +992,7 @@ class CompactReader {
 
       if (size && (size + 1)) {
         String s = String(size, ReserveString);
-        char* buf = s.bufferSlice().ptr;
+        char* buf = s.mutableData();
 
         transport.readBytes(buf, size);
         s.setSize(size);

--- a/hphp/runtime/ext/xml/ext_xml.cpp
+++ b/hphp/runtime/ext/xml/ext_xml.cpp
@@ -226,7 +226,7 @@ static int _xml_xmlcharlen(const XML_Char *s) {
 String xml_utf8_decode(const XML_Char *s, int len,
                        const XML_Char *encoding) {
   String str = String(len, ReserveString);
-  char *newbuf = str.bufferSlice().ptr;
+  char *newbuf = str.mutableData();
   char (*decoder)(unsigned short) = nullptr;
   xml_encoding *enc = xml_get_encoding(encoding);
 
@@ -940,7 +940,7 @@ String HHVM_FUNCTION(xml_error_string,
 String HHVM_FUNCTION(utf8_decode,
                      const String& data) {
   String str = String(data.size(), ReserveString);
-  char *newbuf = str.bufferSlice().ptr;
+  char *newbuf = str.mutableData();
   int newlen = 0;
   const char *s = data.data();
 
@@ -959,7 +959,7 @@ String HHVM_FUNCTION(utf8_encode,
                      const String& data) {
   auto const maxSize = safe_cast<size_t>(data.size()) * 4;
   String str = String(maxSize, ReserveString);
-  char *newbuf = str.bufferSlice().ptr;
+  char *newbuf = str.mutableData();
   int newlen = 0;
   const char *s = data.data();
   for (int pos = data.size(); pos > 0; pos--, s++) {

--- a/hphp/runtime/vm/blob-helper.h
+++ b/hphp/runtime/vm/blob-helper.h
@@ -372,7 +372,7 @@ private:
     if (sz == 0) return empty_string();
 
     String s = String(sz, ReserveString);
-    char* pch = s.bufferSlice().ptr;
+    char* pch = s.mutableData();
     assert(m_last - m_p >= sz);
     std::copy(m_p, m_p + sz, pch);
     m_p += sz;

--- a/hphp/runtime/vm/member-operations.h
+++ b/hphp/runtime/vm/member-operations.h
@@ -796,7 +796,7 @@ inline StringData* SetElemString(TypedValue* base, key_type<keyType> key,
     }
   } else {
     StringData* sd = StringData::Make(slen);
-    char* s = sd->bufferSlice().ptr;
+    char* s = sd->mutableData();
     memcpy(s, base->m_data.pstr->data(), baseLen);
     if (x > baseLen) {
       memset(&s[baseLen], ' ', slen - baseLen - 1);


### PR DESCRIPTION
A list of all the uses of StringData::bufferSlice()
Observe how all of them except the three in StringBuffer immediately just ask for MutableSlice::ptr and discard the capacity() information.
Fixes #4633