### PR TITLE
Add mechanisms to read glob-speced .ini and .hdf files.

### DIFF
--- a/hphp/runtime/base/emulate-zend.cpp
+++ b/hphp/runtime/base/emulate-zend.cpp
@@ -14,12 +14,13 @@
    +----------------------------------------------------------------------+
 */
 #include "hphp/runtime/base/emulate-zend.h"
+#include "hphp/runtime/base/ini-setting.h"
 
-#include <stdlib.h>
+#include <assert.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
-#include <assert.h>
 
 #include <vector>
 #include <string>
@@ -229,16 +230,12 @@ int emulate_zend(int argc, char** argv) {
 
     // If the -c option is specified without a -n, php behavior is to
     // load the default ini/hdf
-    auto default_config_file = "/etc/hhvm/php.ini";
-    if (access(default_config_file, R_OK) != -1) {
+    auto cb = [&newargv] (const char *filename) {
       newargv.push_back("-c");
-      newargv.push_back(default_config_file);
-    }
-    default_config_file = "/etc/hhvm/config.hdf";
-    if (access(default_config_file, R_OK) != -1) {
-      newargv.push_back("-c");
-      newargv.push_back(default_config_file);
-    }
+      newargv.push_back(filename);
+    };
+    add_default_config_files_globbed("/etc/hhvm/php*.ini", cb);
+    add_default_config_files_globbed("/etc/hhvm/config*.hdf", cb);
   }
 
   if (cnt < argc && strcmp(argv[cnt], "--") == 0) cnt++;

--- a/hphp/runtime/base/ini-setting.h
+++ b/hphp/runtime/base/ini-setting.h
@@ -346,6 +346,10 @@ private:
 
 int64_t convert_bytes_to_long(const std::string& value);
 
+void add_default_config_files_globbed(
+  const char *default_config_file,
+  std::function<void (const char *filename)> cb);
+
 ///////////////////////////////////////////////////////////////////////////////
 }
 

--- a/hphp/runtime/base/program-functions.cpp
+++ b/hphp/runtime/base/program-functions.cpp
@@ -1339,16 +1339,12 @@ static int execute_program_impl(int argc, char** argv) {
         return -1;
       }
       if (po.config.empty() && !vm.count("no-config")) {
-        auto default_config_file = "/etc/hhvm/php.ini";
-        if (access(default_config_file, R_OK) != -1) {
-          Logger::Verbose("Using default config file: %s", default_config_file);
-          po.config.push_back(default_config_file);
-        }
-        default_config_file = "/etc/hhvm/config.hdf";
-        if (access(default_config_file, R_OK) != -1) {
-          Logger::Verbose("Using default config file: %s", default_config_file);
-          po.config.push_back(default_config_file);
-        }
+        auto file_callback = [&po] (const char *filename) {
+          Logger::Verbose("Using default config file: %s", filename);
+          po.config.push_back(filename);
+        };
+        add_default_config_files_globbed("/etc/hhvm/php*.ini", file_callback);
+        add_default_config_files_globbed("/etc/hhvm/config*.hdf", file_callback);
       }
 // When we upgrade boost, we can remove this and also get rid of the parent
 // try statement and move opts back into the original try block

--- a/hphp/runtime/base/program-functions.cpp
+++ b/hphp/runtime/base/program-functions.cpp
@@ -1343,8 +1343,10 @@ static int execute_program_impl(int argc, char** argv) {
           Logger::Verbose("Using default config file: %s", filename);
           po.config.push_back(filename);
         };
-        add_default_config_files_globbed("/etc/hhvm/php*.ini", file_callback);
-        add_default_config_files_globbed("/etc/hhvm/config*.hdf", file_callback);
+        add_default_config_files_globbed("/etc/hhvm/php*.ini",
+                                         file_callback);
+        add_default_config_files_globbed("/etc/hhvm/config*.hdf",
+                                         file_callback);
       }
 // When we upgrade boost, we can remove this and also get rid of the parent
 // try statement and move opts back into the original try block

--- a/hphp/runtime/ext/std/ext_std_file.cpp
+++ b/hphp/runtime/ext/std/ext_std_file.cpp
@@ -1677,19 +1677,23 @@ Variant HHVM_FUNCTION(glob,
                   nullptr,
                   &globbuf);
   if (nret == GLOB_NOMATCH) {
+    globfree(&globbuf);
     return empty_array();
   }
 
   if (!globbuf.gl_pathc || !globbuf.gl_pathv) {
     if (ThreadInfo::s_threadInfo->m_reqInjectionData.hasSafeFileAccess()) {
       if (!HHVM_FN(is_dir)(work_pattern)) {
+        globfree(&globbuf);
         return false;
       }
     }
+    globfree(&globbuf);
     return empty_array();
   }
 
   if (nret) {
+    globfree(&globbuf);
     return false;
   }
 


### PR DESCRIPTION
Use these mechanisms to implement a policy of
reading all files that glob match:
  /etc/hhvm/php*.ini
  /etc/hhvm/config*.hdf
The knowledge of which files to load is found in 2 places.

This is an architectural change with ramifications I don't fully
understand.

This change will, however, make it easier to install and uninstall a .so
file and its corresponding .ini file.

Fix what seems to be a memory leak for error paths
out of the code implementing the php function "glob".