### PR TITLE
Fix display of -c option in hhvm man page

### DIFF
--- a/hphp/doc/man/hhvm.1
+++ b/hphp/doc/man/hhvm.1
@@ -106,8 +106,8 @@ Unique identifier to compiled server code.
 .TP
 .B \-c ", " \-\-config " FILE"
 Load specified config (.hdf or .ini)
-.I FILE
-. Use multiple
+.IR FILE .
+Use multiple
 .B \-c
 to specify multiple config files.
 


### PR DESCRIPTION
This is a fix (not THE fix) for https://github.com/facebook/hhvm/issues/4689

Without it, the -c (config file) option does not show the correct
text to use multiple config files.

This still needs to be fixed at the ronn source, but i have no
idea when that might happen. I think it is best that the man page
text for -c makes sense until then.