### PR TITLE
zend initialization settings now work better

### DIFF
--- a/hphp/runtime/base/memory-manager.cpp
+++ b/hphp/runtime/base/memory-manager.cpp
@@ -505,7 +505,7 @@ void MemoryManager::flush() {
  *     through a different entry point.  (E.g. MM().smartFreeSize or
  *     MM().smartFreeSizeBig.)
  *
- * When small blocks are freed (case b and c), they're placed the
+ * When small blocks are freed (case b and c), they're placed in the
  * appropriate size-segregated freelist.  Large blocks are immediately
  * passed back to libc via free.
  *

--- a/hphp/runtime/ext_zend_compat/php-src/Zend/zend_ini.cpp
+++ b/hphp/runtime/ext_zend_compat/php-src/Zend/zend_ini.cpp
@@ -28,8 +28,8 @@
 
 #include "hphp/runtime/base/ini-setting.h"
 
-#define NO_VALUE_PLAINTEXT		"no value"
-#define NO_VALUE_HTML			"<i>no value</i>"
+#define NO_VALUE_PLAINTEXT "no value"
+#define NO_VALUE_HTML      "<i>no value</i>"
 
 /* {{{ */
 
@@ -177,7 +177,9 @@ ZEND_API int zend_register_ini_entries_of_certain_mode(
   return code;
 }
 
-ZEND_API int zend_register_ini_entries(const zend_ini_entry *ini_entry, int module_number TSRMLS_DC)
+ZEND_API int zend_register_ini_entries(
+  const zend_ini_entry *ini_entry,
+  int module_number TSRMLS_DC)
 {
   int acceptable_mode_mask = 0;
   acceptable_mode_mask |= ZEND_INI_USER;

--- a/hphp/runtime/ext_zend_compat/php-src/Zend/zend_ini.cpp
+++ b/hphp/runtime/ext_zend_compat/php-src/Zend/zend_ini.cpp
@@ -31,50 +31,163 @@
 #define NO_VALUE_PLAINTEXT		"no value"
 #define NO_VALUE_HTML			"<i>no value</i>"
 
-ZEND_API int zend_register_ini_entries(const zend_ini_entry *ini_entry, int module_number TSRMLS_DC) /* {{{ */
-{
-  const zend_ini_entry *p = ini_entry;
+/* {{{ */
 
+namespace HPHP {
+
+class ZendUserIniData : public UserIniData {
+public:
+
+  ZendUserIniData (zend_ini_entry *p) : UserIniData(), p(p) {
+  }
+
+  virtual ~ZendUserIniData () {
+    if (p) {
+      /*
+       * The string p->value was allocated by estrndup, which calls*
+       * through to MemoryManager::smartMalloc.
+       * As such, the string will be freed at the end of the request.
+       *
+       * This destructor is called, for example, in the course
+       * of deleting the CallbackMap s_system_ini_callbacks,
+       * which happens after the end of the request.
+       * So at this point we may not actually own p->value,
+       * and its referent may already have been freed.
+       *
+       * Just be overly fussy here and have us forget about p->value.
+       */
+      p->value = nullptr;
+      p->value_length = -1;
+    }
+    delete p;
+    p = nullptr;
+  }
+
+public:
+  zend_ini_entry *p;
+};
+
+} /* namespace HPHP */
+
+static int hhvm_register_ini_entries_do_work(
+  const zend_ini_entry *ini_entry,
+  int module_number,
+  int acceptable_mode_mask
+  TSRMLS_DC)
+{
   auto extension = HPHP::ZendExtension::GetByModuleNumber(module_number);
   assert(extension);
 
-  while (p->name) {
+  for (const zend_ini_entry *constp = ini_entry; constp->name; constp++) {
+    /*
+     * Make a copy of the const version of zend_ini_entry.
+     * This const version is static const in the compiled php extension.
+     *
+     * Copy the given (default) value into a freeable string,
+     * so that assignments to the setting will consistently free the
+     * previous string.
+     *
+     * This copy will have its ownership in the 1:1 corresponding
+     * ZendUserIniData structure.
+     */
+    zend_ini_entry *p = new zend_ini_entry();
+    *p = *constp;
+    p->value = estrndup(p->value, p->value_length);
+
+    /*
+     * A factory to generate a unique instance of a UserIniData
+     * which will eventually end up in either the per-request or system-wide
+     * table that maps ini settings to their callbacks.
+     */
+    auto userDataCallback = [p]() -> HPHP::UserIniData * {
+      return new HPHP::ZendUserIniData(p);
+    };
+
     auto updateCallback = [p](const std::string& value) -> bool {
       TSRMLS_FETCH();
-      // TODO Who is supposed to free this?
       char* data = estrndup(value.data(), value.size());
       int ret = FAILURE;
+      /*
+       * Store the data as the current value of this extension's ini setting.
+       *
+       * It should be safe to free the string we previously allocated,
+       * since we have not got to the end of the request when the
+       * MemoryManager::smartMalloc engine will free these strings.
+       */
+      efree(p->value);
+      p->value = data;
+      p->value_length = value.size();
       if (p->on_modify) {
         ret = p->on_modify(
-          const_cast<zend_ini_entry*>(p), data, value.size(),
+          p, p->value, p->value_length,
           p->mh_arg1, p->mh_arg2, p->mh_arg3, ZEND_INI_STAGE_STARTUP TSRMLS_CC
         );
       }
       return (ret == SUCCESS);
     };
+
     auto getCallback = [p]() {
       return std::string(p->value, p->value_length);
     };
 
     int mode_mask = 0;
     assert(HPHP::IniSetting::Mode::PHP_INI_NONE == 0);
-    if (p->modifiable & ZEND_INI_USER) {
+    if (p->modifiable & ZEND_INI_USER & acceptable_mode_mask) {
       mode_mask |= HPHP::IniSetting::Mode::PHP_INI_USER;
     }
-    if (p->modifiable & ZEND_INI_PERDIR) {
+    if (p->modifiable & ZEND_INI_PERDIR & acceptable_mode_mask) {
       mode_mask |= HPHP::IniSetting::Mode::PHP_INI_PERDIR;
     }
-    if (p->modifiable & ZEND_INI_SYSTEM) {
+    if (p->modifiable & ZEND_INI_SYSTEM & acceptable_mode_mask) {
       mode_mask |= HPHP::IniSetting::Mode::PHP_INI_SYSTEM;
     }
-    HPHP::IniSetting::Mode mode = (HPHP::IniSetting::Mode) mode_mask;
-    HPHP::IniSetting::Bind(
+    if (mode_mask) {
+      HPHP::IniSetting::Mode mode = (HPHP::IniSetting::Mode) mode_mask;
+      /*
+       * Calls HPHP::IniSetting::Bind<std::string> from/near
+       *   hphp/runtime/base/ini-setting.h:205
+       * The default value is p->value, which is assigned back
+       * by an immediate call to the updateCallback
+       *
+       */
+      HPHP::IniSetting::Bind(
         extension, mode,
         p->name, p->value,
-        HPHP::IniSetting::SetAndGet<std::string>(updateCallback, getCallback));
-    p++;
+        HPHP::IniSetting::SetAndGet<std::string>(
+          updateCallback,
+          getCallback,
+          userDataCallback));
+    }
   }
   return SUCCESS;
+}
+
+ZEND_API int zend_register_ini_entries_of_certain_mode(
+  const zend_ini_entry *ini_entry,
+  int module_number,
+  int acceptable_mode_mask
+  TSRMLS_DC)
+{
+  int code = 0;
+  code = hhvm_register_ini_entries_do_work(
+    ini_entry,
+    module_number,
+    acceptable_mode_mask
+    TSRMLS_CC);
+  return code;
+}
+
+ZEND_API int zend_register_ini_entries(const zend_ini_entry *ini_entry, int module_number TSRMLS_DC)
+{
+  int acceptable_mode_mask = 0;
+  acceptable_mode_mask |= ZEND_INI_USER;
+  acceptable_mode_mask |= ZEND_INI_PERDIR;
+  acceptable_mode_mask |= ZEND_INI_SYSTEM;
+  return zend_register_ini_entries_of_certain_mode(
+    ini_entry,
+    module_number,
+    acceptable_mode_mask
+    TSRMLS_CC);
 }
 
 ZEND_API void zend_unregister_ini_entries(int module_number TSRMLS_DC) {

--- a/hphp/runtime/ext_zend_compat/php-src/Zend/zend_ini.h
+++ b/hphp/runtime/ext_zend_compat/php-src/Zend/zend_ini.h
@@ -92,7 +92,10 @@ ZEND_API int zend_copy_ini_directives(TSRMLS_D);
 ZEND_API void zend_ini_sort_entries(TSRMLS_D);
 
 ZEND_API int zend_register_ini_entries(const zend_ini_entry *ini_entry, int module_number TSRMLS_DC);
-ZEND_API int zend_register_ini_entries_of_certain_mode(const zend_ini_entry *ini_entry, int module_number, int acceptable_mode_mask TSRMLS_DC);
+ZEND_API int zend_register_ini_entries_of_certain_mode(
+  const zend_ini_entry *ini_entry,
+  int module_number,
+  int acceptable_mode_mask TSRMLS_DC);
 ZEND_API void zend_unregister_ini_entries(int module_number TSRMLS_DC);
 ZEND_API void zend_ini_refresh_caches(int stage TSRMLS_DC);
 ZEND_API int zend_alter_ini_entry(char *name, uint name_length, char *new_value, uint new_value_length, int modify_type, int stage);

--- a/hphp/runtime/ext_zend_compat/php-src/Zend/zend_ini.h
+++ b/hphp/runtime/ext_zend_compat/php-src/Zend/zend_ini.h
@@ -92,6 +92,7 @@ ZEND_API int zend_copy_ini_directives(TSRMLS_D);
 ZEND_API void zend_ini_sort_entries(TSRMLS_D);
 
 ZEND_API int zend_register_ini_entries(const zend_ini_entry *ini_entry, int module_number TSRMLS_DC);
+ZEND_API int zend_register_ini_entries_of_certain_mode(const zend_ini_entry *ini_entry, int module_number, int acceptable_mode_mask TSRMLS_DC);
 ZEND_API void zend_unregister_ini_entries(int module_number TSRMLS_DC);
 ZEND_API void zend_ini_refresh_caches(int stage TSRMLS_DC);
 ZEND_API int zend_alter_ini_entry(char *name, uint name_length, char *new_value, uint new_value_length, int modify_type, int stage);

--- a/hphp/runtime/vm/jit/irgen-builtin.cpp
+++ b/hphp/runtime/vm/jit/irgen-builtin.cpp
@@ -125,8 +125,13 @@ SSATmp* opt_ini_get(HTS& env, uint32_t numArgs) {
   // settings can be overridden during the execution of a request.
   auto const settingName = top(env, Type::Str, 0)->strVal()->toCppString();
   IniSetting::Mode mode = IniSetting::PHP_INI_NONE;
-  if (!IniSetting::GetMode(settingName, mode) ||
-      !(mode & IniSetting::PHP_INI_SYSTEM)) {
+  if (!IniSetting::GetMode(settingName, mode)) {
+    return nullptr;
+  }
+  if (mode & ~IniSetting::PHP_INI_SYSTEM) {
+    return nullptr;
+  }
+  if (mode == IniSetting::PHP_INI_ALL) {  /* PHP_INI_ALL has a weird encoding */
     return nullptr;
   }
 

--- a/hphp/test/slow/ext_ezc_test/ini_setget.php
+++ b/hphp/test/slow/ext_ezc_test/ini_setget.php
@@ -1,0 +1,16 @@
+<?php
+
+printf("BEGIN\n");
+
+printf("PHP ezc_test.integer %d\n", ini_get("ezc_test.integer")); // 42
+printf("PHP ezc_test.string  %s\n", ini_get("ezc_test.string"));  // foobar
+
+printf("SET int\n");
+ini_set("ezc_test.integer", 57);
+printf("SET string\n");
+ini_set("ezc_test.string", "helium");
+
+printf("PHP ezc_test.integer %d\n", ini_get("ezc_test.integer"));  // 57
+printf("PHP ezc_test.string  %s\n", ini_get("ezc_test.string"));   // helium
+
+printf("END\n");

--- a/hphp/test/slow/ext_ezc_test/ini_setget.php.expectf
+++ b/hphp/test/slow/ext_ezc_test/ini_setget.php.expectf
@@ -1,0 +1,8 @@
+BEGIN
+PHP ezc_test.integer 42
+PHP ezc_test.string  foobar
+SET int
+SET string
+PHP ezc_test.integer 57
+PHP ezc_test.string  helium
+END


### PR DESCRIPTION
The const zend_ini_entry received from the PHP_INI_BEGIN..PHP_INI_END
data structure in the zend extension's source code is now copied
and associated with the system or user (per-request) CallbackMap.
This association is done with a new intermediate class UserIniData,
and mechanisms for registering a factory to produce (sub)classes of
UserIniData depending on the fundamental underlying semantics of the ini
setting.

The ini setting mechanisms in the zend compat layer have an instance
of a subclass of UserIniData to hold a pointer to the copy of the
zend_ini_entry, and that copy is freed when the request finishes or the
system finishes, perhaps with some "don't care" elision on a fast path
towards exit.

The string value assigned to a zend ini setting, as for example from
"ini_set", is now saved using estrndup, so that it can be regurgitated
directly when the zend ini setting is to be gotten with "ini_get". The
string is implicitly released at request finish time, or explictly
released on the next call to ini_set.

This change removes a code smell wherein the const zend_ini_entry was
const_cast'ed to remove the const.

There's still code smell regarding the encoding of PHP_INI_ALL.  The bit
encoding of PHP_INI_ALL in zend differs from the encoding used HHVM,
and since the bitset from zend is presented as is to hhvm, bit-wise
operations on PHP_INI_ALL are potentially incorrect.

This change also rewrites for clarity the critical code that
differentiates between user (per-request) and system settings. There's a
slight change in semantics: the new code will stickly keep the setting
in user space if it is already there. The rewrite also fixes a bug(s)
related to the encoding mismatch of PHP_INI_ALL between zend and hhvm.

There was a bug in the optimization of ini_get, wherein a call to
ini_get with a constant argument referencing a user setting would get
incorrectly treated as if it were a system setting. This bug prevented
ini_get from seeing the previous ini_set to the same setting.

This commit adds a single test case of ini_set/ini_get on the
ezc_test.integer and ezc_test.string.

Known failures of ini settings associated with HNI extensions (such as
mongo or mysql) have not been addressed in this commit, which focuses
solely on improving the zend extension layer.