### PR TITLE
In ob_get_status() fix type key

### DIFF
--- a/hphp/runtime/base/execution-context.cpp
+++ b/hphp/runtime/base/execution-context.cpp
@@ -391,6 +391,8 @@ const StaticString
   s_type("type"),
   s_name("name"),
   s_args("args"),
+  s_chunk_size("chunk_size"),
+  s_buffer_used("buffer_used"),
   s_default_output_handler("default output handler");
 
 Array ExecutionContext::obGetStatus(bool full) {
@@ -398,14 +400,16 @@ Array ExecutionContext::obGetStatus(bool full) {
   int level = 0;
   for (auto& buffer : m_buffers) {
     Array status;
-    status.set(s_level, level);
-    if (level < m_protectedLevel) {
-      status.set(s_type, 1);
+    if (level < m_protectedLevel || buffer.handler.isNull()) {
       status.set(s_name, s_default_output_handler);
-    } else {
       status.set(s_type, 0);
+    } else {
       status.set(s_name, buffer.handler);
+      status.set(s_type, 1);
     }
+    status.set(s_level, level);
+    status.set(s_chunk_size, buffer.chunk_size);
+    status.set(s_buffer_used, buffer.oss.size());
 
     if (full) {
       ret.append(status);

--- a/hphp/test/slow/ext_output/ob_get_status_empty.php
+++ b/hphp/test/slow/ext_output/ob_get_status_empty.php
@@ -1,5 +1,5 @@
 <?php
 
 ob_start();
-var_dump(ob_get_status(false));
-var_dump(ob_get_status(true));
+var_dump((bool)ob_get_status(false));
+var_dump(count(ob_get_status(true)));

--- a/hphp/test/slow/ext_output/ob_get_status_empty.php.expect
+++ b/hphp/test/slow/ext_output/ob_get_status_empty.php.expect
@@ -1,19 +1,2 @@
-array(3) {
-  ["level"]=>
-  int(0)
-  ["type"]=>
-  int(0)
-  ["name"]=>
-  NULL
-}
-array(1) {
-  [0]=>
-  array(3) {
-    ["level"]=>
-    int(0)
-    ["type"]=>
-    int(0)
-    ["name"]=>
-    NULL
-  }
-}
+bool(true)
+int(1)


### PR DESCRIPTION
As documented and implemented in PHP PHP, type=0 is internal, and type=1 is for user handlers. This function got it the wrong way around.

This is an untested fix for https://phabricator.wikimedia.org/T89918 . MediaWiki relies on seeing type=1 to know which output buffers it can safely cancel in wfResetOutputBuffers(). When HHVM gives type=0 instead, MediaWiki fails to disable output buffering, and thus hits an OOM when it tries to stream out large output, e.g. a 200MB PDF file in the current test case.