### PR TITLE
Fix a typo in a macro name related to HHVM versions and DSOs.

### DIFF
--- a/hphp/runtime/ext/extension.h
+++ b/hphp/runtime/ext/extension.h
@@ -120,7 +120,7 @@ struct ExtensionBuildInfo {
 #define HHVM_GET_MODULE(name) \
 static ExtensionBuildInfo s_##name##_extension_build_info = { \
   HHVM_DSO_VERSION, \
-  HHVM_VERISON_BRANCH, \
+  HHVM_VERSION_BRANCH, \
 }; \
 extern "C" ExtensionBuildInfo* getModuleBuildInfo() { \
   return &s_##name##_extension_build_info; \


### PR DESCRIPTION
[[Was this code ever tested?]]