### PR TITLE
Perform strict comparison for set() options array

### DIFF
--- a/hphp/system/php/redis/Redis.php
+++ b/hphp/system/php/redis/Redis.php
@@ -225,8 +225,8 @@ class Redis {
         count($optionArrayOrExpiration) > 0) {
       $ex = array_key_exists('ex', $optionArrayOrExpiration);
       $px = array_key_exists('px', $optionArrayOrExpiration);
-      $nx = in_array('nx', $optionArrayOrExpiration);
-      $xx = in_array('xx', $optionArrayOrExpiration);
+      $nx = in_array('nx', $optionArrayOrExpiration, true);
+      $xx = in_array('xx', $optionArrayOrExpiration, true);
       if ($nx && $xx) {
         throw new RedisException(
           "Invalid set options: nx and xx may not be specified at the same time"


### PR DESCRIPTION
The non-strict check results in false positives with a zero expiration time.
The following returns `true` for $nx, even though it's a valid options array & doesn't include nx.

    $optionArrayOrExpiration = array(
        'xx', // if exists
        'ex' => 0 // expire time in seconds
    );
    $nx = in_array('nx', $optionArrayOrExpiration);

Making it a strict check fixes that:

    $nx = in_array('nx', $optionArrayOrExpiration, true); // returns false