### PR TITLE
Modified StringData::shrink() to check against the capacity

### DIFF
--- a/hphp/runtime/base/string-data.cpp
+++ b/hphp/runtime/base/string-data.cpp
@@ -621,13 +621,11 @@ StringData* StringData::reserve(size_t cap) {
 StringData* StringData::shrinkImpl(size_t len) {
   assert(!isImmutable() && !hasMultipleRefs());
   assert(isFlat());
-  assert(len <= m_len);
   assert(len <= capacity());
 
   auto const sd = Make(len);
   auto const src = slice();
   auto const dst = sd->mutableData();
-  assert(len <= src.len);
   sd->setSize(len);
 
   auto const mcret = memcpy(dst, src.ptr, len);
@@ -640,7 +638,7 @@ StringData* StringData::shrinkImpl(size_t len) {
 }
 
 StringData* StringData::shrink(size_t len) {
-  if (len < size() && size() - len > kMinShrinkThreshold) {
+  if (capacity() - len > kMinShrinkThreshold) {
     return shrinkImpl(len);
   }
   assert(len < MaxSize);

--- a/hphp/runtime/base/type-string.h
+++ b/hphp/runtime/base/type-string.h
@@ -223,7 +223,7 @@ public:
   }
   const String& shrink(size_t len) {
     assert(m_px);
-    if (len < m_px->size() && m_px->size() - len > kMinShrinkThreshold) {
+    if (m_px->capacity() - len > kMinShrinkThreshold) {
       StringBase::operator=(m_px->shrinkImpl(len));
     } else {
       assert(len < StringData::MaxSize);


### PR DESCRIPTION
I also added comments to places where shrink() was being used potentially incorrectly, per request by Ed.
Technically this implementation of shrink() is still wrong, it should be comparing the (predicted) new capacity against the old one, which could potentially be calculated by calling MemoryManager::smartSizeClass() on the new length value.

Ref #4632