### PR TITLE
Match PHP5 error handling defaults unless configured otherwise

### DIFF
--- a/hphp/runtime/base/runtime-option.cpp
+++ b/hphp/runtime/base/runtime-option.cpp
@@ -840,7 +840,7 @@ void RuntimeOption::Load(IniSetting::Map& ini, Hdf& config,
     Config::Bind(CallUserHandlerOnFatals, ini,
                  error["CallUserHandlerOnFatals"], true);
     Config::Bind(ThrowExceptionOnBadMethodCall, ini,
-                 error["ThrowExceptionOnBadMethodCall"], true);
+                 error["ThrowExceptionOnBadMethodCall"], false);
     Config::Bind(LogNativeStackOnOOM, ini,
                  error["LogNativeStackOnOOM"], false);
     Config::Bind(MaxLoopCount, ini, error["MaxLoopCount"], 0);

--- a/hphp/runtime/base/runtime-option.cpp
+++ b/hphp/runtime/base/runtime-option.cpp
@@ -838,7 +838,7 @@ void RuntimeOption::Load(IniSetting::Map& ini, Hdf& config,
     Config::Bind(MaxSerializedStringSize, ini,
                  error["MaxSerializedStringSize"], 64 * 1024 * 1024);
     Config::Bind(CallUserHandlerOnFatals, ini,
-                 error["CallUserHandlerOnFatals"], false);
+                 error["CallUserHandlerOnFatals"], true);
     Config::Bind(ThrowExceptionOnBadMethodCall, ini,
                  error["ThrowExceptionOnBadMethodCall"], true);
     Config::Bind(LogNativeStackOnOOM, ini,


### PR DESCRIPTION
Resolves #4819 and probably #4818. Split into two commits in case we want to leave bad method call config default the way it is now.