### PR TITLE
PDOMySqlStatement::nextRowset() now returning true on empty result

### DIFF
--- a/hphp/runtime/ext/pdo_mysql.cpp
+++ b/hphp/runtime/ext/pdo_mysql.cpp
@@ -1284,22 +1284,29 @@ bool PDOMySqlStatement::nextRowset() {
     return false;
   }
 
-  my_ulonglong row_count;
+  my_ulonglong affected_count;
   if (!m_conn->buffered()) {
     m_result = mysql_use_result(m_server);
-    row_count = 0;
+    affected_count = 0;
   } else {
     m_result = mysql_store_result(m_server);
-    if ((my_ulonglong)-1 == (row_count = mysql_affected_rows(m_server))) {
+    if ((my_ulonglong)-1 == (affected_count = mysql_affected_rows(m_server))) {
       handleError(__FILE__, __LINE__);
       return false;
     }
   }
-
+  row_count = affected_count;
+  
   if (!m_result) {
-    return false;
+    if (mysql_errno(m_server)) {
+      handleError(__FILE__, __LINE__);
+      return false;
+    } else {
+      /* DML queries */
+      return true;
+    }
   }
-
+  
   column_count = (int)mysql_num_fields(m_result);
   m_fields = mysql_fetch_fields(m_result);
   return true;

--- a/hphp/test/slow/ext_pdo/pdo_mysql_nextrowset.php
+++ b/hphp/test/slow/ext_pdo/pdo_mysql_nextrowset.php
@@ -1,0 +1,29 @@
+<?php
+$host   = getenv("MYSQL_TEST_HOST");
+$port   = getenv("MYSQL_TEST_PORT");
+$user   = getenv("MYSQL_TEST_USER");
+$passwd = getenv("MYSQL_TEST_PASSWD");
+$db     = getenv("MYSQL_TEST_DB");
+
+$pdo = new PDO("mysql:dbname=$db;host=$host", $user, $passwd);
+
+try {
+  $pdo->query("CREATE TABLE test_nextrowset (
+    id INT(1),
+    PRIMARY KEY(id)
+  )");
+
+  $stm = $pdo->query("INSERT INTO test_nextrowset (id) VALUES (1);
+               INSERT INTO test_nextrowset (id) VALUES (2), (3);
+               INSERT INTO test_nextrowset (id) VALUES (4), (5), (6)");
+  for ($i = 0; $i < 3; $i++) {
+      var_dump($stm->rowCount());
+      var_dump($stm->nextRowset());
+  }
+
+} catch (Exception $ex) {
+  var_dump($ex);
+} finally {
+  $pdo->query("DROP TABLE test_nextrowset");
+}
+

--- a/hphp/test/slow/ext_pdo/pdo_mysql_nextrowset.php.expect
+++ b/hphp/test/slow/ext_pdo/pdo_mysql_nextrowset.php.expect
@@ -1,0 +1,6 @@
+int(1)
+bool(true)
+int(2)
+bool(true)
+int(3)
+bool(false)

--- a/hphp/test/slow/ext_pdo/pdo_mysql_nextrowset.php.skipif
+++ b/hphp/test/slow/ext_pdo/pdo_mysql_nextrowset.php.skipif
@@ -1,0 +1,21 @@
+<?php
+$drivers = PDO::getAvailableDrivers();
+
+if (!in_array('mysql', $drivers)) {
+  die("Skip. Driver not found");
+}
+
+$environmentVars = [
+  "MYSQL_TEST_HOST",
+  "MYSQL_TEST_PORT",
+  "MYSQL_TEST_USER",
+  "MYSQL_TEST_PASSWD",
+  "MYSQL_TEST_DB",
+];
+
+foreach ($environmentVars as $environmentVar) {
+ if (false === getenv($envrionmentVar)) {
+    die ("Skip. Environment variable $environmentVar is not set.");
+  }  
+}
+


### PR DESCRIPTION
Fixes #4942

According to MySQL docs:

Anyway, to put some light on my solution with m_result:
```
mysql_store_result() returns a null pointer if the statement did not return a result set (for example, if it was an INSERT statement).

mysql_store_result() also returns a null pointer if reading of the result set failed. You can check whether an error occurred by checking whether mysql_error() returns a nonempty string, mysql_errno() returns nonzero, or mysql_field_count() returns zero.
```

Also, I've tried to fix bug with shadowing public property `row_count` by local variable.