### PR TITLE
Remove $ENV config from FindMySQL.cmake

### DIFF
--- a/CMake/FindMySQL.cmake
+++ b/CMake/FindMySQL.cmake
@@ -31,8 +31,6 @@
 
 #-------------- FIND MYSQL_INCLUDE_DIR ------------------
 FIND_PATH(MYSQL_INCLUDE_DIR mysql.h
-  $ENV{MYSQL_INCLUDE_DIR}
-  $ENV{MYSQL_DIR}/include
   /usr/include/mysql
   /usr/local/include/mysql
   /opt/mysql/mysql/include
@@ -70,9 +68,6 @@ IF (WIN32)
 ELSE (WIN32)
   FIND_LIBRARY(MYSQL_LIB NAMES mysqlclient_r
     PATHS
-    $ENV{MYSQL_DIR}/libmysql_r/.libs
-    $ENV{MYSQL_DIR}/lib
-    $ENV{MYSQL_DIR}/lib/mysql
     /usr/lib/mysql
     /usr/local/lib/mysql
     /usr/local/mysql/lib


### PR DESCRIPTION
These are seemingly superflous, considering that you can
still configure which library and include directory to use
with cmake -D parameters.

I was figuring out why

 # cmake .

 show showing me:

  -- MySQL Include dir: /usr/include/mysql  library dir: /lib/mysql

when it should have been:

  -- MySQL Include dir: /usr/include/mysql  library dir: /usr/lib64/mysqlh


For some reason that i don't comprehend, this particular line was causing the problem:

$ENV{MYSQL_DIR}/lib/mysql


I didn't touch the windows section because such variables may or may not still be useful there, I don't know enough about windows stuff to be able to tell.

If you think they should be removed too, then i will add that to this PR also.