### PR TITLE
PDOMySqlStatement::getColumnMeta now handling 'native_type' for TINYINT ...

### DIFF
--- a/hphp/runtime/ext/pdo_mysql.cpp
+++ b/hphp/runtime/ext/pdo_mysql.cpp
@@ -796,7 +796,7 @@ static const char *type_to_name_native(int type) {
   switch (type) {
         PDO_MYSQL_NATIVE_TYPE_NAME(STRING)
         PDO_MYSQL_NATIVE_TYPE_NAME(VAR_STRING)
-#ifdef MYSQL_HAS_TINY
+#ifdef FIELD_TYPE_TINY
         PDO_MYSQL_NATIVE_TYPE_NAME(TINY)
 #endif
         PDO_MYSQL_NATIVE_TYPE_NAME(SHORT)

--- a/hphp/test/slow/ext_pdo/pdo_mysql_getColumnMeta_native_type.php
+++ b/hphp/test/slow/ext_pdo/pdo_mysql_getColumnMeta_native_type.php
@@ -1,0 +1,21 @@
+<?php
+$host   = getenv("MYSQL_TEST_HOST");
+$port   = getenv("MYSQL_TEST_PORT");
+$user   = getenv("MYSQL_TEST_USER");
+$passwd = getenv("MYSQL_TEST_PASSWD");
+$db     = getenv("MYSQL_TEST_DB");
+
+$pdo = new PDO("mysql:dbname=$db;host=$host", $user, $passwd);
+
+try {
+  $pdo->query("CREATE TABLE test_native_type (
+    true_false TINYINT(1)
+  )");
+
+  $stm = $pdo->query("SELECT true_false FROM test_native_type");
+  var_dump($stm->getColumnMeta(0)['native_type']);
+} catch (Exception $ex) {
+} finally {
+  $pdo->query("DROP TABLE test_native_type");
+}
+

--- a/hphp/test/slow/ext_pdo/pdo_mysql_getColumnMeta_native_type.php.expect
+++ b/hphp/test/slow/ext_pdo/pdo_mysql_getColumnMeta_native_type.php.expect
@@ -1,0 +1,1 @@
+string(4) "TINY"

--- a/hphp/test/slow/ext_pdo/pdo_mysql_getColumnMeta_native_type.php.skipif
+++ b/hphp/test/slow/ext_pdo/pdo_mysql_getColumnMeta_native_type.php.skipif
@@ -1,0 +1,21 @@
+<?php
+$drivers = PDO::getAvailableDrivers();
+
+if (!in_array('mysql', $drivers)) {
+  die("Skip. Driver not found");
+}
+
+$environmentVars = [
+  "MYSQL_TEST_HOST",
+  "MYSQL_TEST_PORT",
+  "MYSQL_TEST_USER",
+  "MYSQL_TEST_PASSWD",
+  "MYSQL_TEST_DB",
+];
+
+foreach ($environmentVars as $environmentVar) {
+ if (false === getenv($envrionmentVar)) {
+    die ("Skip. Environment variable $environmentVar is not set.");
+  }  
+}
+


### PR DESCRIPTION
...correctly.

Fixes #4944.

Constant `MYSQL_HAS_TINY` is missing.