### PR TITLE
Define FOLLY_HAVE_PTHREAD_ATFORK

### DIFF
--- a/CMake/FollySetup.cmake
+++ b/CMake/FollySetup.cmake
@@ -12,12 +12,16 @@ if (FOLLY_IFUNC)
   add_definitions("-DHAVE_IFUNC=1")
 endif()
 
-set(CMAKE_REQUIRED_LIBRARIES rt)
+set(CMAKE_REQUIRED_LIBRARIES rt pthread)
 include(CheckFunctionExists)
 CHECK_FUNCTION_EXISTS("clock_gettime" HAVE_CLOCK_GETTIME)
+CHECK_FUNCTION_EXISTS("pthread_atfork" HAVE_PTHREAD_ATFORK)
 
 if (HAVE_CLOCK_GETTIME)
   add_definitions("-DFOLLY_HAVE_CLOCK_GETTIME=1")
+endif()
+if (HAVE_PTHREAD_ATFORK)
+  add_definitions("-DFOLLY_HAVE_PTHREAD_ATFORK=1")
 endif()
 set(CMAKE_REQUIRED_LIBRARIES)
 


### PR DESCRIPTION
I want to add a third party library that uses folly/futures - this requires updating folly, which requires adding this definition.