### PR TITLE
The ZRANGEBYSCORE and ZREVRANGEBYSCORE need to take in start/end scores as strings

### DIFF
--- a/hphp/system/php/redis/Redis.php
+++ b/hphp/system/php/redis/Redis.php
@@ -462,7 +462,7 @@ class Redis {
                                        $start,
                                        $end,
                                        array $opts = null) {
-    $args = [$this->_prefix($key), (int)$start, (int)$end];
+    $args = [$this->_prefix($key), $start, $end];
     if (isset($opts['limit']) AND
         is_array($opts['limit']) AND
         (count($opts['limit']) == 2)) {

--- a/hphp/test/slow/ext_redis/zrangebyscore.php
+++ b/hphp/test/slow/ext_redis/zrangebyscore.php
@@ -1,0 +1,17 @@
+<?php
+
+include (__DIR__ . '/redis.inc');
+
+$r = NewRedisTestInstance();
+$r->setOption(Redis::OPT_PREFIX, GetTestKeyName(__FILE__) . ':');
+$r->delete('A');
+
+$r->zAdd('A', 1.2, 'one');
+$r->zAdd('A', 1.4, 'two');
+$r->zAdd('A', 1.1, 'three');
+var_dump($r->zRangeByScore('A', '-inf', '+inf'));
+var_dump($r->zRevRangeByScore('A', '+inf', '-inf'));
+var_dump($r->zRangeByScore('A', 1.2, 1.3));
+var_dump($r->zRevRangeByScore('A', 1.3, 1.2));
+
+$r->delete('A');

--- a/hphp/test/slow/ext_redis/zrangebyscore.php.expect
+++ b/hphp/test/slow/ext_redis/zrangebyscore.php.expect
@@ -1,0 +1,24 @@
+array(3) {
+  [0]=>
+  string(5) "three"
+  [1]=>
+  string(3) "one"
+  [2]=>
+  string(3) "two"
+}
+array(3) {
+  [0]=>
+  string(3) "two"
+  [1]=>
+  string(3) "one"
+  [2]=>
+  string(5) "three"
+}
+array(1) {
+  [0]=>
+  string(3) "one"
+}
+array(1) {
+  [0]=>
+  string(3) "one"
+}


### PR DESCRIPTION
...to support +/- inf. Docs: http://redis.io/commands/zrangebyscore