### PR TITLE
Eagerly copy the memcache key prior to normalization.

### DIFF
--- a/hphp/runtime/ext/memcache/ext_memcache.cpp
+++ b/hphp/runtime/ext/memcache/ext_memcache.cpp
@@ -227,7 +227,8 @@ static std::vector<char> memcache_prepare_for_storage(const MemcacheData* data,
 }
 
 static String memcache_prepare_key(const String& var) {
-  auto data = var.get()->mutableData();
+  String var_mutable(var, CopyString);
+  auto data = var_mutable.get()->mutableData();
   for (int i = 0; i < var.length(); i++) {
     // This is a stupid encoding since it causes collisions but it matches php5
     if (data[i] <= ' ') {


### PR DESCRIPTION
This avoids a new run time assertion about modifying
immutable data.

The run time assertion was added :
  https://github.com/facebook/hhvm/commit/4d9b5b19afc0581856c79298f0672d7b55df9339

This closes:
  https://github.com/facebook/hhvm/issues/4801