### PR TITLE
Adding empty back-end for PPC64 and arch specific code

### DIFF
--- a/hphp/runtime/base/program-functions.cpp
+++ b/hphp/runtime/base/program-functions.cpp
@@ -619,6 +619,10 @@ void execute_command_line_begin(int argc, char **argv, int xhprof,
     case Arch::ARM:
       envArr.set(s_HHVM_ARCH, "arm");
       break;
+    case Arch::PPC64:
+      envArr.set(s_HHVM_ARCH, "ppc64");
+      break;
+
     }
     php_global_set(s__ENV, envArr);
   }

--- a/hphp/runtime/base/runtime-option.cpp
+++ b/hphp/runtime/base/runtime-option.cpp
@@ -445,7 +445,7 @@ static bool refcountOptsDefault() {
 }
 
 static inline bool evalJitDefault() {
-#if defined(__APPLE__) || defined(__CYGWIN__)
+#if defined(__APPLE__) || defined(__CYGWIN__) || defined(__powerpc64__)
   return false;
 #else
   return true;

--- a/hphp/runtime/server/http-protocol.cpp
+++ b/hphp/runtime/server/http-protocol.cpp
@@ -182,6 +182,9 @@ static void PrepareEnv(Array& env, Transport *transport) {
   case Arch::ARM:
     env.set(s_HHVM_ARCH, "arm");
     break;
+  case Arch::PPC64:
+    env.set(s_HHVM_ARCH, "ppc64");
+    break;
   }
 
   bool isServer = RuntimeOption::ServerExecutionMode();

--- a/hphp/runtime/vm/jit/back-end-ppc64.cpp
+++ b/hphp/runtime/vm/jit/back-end-ppc64.cpp
@@ -1,0 +1,168 @@
+/*
+   +----------------------------------------------------------------------+
+   | HipHop for PHP                                                       |
+   +----------------------------------------------------------------------+
+   | Copyright (c) 2010-2014 Facebook, Inc. (http://www.facebook.com)     |
+   +----------------------------------------------------------------------+
+   | This source file is subject to version 3.01 of the PHP license,      |
+   | that is bundled with this package in the file LICENSE, and is        |
+   | available through the world-wide-web at the following url:           |
+   | http://www.php.net/license/3_01.txt                                  |
+   | If you did not receive a copy of the PHP license and are unable to   |
+   | obtain it through the world-wide-web, please send a note to          |
+   | license@php.net so we can mail you a copy immediately.               |
+   +----------------------------------------------------------------------+
+*/
+
+/*
+ * This pragma was set to do not show warnings of no return value for the
+ * "implemented" functions for this class.
+ * This file was created just to handle PPC64 architecture and initially
+ * to support PPC64 with EvalJit=false.
+ * This is a work in progress to port HHVM Jit to PPC64 architecture.
+ * */
+
+#pragma GCC diagnostic ignored "-Wreturn-type"
+
+#include "hphp/runtime/vm/jit/back-end-ppc64.h"
+
+#include "hphp/util/asm-x64.h"
+#include "hphp/util/disasm.h"
+#include "hphp/util/text-color.h"
+
+#include "hphp/runtime/vm/jit/block.h"
+#include "hphp/runtime/vm/jit/check.h"
+#include "hphp/runtime/vm/jit/cfg.h"
+#include "hphp/runtime/vm/jit/mc-generator.h"
+#include "hphp/runtime/vm/jit/print.h"
+#include "hphp/runtime/vm/jit/service-requests-inline.h"
+#include "hphp/runtime/vm/jit/timer.h"
+#include "hphp/runtime/vm/jit/vasm-print.h"
+#include "hphp/runtime/vm/jit/vasm-llvm.h"
+
+namespace HPHP { namespace jit {
+
+namespace ppc64 {
+
+struct BackEnd : public jit::BackEnd {
+  BackEnd() {}
+  ~BackEnd() {}
+
+  Abi abi() override {}
+
+  size_t cacheLineSize() override {}
+
+  PhysReg rSp() override {}
+
+  PhysReg rVmSp() override {}
+
+  PhysReg rVmFp() override {}
+
+  PhysReg rVmTl() override {}
+
+  bool storesCell(const IRInstruction& inst, uint32_t srcIdx) override {}
+
+  bool loadsCell(const IRInstruction& inst) override {}
+
+  void enterTCHelper(TCA start, ActRec* stashedAR) override {}
+
+  void moveToAlign(CodeBlock& cb,
+                   MoveToAlignFlags alignment
+                   = MoveToAlignFlags::kJmpTargetAlign) override {}
+
+  UniqueStubs emitUniqueStubs() override {}
+
+  TCA emitServiceReqWork(CodeBlock& cb, TCA start, SRFlags flags,
+                         ServiceRequest req,
+                         const ServiceReqArgVec& argv) override {}
+
+  void emitInterpReq(CodeBlock& mainCode, CodeBlock& coldCode,
+                     SrcKey sk) override {}
+
+  bool funcPrologueHasGuard(TCA prologue, const Func* func) override {}
+
+  TCA funcPrologueToGuard(TCA prologue, const Func* func) override {}
+
+  SrcKey emitFuncPrologue(CodeBlock& mainCode, CodeBlock& coldCode, Func* func,
+                          bool funcIsMagic, int nPassed, TCA& start,
+                          TCA& aStart) override {}
+
+  TCA emitCallArrayPrologue(Func* func, DVFuncletsVec& dvs) override {}
+
+  void funcPrologueSmashGuard(TCA prologue, const Func* func) override {}
+
+  void emitIncStat(CodeBlock& cb, intptr_t disp, int n) override {}
+
+  void emitTraceCall(CodeBlock& cb, Offset pcOff) override {}
+
+  bool isSmashable(Address frontier, int nBytes, int offset = 0) override {}
+
+ private:
+
+ public:
+  void prepareForSmash(CodeBlock& cb, int nBytes, int offset = 0) override {}
+
+  void prepareForTestAndSmash(CodeBlock& cb, int testBytes,
+                              TestAndSmashFlags flags) override {}
+
+  bool supportsRelocation() const override {
+    return true;
+  }
+
+  void adjustForRelocation(RelocationInfo& rel) override {}
+
+  void adjustForRelocation(RelocationInfo& rel,
+                           TCA srcStart, TCA srcEnd) override {}
+
+  void adjustMetaDataForRelocation(RelocationInfo& rel,
+                                   AsmInfo* asmInfo,
+                                   CodeGenFixups& fixups) override {}
+
+  void adjustCodeForRelocation(RelocationInfo& rel,
+                               CodeGenFixups& fixups) override {}
+
+ private:
+
+ public:
+  void smashJmp(TCA jmpAddr, TCA newDest) override {}
+
+  void smashCall(TCA callAddr, TCA newDest) override {}
+
+  void smashJcc(TCA jccAddr, TCA newDest) override {}
+
+  void emitSmashableJump(CodeBlock& cb, TCA dest, ConditionCode cc) override {}
+
+  TCA smashableCallFromReturn(TCA retAddr) override {}
+
+  void emitSmashableCall(CodeBlock& cb, TCA dest) override {}
+
+  TCA jmpTarget(TCA jmp) override {}
+
+  TCA jccTarget(TCA jmp) override {}
+
+  ConditionCode jccCondCode(TCA jmp) override {}
+
+  TCA callTarget(TCA call) override {}
+
+  void addDbgGuard(CodeBlock& codeMain, CodeBlock& codeCold,
+                   SrcKey sk, size_t dbgOff) override {}
+
+  void streamPhysReg(std::ostream& os, PhysReg reg) override {}
+
+  void disasmRange(std::ostream& os, int indent, bool dumpIR, TCA begin,
+                   TCA end) override {}
+
+  void genCodeImpl(IRUnit& unit, AsmInfo*) override;
+};
+
+
+std::unique_ptr<jit::BackEnd> newBackEnd() {
+  return folly::make_unique<BackEnd>();
+}
+
+void BackEnd::genCodeImpl(IRUnit& unit, AsmInfo* asmInfo) {}
+
+}}}
+
+#pragma GCC diagnostic pop
+

--- a/hphp/runtime/vm/jit/back-end-ppc64.h
+++ b/hphp/runtime/vm/jit/back-end-ppc64.h
@@ -13,28 +13,16 @@
    | license@php.net so we can mail you a copy immediately.               |
    +----------------------------------------------------------------------+
 */
-#ifndef incl_HPHP_ARCH_H
-#define incl_HPHP_ARCH_H
+#ifndef incl_HPHP_JIT_BACK_END_PPC64_H
+#define incl_HPHP_JIT_BACK_END_PPC64_H
 
-#include "hphp/runtime/base/runtime-option.h"
+#include "hphp/runtime/vm/jit/back-end.h"
 
-namespace HPHP {
+namespace HPHP { namespace jit { namespace ppc64 {
 
-enum class Arch {
-  X64,
-  ARM,
-  PPC64,
-};
+std::unique_ptr<BackEnd> newBackEnd();
 
-inline Arch arch() {
-#if defined(__powerpc64__)
-       return Arch::PPC64;
-#else
-    if (RuntimeOption::EvalSimulateARM) return Arch::ARM;
-      return Arch::X64;
-#endif
-}
-
-}
+}}}
 
 #endif
+

--- a/hphp/runtime/vm/jit/back-end-x64.cpp
+++ b/hphp/runtime/vm/jit/back-end-x64.cpp
@@ -94,8 +94,12 @@ struct BackEnd : public jit::BackEnd {
    * when we call it from C++, we have to tell gcc to clobber all the other
    * callee-saved registers.
    */
+#if defined (__powerpc64__)
+  #define CALLEE_SAVED_BARRIER()
+#else
   #define CALLEE_SAVED_BARRIER()                                    \
       asm volatile("" : : : "rbx", "r12", "r13", "r14", "r15");
+#endif
 
   /*
    * enterTCHelper is a handwritten assembly function that transfers control in

--- a/hphp/runtime/vm/jit/back-end.cpp
+++ b/hphp/runtime/vm/jit/back-end.cpp
@@ -19,6 +19,7 @@
 #include "hphp/runtime/base/arch.h"
 #include "hphp/runtime/vm/jit/back-end-x64.h"
 #include "hphp/runtime/vm/jit/back-end-arm.h"
+#include "hphp/runtime/vm/jit/back-end-ppc64.h"
 
 namespace HPHP { namespace jit {
 
@@ -28,6 +29,8 @@ std::unique_ptr<BackEnd> newBackEnd() {
     return x64::newBackEnd();
   case Arch::ARM:
     return arm::newBackEnd();
+  case Arch::PPC64:
+    return ppc64::newBackEnd();
   }
   not_reached();
 }

--- a/hphp/runtime/vm/jit/reg-alloc.cpp
+++ b/hphp/runtime/vm/jit/reg-alloc.cpp
@@ -42,7 +42,7 @@ PhysReg forceAlloc(const SSATmp& tmp) {
   // measurably impact performance, so keep forcing things into rVmSp for
   // now. We should be able to remove this completely once the necessary
   // improvements are made to vxls.
-  auto const forceStkPtrs = arch() != Arch::X64 || !mcg->useLLVM();
+  auto const forceStkPtrs = (arch() != Arch::X64 && arch() != Arch::PPC64 ) || !RuntimeOption::EvalJitLLVM;
 
   if (forceStkPtrs && tmp.isA(Type::StkPtr)) {
     assert_flog(

--- a/hphp/runtime/vm/jit/translate-region.cpp
+++ b/hphp/runtime/vm/jit/translate-region.cpp
@@ -246,6 +246,8 @@ void emitPredictionGuards(HTS& hts,
         // Don't do this for ARM, because it can lead to interpOne on the
         // first SrcKey in a translation, which isn't allowed.
         break;
+      case Arch::PPC64:
+        break;
     }
   }
 

--- a/hphp/runtime/vm/jit/translator-asm-helpers.S
+++ b/hphp/runtime/vm/jit/translator-asm-helpers.S
@@ -142,4 +142,17 @@ enterTCHelper:
 enterTCServiceReq:
   brk 0
 
+#elif defined(__powerpc64__)
+  .globl enterTCHelper
+enterTCHelper:
+  .globl enterTCExit
+enterTCExit:
+  .globl handleSRResumeTC
+handleSRResumeTC:
+  .globl handleSRHelper
+handleSRHelper:
+  .globl enterTCServiceReq
+enterTCServiceReq:
+  blr
+
 #endif

--- a/hphp/runtime/vm/jit/vasm-emit.cpp
+++ b/hphp/runtime/vm/jit/vasm-emit.cpp
@@ -102,6 +102,8 @@ Vauto::~Vauto() {
         case Arch::ARM:
           finishARM(vauto_abi, nullptr);
           break;
+        case Arch::PPC64:
+          break;
       }
       return;
     }

--- a/hphp/runtime/vm/jit/vasm-xls.cpp
+++ b/hphp/runtime/vm/jit/vasm-xls.cpp
@@ -156,6 +156,8 @@ struct Vxls {
         m_tmp = vixl::x17; // also used as tmp1 by MacroAssembler
         m_srkill = RegSet(arm::rAsm);//m_abi.all();
         break;
+      case Arch::PPC64:
+        break;
     }
     m_abi.simdUnreserved.remove(m_tmp);
     m_abi.simdReserved.add(m_tmp);
@@ -746,6 +748,7 @@ void Vxls::getEffects(const Vinstr& i, RegSet& uses, RegSet& across,
       switch (arch()) {
         case Arch::ARM: defs.add(PhysReg(arm::rLinkReg)); break;
         case Arch::X64: break;
+        case Arch::PPC64: break;
       }
       break;
     case Vinstr::callstub:

--- a/hphp/util/bitops.h
+++ b/hphp/util/bitops.h
@@ -44,6 +44,23 @@ inline bool ffs64(I64 input, I64 &out) {
     :
     "cc"
   );
+#elif defined(__powerpc64__)
+  // In PowerPC 64, bit 0 is the most significant
+  asm volatile (
+    "nor    23, %2, %2\n\t" // negate each bit of input
+    "addi   23, 23, 1\n\t"
+    "and    23, %2, 23\n\t"
+    "cntlzd %1, 23\n\t" // count leading zeros (starting from index 0)
+    "cmpdi  %1, 64\n\t"
+    "beq    0f\n\t"     // zero retval if input == 0
+    "addi   23, 0, 63\n\t"
+    "sub    %1, 23, %1\n\t"
+    "addi   %0, 0, 1\n\t"
+    "0:\n\t":
+    "=r"(retval), "=r"(out):
+    "r"(input):
+    "r23", "cr0"
+  );
 #endif
   return retval;
 }
@@ -70,6 +87,23 @@ inline bool fls64(I64 input, I64 &out) {
     "=r"(retval), "=r"(out):
     "r"(input):
     "cc"
+  );
+#elif defined(__powerpc64__)
+  // In PowerPC 64, bit 0 is the most significant
+  asm volatile (
+    "nor    23, %2, %2\n\t" // negate each bit of input
+    "addi   23, 23, 1\n\t"
+    "and    23, %2, 23\n\t"
+    "cntlzd %1, 23\n\t" // count leading zeros (starting from index 0)
+    "cmpdi  %1, 64\n\t"
+    "beq    0f\n\t"     // zero retval if input == 0
+    "addi   23, 0, 63\n\t"
+    "sub    %1, 23, %1\n\t"
+    "addi   %0, 0, 1\n\t"
+    "0:\n\t":
+    "=r"(retval), "=r"(out):
+    "r"(input):
+    "r23", "cr0"
   );
 #endif
   return retval;

--- a/hphp/util/compact-tagged-ptrs.h
+++ b/hphp/util/compact-tagged-ptrs.h
@@ -38,7 +38,7 @@ namespace HPHP {
 
 //////////////////////////////////////////////////////////////////////
 
-#ifdef __x86_64__
+#if defined(__x86_64__) || defined(__powerpc64__)
 
 template<class T, class TagType = uint32_t>
 struct CompactTaggedPtr {

--- a/hphp/zend/crypt-blowfish.c
+++ b/hphp/zend/crypt-blowfish.c
@@ -60,6 +60,9 @@
 #elif defined(__x86_64__) || defined(__alpha__) || defined(__hppa__)
 #define BF_ASM        0
 #define BF_SCALE      1
+#elif defined(__powerpc64__)
+#define BF_ASM        0
+#define BF_SCALE      0
 #else
 #define BF_ASM        0
 #define BF_SCALE      0


### PR DESCRIPTION
This change adds an empty back-end for PPC64 architecture. Currently HHVM works on PPC64 with JIT disabled.