### PR TITLE
Fix total breakage of Apache mod_proxy_fcgi

### DIFF
--- a/hphp/runtime/server/fastcgi/fastcgi-transport.cpp
+++ b/hphp/runtime/server/fastcgi/fastcgi-transport.cpp
@@ -238,7 +238,7 @@ void FastCGITransport::onHeadersComplete() {
 
   [&] { // do a check for mod_proxy_fcgi and remove the extra portions of
         // the string
-    if (!strncmp(m_scriptName.c_str(), "proxy:", sizeof("proxy:"))) {
+    if (!strncmp(m_scriptName.c_str(), "proxy:", sizeof("proxy:") - 1)) {
       folly::StringPiece newName {m_scriptName};
 
       // remove the proxy:type + :// from the start.


### PR DESCRIPTION
Fix attempted string prefix match: sizeof("1") is 2.
Broken in 87f853d16db9fb0b443f856de1c5f28a6803b5c8