### PR TITLE
Accept image/png as a legal mimetype from ext_imagick.

### DIFF
--- a/hphp/test/slow/ext_imagick/getImageMimeType.php.expectf
+++ b/hphp/test/slow/ext_imagick/getImageMimeType.php.expectf
@@ -1,1 +1,1 @@
-string(%s) "image/%spng"
+string(%s) "image/%Spng"


### PR DESCRIPTION
The expect pattern string %s matches >1 characters; %S matches >0 characters.
The mimetype "image/png" is enumerated as such in
  http://php.net/manual/en/function.image-type-to-mime-type.php