### PR TITLE
made the url parsing faster and updated license headers

### DIFF
--- a/hphp/runtime/base/url.cpp
+++ b/hphp/runtime/base/url.cpp
@@ -2,7 +2,7 @@
    +----------------------------------------------------------------------+
    | HipHop for PHP                                                       |
    +----------------------------------------------------------------------+
-   | Copyright (c) 2010-2014 Facebook, Inc. (http://www.facebook.com)     |
+   | Copyright (c) 2010-2015 Facebook, Inc. (http://www.facebook.com)     |
    +----------------------------------------------------------------------+
    | This source file is subject to version 3.01 of the PHP license,      |
    | that is bundled with this package in the file LICENSE, and is        |
@@ -23,19 +23,20 @@ namespace URL {
 
 const char *getServerObject(const char* url) {
   assert(url);
-  int strip = 0;
+  const char *p;
   if (strncmp(url, "http://", 7) == 0) {
-    strip = 7;
+    p = strchr(url + 7, '/');
   } else if (strncmp(url, "https://", 8) == 0) {
-    strip = 8;
+    p = strchr(url + 8, '/');
+  } else {
+    p = strchr(url, '/');
   }
-  const char *p = strchr(url + strip, '/');
+  
   if (p) {
     while (*(p + 1) == '/') p++;
     return p;
   }
-  if (strip == 0) return url;
-  return "";
+  return url;
 }
 
 std::string getCommand(const char* serverObject) {

--- a/hphp/runtime/base/url.h
+++ b/hphp/runtime/base/url.h
@@ -2,7 +2,7 @@
    +----------------------------------------------------------------------+
    | HipHop for PHP                                                       |
    +----------------------------------------------------------------------+
-   | Copyright (c) 2010-2014 Facebook, Inc. (http://www.facebook.com)     |
+   | Copyright (c) 2010-2015 Facebook, Inc. (http://www.facebook.com)     |
    +----------------------------------------------------------------------+
    | This source file is subject to version 3.01 of the PHP license,      |
    | that is bundled with this package in the file LICENSE, and is        |

--- a/hphp/runtime/base/url.h
+++ b/hphp/runtime/base/url.h
@@ -18,8 +18,6 @@
 #define incl_HPHP_URL_H_
 
 #include <string>
-#include <cstring>
-#include <cassert>
 
 namespace HPHP {
 

--- a/hphp/runtime/base/url.h
+++ b/hphp/runtime/base/url.h
@@ -18,6 +18,8 @@
 #define incl_HPHP_URL_H_
 
 #include <string>
+#include <cstring>
+#include <cassert>
 
 namespace HPHP {
 

--- a/hphp/runtime/test/url.cpp
+++ b/hphp/runtime/test/url.cpp
@@ -1,0 +1,66 @@
+/*
+   +----------------------------------------------------------------------+
+   | HipHop for PHP                                                       |
+   +----------------------------------------------------------------------+
+   | Copyright (c) 2010-2015 Facebook, Inc. (http://www.facebook.com)     |
+   +----------------------------------------------------------------------+
+   | This source file is subject to version 3.01 of the PHP license,      |
+   | that is bundled with this package in the file LICENSE, and is        |
+   | available through the world-wide-web at the following url:           |
+   | http://www.php.net/license/3_01.txt                                  |
+   | If you did not receive a copy of the PHP license and are unable to   |
+   | obtain it through the world-wide-web, please send a note to          |
+   | license@php.net so we can mail you a copy immediately.               |
+   +----------------------------------------------------------------------+
+*/
+
+#include <string>
+
+#include <gtest/gtest.h>
+
+#include "hphp/runtime/base/url.h"
+
+using std::string;
+
+namespace HPHP {
+
+TEST(TestUrl, GetServerObject) {
+  const char* full_url = "http://facebook.com/foo?x=1";
+  const char* expected_object = "/foo?x=1";
+  const char* returned_object = URL::getServerObject(full_url);
+
+  ASSERT_TRUE(strcmp(expected_object, returned_object) == 0);
+  
+  full_url = "http://facebook.com/foo/bar?x=1";
+  expected_object = "/foo/bar?x=1";
+  returned_object = URL::getServerObject(full_url);
+  
+  ASSERT_TRUE(strcmp(expected_object, returned_object) == 0);
+
+  full_url = "https://facebook.com/foo?x=1";
+  expected_object = "/foo/bar?x=1";
+  returned_object = URL::getServerObject(full_url);
+  
+  ASSERT_TRUE(strcmp(expected_object, returned_object) == 0);
+
+  full_url = "https://facebook.com/foo/bar?x=1";
+  expected_object = "/foo/bar?x=1";
+  returned_object = URL::getServerObject(full_url);
+  
+  ASSERT_TRUE(strcmp(expected_object, returned_object) == 0);
+
+  full_url = "facebook.com/foo?x=1";
+  expected_object = "/foo?x=1";
+  returned_object = URL::getServerObject(full_url);
+  
+  ASSERT_TRUE(strcmp(expected_object, returned_object) == 0);
+
+  full_url = "facebook.com/foo/bar?x=1";
+  expected_object = "/foo/bar?x=1";
+  returned_object = URL::getServerObject(full_url);
+  
+  ASSERT_TRUE(strcmp(expected_object, returned_object) == 0);
+
+}
+
+}  // namespace HPHP


### PR DESCRIPTION
Line 38 (return "") was never getting executed because int strip would always be either 0, 7, or 8. Therefore the last return statement could only be url. So I fixed that as well as eliminating the need for int strip by inlining the strchr calls.

It's a small change, but it has a minor (very minor) performance improvement.