### PR TITLE
adds proxy server support in the http stream wrapper class so that setti...

### DIFF
--- a/hphp/runtime/base/http-stream-wrapper.cpp
+++ b/hphp/runtime/base/http-stream-wrapper.cpp
@@ -14,6 +14,7 @@
    +----------------------------------------------------------------------+
 */
 
+#include "hphp/runtime/base/comparisons.h"
 #include "hphp/runtime/base/http-stream-wrapper.h"
 #include "hphp/runtime/base/string-util.h"
 #include "hphp/runtime/base/url-file.h"

--- a/hphp/runtime/base/http-stream-wrapper.cpp
+++ b/hphp/runtime/base/http-stream-wrapper.cpp
@@ -14,8 +14,8 @@
    +----------------------------------------------------------------------+
 */
 
-#include "hphp/runtime/base/comparisons.h"
 #include "hphp/runtime/base/http-stream-wrapper.h"
+#include "hphp/runtime/base/comparisons.h"
 #include "hphp/runtime/base/string-util.h"
 #include "hphp/runtime/base/url-file.h"
 #include "hphp/runtime/base/runtime-option.h"

--- a/hphp/runtime/base/url-file.cpp
+++ b/hphp/runtime/base/url-file.cpp
@@ -60,6 +60,13 @@ void UrlFile::sweep() {
 const StaticString
   s_remove_user_pass_pattern("#://[^@]+@#"),
   s_remove_user_pass_replace("://");
+void UrlFile::setProxy(const String& proxy_host, int proxy_port,
+                       const String& proxy_user, const String& proxy_pass) {
+  m_proxyHost = proxy_host.c_str();
+  m_proxyPort = proxy_port;
+  m_proxyUsername = proxy_user.c_str();
+  m_proxyPassword = proxy_pass.c_str();
+}
 bool UrlFile::open(const String& input_url, const String& mode) {
   String url = input_url;
   const char* modestr = mode.c_str();
@@ -71,6 +78,8 @@ bool UrlFile::open(const String& input_url, const String& mode) {
   }
   HttpClient http(m_timeout, m_maxRedirect);
   m_response.clear();
+
+  http.proxy(m_proxyHost, m_proxyPort, m_proxyUsername, m_proxyPassword);
 
   HeaderMap *pHeaders = nullptr;
   HeaderMap requestHeaders;

--- a/hphp/runtime/base/url-file.h
+++ b/hphp/runtime/base/url-file.h
@@ -39,8 +39,8 @@ public:
   // overriding ResourceData
   const String& o_getClassNameHook() const { return classnameof(); }
 
-  virtual void setProxy(const String& proxy_host, int proxy_port,
-                        const String& proxy_user, const String& proxy_pass);
+  void setProxy(const String& proxy_host, int proxy_port,
+                const String& proxy_user, const String& proxy_pass);
   virtual bool open(const String& filename, const String& mode);
   virtual int64_t writeImpl(const char *buffer, int64_t length);
   virtual bool seekable() { return false; }

--- a/hphp/runtime/base/url-file.h
+++ b/hphp/runtime/base/url-file.h
@@ -39,6 +39,8 @@ public:
   // overriding ResourceData
   const String& o_getClassNameHook() const { return classnameof(); }
 
+  virtual void setProxy(const String& proxy_host, int proxy_port,
+                        const String& proxy_user, const String& proxy_pass);
   virtual bool open(const String& filename, const String& mode);
   virtual int64_t writeImpl(const char *buffer, int64_t length);
   virtual bool seekable() { return false; }
@@ -57,6 +59,11 @@ private:
   std::string m_error;
   StringBuffer m_response;
   Array m_responseHeaders;
+
+  std::string m_proxyHost;
+  int         m_proxyPort;
+  std::string m_proxyUsername;
+  std::string m_proxyPassword;
 };
 
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
...ng a proxy in the default context works eg:

```
<?php
stream_context_set_default(array(
  'http'=>array(
    'proxy'=>'tcp://ipaddress.com:8080'
  )
));

$data = file_get_contents('http://bucket.s3-ap-southeast-2.amazonaws.com/file.jpg');
```