### PR TITLE
Implemented `hhvm-gdb` command and distribute gdb scripts

### DIFF
--- a/hphp/CMakeLists.txt
+++ b/hphp/CMakeLists.txt
@@ -92,5 +92,7 @@ if (TEST_BIN)
   add_subdirectory(test)
 endif ()
 
+add_subdirectory(tools/gdb)
+
 # Keep this last
 add_subdirectory(tools/hphpize)

--- a/hphp/tools/gdb/CMakeLists.txt
+++ b/hphp/tools/gdb/CMakeLists.txt
@@ -1,0 +1,12 @@
+GET_DIRECTORY_PROPERTY(SOURCE_INCLUDE_DIRS INCLUDE_DIRECTORIES)
+GET_DIRECTORY_PROPERTY(HHVM_DEFINITIONS COMPILE_DEFINITIONS)
+
+configure_file(hhvm-gdb.in hhvm-gdb ESCAPE_QUOTES @ONLY)
+install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/hhvm-gdb
+  DESTINATION bin
+  COMPONENT dev)
+
+install(FILES deref.py gdbutils.py hashes.py hhbc.py hhvm.py idx.py
+              lookup.py nameof.py pretty.py stack.py unit.py
+  DESTINATION "${CMAKE_INSTALL_LIBDIR}/hhvm/gdb"
+  COMPONENT dev)

--- a/hphp/tools/gdb/README.md
+++ b/hphp/tools/gdb/README.md
@@ -5,8 +5,12 @@ This directory contains a collection of Python-GDB utilities for HHVM
 debugging, catered in particular towards debugging with a core, when no live
 inferior is present.
 
-To make use of them, simply execute the following line when running GDB, or add
-it to your ~/.gdbinit (substituting the path to your hphp directory as
+
+If you have installed `hhvm-dev` pacakge, there should be a `hhvm-gdb` command
+available, it will automatically load those library files for you.
+
+If you havn't install it, you can simply execute the following line when running
+GDB, or add it to your ~/.gdbinit (substituting the path to your hphp directory as
 appropriate):
 
     source <path-to-hphp>/tools/gdb/hhvm.py

--- a/hphp/tools/gdb/hhvm-gdb.in
+++ b/hphp/tools/gdb/hhvm-gdb.in
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+set -e
+
+HHVM_INSTALL_PREFIX="@CMAKE_INSTALL_PREFIX@"
+HHVM_INSTALL_LIBDIR="@CMAKE_INSTALL_LIBDIR@"
+HHVM_LIB="$HHVM_INSTALL_PREFIX/$HHVM_INSTALL_LIBDIR/hhvm"
+
+if [ -z "$HHVM_BIN" ] ; then
+  HHVM_BIN=$HHVM_INSTALL_PREFIX/bin/hhvm
+fi
+
+echo "Debugging with hhvm: $HHVM_BIN ..."
+
+gdb --command=$HHVM_LIB/gdb/hhvm.py --exec=$HHVM_BIN "$@"

--- a/hphp/tools/gdb/hhvm-gdb.in
+++ b/hphp/tools/gdb/hhvm-gdb.in
@@ -12,4 +12,9 @@ fi
 
 echo "Debugging with hhvm: $HHVM_BIN ..."
 
-gdb --command=$HHVM_LIB/gdb/hhvm.py --exec=$HHVM_BIN "$@"
+EXEC_CMD=--exec=$HHVM_BIN
+if [ "$1" = "--args" ]; then
+  EXEC_CMD=""
+fi
+
+exec gdb --command=$HHVM_LIB/gdb/hhvm.py $EXEC_CMD "$@"


### PR DESCRIPTION
This diff add a `hhvm-gdb` command to help debugging with hhvm.
it will be distributed with `hhvm-dev` package.

Debug with distributed hhvm bin

`hhvm-gdb $OTHER_GDB_PARAMS`

or specified one:

`HHVM_BIN=/path/to/your/hhvm-bin hhvm-gdb $OTHER_GDB_PARAMS`

---
After the diff been merged I will add a note to the wiki page:
https://github.com/facebook/hhvm/wiki/Reporting-Crashes