### PR TITLE
Propagate AttrMayUseVV in the fallback function of FPushFuncU to current function.

### DIFF
--- a/hphp/runtime/vm/jit/irgen-call.cpp
+++ b/hphp/runtime/vm/jit/irgen-call.cpp
@@ -563,6 +563,11 @@ void emitFPushFuncU(HTS& env,
                     int32_t nargs,
                     const StringData* name,
                     const StringData* fallback) {
+  auto const fallbackFunc = Unit::lookupFunc(fallback);
+  if (fallbackFunc && (fallbackFunc->attrs() & AttrMayUseVV)) {
+    const_cast<Func*>(curFunc(env))->setAttrs(
+        curFunc(env)->attrs() | AttrMayUseVV);
+  }
   fpushFuncCommon(env, nargs, name, fallback);
 }
 


### PR DESCRIPTION
This will free the memory of variables created by the fallback function.

Fix #4846.