### PR TITLE
Extend ZEND_GET_MODULE to present getModuleBuildInfo.

### DIFF
--- a/hphp/runtime/ext_zend_compat/php-src/Zend/zend_API.h
+++ b/hphp/runtime/ext_zend_compat/php-src/Zend/zend_API.h
@@ -136,8 +136,15 @@ typedef struct _zend_fcall_info_cache {
 
 #ifdef HHVM
 #define ZEND_GET_MODULE(module_name) \
+  static HPHP::ExtensionBuildInfo s_##module_name##_extension_build_info = { \
+    HHVM_DSO_VERSION, \
+    HHVM_VERSION_BRANCH, \
+  }; \
   extern "C" HPHP::Extension * getModule() { \
     return &module_name##_module_entry.name; \
+  } \
+  extern "C" HPHP::ExtensionBuildInfo * getModuleBuildInfo() { \
+    return &s_##module_name##_extension_build_info; \
   }
 #else
 #define ZEND_GET_MODULE(name) \


### PR DESCRIPTION
Function getModuleBuildInfo must now be callable at dlopen time
per recent changes to API/DSO revision level checking.

With this change zend extensions can be DSOs.