### PR TITLE
Fix unnecessary dns lookups on startup of hhvm in non-server mode.

### DIFF
--- a/hphp/runtime/base/runtime-option.cpp
+++ b/hphp/runtime/base/runtime-option.cpp
@@ -130,8 +130,6 @@ std::string RuntimeOption::DefaultServerNameSuffix;
 std::string RuntimeOption::ServerType = "libevent";
 std::string RuntimeOption::ServerIP;
 std::string RuntimeOption::ServerFileSocket;
-std::string RuntimeOption::ServerPrimaryIPv4;
-std::string RuntimeOption::ServerPrimaryIPv6;
 int RuntimeOption::ServerPort = 80;
 int RuntimeOption::ServerPortFd = -1;
 int RuntimeOption::ServerBacklog = 128;
@@ -393,22 +391,14 @@ int RuntimeOption::GetScannerType() {
 }
 
 std::string RuntimeOption::GetServerPrimaryIPv4() {
-   static bool once=true;
-   if (once) {
-      once=false;
-      RuntimeOption::ServerPrimaryIPv4 = GetPrimaryIPv4();
-   }
-   return RuntimeOption::ServerPrimaryIPv4;
-}
-std::string RuntimeOption::GetServerPrimaryIPv6() {
-   static bool once=ture;
-   if (once) {
-      once=false;
-      RuntimeOption::ServerPrimaryIPv6 = GetPrimaryIPv6();
-   }
-   return RuntimeOption::ServerPrimaryIPv6;
+   static std::string serverPrimaryIPv4 = GetPrimaryIPv4();
+   return serverPrimaryIPv4;
 }
 
+std::string RuntimeOption::GetServerPrimaryIPv6() {
+   static std::string serverPrimaryIPv6 = GetPrimaryIPv6(); 
+   return serverPrimaryIPv6;
+}
 
 static inline std::string regionSelectorDefault() {
   return "tracelet";
@@ -1071,9 +1061,7 @@ void RuntimeOption::Load(IniSetting::Map& ini, Hdf& config,
 
 #ifdef FACEBOOK
     //Do not cause slowness on startup -- except for Facebook 
-    ServerPrimaryIPv4 = GetPrimaryIPv4();
-    ServerPrimaryIPv6 = GetPrimaryIPv6();
-    if (GetServerPrimaryIPv4.empty() && GetServerPrimaryIPv6.empty()) {
+    if (GetServerPrimaryIPv4().empty() && GetServerPrimaryIPv6().empty()) {
       throw std::runtime_error("Unable to resolve the server's "
           "IPv4 or IPv6 address");
     }

--- a/hphp/runtime/base/runtime-option.cpp
+++ b/hphp/runtime/base/runtime-option.cpp
@@ -392,6 +392,24 @@ int RuntimeOption::GetScannerType() {
   return type;
 }
 
+std::string RuntimeOption::GetServerPrimaryIPv4() {
+   static bool once=true;
+   if (once) {
+      once=false;
+      RuntimeOption::ServerPrimaryIPv4 = GetPrimaryIPv4();
+   }
+   return RuntimeOption::ServerPrimaryIPv4;
+}
+std::string RuntimeOption::GetServerPrimaryIPv6() {
+   static bool once=ture;
+   if (once) {
+      once=false;
+      RuntimeOption::ServerPrimaryIPv6 = GetPrimaryIPv6();
+   }
+   return RuntimeOption::ServerPrimaryIPv6;
+}
+
+
 static inline std::string regionSelectorDefault() {
   return "tracelet";
 }
@@ -1050,10 +1068,12 @@ void RuntimeOption::Load(IniSetting::Map& ini, Hdf& config,
     Config::Bind(ServerType, ini, server["Type"], ServerType);
     Config::Bind(ServerIP, ini, server["IP"]);
     Config::Bind(ServerFileSocket, ini, server["FileSocket"]);
+
+#ifdef FACEBOOK
+    //Do not cause slowness on startup -- except for Facebook 
     ServerPrimaryIPv4 = GetPrimaryIPv4();
     ServerPrimaryIPv6 = GetPrimaryIPv6();
-#ifdef FACEBOOK
-    if (ServerPrimaryIPv4.empty() && ServerPrimaryIPv6.empty()) {
+    if (GetServerPrimaryIPv4.empty() && GetServerPrimaryIPv6.empty()) {
       throw std::runtime_error("Unable to resolve the server's "
           "IPv4 or IPv6 address");
     }

--- a/hphp/runtime/base/runtime-option.h
+++ b/hphp/runtime/base/runtime-option.h
@@ -109,8 +109,6 @@ public:
   static std::string ServerType;
   static std::string ServerIP;
   static std::string ServerFileSocket;
-  static std::string ServerPrimaryIPv4;
-  static std::string ServerPrimaryIPv6;
   static std::string GetServerPrimaryIPv4();
   static std::string GetServerPrimaryIPv6();
   static int ServerPort;

--- a/hphp/runtime/base/runtime-option.h
+++ b/hphp/runtime/base/runtime-option.h
@@ -111,6 +111,8 @@ public:
   static std::string ServerFileSocket;
   static std::string ServerPrimaryIPv4;
   static std::string ServerPrimaryIPv6;
+  static std::string GetServerPrimaryIPv4();
+  static std::string GetServerPrimaryIPv6();
   static int ServerPort;
   static int ServerPortFd;
   static int ServerBacklog;

--- a/hphp/runtime/server/http-protocol.cpp
+++ b/hphp/runtime/server/http-protocol.cpp
@@ -677,7 +677,8 @@ static void CopyPathInfo(Array& server,
   if (r.rewritten()) {
     server.set(s_PHP_SELF, r.originalURL());
   } else {
-    server.set(s_PHP_SELF, r.resolvedURL() + r.origPathInfo());
+    //server.set(s_PHP_SELF, r.resolvedURL() + r.origPathInfo());
+    server.set(s_PHP_SELF, r.resolvedURL());
   }
 
   String documentRoot = transport->getDocumentRoot();

--- a/hphp/runtime/server/http-protocol.cpp
+++ b/hphp/runtime/server/http-protocol.cpp
@@ -677,8 +677,7 @@ static void CopyPathInfo(Array& server,
   if (r.rewritten()) {
     server.set(s_PHP_SELF, r.originalURL());
   } else {
-    //server.set(s_PHP_SELF, r.resolvedURL() + r.origPathInfo());
-    server.set(s_PHP_SELF, r.resolvedURL());
+    server.set(s_PHP_SELF, r.resolvedURL() + r.origPathInfo());
   }
 
   String documentRoot = transport->getDocumentRoot();

--- a/hphp/runtime/server/libevent-transport.cpp
+++ b/hphp/runtime/server/libevent-transport.cpp
@@ -97,8 +97,8 @@ uint16_t LibEventTransport::getRemotePort() {
 
 const char *LibEventTransport::getServerAddr() {
   return m_remote_ip.isV6() ?
-    RuntimeOption::ServerPrimaryIPv6.c_str() :
-    RuntimeOption::ServerPrimaryIPv4.c_str();
+    RuntimeOption::GetServerPrimaryIPv6().c_str() :
+    RuntimeOption::GetServerPrimaryIPv4().c_str();
 }
 
 const void *LibEventTransport::getPostData(int &size) {

--- a/hphp/runtime/server/transport.h
+++ b/hphp/runtime/server/transport.h
@@ -140,7 +140,7 @@ public:
   virtual const char *getServerAddr() {
     std::string ipv4 =  RuntimeOption::GetServerPrimaryIPv4();
     return ipv4.empty() ?
-       RuntimeOption::GetServerPrimaryIPv6() :
+       RuntimeOption::GetServerPrimaryIPv6().c_str() :
        ipv4.c_str();
   };
   virtual uint16_t getServerPort() {

--- a/hphp/runtime/server/transport.h
+++ b/hphp/runtime/server/transport.h
@@ -138,9 +138,10 @@ public:
     return "";
   };
   virtual const char *getServerAddr() {
-    return  RuntimeOption::ServerPrimaryIPv4.empty() ?
-       RuntimeOption::ServerPrimaryIPv6.c_str() :
-       RuntimeOption::ServerPrimaryIPv4.c_str();
+    std::string ipv4 =  RuntimeOption::GetServerPrimaryIPv4();
+    return ipv4.empty() ?
+       RuntimeOption::GetServerPrimaryIPv6() :
+       ipv4.c_str();
   };
   virtual uint16_t getServerPort() {
     return RuntimeOption::ServerPort;

--- a/hphp/runtime/server/xbox-server.h
+++ b/hphp/runtime/server/xbox-server.h
@@ -104,9 +104,10 @@ public:
   virtual const char *getRemoteHost() { return "127.0.0.1"; }
   virtual uint16_t getRemotePort() { return 0; }
   virtual const char *getServerAddr() {
-    return RuntimeOption::ServerPrimaryIPv4.empty() ?
-      RuntimeOption::ServerPrimaryIPv6.c_str() :
-      RuntimeOption::ServerPrimaryIPv4.c_str();
+    std::string ipv4 = RuntimeOption::GetServerPrimaryIPv4();
+    return ipv4.empty() ?
+      RuntimeOption::GetServerPrimaryIPv6().c_str() :
+      ipv4.c_str();
   }
 
   /**


### PR DESCRIPTION
Potentially several reverse DNS lookups are done with every invocation of
hphp,even with no arguments anticipating hphp only being used as a server.
If your primary DNS server is down, this makes running scripts hang for a
long period before failure, and slows all scripts down even if your DNS
server is fast.

This makes the lookup lazy so only when necessary, except for #define
FACEBOOK which I didn't want to change the behaviour of (but they probably
should).
