### PR TITLE
fixed a type for building extensions 

### DIFF
--- a/hphp/runtime/ext/extension.h
+++ b/hphp/runtime/ext/extension.h
@@ -120,7 +120,7 @@ struct ExtensionBuildInfo {
 #define HHVM_GET_MODULE(name) \
 static ExtensionBuildInfo s_##name##_extension_build_info = { \
   HHVM_DSO_VERSION, \
-  HHVM_VERISON_BRANCH, \
+  HHVM_VERSION_BRANCH, \
 }; \
 extern "C" ExtensionBuildInfo* getModuleBuildInfo() { \
   return &s_##name##_extension_build_info; \


### PR DESCRIPTION
while including hphp/runtime/base/base-includes.h in extensions source the building failed with
error: ‘HHVM_VERISON_BRANCH’ was not declared in this scope
 HHVM_GET_MODULE(geoip);

The corresponding typo is in hphp/runtime/ext/extension.h and is fixed with this pull request.
