### PR TITLE
Normalize modern ICU's Farsi's (fa_IR) output.

### DIFF
--- a/hphp/test/slow/ext_icu/NumberFormatter_rounding.php
+++ b/hphp/test/slow/ext_icu/NumberFormatter_rounding.php
@@ -25,14 +25,16 @@ function test_rounding($locale, $digits, $mode = null) {
     //
     // Remove the Unicode Character 'LEFT-TO-RIGHT MARK' (U+200E)
     // which some versions of ICU use for Farsi.
+    // See http://www.fileformat.info/info/unicode/char/200e/index.htm
     //
-    $to_print = str_replace("‎", "", $to_print);
+    $to_print = str_replace("\xe2\x80\x8e", "", $to_print);
 
     //
     // Replace the Unicode Character 'MINUS SIGN' (U+2212)
     // which some versions of ICU use for Farsi.
+    // See http://www.fileformat.info/info/unicode/char/2212/index.htm
     //
-    $to_print = str_replace("−", "-", $to_print);
+    $to_print = str_replace("\xe2\x88\x92", "-", $to_print);
 
     echo $to_print;
     echo "\n";

--- a/hphp/test/slow/ext_icu/NumberFormatter_rounding.php
+++ b/hphp/test/slow/ext_icu/NumberFormatter_rounding.php
@@ -20,7 +20,21 @@ function test_rounding($locale, $digits, $mode = null) {
   foreach ($values as $value) {
     echo $value;
     echo " -> ";
-    echo $formatter->format($value);
+    $to_print = $formatter->format($value);
+
+    //
+    // Remove the Unicode Character 'LEFT-TO-RIGHT MARK' (U+200E)
+    // which some versions of ICU use for Farsi.
+    //
+    $to_print = str_replace("‎", "", $to_print);
+
+    //
+    // Replace the Unicode Character 'MINUS SIGN' (U+2212)
+    // which some versions of ICU use for Farsi.
+    //
+    $to_print = str_replace("−", "-", $to_print);
+
+    echo $to_print;
     echo "\n";
   }
 }


### PR DESCRIPTION
In order to match the expect, which was generated
on a slightly different version ofICU:
  * Remove  the Unicode left-to-right mark;
  * Replace the Unicode MINUS sign with an ASCII minus.

Ubuntu 14.04 stock ICU now passes NumberFormatter_rounding.php;
See the chatter in
  https://github.com/facebook/hhvm/commit/2c0b77ece17b4a7516eebcb628bf04e1f649c902

The direct embedding of UTF8 characters in "" strings in the PHP source may violate conventions.