### PR TITLE
Add TYPO3 Flow unit tests to framework parity check

### DIFF
--- a/hphp/test/frameworks/framework_class_overrides/Flow.php
+++ b/hphp/test/frameworks/framework_class_overrides/Flow.php
@@ -1,0 +1,13 @@
+<?hh
+require_once __DIR__.'/../Framework.php';
+
+class Flow extends Framework {
+
+  public function __construct(string $name) {
+    //we need newer phpunit 4.5
+    $tc = get_runtime_build().' '.__DIR__.
+      '/../framework_downloads/flow/bin/phpunit';
+    //parallel is disabled because it prevented hhvm from finding tests
+    parent::__construct($name, $tc, null, null, false);
+  }
+}

--- a/hphp/test/frameworks/frameworks.yaml
+++ b/hphp/test/frameworks/frameworks.yaml
@@ -139,6 +139,13 @@
     commit: 7dc9a43cb856debc22fe158a1144018e16f7a637
     install_root: fastroute
     test_root: fastroute
+  flow:
+    url: https://git.typo3.org/Flow/Distributions/Base.git
+    branch: '3.0'
+    commit: 300f50f02bf41c25677111bd0c8962643b16bff8
+    install_root: flow
+    test_root: flow
+    config_file: flow/Build/BuildEssentials/PhpUnit/UnitTests.xml
   guzzle:
     url: https://github.com/guzzle/guzzle3.git
     branch: v3.9.2

--- a/hphp/test/frameworks/results/flow.expect
+++ b/hphp/test/frameworks/results/flow.expect
@@ -1,0 +1,8904 @@
+TYPO3\Eel\Tests\Unit\ArrayHelperTest::concatWorks with data set "alpha and numeric values"
+.
+TYPO3\Eel\Tests\Unit\ArrayHelperTest::concatWorks with data set "mixed arguments"
+.
+TYPO3\Eel\Tests\Unit\ArrayHelperTest::concatWorks with data set "variable arguments"
+.
+TYPO3\Eel\Tests\Unit\ArrayHelperTest::firstWorks with data set "empty array"
+.
+TYPO3\Eel\Tests\Unit\ArrayHelperTest::firstWorks with data set "numeric indices"
+.
+TYPO3\Eel\Tests\Unit\ArrayHelperTest::firstWorks with data set "string keys"
+.
+TYPO3\Eel\Tests\Unit\ArrayHelperTest::indexOfWorks with data set "array with values"
+.
+TYPO3\Eel\Tests\Unit\ArrayHelperTest::indexOfWorks with data set "empty array"
+.
+TYPO3\Eel\Tests\Unit\ArrayHelperTest::indexOfWorks with data set "with offset"
+.
+TYPO3\Eel\Tests\Unit\ArrayHelperTest::isEmptyWorks with data set "array with values"
+.
+TYPO3\Eel\Tests\Unit\ArrayHelperTest::isEmptyWorks with data set "empty array"
+.
+TYPO3\Eel\Tests\Unit\ArrayHelperTest::joinWorks with data set "empty array"
+.
+TYPO3\Eel\Tests\Unit\ArrayHelperTest::joinWorks with data set "words with custom separator"
+.
+TYPO3\Eel\Tests\Unit\ArrayHelperTest::joinWorks with data set "words with default separator"
+.
+TYPO3\Eel\Tests\Unit\ArrayHelperTest::keysWorks with data set "empty array"
+.
+TYPO3\Eel\Tests\Unit\ArrayHelperTest::keysWorks with data set "numeric indices"
+.
+TYPO3\Eel\Tests\Unit\ArrayHelperTest::keysWorks with data set "string keys"
+.
+TYPO3\Eel\Tests\Unit\ArrayHelperTest::lastWorks with data set "empty array"
+.
+TYPO3\Eel\Tests\Unit\ArrayHelperTest::lastWorks with data set "numeric indices"
+.
+TYPO3\Eel\Tests\Unit\ArrayHelperTest::lastWorks with data set "string keys"
+.
+TYPO3\Eel\Tests\Unit\ArrayHelperTest::lengthWorks with data set "array with values"
+.
+TYPO3\Eel\Tests\Unit\ArrayHelperTest::lengthWorks with data set "empty array"
+.
+TYPO3\Eel\Tests\Unit\ArrayHelperTest::popWorks with data set "empty array"
+.
+TYPO3\Eel\Tests\Unit\ArrayHelperTest::popWorks with data set "mixed keys"
+.
+TYPO3\Eel\Tests\Unit\ArrayHelperTest::popWorks with data set "numeric indices"
+.
+TYPO3\Eel\Tests\Unit\ArrayHelperTest::popWorks with data set "string keys"
+.
+TYPO3\Eel\Tests\Unit\ArrayHelperTest::pushWorks with data set "empty array"
+.
+TYPO3\Eel\Tests\Unit\ArrayHelperTest::pushWorks with data set "mixed keys"
+.
+TYPO3\Eel\Tests\Unit\ArrayHelperTest::pushWorks with data set "numeric indices"
+.
+TYPO3\Eel\Tests\Unit\ArrayHelperTest::pushWorks with data set "string keys"
+.
+TYPO3\Eel\Tests\Unit\ArrayHelperTest::randomWorks with data set "empty array"
+.
+TYPO3\Eel\Tests\Unit\ArrayHelperTest::randomWorks with data set "numeric indices"
+.
+TYPO3\Eel\Tests\Unit\ArrayHelperTest::randomWorks with data set "string keys"
+.
+TYPO3\Eel\Tests\Unit\ArrayHelperTest::reverseWorks with data set "empty array"
+.
+TYPO3\Eel\Tests\Unit\ArrayHelperTest::reverseWorks with data set "numeric indices"
+.
+TYPO3\Eel\Tests\Unit\ArrayHelperTest::reverseWorks with data set "string keys"
+.
+TYPO3\Eel\Tests\Unit\ArrayHelperTest::shiftWorks with data set "empty array"
+.
+TYPO3\Eel\Tests\Unit\ArrayHelperTest::shiftWorks with data set "mixed keys"
+.
+TYPO3\Eel\Tests\Unit\ArrayHelperTest::shiftWorks with data set "numeric indices"
+.
+TYPO3\Eel\Tests\Unit\ArrayHelperTest::shiftWorks with data set "string keys"
+.
+TYPO3\Eel\Tests\Unit\ArrayHelperTest::shuffleWorks with data set "empty array"
+.
+TYPO3\Eel\Tests\Unit\ArrayHelperTest::shuffleWorks with data set "mixed keys"
+.
+TYPO3\Eel\Tests\Unit\ArrayHelperTest::shuffleWorks with data set "numeric indices"
+.
+TYPO3\Eel\Tests\Unit\ArrayHelperTest::shuffleWorks with data set "string keys"
+.
+TYPO3\Eel\Tests\Unit\ArrayHelperTest::sliceWorks with data set "empty array"
+.
+TYPO3\Eel\Tests\Unit\ArrayHelperTest::sliceWorks with data set "negative begin without end"
+.
+TYPO3\Eel\Tests\Unit\ArrayHelperTest::sliceWorks with data set "positive begin and end"
+.
+TYPO3\Eel\Tests\Unit\ArrayHelperTest::sliceWorks with data set "positive begin with negative end"
+.
+TYPO3\Eel\Tests\Unit\ArrayHelperTest::sliceWorks with data set "positive begin without end"
+.
+TYPO3\Eel\Tests\Unit\ArrayHelperTest::sliceWorks with data set "zero begin with negative end"
+.
+TYPO3\Eel\Tests\Unit\ArrayHelperTest::sortWorks with data set "empty array"
+.
+TYPO3\Eel\Tests\Unit\ArrayHelperTest::sortWorks with data set "mixed keys"
+.
+TYPO3\Eel\Tests\Unit\ArrayHelperTest::sortWorks with data set "numeric indices"
+.
+TYPO3\Eel\Tests\Unit\ArrayHelperTest::sortWorks with data set "string keys"
+.
+TYPO3\Eel\Tests\Unit\ArrayHelperTest::spliceNoReplacements
+.
+TYPO3\Eel\Tests\Unit\ArrayHelperTest::spliceWorks with data set "empty array"
+.
+TYPO3\Eel\Tests\Unit\ArrayHelperTest::spliceWorks with data set "mixed keys"
+.
+TYPO3\Eel\Tests\Unit\ArrayHelperTest::spliceWorks with data set "numeric indices"
+.
+TYPO3\Eel\Tests\Unit\ArrayHelperTest::spliceWorks with data set "string keys"
+.
+TYPO3\Eel\Tests\Unit\ArrayHelperTest::unshiftWorks with data set "empty array"
+.
+TYPO3\Eel\Tests\Unit\ArrayHelperTest::unshiftWorks with data set "mixed keys"
+.
+TYPO3\Eel\Tests\Unit\ArrayHelperTest::unshiftWorks with data set "numeric indices"
+.
+TYPO3\Eel\Tests\Unit\ArrayHelperTest::unshiftWorks with data set "string keys"
+.
+TYPO3\Eel\Tests\Unit\CompilingEvaluatorBenchmarkTest::loopedExpressions
+S
+TYPO3\Eel\Tests\Unit\CompilingEvaluatorTest::arrayLiteralsCanBeParsed with data set #0
+.
+TYPO3\Eel\Tests\Unit\CompilingEvaluatorTest::arrayLiteralsCanBeParsed with data set #1
+.
+TYPO3\Eel\Tests\Unit\CompilingEvaluatorTest::arrayLiteralsCanBeParsed with data set #2
+.
+TYPO3\Eel\Tests\Unit\CompilingEvaluatorTest::arrayLiteralsCanBeParsed with data set #3
+.
+TYPO3\Eel\Tests\Unit\CompilingEvaluatorTest::booleanExpressionsCanBeParsed with data set #0
+.
+TYPO3\Eel\Tests\Unit\CompilingEvaluatorTest::booleanExpressionsCanBeParsed with data set #1
+.
+TYPO3\Eel\Tests\Unit\CompilingEvaluatorTest::booleanExpressionsCanBeParsed with data set #10
+.
+TYPO3\Eel\Tests\Unit\CompilingEvaluatorTest::booleanExpressionsCanBeParsed with data set #11
+.
+TYPO3\Eel\Tests\Unit\CompilingEvaluatorTest::booleanExpressionsCanBeParsed with data set #12
+.
+TYPO3\Eel\Tests\Unit\CompilingEvaluatorTest::booleanExpressionsCanBeParsed with data set #13
+.
+TYPO3\Eel\Tests\Unit\CompilingEvaluatorTest::booleanExpressionsCanBeParsed with data set #14
+.
+TYPO3\Eel\Tests\Unit\CompilingEvaluatorTest::booleanExpressionsCanBeParsed with data set #15
+.
+TYPO3\Eel\Tests\Unit\CompilingEvaluatorTest::booleanExpressionsCanBeParsed with data set #16
+.
+TYPO3\Eel\Tests\Unit\CompilingEvaluatorTest::booleanExpressionsCanBeParsed with data set #17
+.
+TYPO3\Eel\Tests\Unit\CompilingEvaluatorTest::booleanExpressionsCanBeParsed with data set #18
+.
+TYPO3\Eel\Tests\Unit\CompilingEvaluatorTest::booleanExpressionsCanBeParsed with data set #19
+.
+TYPO3\Eel\Tests\Unit\CompilingEvaluatorTest::booleanExpressionsCanBeParsed with data set #2
+.
+TYPO3\Eel\Tests\Unit\CompilingEvaluatorTest::booleanExpressionsCanBeParsed with data set #3
+.
+TYPO3\Eel\Tests\Unit\CompilingEvaluatorTest::booleanExpressionsCanBeParsed with data set #4
+.
+TYPO3\Eel\Tests\Unit\CompilingEvaluatorTest::booleanExpressionsCanBeParsed with data set #5
+.
+TYPO3\Eel\Tests\Unit\CompilingEvaluatorTest::booleanExpressionsCanBeParsed with data set #6
+.
+TYPO3\Eel\Tests\Unit\CompilingEvaluatorTest::booleanExpressionsCanBeParsed with data set #7
+.
+TYPO3\Eel\Tests\Unit\CompilingEvaluatorTest::booleanExpressionsCanBeParsed with data set #8
+.
+TYPO3\Eel\Tests\Unit\CompilingEvaluatorTest::booleanExpressionsCanBeParsed with data set #9
+.
+TYPO3\Eel\Tests\Unit\CompilingEvaluatorTest::calculationExpressionsCanBeParsed with data set #0
+.
+TYPO3\Eel\Tests\Unit\CompilingEvaluatorTest::calculationExpressionsCanBeParsed with data set #1
+.
+TYPO3\Eel\Tests\Unit\CompilingEvaluatorTest::calculationExpressionsCanBeParsed with data set #2
+.
+TYPO3\Eel\Tests\Unit\CompilingEvaluatorTest::calculationExpressionsCanBeParsed with data set #3
+.
+TYPO3\Eel\Tests\Unit\CompilingEvaluatorTest::calculationExpressionsCanBeParsed with data set #4
+.
+TYPO3\Eel\Tests\Unit\CompilingEvaluatorTest::calculationExpressionsCanBeParsed with data set #5
+.
+TYPO3\Eel\Tests\Unit\CompilingEvaluatorTest::calculationExpressionsCanBeParsed with data set #6
+.
+TYPO3\Eel\Tests\Unit\CompilingEvaluatorTest::combinedExpressionsCanBeParsed with data set #0
+.
+TYPO3\Eel\Tests\Unit\CompilingEvaluatorTest::combinedExpressionsCanBeParsed with data set #1
+.
+TYPO3\Eel\Tests\Unit\CompilingEvaluatorTest::combinedExpressionsCanBeParsed with data set #2
+.
+TYPO3\Eel\Tests\Unit\CompilingEvaluatorTest::comparisonExpressionsCanBeParsed with data set #0
+.
+TYPO3\Eel\Tests\Unit\CompilingEvaluatorTest::comparisonExpressionsCanBeParsed with data set #1
+.
+TYPO3\Eel\Tests\Unit\CompilingEvaluatorTest::comparisonExpressionsCanBeParsed with data set #10
+.
+TYPO3\Eel\Tests\Unit\CompilingEvaluatorTest::comparisonExpressionsCanBeParsed with data set #11
+.
+TYPO3\Eel\Tests\Unit\CompilingEvaluatorTest::comparisonExpressionsCanBeParsed with data set #12
+.
+TYPO3\Eel\Tests\Unit\CompilingEvaluatorTest::comparisonExpressionsCanBeParsed with data set #13
+.
+TYPO3\Eel\Tests\Unit\CompilingEvaluatorTest::comparisonExpressionsCanBeParsed with data set #14
+.
+TYPO3\Eel\Tests\Unit\CompilingEvaluatorTest::comparisonExpressionsCanBeParsed with data set #2
+.
+TYPO3\Eel\Tests\Unit\CompilingEvaluatorTest::comparisonExpressionsCanBeParsed with data set #3
+.
+TYPO3\Eel\Tests\Unit\CompilingEvaluatorTest::comparisonExpressionsCanBeParsed with data set #4
+.
+TYPO3\Eel\Tests\Unit\CompilingEvaluatorTest::comparisonExpressionsCanBeParsed with data set #5
+.
+TYPO3\Eel\Tests\Unit\CompilingEvaluatorTest::comparisonExpressionsCanBeParsed with data set #6
+.
+TYPO3\Eel\Tests\Unit\CompilingEvaluatorTest::comparisonExpressionsCanBeParsed with data set #7
+.
+TYPO3\Eel\Tests\Unit\CompilingEvaluatorTest::comparisonExpressionsCanBeParsed with data set #8
+.
+TYPO3\Eel\Tests\Unit\CompilingEvaluatorTest::comparisonExpressionsCanBeParsed with data set #9
+.
+TYPO3\Eel\Tests\Unit\CompilingEvaluatorTest::conditionalOperatorsCanBeParsed with data set #0
+.
+TYPO3\Eel\Tests\Unit\CompilingEvaluatorTest::conditionalOperatorsCanBeParsed with data set #1
+.
+TYPO3\Eel\Tests\Unit\CompilingEvaluatorTest::conditionalOperatorsCanBeParsed with data set #2
+.
+TYPO3\Eel\Tests\Unit\CompilingEvaluatorTest::conditionalOperatorsCanBeParsed with data set #3
+.
+TYPO3\Eel\Tests\Unit\CompilingEvaluatorTest::conditionalOperatorsCanBeParsed with data set #4
+.
+TYPO3\Eel\Tests\Unit\CompilingEvaluatorTest::conditionalOperatorsCanBeParsed with data set #5
+.
+TYPO3\Eel\Tests\Unit\CompilingEvaluatorTest::doubleQuotedStringLiteralVariablesAreEscaped
+.
+TYPO3\Eel\Tests\Unit\CompilingEvaluatorTest::floatLiteralsCanBeParsed with data set #0
+.
+TYPO3\Eel\Tests\Unit\CompilingEvaluatorTest::floatLiteralsCanBeParsed with data set #1
+.
+TYPO3\Eel\Tests\Unit\CompilingEvaluatorTest::floatLiteralsCanBeParsed with data set #2
+.
+TYPO3\Eel\Tests\Unit\CompilingEvaluatorTest::integerLiteralsCanBeParsed with data set #0
+.
+TYPO3\Eel\Tests\Unit\CompilingEvaluatorTest::integerLiteralsCanBeParsed with data set #1
+.
+TYPO3\Eel\Tests\Unit\CompilingEvaluatorTest::integerLiteralsCanBeParsed with data set #2
+.
+TYPO3\Eel\Tests\Unit\CompilingEvaluatorTest::integerLiteralsCanBeParsed with data set #3
+.
+TYPO3\Eel\Tests\Unit\CompilingEvaluatorTest::invalidExpressionsThrowExceptions with data set #0
+.
+TYPO3\Eel\Tests\Unit\CompilingEvaluatorTest::invalidExpressionsThrowExceptions with data set #1
+.
+TYPO3\Eel\Tests\Unit\CompilingEvaluatorTest::invalidExpressionsThrowExceptions with data set #2
+.
+TYPO3\Eel\Tests\Unit\CompilingEvaluatorTest::invalidExpressionsThrowExceptions with data set #3
+.
+TYPO3\Eel\Tests\Unit\CompilingEvaluatorTest::invalidExpressionsThrowExceptions with data set #4
+.
+TYPO3\Eel\Tests\Unit\CompilingEvaluatorTest::methodCallExpressionsCanBeParsed with data set #0
+.
+TYPO3\Eel\Tests\Unit\CompilingEvaluatorTest::methodCallExpressionsCanBeParsed with data set #1
+.
+TYPO3\Eel\Tests\Unit\CompilingEvaluatorTest::methodCallExpressionsCanBeParsed with data set #2
+.
+TYPO3\Eel\Tests\Unit\CompilingEvaluatorTest::methodCallExpressionsCanBeParsed with data set #3
+.
+TYPO3\Eel\Tests\Unit\CompilingEvaluatorTest::methodCallExpressionsCanBeParsed with data set #4
+.
+TYPO3\Eel\Tests\Unit\CompilingEvaluatorTest::methodCallExpressionsCanBeParsed with data set #5
+.
+TYPO3\Eel\Tests\Unit\CompilingEvaluatorTest::methodCallExpressionsCanBeParsed with data set #6
+.
+TYPO3\Eel\Tests\Unit\CompilingEvaluatorTest::methodCallExpressionsCanBeParsed with data set #7
+.
+TYPO3\Eel\Tests\Unit\CompilingEvaluatorTest::methodCallExpressionsCanBeParsed with data set #8
+.
+TYPO3\Eel\Tests\Unit\CompilingEvaluatorTest::methodCallOfUndefinedFunctionThrowsException
+.
+TYPO3\Eel\Tests\Unit\CompilingEvaluatorTest::methodCallOfUnknownMethodThrowsException
+.
+TYPO3\Eel\Tests\Unit\CompilingEvaluatorTest::notExpressionsCanBeParsed with data set #0
+.
+TYPO3\Eel\Tests\Unit\CompilingEvaluatorTest::notExpressionsCanBeParsed with data set #1
+.
+TYPO3\Eel\Tests\Unit\CompilingEvaluatorTest::notExpressionsCanBeParsed with data set #2
+.
+TYPO3\Eel\Tests\Unit\CompilingEvaluatorTest::notExpressionsCanBeParsed with data set #3
+.
+TYPO3\Eel\Tests\Unit\CompilingEvaluatorTest::objectLiteralsCanBeParsed with data set #0
+.
+TYPO3\Eel\Tests\Unit\CompilingEvaluatorTest::objectLiteralsCanBeParsed with data set #1
+.
+TYPO3\Eel\Tests\Unit\CompilingEvaluatorTest::objectLiteralsCanBeParsed with data set #2
+.
+TYPO3\Eel\Tests\Unit\CompilingEvaluatorTest::objectPathOnArrayExpressionsCanBeParsed with data set #0
+.
+TYPO3\Eel\Tests\Unit\CompilingEvaluatorTest::objectPathOnArrayExpressionsCanBeParsed with data set #1
+.
+TYPO3\Eel\Tests\Unit\CompilingEvaluatorTest::objectPathOnArrayExpressionsCanBeParsed with data set #2
+.
+TYPO3\Eel\Tests\Unit\CompilingEvaluatorTest::objectPathOnArrayExpressionsCanBeParsed with data set #3
+.
+TYPO3\Eel\Tests\Unit\CompilingEvaluatorTest::objectPathOnArrayExpressionsCanBeParsed with data set #4
+.
+TYPO3\Eel\Tests\Unit\CompilingEvaluatorTest::objectPathOnArrayExpressionsCanBeParsed with data set #5
+.
+TYPO3\Eel\Tests\Unit\CompilingEvaluatorTest::objectPathOnArrayExpressionsCanBeParsed with data set #6
+.
+TYPO3\Eel\Tests\Unit\CompilingEvaluatorTest::objectPathOnObjectExpressionsCanBeParsed with data set #0
+.
+TYPO3\Eel\Tests\Unit\CompilingEvaluatorTest::objectPathOnObjectExpressionsCanBeParsed with data set #1
+.
+TYPO3\Eel\Tests\Unit\CompilingEvaluatorTest::objectPathOnObjectExpressionsCanBeParsed with data set #2
+.
+TYPO3\Eel\Tests\Unit\CompilingEvaluatorTest::stringConcatenationsCanBeParsed with data set #0
+.
+TYPO3\Eel\Tests\Unit\CompilingEvaluatorTest::stringConcatenationsCanBeParsed with data set #1
+.
+TYPO3\Eel\Tests\Unit\CompilingEvaluatorTest::stringConcatenationsCanBeParsed with data set #2
+.
+TYPO3\Eel\Tests\Unit\CompilingEvaluatorTest::stringConcatenationsCanBeParsed with data set #3
+.
+TYPO3\Eel\Tests\Unit\CompilingEvaluatorTest::stringLiteralsCanBeParsed with data set #0
+.
+TYPO3\Eel\Tests\Unit\CompilingEvaluatorTest::stringLiteralsCanBeParsed with data set #1
+.
+TYPO3\Eel\Tests\Unit\CompilingEvaluatorTest::stringLiteralsCanBeParsed with data set #2
+.
+TYPO3\Eel\Tests\Unit\CompilingEvaluatorTest::stringLiteralsCanBeParsed with data set #3
+.
+TYPO3\Eel\Tests\Unit\CompilingEvaluatorTest::stringLiteralsCanBeParsed with data set #4
+.
+TYPO3\Eel\Tests\Unit\CompilingEvaluatorTest::stringLiteralsCanBeParsed with data set #5
+.
+TYPO3\Eel\Tests\Unit\ContextTest::getValueByPathForArrayValues with data set #0
+.
+TYPO3\Eel\Tests\Unit\ContextTest::getValueByPathForArrayValues with data set #1
+.
+TYPO3\Eel\Tests\Unit\ContextTest::getValueByPathForArrayValues with data set #2
+.
+TYPO3\Eel\Tests\Unit\ContextTest::getValueByPathForArrayValues with data set #3
+.
+TYPO3\Eel\Tests\Unit\ContextTest::getValueByPathForArrayValues with data set #4
+.
+TYPO3\Eel\Tests\Unit\ContextTest::getValueByPathForObjectValues with data set #0
+.
+TYPO3\Eel\Tests\Unit\ContextTest::getValueByPathForObjectValues with data set #1
+.
+TYPO3\Eel\Tests\Unit\ContextTest::getValueByPathForObjectValues with data set #2
+.
+TYPO3\Eel\Tests\Unit\ContextTest::getValueByPathForObjectValues with data set #3
+.
+TYPO3\Eel\Tests\Unit\ContextTest::getValueByPathForObjectValues with data set #4
+.
+TYPO3\Eel\Tests\Unit\ContextTest::unwrapArrayValues with data set #0
+.
+TYPO3\Eel\Tests\Unit\ContextTest::unwrapArrayValues with data set #1
+.
+TYPO3\Eel\Tests\Unit\ContextTest::unwrapArrayValues with data set #2
+.
+TYPO3\Eel\Tests\Unit\ContextTest::unwrapArrayValues with data set #3
+.
+TYPO3\Eel\Tests\Unit\ContextTest::unwrapSimpleValues with data set #0
+.
+TYPO3\Eel\Tests\Unit\ContextTest::unwrapSimpleValues with data set #1
+.
+TYPO3\Eel\Tests\Unit\ContextTest::unwrapSimpleValues with data set #2
+.
+TYPO3\Eel\Tests\Unit\ContextTest::unwrapSimpleValues with data set #3
+.
+TYPO3\Eel\Tests\Unit\ContextTest::unwrapSimpleValues with data set #4
+.
+TYPO3\Eel\Tests\Unit\DateHelperTest::calculationWorks with data set "add DateTime with DateInterval"
+.
+TYPO3\Eel\Tests\Unit\DateHelperTest::calculationWorks with data set "add DateTime with string"
+.
+TYPO3\Eel\Tests\Unit\DateHelperTest::calculationWorks with data set "subtract DateTime with DateInterval"
+.
+TYPO3\Eel\Tests\Unit\DateHelperTest::calculationWorks with data set "subtract DateTime with string"
+.
+TYPO3\Eel\Tests\Unit\DateHelperTest::dateAccessorsWork
+.
+TYPO3\Eel\Tests\Unit\DateHelperTest::diffWorks
+.
+TYPO3\Eel\Tests\Unit\DateHelperTest::formatWorks with data set "DateTime object"
+.
+TYPO3\Eel\Tests\Unit\DateHelperTest::formatWorks with data set "interval"
+.
+TYPO3\Eel\Tests\Unit\DateHelperTest::formatWorks with data set "now"
+.
+TYPO3\Eel\Tests\Unit\DateHelperTest::formatWorks with data set "timestamp as integer"
+.
+TYPO3\Eel\Tests\Unit\DateHelperTest::formatWorks with data set "timestamp as string"
+.
+TYPO3\Eel\Tests\Unit\DateHelperTest::nowWorks
+.
+TYPO3\Eel\Tests\Unit\DateHelperTest::parseWorks with data set "basic date"
+.
+TYPO3\Eel\Tests\Unit\DateHelperTest::parseWorks with data set "date with time"
+.
+TYPO3\Eel\Tests\Unit\DateHelperTest::todayWorks
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\FizzleParserTest::attributeFilterIsMatched
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\FizzleParserTest::booleanOperandsAreConvertedToBoolean
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\FizzleParserTest::filterGroupIsMatched
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\FizzleParserTest::filterIsMatched
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\FizzleParserTest::propertyNameFilterIsMatched
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\FlowQueryTest::childrenAndFilterAndPropertyWorks with data set "children() on empty array always returns empty flowquery object"
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\FlowQueryTest::childrenAndFilterAndPropertyWorks with data set "children() with property name and attribute filter returns all corresponding child objects"
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\FlowQueryTest::childrenAndFilterAndPropertyWorks with data set "children() with property name filter returns all corresponding child objects"
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\FlowQueryTest::childrenAndFilterAndPropertyWorks with data set "property() with property name returns object accessor on first object"
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\FlowQueryTest::childrenAndFilterAndPropertyWorks with data set "property() with property name works with property paths"
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\FlowQueryTest::constructWithFlowQueryIsIdempotent
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\FlowQueryTest::countReturnsCorrectNumber with data set "Begin query match"
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\FlowQueryTest::countReturnsCorrectNumber with data set "Boolean matches"
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\FlowQueryTest::countReturnsCorrectNumber with data set "End query match (1)"
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\FlowQueryTest::countReturnsCorrectNumber with data set "End query match (2)"
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\FlowQueryTest::countReturnsCorrectNumber with data set "Exact matches are supported"
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\FlowQueryTest::countReturnsCorrectNumber with data set "Greater than or equal to query match"
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\FlowQueryTest::countReturnsCorrectNumber with data set "Greater than query match"
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\FlowQueryTest::countReturnsCorrectNumber with data set "Identifier match"
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\FlowQueryTest::countReturnsCorrectNumber with data set "In-Between Query Match"
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\FlowQueryTest::countReturnsCorrectNumber with data set "Instanceof test works (1)"
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\FlowQueryTest::countReturnsCorrectNumber with data set "Instanceof test works (2)"
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\FlowQueryTest::countReturnsCorrectNumber with data set "Instanceof test works (with test for array)"
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\FlowQueryTest::countReturnsCorrectNumber with data set "Instanceof test works (with test for boolean)"
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\FlowQueryTest::countReturnsCorrectNumber with data set "Instanceof test works (with test for float)"
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\FlowQueryTest::countReturnsCorrectNumber with data set "Instanceof test works (with test for integer 2)"
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\FlowQueryTest::countReturnsCorrectNumber with data set "Instanceof test works (with test for integer)"
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\FlowQueryTest::countReturnsCorrectNumber with data set "Instanceof test works (with test for object)"
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\FlowQueryTest::countReturnsCorrectNumber with data set "Instanceof test works (with test for string)"
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\FlowQueryTest::countReturnsCorrectNumber with data set "Instanceof test works on attributes"
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\FlowQueryTest::countReturnsCorrectNumber with data set "Integer matches"
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\FlowQueryTest::countReturnsCorrectNumber with data set "Less than or equal to query match"
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\FlowQueryTest::countReturnsCorrectNumber with data set "Less than query match"
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\FlowQueryTest::countReturnsCorrectNumber with data set "Multiple filters are combined with AND together"
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\FlowQueryTest::countReturnsCorrectNumber with data set "Multiple filters can be ORed together using comma"
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\FlowQueryTest::countReturnsCorrectNumber with data set "Not equals query match"
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\FlowQueryTest::countReturnsCorrectNumber with data set "Property existance test works"
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\FlowQueryTest::errorQueriesThrowError with data set #0
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\FlowQueryTest::errorQueriesThrowError with data set #1
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\FlowQueryTest::errorQueriesThrowError with data set #10
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\FlowQueryTest::errorQueriesThrowError with data set #11
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\FlowQueryTest::errorQueriesThrowError with data set #12
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\FlowQueryTest::errorQueriesThrowError with data set #13
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\FlowQueryTest::errorQueriesThrowError with data set #2
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\FlowQueryTest::errorQueriesThrowError with data set #3
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\FlowQueryTest::errorQueriesThrowError with data set #4
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\FlowQueryTest::errorQueriesThrowError with data set #5
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\FlowQueryTest::errorQueriesThrowError with data set #6
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\FlowQueryTest::errorQueriesThrowError with data set #7
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\FlowQueryTest::errorQueriesThrowError with data set #8
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\FlowQueryTest::errorQueriesThrowError with data set #9
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\FlowQueryTest::filterCanFilterObjects with data set "Begin query match"
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\FlowQueryTest::filterCanFilterObjects with data set "Boolean matches"
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\FlowQueryTest::filterCanFilterObjects with data set "End query match (1)"
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\FlowQueryTest::filterCanFilterObjects with data set "End query match (2)"
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\FlowQueryTest::filterCanFilterObjects with data set "Exact matches are supported"
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\FlowQueryTest::filterCanFilterObjects with data set "Greater than or equal to query match"
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\FlowQueryTest::filterCanFilterObjects with data set "Greater than query match"
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\FlowQueryTest::filterCanFilterObjects with data set "Identifier match"
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\FlowQueryTest::filterCanFilterObjects with data set "In-Between Query Match"
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\FlowQueryTest::filterCanFilterObjects with data set "Instanceof test works (1)"
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\FlowQueryTest::filterCanFilterObjects with data set "Instanceof test works (2)"
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\FlowQueryTest::filterCanFilterObjects with data set "Instanceof test works (with test for array)"
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\FlowQueryTest::filterCanFilterObjects with data set "Instanceof test works (with test for boolean)"
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\FlowQueryTest::filterCanFilterObjects with data set "Instanceof test works (with test for float)"
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\FlowQueryTest::filterCanFilterObjects with data set "Instanceof test works (with test for integer 2)"
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\FlowQueryTest::filterCanFilterObjects with data set "Instanceof test works (with test for integer)"
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\FlowQueryTest::filterCanFilterObjects with data set "Instanceof test works (with test for object)"
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\FlowQueryTest::filterCanFilterObjects with data set "Instanceof test works (with test for string)"
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\FlowQueryTest::filterCanFilterObjects with data set "Instanceof test works on attributes"
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\FlowQueryTest::filterCanFilterObjects with data set "Integer matches"
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\FlowQueryTest::filterCanFilterObjects with data set "Less than or equal to query match"
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\FlowQueryTest::filterCanFilterObjects with data set "Less than query match"
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\FlowQueryTest::filterCanFilterObjects with data set "Multiple filters are combined with AND together"
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\FlowQueryTest::filterCanFilterObjects with data set "Multiple filters can be ORed together using comma"
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\FlowQueryTest::filterCanFilterObjects with data set "Not equals query match"
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\FlowQueryTest::filterCanFilterObjects with data set "Property existance test works"
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\FlowQueryTest::firstReturnsFirstObject
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\FlowQueryTest::isCanFilterObjects with data set "Begin query match"
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\FlowQueryTest::isCanFilterObjects with data set "Boolean matches"
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\FlowQueryTest::isCanFilterObjects with data set "End query match (1)"
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\FlowQueryTest::isCanFilterObjects with data set "End query match (2)"
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\FlowQueryTest::isCanFilterObjects with data set "Exact matches are supported"
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\FlowQueryTest::isCanFilterObjects with data set "Greater than or equal to query match"
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\FlowQueryTest::isCanFilterObjects with data set "Greater than query match"
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\FlowQueryTest::isCanFilterObjects with data set "Identifier match"
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\FlowQueryTest::isCanFilterObjects with data set "In-Between Query Match"
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\FlowQueryTest::isCanFilterObjects with data set "Instanceof test works (1)"
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\FlowQueryTest::isCanFilterObjects with data set "Instanceof test works (2)"
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\FlowQueryTest::isCanFilterObjects with data set "Instanceof test works (with test for array)"
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\FlowQueryTest::isCanFilterObjects with data set "Instanceof test works (with test for boolean)"
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\FlowQueryTest::isCanFilterObjects with data set "Instanceof test works (with test for float)"
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\FlowQueryTest::isCanFilterObjects with data set "Instanceof test works (with test for integer 2)"
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\FlowQueryTest::isCanFilterObjects with data set "Instanceof test works (with test for integer)"
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\FlowQueryTest::isCanFilterObjects with data set "Instanceof test works (with test for object)"
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\FlowQueryTest::isCanFilterObjects with data set "Instanceof test works (with test for string)"
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\FlowQueryTest::isCanFilterObjects with data set "Instanceof test works on attributes"
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\FlowQueryTest::isCanFilterObjects with data set "Integer matches"
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\FlowQueryTest::isCanFilterObjects with data set "Less than or equal to query match"
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\FlowQueryTest::isCanFilterObjects with data set "Less than query match"
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\FlowQueryTest::isCanFilterObjects with data set "Multiple filters are combined with AND together"
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\FlowQueryTest::isCanFilterObjects with data set "Multiple filters can be ORed together using comma"
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\FlowQueryTest::isCanFilterObjects with data set "Not equals query match"
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\FlowQueryTest::isCanFilterObjects with data set "Property existance test works"
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\FlowQueryTest::lastReturnsLastObject
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\FlowQueryTest::sliceReturnsSlicedObject
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\Operations\AddOperationTest::addWithArrayArgumentAppendsToCurrentContext
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\Operations\AddOperationTest::addWithFlowQueryArgumentAppendsToCurrentContext
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\Operations\AddOperationTest::addWithNodeArgumentAppendsToCurrentContext
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\Operations\ChildrenOperationTest::evaluateSetsTheCorrectPartOfTheContextArray with data set "traversal of arrays unrolls them"
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\Operations\ChildrenOperationTest::evaluateSetsTheCorrectPartOfTheContextArray with data set "traversal of objects"
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\Operations\ChildrenOperationTest::evaluateSetsTheCorrectPartOfTheContextArray with data set "traversal of traversables unrolls them"
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\Operations\SliceOperationTest::evaluateSetsTheCorrectPartOfTheContextArray with data set "empty array with end"
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\Operations\SliceOperationTest::evaluateSetsTheCorrectPartOfTheContextArray with data set "empty array"
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\Operations\SliceOperationTest::evaluateSetsTheCorrectPartOfTheContextArray with data set "end out of bounds"
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\Operations\SliceOperationTest::evaluateSetsTheCorrectPartOfTheContextArray with data set "negative start and end"
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\Operations\SliceOperationTest::evaluateSetsTheCorrectPartOfTheContextArray with data set "negative start"
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\Operations\SliceOperationTest::evaluateSetsTheCorrectPartOfTheContextArray with data set "no argument"
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\Operations\SliceOperationTest::evaluateSetsTheCorrectPartOfTheContextArray with data set "positive start"
+.
+TYPO3\Eel\Tests\Unit\FlowQuery\Operations\SliceOperationTest::evaluateSetsTheCorrectPartOfTheContextArray with data set "slice in bounds"
+.
+TYPO3\Eel\Tests\Unit\InterpretedEvaluatorBenchmarkTest::loopedExpressions
+S
+TYPO3\Eel\Tests\Unit\InterpretedEvaluatorTest::arrayLiteralsCanBeParsed with data set #0
+.
+TYPO3\Eel\Tests\Unit\InterpretedEvaluatorTest::arrayLiteralsCanBeParsed with data set #1
+.
+TYPO3\Eel\Tests\Unit\InterpretedEvaluatorTest::arrayLiteralsCanBeParsed with data set #2
+.
+TYPO3\Eel\Tests\Unit\InterpretedEvaluatorTest::arrayLiteralsCanBeParsed with data set #3
+.
+TYPO3\Eel\Tests\Unit\InterpretedEvaluatorTest::booleanExpressionsCanBeParsed with data set #0
+.
+TYPO3\Eel\Tests\Unit\InterpretedEvaluatorTest::booleanExpressionsCanBeParsed with data set #1
+.
+TYPO3\Eel\Tests\Unit\InterpretedEvaluatorTest::booleanExpressionsCanBeParsed with data set #10
+.
+TYPO3\Eel\Tests\Unit\InterpretedEvaluatorTest::booleanExpressionsCanBeParsed with data set #11
+.
+TYPO3\Eel\Tests\Unit\InterpretedEvaluatorTest::booleanExpressionsCanBeParsed with data set #12
+.
+TYPO3\Eel\Tests\Unit\InterpretedEvaluatorTest::booleanExpressionsCanBeParsed with data set #13
+.
+TYPO3\Eel\Tests\Unit\InterpretedEvaluatorTest::booleanExpressionsCanBeParsed with data set #14
+.
+TYPO3\Eel\Tests\Unit\InterpretedEvaluatorTest::booleanExpressionsCanBeParsed with data set #15
+.
+TYPO3\Eel\Tests\Unit\InterpretedEvaluatorTest::booleanExpressionsCanBeParsed with data set #16
+.
+TYPO3\Eel\Tests\Unit\InterpretedEvaluatorTest::booleanExpressionsCanBeParsed with data set #17
+.
+TYPO3\Eel\Tests\Unit\InterpretedEvaluatorTest::booleanExpressionsCanBeParsed with data set #18
+.
+TYPO3\Eel\Tests\Unit\InterpretedEvaluatorTest::booleanExpressionsCanBeParsed with data set #19
+.
+TYPO3\Eel\Tests\Unit\InterpretedEvaluatorTest::booleanExpressionsCanBeParsed with data set #2
+.
+TYPO3\Eel\Tests\Unit\InterpretedEvaluatorTest::booleanExpressionsCanBeParsed with data set #3
+.
+TYPO3\Eel\Tests\Unit\InterpretedEvaluatorTest::booleanExpressionsCanBeParsed with data set #4
+.
+TYPO3\Eel\Tests\Unit\InterpretedEvaluatorTest::booleanExpressionsCanBeParsed with data set #5
+.
+TYPO3\Eel\Tests\Unit\InterpretedEvaluatorTest::booleanExpressionsCanBeParsed with data set #6
+.
+TYPO3\Eel\Tests\Unit\InterpretedEvaluatorTest::booleanExpressionsCanBeParsed with data set #7
+.
+TYPO3\Eel\Tests\Unit\InterpretedEvaluatorTest::booleanExpressionsCanBeParsed with data set #8
+.
+TYPO3\Eel\Tests\Unit\InterpretedEvaluatorTest::booleanExpressionsCanBeParsed with data set #9
+.
+TYPO3\Eel\Tests\Unit\InterpretedEvaluatorTest::calculationExpressionsCanBeParsed with data set #0
+.
+TYPO3\Eel\Tests\Unit\InterpretedEvaluatorTest::calculationExpressionsCanBeParsed with data set #1
+.
+TYPO3\Eel\Tests\Unit\InterpretedEvaluatorTest::calculationExpressionsCanBeParsed with data set #2
+.
+TYPO3\Eel\Tests\Unit\InterpretedEvaluatorTest::calculationExpressionsCanBeParsed with data set #3
+.
+TYPO3\Eel\Tests\Unit\InterpretedEvaluatorTest::calculationExpressionsCanBeParsed with data set #4
+.
+TYPO3\Eel\Tests\Unit\InterpretedEvaluatorTest::calculationExpressionsCanBeParsed with data set #5
+.
+TYPO3\Eel\Tests\Unit\InterpretedEvaluatorTest::calculationExpressionsCanBeParsed with data set #6
+.
+TYPO3\Eel\Tests\Unit\InterpretedEvaluatorTest::combinedExpressionsCanBeParsed with data set #0
+.
+TYPO3\Eel\Tests\Unit\InterpretedEvaluatorTest::combinedExpressionsCanBeParsed with data set #1
+.
+TYPO3\Eel\Tests\Unit\InterpretedEvaluatorTest::combinedExpressionsCanBeParsed with data set #2
+.
+TYPO3\Eel\Tests\Unit\InterpretedEvaluatorTest::comparisonExpressionsCanBeParsed with data set #0
+.
+TYPO3\Eel\Tests\Unit\InterpretedEvaluatorTest::comparisonExpressionsCanBeParsed with data set #1
+.
+TYPO3\Eel\Tests\Unit\InterpretedEvaluatorTest::comparisonExpressionsCanBeParsed with data set #10
+.
+TYPO3\Eel\Tests\Unit\InterpretedEvaluatorTest::comparisonExpressionsCanBeParsed with data set #11
+.
+TYPO3\Eel\Tests\Unit\InterpretedEvaluatorTest::comparisonExpressionsCanBeParsed with data set #12
+.
+TYPO3\Eel\Tests\Unit\InterpretedEvaluatorTest::comparisonExpressionsCanBeParsed with data set #13
+.
+TYPO3\Eel\Tests\Unit\InterpretedEvaluatorTest::comparisonExpressionsCanBeParsed with data set #14
+.
+TYPO3\Eel\Tests\Unit\InterpretedEvaluatorTest::comparisonExpressionsCanBeParsed with data set #2
+.
+TYPO3\Eel\Tests\Unit\InterpretedEvaluatorTest::comparisonExpressionsCanBeParsed with data set #3
+.
+TYPO3\Eel\Tests\Unit\InterpretedEvaluatorTest::comparisonExpressionsCanBeParsed with data set #4
+.
+TYPO3\Eel\Tests\Unit\InterpretedEvaluatorTest::comparisonExpressionsCanBeParsed with data set #5
+.
+TYPO3\Eel\Tests\Unit\InterpretedEvaluatorTest::comparisonExpressionsCanBeParsed with data set #6
+.
+TYPO3\Eel\Tests\Unit\InterpretedEvaluatorTest::comparisonExpressionsCanBeParsed with data set #7
+.
+TYPO3\Eel\Tests\Unit\InterpretedEvaluatorTest::comparisonExpressionsCanBeParsed with data set #8
+.
+TYPO3\Eel\Tests\Unit\InterpretedEvaluatorTest::comparisonExpressionsCanBeParsed with data set #9
+.
+TYPO3\Eel\Tests\Unit\InterpretedEvaluatorTest::conditionalOperatorsCanBeParsed with data set #0
+.
+TYPO3\Eel\Tests\Unit\InterpretedEvaluatorTest::conditionalOperatorsCanBeParsed with data set #1
+.
+TYPO3\Eel\Tests\Unit\InterpretedEvaluatorTest::conditionalOperatorsCanBeParsed with data set #2
+.
+TYPO3\Eel\Tests\Unit\InterpretedEvaluatorTest::conditionalOperatorsCanBeParsed with data set #3
+.
+TYPO3\Eel\Tests\Unit\InterpretedEvaluatorTest::conditionalOperatorsCanBeParsed with data set #4
+.
+TYPO3\Eel\Tests\Unit\InterpretedEvaluatorTest::conditionalOperatorsCanBeParsed with data set #5
+.
+TYPO3\Eel\Tests\Unit\InterpretedEvaluatorTest::floatLiteralsCanBeParsed with data set #0
+.
+TYPO3\Eel\Tests\Unit\InterpretedEvaluatorTest::floatLiteralsCanBeParsed with data set #1
+.
+TYPO3\Eel\Tests\Unit\InterpretedEvaluatorTest::floatLiteralsCanBeParsed with data set #2
+.
+TYPO3\Eel\Tests\Unit\InterpretedEvaluatorTest::integerLiteralsCanBeParsed with data set #0
+.
+TYPO3\Eel\Tests\Unit\InterpretedEvaluatorTest::integerLiteralsCanBeParsed with data set #1
+.
+TYPO3\Eel\Tests\Unit\InterpretedEvaluatorTest::integerLiteralsCanBeParsed with data set #2
+.
+TYPO3\Eel\Tests\Unit\InterpretedEvaluatorTest::integerLiteralsCanBeParsed with data set #3
+.
+TYPO3\Eel\Tests\Unit\InterpretedEvaluatorTest::invalidExpressionsThrowExceptions with data set #0
+.
+TYPO3\Eel\Tests\Unit\InterpretedEvaluatorTest::invalidExpressionsThrowExceptions with data set #1
+.
+TYPO3\Eel\Tests\Unit\InterpretedEvaluatorTest::invalidExpressionsThrowExceptions with data set #2
+.
+TYPO3\Eel\Tests\Unit\InterpretedEvaluatorTest::invalidExpressionsThrowExceptions with data set #3
+.
+TYPO3\Eel\Tests\Unit\InterpretedEvaluatorTest::invalidExpressionsThrowExceptions with data set #4
+.
+TYPO3\Eel\Tests\Unit\InterpretedEvaluatorTest::methodCallExpressionsCanBeParsed with data set #0
+.
+TYPO3\Eel\Tests\Unit\InterpretedEvaluatorTest::methodCallExpressionsCanBeParsed with data set #1
+.
+TYPO3\Eel\Tests\Unit\InterpretedEvaluatorTest::methodCallExpressionsCanBeParsed with data set #2
+.
+TYPO3\Eel\Tests\Unit\InterpretedEvaluatorTest::methodCallExpressionsCanBeParsed with data set #3
+.
+TYPO3\Eel\Tests\Unit\InterpretedEvaluatorTest::methodCallExpressionsCanBeParsed with data set #4
+.
+TYPO3\Eel\Tests\Unit\InterpretedEvaluatorTest::methodCallExpressionsCanBeParsed with data set #5
+.
+TYPO3\Eel\Tests\Unit\InterpretedEvaluatorTest::methodCallExpressionsCanBeParsed with data set #6
+.
+TYPO3\Eel\Tests\Unit\InterpretedEvaluatorTest::methodCallExpressionsCanBeParsed with data set #7
+.
+TYPO3\Eel\Tests\Unit\InterpretedEvaluatorTest::methodCallExpressionsCanBeParsed with data set #8
+.
+TYPO3\Eel\Tests\Unit\InterpretedEvaluatorTest::methodCallOfUndefinedFunctionThrowsException
+.
+TYPO3\Eel\Tests\Unit\InterpretedEvaluatorTest::methodCallOfUnknownMethodThrowsException
+.
+TYPO3\Eel\Tests\Unit\InterpretedEvaluatorTest::notExpressionsCanBeParsed with data set #0
+.
+TYPO3\Eel\Tests\Unit\InterpretedEvaluatorTest::notExpressionsCanBeParsed with data set #1
+.
+TYPO3\Eel\Tests\Unit\InterpretedEvaluatorTest::notExpressionsCanBeParsed with data set #2
+.
+TYPO3\Eel\Tests\Unit\InterpretedEvaluatorTest::notExpressionsCanBeParsed with data set #3
+.
+TYPO3\Eel\Tests\Unit\InterpretedEvaluatorTest::objectLiteralsCanBeParsed with data set #0
+.
+TYPO3\Eel\Tests\Unit\InterpretedEvaluatorTest::objectLiteralsCanBeParsed with data set #1
+.
+TYPO3\Eel\Tests\Unit\InterpretedEvaluatorTest::objectLiteralsCanBeParsed with data set #2
+.
+TYPO3\Eel\Tests\Unit\InterpretedEvaluatorTest::objectPathOnArrayExpressionsCanBeParsed with data set #0
+.
+TYPO3\Eel\Tests\Unit\InterpretedEvaluatorTest::objectPathOnArrayExpressionsCanBeParsed with data set #1
+.
+TYPO3\Eel\Tests\Unit\InterpretedEvaluatorTest::objectPathOnArrayExpressionsCanBeParsed with data set #2
+.
+TYPO3\Eel\Tests\Unit\InterpretedEvaluatorTest::objectPathOnArrayExpressionsCanBeParsed with data set #3
+.
+TYPO3\Eel\Tests\Unit\InterpretedEvaluatorTest::objectPathOnArrayExpressionsCanBeParsed with data set #4
+.
+TYPO3\Eel\Tests\Unit\InterpretedEvaluatorTest::objectPathOnArrayExpressionsCanBeParsed with data set #5
+.
+TYPO3\Eel\Tests\Unit\InterpretedEvaluatorTest::objectPathOnArrayExpressionsCanBeParsed with data set #6
+.
+TYPO3\Eel\Tests\Unit\InterpretedEvaluatorTest::objectPathOnObjectExpressionsCanBeParsed with data set #0
+.
+TYPO3\Eel\Tests\Unit\InterpretedEvaluatorTest::objectPathOnObjectExpressionsCanBeParsed with data set #1
+.
+TYPO3\Eel\Tests\Unit\InterpretedEvaluatorTest::objectPathOnObjectExpressionsCanBeParsed with data set #2
+.
+TYPO3\Eel\Tests\Unit\InterpretedEvaluatorTest::stringConcatenationsCanBeParsed with data set #0
+.
+TYPO3\Eel\Tests\Unit\InterpretedEvaluatorTest::stringConcatenationsCanBeParsed with data set #1
+.
+TYPO3\Eel\Tests\Unit\InterpretedEvaluatorTest::stringConcatenationsCanBeParsed with data set #2
+.
+TYPO3\Eel\Tests\Unit\InterpretedEvaluatorTest::stringConcatenationsCanBeParsed with data set #3
+.
+TYPO3\Eel\Tests\Unit\InterpretedEvaluatorTest::stringLiteralsCanBeParsed with data set #0
+.
+TYPO3\Eel\Tests\Unit\InterpretedEvaluatorTest::stringLiteralsCanBeParsed with data set #1
+.
+TYPO3\Eel\Tests\Unit\InterpretedEvaluatorTest::stringLiteralsCanBeParsed with data set #2
+.
+TYPO3\Eel\Tests\Unit\InterpretedEvaluatorTest::stringLiteralsCanBeParsed with data set #3
+.
+TYPO3\Eel\Tests\Unit\InterpretedEvaluatorTest::stringLiteralsCanBeParsed with data set #4
+.
+TYPO3\Eel\Tests\Unit\InterpretedEvaluatorTest::stringLiteralsCanBeParsed with data set #5
+.
+TYPO3\Eel\Tests\Unit\JsonHelperTest::parseWorks with data set "array value"
+.
+TYPO3\Eel\Tests\Unit\JsonHelperTest::parseWorks with data set "null value"
+.
+TYPO3\Eel\Tests\Unit\JsonHelperTest::parseWorks with data set "numeric value"
+.
+TYPO3\Eel\Tests\Unit\JsonHelperTest::parseWorks with data set "object value is parsed as associative array by default"
+.
+TYPO3\Eel\Tests\Unit\JsonHelperTest::parseWorks with data set "object value without associative array"
+.
+TYPO3\Eel\Tests\Unit\JsonHelperTest::parseWorks with data set "string value"
+.
+TYPO3\Eel\Tests\Unit\JsonHelperTest::stringifyWorks with data set "array value"
+.
+TYPO3\Eel\Tests\Unit\JsonHelperTest::stringifyWorks with data set "null value"
+.
+TYPO3\Eel\Tests\Unit\JsonHelperTest::stringifyWorks with data set "numeric value"
+.
+TYPO3\Eel\Tests\Unit\JsonHelperTest::stringifyWorks with data set "string value"
+.
+TYPO3\Eel\Tests\Unit\MathHelperTest::constantsWorks with data set "E"
+.
+TYPO3\Eel\Tests\Unit\MathHelperTest::constantsWorks with data set "LN10"
+.
+TYPO3\Eel\Tests\Unit\MathHelperTest::constantsWorks with data set "LN2"
+.
+TYPO3\Eel\Tests\Unit\MathHelperTest::constantsWorks with data set "LOG10E"
+.
+TYPO3\Eel\Tests\Unit\MathHelperTest::constantsWorks with data set "LOG2E"
+.
+TYPO3\Eel\Tests\Unit\MathHelperTest::constantsWorks with data set "PI"
+.
+TYPO3\Eel\Tests\Unit\MathHelperTest::constantsWorks with data set "SQRT1_2"
+.
+TYPO3\Eel\Tests\Unit\MathHelperTest::constantsWorks with data set "SQRT2"
+.
+TYPO3\Eel\Tests\Unit\MathHelperTest::finiteAndNanFunctionsWork with data set "isFinite("
+.
+TYPO3\Eel\Tests\Unit\MathHelperTest::finiteAndNanFunctionsWork with data set "isFinite(42)"
+.
+TYPO3\Eel\Tests\Unit\MathHelperTest::finiteAndNanFunctionsWork with data set "isFinite(INF)"
+.
+TYPO3\Eel\Tests\Unit\MathHelperTest::finiteAndNanFunctionsWork with data set "isFinite(NAN)"
+.
+TYPO3\Eel\Tests\Unit\MathHelperTest::finiteAndNanFunctionsWork with data set "isInfinite("
+.
+TYPO3\Eel\Tests\Unit\MathHelperTest::finiteAndNanFunctionsWork with data set "isInfinite(-INF)"
+.
+TYPO3\Eel\Tests\Unit\MathHelperTest::finiteAndNanFunctionsWork with data set "isInfinite(42)"
+.
+TYPO3\Eel\Tests\Unit\MathHelperTest::finiteAndNanFunctionsWork with data set "isInfinite(INF)"
+.
+TYPO3\Eel\Tests\Unit\MathHelperTest::finiteAndNanFunctionsWork with data set "isInfinite(NAN)"
+.
+TYPO3\Eel\Tests\Unit\MathHelperTest::finiteAndNanFunctionsWork with data set "isNaN("
+.
+TYPO3\Eel\Tests\Unit\MathHelperTest::finiteAndNanFunctionsWork with data set "isNaN(42)"
+.
+TYPO3\Eel\Tests\Unit\MathHelperTest::finiteAndNanFunctionsWork with data set "isNaN(INF)"
+.
+TYPO3\Eel\Tests\Unit\MathHelperTest::finiteAndNanFunctionsWork with data set "isNaN(NAN)"
+.
+TYPO3\Eel\Tests\Unit\MathHelperTest::randomIntReturnsARandomResultFromMinToMaxExclusive
+.
+TYPO3\Eel\Tests\Unit\MathHelperTest::randomReturnsARandomResultFromZeroToOneExclusive
+.
+TYPO3\Eel\Tests\Unit\MathHelperTest::roundWorks with data set "round with 2 digit precision"
+.
+TYPO3\Eel\Tests\Unit\MathHelperTest::roundWorks with data set "round with default precision"
+.
+TYPO3\Eel\Tests\Unit\MathHelperTest::roundWorks with data set "round with float precision"
+.
+TYPO3\Eel\Tests\Unit\MathHelperTest::roundWorks with data set "round with integer"
+.
+TYPO3\Eel\Tests\Unit\MathHelperTest::roundWorks with data set "round with negative precision"
+.
+TYPO3\Eel\Tests\Unit\MathHelperTest::roundWorks with data set "round with string"
+.
+TYPO3\Eel\Tests\Unit\MathHelperTest::trigonometricFunctionsWork with data set "acos(x)"
+.
+TYPO3\Eel\Tests\Unit\MathHelperTest::trigonometricFunctionsWork with data set "acosh(x)"
+.
+TYPO3\Eel\Tests\Unit\MathHelperTest::trigonometricFunctionsWork with data set "asin(x)"
+.
+TYPO3\Eel\Tests\Unit\MathHelperTest::trigonometricFunctionsWork with data set "asinh(x)"
+.
+TYPO3\Eel\Tests\Unit\MathHelperTest::trigonometricFunctionsWork with data set "atan(x)"
+.
+TYPO3\Eel\Tests\Unit\MathHelperTest::trigonometricFunctionsWork with data set "atan2(y, x)"
+.
+TYPO3\Eel\Tests\Unit\MathHelperTest::trigonometricFunctionsWork with data set "atanh(x)"
+.
+TYPO3\Eel\Tests\Unit\MathHelperTest::trigonometricFunctionsWork with data set "cos(x)"
+.
+TYPO3\Eel\Tests\Unit\MathHelperTest::trigonometricFunctionsWork with data set "cosh(x)"
+.
+TYPO3\Eel\Tests\Unit\MathHelperTest::trigonometricFunctionsWork with data set "sin(x)"
+.
+TYPO3\Eel\Tests\Unit\MathHelperTest::trigonometricFunctionsWork with data set "sinh(x)"
+.
+TYPO3\Eel\Tests\Unit\MathHelperTest::trigonometricFunctionsWork with data set "tan(x)"
+.
+TYPO3\Eel\Tests\Unit\MathHelperTest::trigonometricFunctionsWork with data set "tanh(x)"
+.
+TYPO3\Eel\Tests\Unit\MathHelperTest::variousFunctionsWork with data set "abs("
+.
+TYPO3\Eel\Tests\Unit\MathHelperTest::variousFunctionsWork with data set "abs()"
+.
+TYPO3\Eel\Tests\Unit\MathHelperTest::variousFunctionsWork with data set "abs(-2)"
+.
+TYPO3\Eel\Tests\Unit\MathHelperTest::variousFunctionsWork with data set "abs(null)"
+.
+TYPO3\Eel\Tests\Unit\MathHelperTest::variousFunctionsWork with data set "cbrt(-1)"
+.
+TYPO3\Eel\Tests\Unit\MathHelperTest::variousFunctionsWork with data set "cbrt(2)"
+.
+TYPO3\Eel\Tests\Unit\MathHelperTest::variousFunctionsWork with data set "ceil(-1.004)"
+.
+TYPO3\Eel\Tests\Unit\MathHelperTest::variousFunctionsWork with data set "ceil(0.95)"
+.
+TYPO3\Eel\Tests\Unit\MathHelperTest::variousFunctionsWork with data set "ceil(4)"
+.
+TYPO3\Eel\Tests\Unit\MathHelperTest::variousFunctionsWork with data set "ceil(7.004)"
+.
+TYPO3\Eel\Tests\Unit\MathHelperTest::variousFunctionsWork with data set "exp(-1)"
+.
+TYPO3\Eel\Tests\Unit\MathHelperTest::variousFunctionsWork with data set "exp(0)"
+.
+TYPO3\Eel\Tests\Unit\MathHelperTest::variousFunctionsWork with data set "exp(1)"
+.
+TYPO3\Eel\Tests\Unit\MathHelperTest::variousFunctionsWork with data set "expm1(-1)"
+.
+TYPO3\Eel\Tests\Unit\MathHelperTest::variousFunctionsWork with data set "expm1(0)"
+.
+TYPO3\Eel\Tests\Unit\MathHelperTest::variousFunctionsWork with data set "expm1(1)"
+.
+TYPO3\Eel\Tests\Unit\MathHelperTest::variousFunctionsWork with data set "floor(-1.004)"
+.
+TYPO3\Eel\Tests\Unit\MathHelperTest::variousFunctionsWork with data set "floor(0.95)"
+.
+TYPO3\Eel\Tests\Unit\MathHelperTest::variousFunctionsWork with data set "floor(4)"
+.
+TYPO3\Eel\Tests\Unit\MathHelperTest::variousFunctionsWork with data set "hypot(3, 4)"
+.
+TYPO3\Eel\Tests\Unit\MathHelperTest::variousFunctionsWork with data set "hypot(3, 4, 5)"
+.
+TYPO3\Eel\Tests\Unit\MathHelperTest::variousFunctionsWork with data set "log(-1)"
+.
+TYPO3\Eel\Tests\Unit\MathHelperTest::variousFunctionsWork with data set "log(0)"
+.
+TYPO3\Eel\Tests\Unit\MathHelperTest::variousFunctionsWork with data set "log(1)"
+.
+TYPO3\Eel\Tests\Unit\MathHelperTest::variousFunctionsWork with data set "log(10)"
+.
+TYPO3\Eel\Tests\Unit\MathHelperTest::variousFunctionsWork with data set "log10(-2)"
+.
+TYPO3\Eel\Tests\Unit\MathHelperTest::variousFunctionsWork with data set "log10(0)"
+.
+TYPO3\Eel\Tests\Unit\MathHelperTest::variousFunctionsWork with data set "log10(1)"
+.
+TYPO3\Eel\Tests\Unit\MathHelperTest::variousFunctionsWork with data set "log10(2)"
+.
+TYPO3\Eel\Tests\Unit\MathHelperTest::variousFunctionsWork with data set "log1p(-1)"
+.
+TYPO3\Eel\Tests\Unit\MathHelperTest::variousFunctionsWork with data set "log1p(-2)"
+.
+TYPO3\Eel\Tests\Unit\MathHelperTest::variousFunctionsWork with data set "log1p(0)"
+.
+TYPO3\Eel\Tests\Unit\MathHelperTest::variousFunctionsWork with data set "log1p(1)"
+.
+TYPO3\Eel\Tests\Unit\MathHelperTest::variousFunctionsWork with data set "log2(-2)"
+.
+TYPO3\Eel\Tests\Unit\MathHelperTest::variousFunctionsWork with data set "log2(0)"
+.
+TYPO3\Eel\Tests\Unit\MathHelperTest::variousFunctionsWork with data set "log2(1)"
+.
+TYPO3\Eel\Tests\Unit\MathHelperTest::variousFunctionsWork with data set "log2(2)"
+.
+TYPO3\Eel\Tests\Unit\MathHelperTest::variousFunctionsWork with data set "log2(3)"
+.
+TYPO3\Eel\Tests\Unit\MathHelperTest::variousFunctionsWork with data set "max()"
+.
+TYPO3\Eel\Tests\Unit\MathHelperTest::variousFunctionsWork with data set "max(-10, -20)"
+.
+TYPO3\Eel\Tests\Unit\MathHelperTest::variousFunctionsWork with data set "max(10, 20)"
+.
+TYPO3\Eel\Tests\Unit\MathHelperTest::variousFunctionsWork with data set "min()"
+.
+TYPO3\Eel\Tests\Unit\MathHelperTest::variousFunctionsWork with data set "min(-10, -20)"
+.
+TYPO3\Eel\Tests\Unit\MathHelperTest::variousFunctionsWork with data set "min(10, 20)"
+.
+TYPO3\Eel\Tests\Unit\MathHelperTest::variousFunctionsWork with data set "pow(2, 0.5)"
+.
+TYPO3\Eel\Tests\Unit\MathHelperTest::variousFunctionsWork with data set "pow(2, 3)"
+.
+TYPO3\Eel\Tests\Unit\MathHelperTest::variousFunctionsWork with data set "sign("
+.
+TYPO3\Eel\Tests\Unit\MathHelperTest::variousFunctionsWork with data set "sign(-3.5)"
+.
+TYPO3\Eel\Tests\Unit\MathHelperTest::variousFunctionsWork with data set "sign(0)"
+.
+TYPO3\Eel\Tests\Unit\MathHelperTest::variousFunctionsWork with data set "sign(0.0)"
+.
+TYPO3\Eel\Tests\Unit\MathHelperTest::variousFunctionsWork with data set "sign(3)"
+.
+TYPO3\Eel\Tests\Unit\MathHelperTest::variousFunctionsWork with data set "sqrt(-1)"
+.
+TYPO3\Eel\Tests\Unit\MathHelperTest::variousFunctionsWork with data set "sqrt(0)"
+.
+TYPO3\Eel\Tests\Unit\MathHelperTest::variousFunctionsWork with data set "sqrt(2)"
+.
+TYPO3\Eel\Tests\Unit\MathHelperTest::variousFunctionsWork with data set "sqrt(9)"
+.
+TYPO3\Eel\Tests\Unit\MathHelperTest::variousFunctionsWork with data set "trunc("
+.
+TYPO3\Eel\Tests\Unit\MathHelperTest::variousFunctionsWork with data set "trunc(-0.123)"
+.
+TYPO3\Eel\Tests\Unit\MathHelperTest::variousFunctionsWork with data set "trunc(0)"
+.
+TYPO3\Eel\Tests\Unit\MathHelperTest::variousFunctionsWork with data set "trunc(0.0)"
+.
+TYPO3\Eel\Tests\Unit\MathHelperTest::variousFunctionsWork with data set "trunc(13.37)"
+.
+TYPO3\Eel\Tests\Unit\ProtectedContextTest::arrayAccessResultIsStillUntrusted
+.
+TYPO3\Eel\Tests\Unit\ProtectedContextTest::chainedCallsArePossibleWithExplicitContextWrapping
+.
+TYPO3\Eel\Tests\Unit\ProtectedContextTest::firstLevelFunctionsHaveToBeWhitelisted
+.
+TYPO3\Eel\Tests\Unit\ProtectedContextTest::methodCallToAnyValueIsNotAllowed
+.
+TYPO3\Eel\Tests\Unit\ProtectedContextTest::methodCallToNullValueDoesNotThrowNotAllowedException
+.
+TYPO3\Eel\Tests\Unit\ProtectedContextTest::methodCallToWhitelistedValueIsAllowed
+.
+TYPO3\Eel\Tests\Unit\ProtectedContextTest::propertyAccessToAnyValueIsAllowed
+.
+TYPO3\Eel\Tests\Unit\ProtectedContextTest::protectedContextAwareInterfaceAllowsCallsDynamicallyWithoutWhitelist
+.
+TYPO3\Eel\Tests\Unit\ProtectedContextTest::resultOfFirstLevelMethodCallIsProtected
+.
+TYPO3\Eel\Tests\Unit\ProtectedContextTest::resultOfWhitelistedMethodCallIsProtected
+.
+TYPO3\Eel\Tests\Unit\StringHelperTest::charAtWorks with data set "index greater than count"
+.
+TYPO3\Eel\Tests\Unit\StringHelperTest::charAtWorks with data set "index in string"
+.
+TYPO3\Eel\Tests\Unit\StringHelperTest::charAtWorks with data set "index negative"
+.
+TYPO3\Eel\Tests\Unit\StringHelperTest::charAtWorks with data set "unicode content can be accessed"
+.
+TYPO3\Eel\Tests\Unit\StringHelperTest::cropWorks with data set "crop at sentence"
+.
+TYPO3\Eel\Tests\Unit\StringHelperTest::cropWorks with data set "crop at word"
+.
+TYPO3\Eel\Tests\Unit\StringHelperTest::cropWorks with data set "prefixCanBeChanged"
+.
+TYPO3\Eel\Tests\Unit\StringHelperTest::cropWorks with data set "standard options"
+.
+TYPO3\Eel\Tests\Unit\StringHelperTest::cropWorks with data set "subject is not modified if run without options"
+.
+TYPO3\Eel\Tests\Unit\StringHelperTest::endsWithWorks with data set "search matched"
+.
+TYPO3\Eel\Tests\Unit\StringHelperTest::endsWithWorks with data set "search not matched"
+.
+TYPO3\Eel\Tests\Unit\StringHelperTest::endsWithWorks with data set "search with position"
+.
+TYPO3\Eel\Tests\Unit\StringHelperTest::endsWithWorks with data set "unicode content can be searched"
+.
+TYPO3\Eel\Tests\Unit\StringHelperTest::firstLetterToLowerCaseWorks with data set "firstLetterUpperCase"
+.
+TYPO3\Eel\Tests\Unit\StringHelperTest::firstLetterToLowerCaseWorks with data set "lowercase"
+.
+TYPO3\Eel\Tests\Unit\StringHelperTest::firstLetterToUpperCaseWorks with data set "firstLetterUpperCase"
+.
+TYPO3\Eel\Tests\Unit\StringHelperTest::firstLetterToUpperCaseWorks with data set "lowercase"
+.
+TYPO3\Eel\Tests\Unit\StringHelperTest::htmlSpecialCharsWorks with data set "encode entities"
+.
+TYPO3\Eel\Tests\Unit\StringHelperTest::htmlSpecialCharsWorks with data set "preserve entities"
+.
+TYPO3\Eel\Tests\Unit\StringHelperTest::indexOfWorks with data set "case sensitive match"
+.
+TYPO3\Eel\Tests\Unit\StringHelperTest::indexOfWorks with data set "empty search with from index larger than count"
+.
+TYPO3\Eel\Tests\Unit\StringHelperTest::indexOfWorks with data set "empty search with from index"
+.
+TYPO3\Eel\Tests\Unit\StringHelperTest::indexOfWorks with data set "empty search"
+.
+TYPO3\Eel\Tests\Unit\StringHelperTest::indexOfWorks with data set "from index after match"
+.
+TYPO3\Eel\Tests\Unit\StringHelperTest::indexOfWorks with data set "from index at begin of match"
+.
+TYPO3\Eel\Tests\Unit\StringHelperTest::indexOfWorks with data set "from index at start"
+.
+TYPO3\Eel\Tests\Unit\StringHelperTest::indexOfWorks with data set "match at start"
+.
+TYPO3\Eel\Tests\Unit\StringHelperTest::indexOfWorks with data set "no match"
+.
+TYPO3\Eel\Tests\Unit\StringHelperTest::indexOfWorks with data set "unicode content is matched"
+.
+TYPO3\Eel\Tests\Unit\StringHelperTest::isBlankWorks with data set "NULL string"
+.
+TYPO3\Eel\Tests\Unit\StringHelperTest::isBlankWorks with data set "empty string"
+.
+TYPO3\Eel\Tests\Unit\StringHelperTest::isBlankWorks with data set "string with characters"
+.
+TYPO3\Eel\Tests\Unit\StringHelperTest::isBlankWorks with data set "string with whitespace"
+.
+TYPO3\Eel\Tests\Unit\StringHelperTest::lastIndexOfWorks with data set "match last occurence"
+.
+TYPO3\Eel\Tests\Unit\StringHelperTest::lastIndexOfWorks with data set "match with from index"
+.
+TYPO3\Eel\Tests\Unit\StringHelperTest::lastIndexOfWorks with data set "no match with from index too low"
+.
+TYPO3\Eel\Tests\Unit\StringHelperTest::lastIndexOfWorks with data set "no match"
+.
+TYPO3\Eel\Tests\Unit\StringHelperTest::lastIndexOfWorks with data set "unicode content is matched"
+.
+TYPO3\Eel\Tests\Unit\StringHelperTest::lengthWorks with data set "UTF-8"
+.
+TYPO3\Eel\Tests\Unit\StringHelperTest::lengthWorks with data set "empty"
+.
+TYPO3\Eel\Tests\Unit\StringHelperTest::lengthWorks with data set "non-empty"
+.
+TYPO3\Eel\Tests\Unit\StringHelperTest::lengthWorks with data set "null"
+.
+TYPO3\Eel\Tests\Unit\StringHelperTest::md5Works
+.
+TYPO3\Eel\Tests\Unit\StringHelperTest::pregMatchWorks with data set "matches"
+.
+TYPO3\Eel\Tests\Unit\StringHelperTest::pregReplaceWorks with data set "no match"
+.
+TYPO3\Eel\Tests\Unit\StringHelperTest::pregReplaceWorks with data set "replace non-alphanumeric characters"
+.
+TYPO3\Eel\Tests\Unit\StringHelperTest::pregReplaceWorks with data set "unicode replacement"
+.
+TYPO3\Eel\Tests\Unit\StringHelperTest::rawUrlEncodeWorks
+.
+TYPO3\Eel\Tests\Unit\StringHelperTest::replaceWorks with data set "no match"
+.
+TYPO3\Eel\Tests\Unit\StringHelperTest::replaceWorks with data set "replace"
+.
+TYPO3\Eel\Tests\Unit\StringHelperTest::replaceWorks with data set "unicode replacement"
+.
+TYPO3\Eel\Tests\Unit\StringHelperTest::splitWorks with data set "NULL separator"
+.
+TYPO3\Eel\Tests\Unit\StringHelperTest::splitWorks with data set "empty separator with limit"
+.
+TYPO3\Eel\Tests\Unit\StringHelperTest::splitWorks with data set "empty separator"
+.
+TYPO3\Eel\Tests\Unit\StringHelperTest::splitWorks with data set "split"
+.
+TYPO3\Eel\Tests\Unit\StringHelperTest::startsWithWorks with data set "search matched"
+.
+TYPO3\Eel\Tests\Unit\StringHelperTest::startsWithWorks with data set "search not matched"
+.
+TYPO3\Eel\Tests\Unit\StringHelperTest::startsWithWorks with data set "search with position"
+.
+TYPO3\Eel\Tests\Unit\StringHelperTest::startsWithWorks with data set "unicode content can be searched"
+.
+TYPO3\Eel\Tests\Unit\StringHelperTest::stripTagsWorks with data set "strip tags"
+.
+TYPO3\Eel\Tests\Unit\StringHelperTest::substrWorks with data set "positive start and length lower count"
+.
+TYPO3\Eel\Tests\Unit\StringHelperTest::substrWorks with data set "start equal to count"
+.
+TYPO3\Eel\Tests\Unit\StringHelperTest::substrWorks with data set "start greater than count"
+.
+TYPO3\Eel\Tests\Unit\StringHelperTest::substrWorks with data set "start negative larger than abs(count)"
+.
+TYPO3\Eel\Tests\Unit\StringHelperTest::substrWorks with data set "start negative"
+.
+TYPO3\Eel\Tests\Unit\StringHelperTest::substrWorks with data set "start positive and length is 0"
+.
+TYPO3\Eel\Tests\Unit\StringHelperTest::substrWorks with data set "start positive and length is negative"
+.
+TYPO3\Eel\Tests\Unit\StringHelperTest::substrWorks with data set "start positive and length omitted"
+.
+TYPO3\Eel\Tests\Unit\StringHelperTest::substrWorks with data set "unicode content is extracted"
+.
+TYPO3\Eel\Tests\Unit\StringHelperTest::substringWorks with data set "end greater than count"
+.
+TYPO3\Eel\Tests\Unit\StringHelperTest::substringWorks with data set "end omitted"
+.
+TYPO3\Eel\Tests\Unit\StringHelperTest::substringWorks with data set "negative end"
+.
+TYPO3\Eel\Tests\Unit\StringHelperTest::substringWorks with data set "negative start"
+.
+TYPO3\Eel\Tests\Unit\StringHelperTest::substringWorks with data set "start equals end"
+.
+TYPO3\Eel\Tests\Unit\StringHelperTest::substringWorks with data set "start greater than count"
+.
+TYPO3\Eel\Tests\Unit\StringHelperTest::substringWorks with data set "start greater than end"
+.
+TYPO3\Eel\Tests\Unit\StringHelperTest::substringWorks with data set "unicode content is extracted"
+.
+TYPO3\Eel\Tests\Unit\StringHelperTest::toLowerCaseWorks with data set "lowercase"
+.
+TYPO3\Eel\Tests\Unit\StringHelperTest::toUpperCaseWorks with data set "uppercase"
+.
+TYPO3\Eel\Tests\Unit\StringHelperTest::trimWorks with data set "empty string"
+.
+TYPO3\Eel\Tests\Unit\StringHelperTest::trimWorks with data set "string with characters and whitespace"
+.
+TYPO3\Eel\Tests\Unit\StringHelperTest::trimWorks with data set "string with whitespace"
+.
+TYPO3\Eel\Tests\Unit\StringHelperTest::trimWorks with data set "trim with charlist"
+.
+TYPO3\Eel\Tests\Unit\StringHelperTest::typeConversionWorks with data set "boolean 0"
+.
+TYPO3\Eel\Tests\Unit\StringHelperTest::typeConversionWorks with data set "boolean 1"
+.
+TYPO3\Eel\Tests\Unit\StringHelperTest::typeConversionWorks with data set "boolean anything"
+.
+TYPO3\Eel\Tests\Unit\StringHelperTest::typeConversionWorks with data set "boolean false"
+.
+TYPO3\Eel\Tests\Unit\StringHelperTest::typeConversionWorks with data set "boolean true"
+.
+TYPO3\Eel\Tests\Unit\StringHelperTest::typeConversionWorks with data set "float exp notation"
+.
+TYPO3\Eel\Tests\Unit\StringHelperTest::typeConversionWorks with data set "float invalid value"
+.
+TYPO3\Eel\Tests\Unit\StringHelperTest::typeConversionWorks with data set "float numeric value"
+.
+TYPO3\Eel\Tests\Unit\StringHelperTest::typeConversionWorks with data set "integer empty value"
+.
+TYPO3\Eel\Tests\Unit\StringHelperTest::typeConversionWorks with data set "integer invalid value"
+.
+TYPO3\Eel\Tests\Unit\StringHelperTest::typeConversionWorks with data set "integer numeric value"
+.
+TYPO3\Eel\Tests\Unit\StringHelperTest::typeConversionWorks with data set "string false boolean value"
+.
+TYPO3\Eel\Tests\Unit\StringHelperTest::typeConversionWorks with data set "string numeric value"
+.
+TYPO3\Eel\Tests\Unit\StringHelperTest::typeConversionWorks with data set "string true boolean value"
+.
+TYPO3\Eel\Tests\Unit\Validation\ExpressionSyntaxValidatorTest::invalidExpressionGivesErrorPositionInformation
+.
+TYPO3\Eel\Tests\Unit\Validation\ExpressionSyntaxValidatorTest::invalidExpressionIsConsideredErroneous
+.
+TYPO3\Eel\Tests\Unit\Validation\ExpressionSyntaxValidatorTest::validExpressionPasses
+.
+TYPO3\Flow\Tests\Unit\Aop\Advice\AbstractAdviceTest::invokeDoesNotInvokeTheAdviceIfTheRuntimeEvaluatorReturnsFalse
+.
+TYPO3\Flow\Tests\Unit\Aop\Advice\AbstractAdviceTest::invokeEmitsSignalWithAdviceAndJoinPoint
+.
+TYPO3\Flow\Tests\Unit\Aop\Advice\AbstractAdviceTest::invokeInvokesTheAdviceIfTheRuntimeEvaluatorReturnsTrue
+.
+TYPO3\Flow\Tests\Unit\Aop\Advice\AroundAdviceTest::invokeDoesNotInvokeTheAdviceIfTheRuntimeEvaluatorReturnsFalse
+.
+TYPO3\Flow\Tests\Unit\Aop\Advice\AroundAdviceTest::invokeInvokesTheAdviceIfTheRuntimeEvaluatorReturnsTrue
+.
+TYPO3\Flow\Tests\Unit\Aop\Builder\AbstractMethodInterceptorBuilderTest::buildMethodArgumentsArrayCodeRendersCodeForPassingParametersToTheJoinPoint
+.
+TYPO3\Flow\Tests\Unit\Aop\Builder\AbstractMethodInterceptorBuilderTest::buildMethodArgumentsArrayCodeReturnsAnEmptyStringIfTheClassNameIsNULL
+.
+TYPO3\Flow\Tests\Unit\Aop\Builder\AbstractMethodInterceptorBuilderTest::buildSavedConstructorParametersCodeReturnsTheCorrectParametersCode
+.
+TYPO3\Flow\Tests\Unit\Aop\Builder\ClassNameIndexTest::applyIntersectWorks
+.
+TYPO3\Flow\Tests\Unit\Aop\Builder\ClassNameIndexTest::applyUnionWorks
+.
+TYPO3\Flow\Tests\Unit\Aop\Builder\ClassNameIndexTest::filterByPrefixWork
+.
+TYPO3\Flow\Tests\Unit\Aop\Builder\ClassNameIndexTest::intersectOfTwoIndicesWorks
+.
+TYPO3\Flow\Tests\Unit\Aop\Builder\ClassNameIndexTest::unionOfTwoIndicesWorks
+.
+TYPO3\Flow\Tests\Unit\Aop\Pointcut\PointcutClassAnnotatedWithFilterTest::matchesTellsIfTheSpecifiedRegularExpressionMatchesTheGivenAnnotation
+.
+TYPO3\Flow\Tests\Unit\Aop\Pointcut\PointcutClassAnnotatedWithFilterTest::reduceTargetClassNamesFiltersAllClassesNotHavingTheGivenAnnotation
+.
+TYPO3\Flow\Tests\Unit\Aop\Pointcut\PointcutClassNameFilterTest::matchesTellsIfTheSpecifiedRegularExpressionMatchesTheGivenClassName
+.
+TYPO3\Flow\Tests\Unit\Aop\Pointcut\PointcutClassNameFilterTest::reduceTargetClassNamesFiltersAllClassesNotMatchedByAClassNameFilter
+.
+TYPO3\Flow\Tests\Unit\Aop\Pointcut\PointcutClassNameFilterTest::reduceTargetClassNamesFiltersAllClassesNotMatchedByAClassNameFilterWithRegularExpressions
+.
+TYPO3\Flow\Tests\Unit\Aop\Pointcut\PointcutClassTypeFilterTest::reduceTargetClassNamesFiltersAllClassesExceptTheClassItselfAndAllItsSubclasses
+.
+TYPO3\Flow\Tests\Unit\Aop\Pointcut\PointcutClassTypeFilterTest::reduceTargetClassNamesFiltersAllClassesNotImplementingTheGivenInterface
+.
+TYPO3\Flow\Tests\Unit\Aop\Pointcut\PointcutExpressionParserTest::getArgumentConstraintsFromMethodArgumentsPatternWorks
+.
+TYPO3\Flow\Tests\Unit\Aop\Pointcut\PointcutExpressionParserTest::getRuntimeEvaluationConditionsFromEvaluateStringReturnsTheCorrectArrayForAnEvaluateString
+.
+TYPO3\Flow\Tests\Unit\Aop\Pointcut\PointcutExpressionParserTest::parseCallsParseDesignatorMethodWithTheCorrectSignaturePatternStringIfTheExpressionContainsArgumentPatterns
+.
+TYPO3\Flow\Tests\Unit\Aop\Pointcut\PointcutExpressionParserTest::parseCallsSpecializedMethodsToParseEachDesignator
+.
+TYPO3\Flow\Tests\Unit\Aop\Pointcut\PointcutExpressionParserTest::parseDesignatorClassAddsAFilterToTheGivenFilterComposite
+.
+TYPO3\Flow\Tests\Unit\Aop\Pointcut\PointcutExpressionParserTest::parseDesignatorClassAnnotatedWithAddsAFilterToTheGivenFilterComposite
+.
+TYPO3\Flow\Tests\Unit\Aop\Pointcut\PointcutExpressionParserTest::parseDesignatorClassAnnotatedWithObservesAnnotationPropertyConstraints
+.
+TYPO3\Flow\Tests\Unit\Aop\Pointcut\PointcutExpressionParserTest::parseDesignatorFilterAddsACustomFilterToTheGivenFilterComposite
+.
+TYPO3\Flow\Tests\Unit\Aop\Pointcut\PointcutExpressionParserTest::parseDesignatorFilterThrowsAnExceptionIfACustomFilterDoesNotImplementThePointcutFilterInterface
+.
+TYPO3\Flow\Tests\Unit\Aop\Pointcut\PointcutExpressionParserTest::parseDesignatorMethodAnnotatedWithAddsAFilterToTheGivenFilterComposite
+.
+TYPO3\Flow\Tests\Unit\Aop\Pointcut\PointcutExpressionParserTest::parseDesignatorMethodAnnotatedWithObservesAnnotationPropertyConstraints
+.
+TYPO3\Flow\Tests\Unit\Aop\Pointcut\PointcutExpressionParserTest::parseDesignatorMethodParsesVisibilityForPointcutMethodNameFilter
+.
+TYPO3\Flow\Tests\Unit\Aop\Pointcut\PointcutExpressionParserTest::parseDesignatorMethodThrowsAnExceptionIfTheExpressionLacksTheClassMethodArrow
+.
+TYPO3\Flow\Tests\Unit\Aop\Pointcut\PointcutExpressionParserTest::parseDesignatorPointcutThrowsAnExceptionIfTheExpressionLacksTheAspectClassMethodArrow
+.
+TYPO3\Flow\Tests\Unit\Aop\Pointcut\PointcutExpressionParserTest::parseRuntimeEvaluationsBasicallyWorks
+.
+TYPO3\Flow\Tests\Unit\Aop\Pointcut\PointcutExpressionParserTest::parseSplitsUpTheExpressionIntoDesignatorsAndPassesTheOperatorsToTheDesginatorParseMethod
+.
+TYPO3\Flow\Tests\Unit\Aop\Pointcut\PointcutExpressionParserTest::parseThrowsExceptionIfPointcutExpressionIsNotAString
+.
+TYPO3\Flow\Tests\Unit\Aop\Pointcut\PointcutExpressionParserTest::parseThrowsExceptionIfThePointcutExpressionContainsNoDesignator
+.
+TYPO3\Flow\Tests\Unit\Aop\Pointcut\PointcutFilterCompositeTest::buildGlobalRuntimeEvaluationsConditionCodeBuildsTheCorrectCodeForAConditionWithInOperator
+.
+TYPO3\Flow\Tests\Unit\Aop\Pointcut\PointcutFilterCompositeTest::buildGlobalRuntimeEvaluationsConditionCodeBuildsTheCorrectCodeForAConditionWithMatchesOperator
+.
+TYPO3\Flow\Tests\Unit\Aop\Pointcut\PointcutFilterCompositeTest::buildGlobalRuntimeEvaluationsConditionCodeBuildsTheCorrectCodeForConditionsWithObjectAccess
+.
+TYPO3\Flow\Tests\Unit\Aop\Pointcut\PointcutFilterCompositeTest::buildMethodArgumentsEvaluationConditionCodeBuildsTheCorrectCodeForAConditionWithInOperator
+.
+TYPO3\Flow\Tests\Unit\Aop\Pointcut\PointcutFilterCompositeTest::buildMethodArgumentsEvaluationConditionCodeBuildsTheCorrectCodeForAConditionWithMatchesOperator
+.
+TYPO3\Flow\Tests\Unit\Aop\Pointcut\PointcutFilterCompositeTest::buildMethodArgumentsEvaluationConditionCodeBuildsTheCorrectCodeForAConditionWithObjectAccess
+.
+TYPO3\Flow\Tests\Unit\Aop\Pointcut\PointcutFilterCompositeTest::buildMethodArgumentsEvaluationConditionCodeBuildsTheCorrectCodeForAnArgumentWithMoreThanOneCondition
+.
+TYPO3\Flow\Tests\Unit\Aop\Pointcut\PointcutFilterCompositeTest::getRuntimeEvaluationsClosureCodeHandlesDefinitionsConcatenatedByNegatedOperatorsCorrectly
+.
+TYPO3\Flow\Tests\Unit\Aop\Pointcut\PointcutFilterCompositeTest::getRuntimeEvaluationsClosureCodeReturnsTheCorrectStringForAnEmptyDefinition
+.
+TYPO3\Flow\Tests\Unit\Aop\Pointcut\PointcutFilterCompositeTest::getRuntimeEvaluationsClosureCodeReturnsTheCorrectStringForBasicRuntimeEvaluationsDefintion
+.
+TYPO3\Flow\Tests\Unit\Aop\Pointcut\PointcutFilterCompositeTest::getRuntimeEvaluationsDefintionReturnsTheEvaluationsFromAllContainedFiltersThatMatchedThePointcutWithTheCorrectOperators
+.
+TYPO3\Flow\Tests\Unit\Aop\Pointcut\PointcutFilterCompositeTest::globalRuntimeEvaluationsDefinitionAreAddedCorrectlyToThePointcutFilterComposite
+.
+TYPO3\Flow\Tests\Unit\Aop\Pointcut\PointcutFilterCompositeTest::hasRuntimeEvaluationsDefinitionConsidersGlobalAndFilterRuntimeEvaluationsDefinitions
+.
+TYPO3\Flow\Tests\Unit\Aop\Pointcut\PointcutFilterCompositeTest::matchesReturnsFalseEarlyForAndedNegatedSubfilters
+.
+TYPO3\Flow\Tests\Unit\Aop\Pointcut\PointcutFilterCompositeTest::matchesReturnsFalseEarlyForAndedSubfilters
+.
+TYPO3\Flow\Tests\Unit\Aop\Pointcut\PointcutFilterCompositeTest::matchesReturnsTrueForNegatedSubfilter
+.
+TYPO3\Flow\Tests\Unit\Aop\Pointcut\PointcutFilterCompositeTest::matchesReturnsTrueForNegatedSubfiltersWithRuntimeEvaluations
+.
+TYPO3\Flow\Tests\Unit\Aop\Pointcut\PointcutFilterCompositeTest::reduceTargetClassNamesFiltersAllClassesNotMatchedAByClassNameFilter
+.
+TYPO3\Flow\Tests\Unit\Aop\Pointcut\PointcutFilterTest::getRuntimeEvaluationsDefinitionReturnsAnEmptyArrayIfThePointcutDoesNotExist
+.
+TYPO3\Flow\Tests\Unit\Aop\Pointcut\PointcutFilterTest::getRuntimeEvaluationsDefinitionReturnsTheDefinitionArrayFromThePointcut
+.
+TYPO3\Flow\Tests\Unit\Aop\Pointcut\PointcutFilterTest::matchesTellsIfTheSpecifiedRegularExpressionMatchesTheGivenClassName
+.
+TYPO3\Flow\Tests\Unit\Aop\Pointcut\PointcutFilterTest::matchesThrowsAnExceptionIfTheSpecifiedPointcutDoesNotExist
+.
+TYPO3\Flow\Tests\Unit\Aop\Pointcut\PointcutFilterTest::reduceTargetClassNamesAsksTheResolvedPointcutToReduce
+.
+TYPO3\Flow\Tests\Unit\Aop\Pointcut\PointcutFilterTest::reduceTargetClassNamesReturnsTheInputClassNameIndexIfThePointcutCouldNotBeResolved
+.
+TYPO3\Flow\Tests\Unit\Aop\Pointcut\PointcutMethodAnnotatedWithFilterTest::matchesReturnsFalseIfMethodDoesNotExistOrDeclardingClassHasNotBeenSpecified
+.
+TYPO3\Flow\Tests\Unit\Aop\Pointcut\PointcutMethodAnnotatedWithFilterTest::matchesTellsIfTheSpecifiedRegularExpressionMatchesTheGivenAnnotation
+.
+TYPO3\Flow\Tests\Unit\Aop\Pointcut\PointcutMethodAnnotatedWithFilterTest::reduceTargetClassNamesFiltersAllClassesNotHavingAMethodWithTheGivenAnnotation
+.
+TYPO3\Flow\Tests\Unit\Aop\Pointcut\PointcutMethodNameFilterTest::getRuntimeEvaluationsReturnsTheMethodArgumentConstraintsDefinitions
+.
+TYPO3\Flow\Tests\Unit\Aop\Pointcut\PointcutMethodNameFilterTest::matchesChecksTheAvailablityOfAnArgumentNameIfArgumentConstraintsHaveBeenConfigured
+.
+TYPO3\Flow\Tests\Unit\Aop\Pointcut\PointcutMethodNameFilterTest::matchesIgnoresFinalMethodsEvenIfTheirNameMatches
+.
+TYPO3\Flow\Tests\Unit\Aop\Pointcut\PointcutMethodNameFilterTest::matchesTakesTheVisibilityModifierIntoAccountIfOneWasSpecified
+.
+TYPO3\Flow\Tests\Unit\Aop\Pointcut\PointcutSettingFilterTest::filterCanHandleMissingSpacesInTheConfigurationSettingPath
+.
+TYPO3\Flow\Tests\Unit\Aop\Pointcut\PointcutSettingFilterTest::filterDoesNotMatchOnAFalseCondition
+.
+TYPO3\Flow\Tests\Unit\Aop\Pointcut\PointcutSettingFilterTest::filterDoesNotMatchOnConfigurationSettingThatIsNotBoolean
+.
+TYPO3\Flow\Tests\Unit\Aop\Pointcut\PointcutSettingFilterTest::filterMatchesOnAConditionSetInDoubleQuotes
+.
+TYPO3\Flow\Tests\Unit\Aop\Pointcut\PointcutSettingFilterTest::filterMatchesOnAConditionSetInSingleQuotes
+.
+TYPO3\Flow\Tests\Unit\Aop\Pointcut\PointcutSettingFilterTest::filterMatchesOnConfigurationSettingSetToFalse
+.
+TYPO3\Flow\Tests\Unit\Aop\Pointcut\PointcutSettingFilterTest::filterMatchesOnConfigurationSettingSetToTrue
+.
+TYPO3\Flow\Tests\Unit\Aop\Pointcut\PointcutSettingFilterTest::filterThrowsAnExceptionForAnIncorectCondition
+.
+TYPO3\Flow\Tests\Unit\Aop\Pointcut\PointcutSettingFilterTest::filterThrowsAnExceptionForNotExistingConfigurationSetting
+.
+TYPO3\Flow\Tests\Unit\Aop\Pointcut\PointcutTest::getAspectClassNameReturnsTheAspectClassName
+.
+TYPO3\Flow\Tests\Unit\Aop\Pointcut\PointcutTest::getPointcutExpressionReturnsThePointcutExpression
+.
+TYPO3\Flow\Tests\Unit\Aop\Pointcut\PointcutTest::getPointcutMethodNameReturnsThePointcutMethodName
+.
+TYPO3\Flow\Tests\Unit\Aop\Pointcut\PointcutTest::getRuntimeEvaluationsReturnsTheRuntimeEvaluationsDefinitionOfTheContainedPointcutFilterComposite
+.
+TYPO3\Flow\Tests\Unit\Aop\Pointcut\PointcutTest::matchesChecksIfTheGivenClassAndMethodMatchThePointcutFilterComposite
+.
+TYPO3\Flow\Tests\Unit\Aop\Pointcut\PointcutTest::matchesDetectsCircularMatchesAndThrowsAndException
+.
+TYPO3\Flow\Tests\Unit\Aop\Pointcut\PointcutTest::reduceTargetClassNamesAsksThePointcutsFilterCompositeToReduce
+.
+TYPO3\Flow\Tests\Unit\Cache\Backend\AbstractBackendTest::theConstructorCallsSetterMethodsForAllSpecifiedOptions
+.
+TYPO3\Flow\Tests\Unit\Cache\Backend\ApcBackendTest::backendAllowsForIteratingOverEntries
+S
+TYPO3\Flow\Tests\Unit\Cache\Backend\ApcBackendTest::findIdentifiersByTagFindsSetEntries
+S
+TYPO3\Flow\Tests\Unit\Cache\Backend\ApcBackendTest::flushByTagRemovesCacheEntriesWithSpecifiedTag
+S
+TYPO3\Flow\Tests\Unit\Cache\Backend\ApcBackendTest::flushRemovesAllCacheEntries
+S
+TYPO3\Flow\Tests\Unit\Cache\Backend\ApcBackendTest::flushRemovesOnlyOwnEntries
+S
+TYPO3\Flow\Tests\Unit\Cache\Backend\ApcBackendTest::hasReturnsFalseIfTheEntryDoesntExist
+S
+TYPO3\Flow\Tests\Unit\Cache\Backend\ApcBackendTest::itIsPossibleToOverwriteAnEntryInTheCache
+S
+TYPO3\Flow\Tests\Unit\Cache\Backend\ApcBackendTest::itIsPossibleToRemoveEntryFromCache
+S
+TYPO3\Flow\Tests\Unit\Cache\Backend\ApcBackendTest::itIsPossibleToSetAndCheckExistenceInCache
+S
+TYPO3\Flow\Tests\Unit\Cache\Backend\ApcBackendTest::largeDataIsStored
+S
+TYPO3\Flow\Tests\Unit\Cache\Backend\ApcBackendTest::removeReturnsFalseIfTheEntryDoesntExist
+S
+TYPO3\Flow\Tests\Unit\Cache\Backend\ApcBackendTest::setRemovesTagsFromPreviousSet
+S
+TYPO3\Flow\Tests\Unit\Cache\Backend\ApcBackendTest::setThrowsExceptionIfNoFrontEndHasBeenSet
+S
+TYPO3\Flow\Tests\Unit\Cache\Backend\FileBackendTest::aDedicatedCacheDirectoryIsUsedForCodeCaches
+.
+TYPO3\Flow\Tests\Unit\Cache\Backend\FileBackendTest::backendAllowsForIteratingOverEntries
+.
+TYPO3\Flow\Tests\Unit\Cache\Backend\FileBackendTest::collectGarbageRemovesExpiredCacheEntries
+.
+TYPO3\Flow\Tests\Unit\Cache\Backend\FileBackendTest::findIdentifiersByTagFindsCacheEntriesWithSpecifiedTag
+.
+TYPO3\Flow\Tests\Unit\Cache\Backend\FileBackendTest::findIdentifiersByTagReturnsEmptyArrayForExpiredEntries
+.
+TYPO3\Flow\Tests\Unit\Cache\Backend\FileBackendTest::flushByTagRemovesCacheEntriesWithSpecifiedTag
+.
+TYPO3\Flow\Tests\Unit\Cache\Backend\FileBackendTest::flushRemovesAllCacheEntries
+.
+TYPO3\Flow\Tests\Unit\Cache\Backend\FileBackendTest::flushUnfreezesTheCache
+.
+TYPO3\Flow\Tests\Unit\Cache\Backend\FileBackendTest::getCacheDirectoryReturnsTheCurrentCacheDirectory
+.
+TYPO3\Flow\Tests\Unit\Cache\Backend\FileBackendTest::getDoesNotCheckIfAnEntryIsExpiredIfTheCacheIsFrozen
+.
+TYPO3\Flow\Tests\Unit\Cache\Backend\FileBackendTest::getReturnsContentOfTheCorrectCacheFile
+.
+TYPO3\Flow\Tests\Unit\Cache\Backend\FileBackendTest::getReturnsFalseForExpiredEntries
+.
+TYPO3\Flow\Tests\Unit\Cache\Backend\FileBackendTest::getThrowsExceptionForInvalidIdentifier with data set "dot and slash in middle part"
+.
+TYPO3\Flow\Tests\Unit\Cache\Backend\FileBackendTest::getThrowsExceptionForInvalidIdentifier with data set "multiple dots and slashes in middle part"
+.
+TYPO3\Flow\Tests\Unit\Cache\Backend\FileBackendTest::getThrowsExceptionForInvalidIdentifier with data set "pending dot and slash"
+.
+TYPO3\Flow\Tests\Unit\Cache\Backend\FileBackendTest::getThrowsExceptionForInvalidIdentifier with data set "pending dots and slash"
+.
+TYPO3\Flow\Tests\Unit\Cache\Backend\FileBackendTest::getThrowsExceptionForInvalidIdentifier with data set "pending multiple dots and slashes"
+.
+TYPO3\Flow\Tests\Unit\Cache\Backend\FileBackendTest::getThrowsExceptionForInvalidIdentifier with data set "pending slash"
+.
+TYPO3\Flow\Tests\Unit\Cache\Backend\FileBackendTest::getThrowsExceptionForInvalidIdentifier with data set "slash in middle part"
+.
+TYPO3\Flow\Tests\Unit\Cache\Backend\FileBackendTest::getThrowsExceptionForInvalidIdentifier with data set "trailing dot and slash"
+.
+TYPO3\Flow\Tests\Unit\Cache\Backend\FileBackendTest::getThrowsExceptionForInvalidIdentifier with data set "trailing slash"
+.
+TYPO3\Flow\Tests\Unit\Cache\Backend\FileBackendTest::getThrowsExceptionForInvalidIdentifier with data set "trailing two dots and slash"
+.
+TYPO3\Flow\Tests\Unit\Cache\Backend\FileBackendTest::getThrowsExceptionForInvalidIdentifier with data set "trailing with multiple dots and slashes"
+.
+TYPO3\Flow\Tests\Unit\Cache\Backend\FileBackendTest::getThrowsExceptionForInvalidIdentifier with data set "two dots and slash in middle part"
+.
+TYPO3\Flow\Tests\Unit\Cache\Backend\FileBackendTest::hasDoesNotCheckIfAnEntryIsExpiredIfTheCacheIsFrozen
+.
+TYPO3\Flow\Tests\Unit\Cache\Backend\FileBackendTest::hasReturnsFalseForExpiredEntries
+.
+TYPO3\Flow\Tests\Unit\Cache\Backend\FileBackendTest::hasReturnsTrueIfAnEntryExists
+.
+TYPO3\Flow\Tests\Unit\Cache\Backend\FileBackendTest::hasThrowsExceptionForInvalidIdentifier with data set "dot and slash in middle part"
+.
+TYPO3\Flow\Tests\Unit\Cache\Backend\FileBackendTest::hasThrowsExceptionForInvalidIdentifier with data set "multiple dots and slashes in middle part"
+.
+TYPO3\Flow\Tests\Unit\Cache\Backend\FileBackendTest::hasThrowsExceptionForInvalidIdentifier with data set "pending dot and slash"
+.
+TYPO3\Flow\Tests\Unit\Cache\Backend\FileBackendTest::hasThrowsExceptionForInvalidIdentifier with data set "pending dots and slash"
+.
+TYPO3\Flow\Tests\Unit\Cache\Backend\FileBackendTest::hasThrowsExceptionForInvalidIdentifier with data set "pending multiple dots and slashes"
+.
+TYPO3\Flow\Tests\Unit\Cache\Backend\FileBackendTest::hasThrowsExceptionForInvalidIdentifier with data set "pending slash"
+.
+TYPO3\Flow\Tests\Unit\Cache\Backend\FileBackendTest::hasThrowsExceptionForInvalidIdentifier with data set "slash in middle part"
+.
+TYPO3\Flow\Tests\Unit\Cache\Backend\FileBackendTest::hasThrowsExceptionForInvalidIdentifier with data set "trailing dot and slash"
+.
+TYPO3\Flow\Tests\Unit\Cache\Backend\FileBackendTest::hasThrowsExceptionForInvalidIdentifier with data set "trailing slash"
+.
+TYPO3\Flow\Tests\Unit\Cache\Backend\FileBackendTest::hasThrowsExceptionForInvalidIdentifier with data set "trailing two dots and slash"
+.
+TYPO3\Flow\Tests\Unit\Cache\Backend\FileBackendTest::hasThrowsExceptionForInvalidIdentifier with data set "trailing with multiple dots and slashes"
+.
+TYPO3\Flow\Tests\Unit\Cache\Backend\FileBackendTest::hasThrowsExceptionForInvalidIdentifier with data set "two dots and slash in middle part"
+.
+TYPO3\Flow\Tests\Unit\Cache\Backend\FileBackendTest::removeReallyRemovesACacheEntry
+.
+TYPO3\Flow\Tests\Unit\Cache\Backend\FileBackendTest::removeThrowsExceptionForInvalidIdentifier with data set "dot and slash in middle part"
+.
+TYPO3\Flow\Tests\Unit\Cache\Backend\FileBackendTest::removeThrowsExceptionForInvalidIdentifier with data set "multiple dots and slashes in middle part"
+.
+TYPO3\Flow\Tests\Unit\Cache\Backend\FileBackendTest::removeThrowsExceptionForInvalidIdentifier with data set "pending dot and slash"
+.
+TYPO3\Flow\Tests\Unit\Cache\Backend\FileBackendTest::removeThrowsExceptionForInvalidIdentifier with data set "pending dots and slash"
+.
+TYPO3\Flow\Tests\Unit\Cache\Backend\FileBackendTest::removeThrowsExceptionForInvalidIdentifier with data set "pending multiple dots and slashes"
+.
+TYPO3\Flow\Tests\Unit\Cache\Backend\FileBackendTest::removeThrowsExceptionForInvalidIdentifier with data set "pending slash"
+.
+TYPO3\Flow\Tests\Unit\Cache\Backend\FileBackendTest::removeThrowsExceptionForInvalidIdentifier with data set "slash in middle part"
+.
+TYPO3\Flow\Tests\Unit\Cache\Backend\FileBackendTest::removeThrowsExceptionForInvalidIdentifier with data set "trailing dot and slash"
+.
+TYPO3\Flow\Tests\Unit\Cache\Backend\FileBackendTest::removeThrowsExceptionForInvalidIdentifier with data set "trailing slash"
+.
+TYPO3\Flow\Tests\Unit\Cache\Backend\FileBackendTest::removeThrowsExceptionForInvalidIdentifier with data set "trailing two dots and slash"
+.
+TYPO3\Flow\Tests\Unit\Cache\Backend\FileBackendTest::removeThrowsExceptionForInvalidIdentifier with data set "trailing with multiple dots and slashes"
+.
+TYPO3\Flow\Tests\Unit\Cache\Backend\FileBackendTest::removeThrowsExceptionForInvalidIdentifier with data set "two dots and slash in middle part"
+.
+TYPO3\Flow\Tests\Unit\Cache\Backend\FileBackendTest::requireOnceDoesNotCheckExpiryTimeIfBackendIsFrozen
+.
+TYPO3\Flow\Tests\Unit\Cache\Backend\FileBackendTest::requireOnceIncludesAndReturnsResultOfIncludedPhpFile
+.
+TYPO3\Flow\Tests\Unit\Cache\Backend\FileBackendTest::requireOnceThrowsExceptionForInvalidIdentifier with data set "dot and slash in middle part"
+.
+TYPO3\Flow\Tests\Unit\Cache\Backend\FileBackendTest::requireOnceThrowsExceptionForInvalidIdentifier with data set "multiple dots and slashes in middle part"
+.
+TYPO3\Flow\Tests\Unit\Cache\Backend\FileBackendTest::requireOnceThrowsExceptionForInvalidIdentifier with data set "pending dot and slash"
+.
+TYPO3\Flow\Tests\Unit\Cache\Backend\FileBackendTest::requireOnceThrowsExceptionForInvalidIdentifier with data set "pending dots and slash"
+.
+TYPO3\Flow\Tests\Unit\Cache\Backend\FileBackendTest::requireOnceThrowsExceptionForInvalidIdentifier with data set "pending multiple dots and slashes"
+.
+TYPO3\Flow\Tests\Unit\Cache\Backend\FileBackendTest::requireOnceThrowsExceptionForInvalidIdentifier with data set "pending slash"
+.
+TYPO3\Flow\Tests\Unit\Cache\Backend\FileBackendTest::requireOnceThrowsExceptionForInvalidIdentifier with data set "slash in middle part"
+.
+TYPO3\Flow\Tests\Unit\Cache\Backend\FileBackendTest::requireOnceThrowsExceptionForInvalidIdentifier with data set "trailing dot and slash"
+.
+TYPO3\Flow\Tests\Unit\Cache\Backend\FileBackendTest::requireOnceThrowsExceptionForInvalidIdentifier with data set "trailing slash"
+.
+TYPO3\Flow\Tests\Unit\Cache\Backend\FileBackendTest::requireOnceThrowsExceptionForInvalidIdentifier with data set "trailing two dots and slash"
+.
+TYPO3\Flow\Tests\Unit\Cache\Backend\FileBackendTest::requireOnceThrowsExceptionForInvalidIdentifier with data set "trailing with multiple dots and slashes"
+.
+TYPO3\Flow\Tests\Unit\Cache\Backend\FileBackendTest::requireOnceThrowsExceptionForInvalidIdentifier with data set "two dots and slash in middle part"
+.
+TYPO3\Flow\Tests\Unit\Cache\Backend\FileBackendTest::setAlsoSavesSpecifiedTags
+.
+TYPO3\Flow\Tests\Unit\Cache\Backend\FileBackendTest::setCacheDetectsAndLoadsAFrozenCache
+.
+TYPO3\Flow\Tests\Unit\Cache\Backend\FileBackendTest::setCacheDirectoryAllowsToSetTheCurrentCacheDirectory
+.
+TYPO3\Flow\Tests\Unit\Cache\Backend\FileBackendTest::setCacheThrowsExceptionOnNonWritableDirectory
+.
+TYPO3\Flow\Tests\Unit\Cache\Backend\FileBackendTest::setOverwritesAnAlreadyExistingCacheEntryForTheSameIdentifier
+.
+TYPO3\Flow\Tests\Unit\Cache\Backend\FileBackendTest::setReallySavesToTheSpecifiedDirectory
+.
+TYPO3\Flow\Tests\Unit\Cache\Backend\FileBackendTest::setThrowsExceptionForInvalidIdentifier with data set "dot and slash in middle part"
+.
+TYPO3\Flow\Tests\Unit\Cache\Backend\FileBackendTest::setThrowsExceptionForInvalidIdentifier with data set "multiple dots and slashes in middle part"
+.
+TYPO3\Flow\Tests\Unit\Cache\Backend\FileBackendTest::setThrowsExceptionForInvalidIdentifier with data set "pending dot and slash"
+.
+TYPO3\Flow\Tests\Unit\Cache\Backend\FileBackendTest::setThrowsExceptionForInvalidIdentifier with data set "pending dots and slash"
+.
+TYPO3\Flow\Tests\Unit\Cache\Backend\FileBackendTest::setThrowsExceptionForInvalidIdentifier with data set "pending multiple dots and slashes"
+.
+TYPO3\Flow\Tests\Unit\Cache\Backend\FileBackendTest::setThrowsExceptionForInvalidIdentifier with data set "pending slash"
+.
+TYPO3\Flow\Tests\Unit\Cache\Backend\FileBackendTest::setThrowsExceptionForInvalidIdentifier with data set "slash in middle part"
+.
+TYPO3\Flow\Tests\Unit\Cache\Backend\FileBackendTest::setThrowsExceptionForInvalidIdentifier with data set "trailing dot and slash"
+.
+TYPO3\Flow\Tests\Unit\Cache\Backend\FileBackendTest::setThrowsExceptionForInvalidIdentifier with data set "trailing slash"
+.
+TYPO3\Flow\Tests\Unit\Cache\Backend\FileBackendTest::setThrowsExceptionForInvalidIdentifier with data set "trailing two dots and slash"
+.
+TYPO3\Flow\Tests\Unit\Cache\Backend\FileBackendTest::setThrowsExceptionForInvalidIdentifier with data set "trailing with multiple dots and slashes"
+.
+TYPO3\Flow\Tests\Unit\Cache\Backend\FileBackendTest::setThrowsExceptionForInvalidIdentifier with data set "two dots and slash in middle part"
+.
+TYPO3\Flow\Tests\Unit\Cache\Backend\FileBackendTest::setThrowsExceptionIfCachePathLengthExceedsMaximumPathLength
+.
+TYPO3\Flow\Tests\Unit\Cache\Backend\FileBackendTest::setThrowsExceptionIfDataIsNotAString
+.
+TYPO3\Flow\Tests\Unit\Cache\Backend\MemcachedBackendTest::findIdentifiersByTagFindsCacheEntriesWithSpecifiedTag
+S
+TYPO3\Flow\Tests\Unit\Cache\Backend\MemcachedBackendTest::flushByTagRemovesCacheEntriesWithSpecifiedTag
+S
+TYPO3\Flow\Tests\Unit\Cache\Backend\MemcachedBackendTest::flushRemovesAllCacheEntries
+S
+TYPO3\Flow\Tests\Unit\Cache\Backend\MemcachedBackendTest::flushRemovesOnlyOwnEntries
+S
+TYPO3\Flow\Tests\Unit\Cache\Backend\MemcachedBackendTest::hasReturnsFalseIfTheEntryDoesntExist
+S
+TYPO3\Flow\Tests\Unit\Cache\Backend\MemcachedBackendTest::initializeObjectThrowsExceptionIfNoMemcacheServerIsConfigured
+S
+TYPO3\Flow\Tests\Unit\Cache\Backend\MemcachedBackendTest::itIsPossibleToOverwriteAnEntryInTheCache
+S
+TYPO3\Flow\Tests\Unit\Cache\Backend\MemcachedBackendTest::itIsPossibleToRemoveEntryFromCache
+S
+TYPO3\Flow\Tests\Unit\Cache\Backend\MemcachedBackendTest::itIsPossibleToSetAndCheckExistenceInCache
+S
+TYPO3\Flow\Tests\Unit\Cache\Backend\MemcachedBackendTest::itIsPossibleToSetAndGetEntry
+S
+TYPO3\Flow\Tests\Unit\Cache\Backend\MemcachedBackendTest::largeDataIsStored
+S
+TYPO3\Flow\Tests\Unit\Cache\Backend\MemcachedBackendTest::removeReturnsFalseIfTheEntryDoesntExist
+S
+TYPO3\Flow\Tests\Unit\Cache\Backend\MemcachedBackendTest::setRemovesTagsFromPreviousSet
+S
+TYPO3\Flow\Tests\Unit\Cache\Backend\MemcachedBackendTest::setThrowsExceptionIfConfiguredServersAreUnreachable
+S
+TYPO3\Flow\Tests\Unit\Cache\Backend\MemcachedBackendTest::setThrowsExceptionIfNoFrontEndHasBeenSet
+S
+TYPO3\Flow\Tests\Unit\Cache\Backend\PdoBackendTest::findIdentifiersByTagFindsSetEntries
+.
+TYPO3\Flow\Tests\Unit\Cache\Backend\PdoBackendTest::flushByTagRemovesCacheEntriesWithSpecifiedTag
+.
+TYPO3\Flow\Tests\Unit\Cache\Backend\PdoBackendTest::flushRemovesAllCacheEntries
+.
+TYPO3\Flow\Tests\Unit\Cache\Backend\PdoBackendTest::flushRemovesOnlyOwnEntries
+.
+TYPO3\Flow\Tests\Unit\Cache\Backend\PdoBackendTest::hasReturnsFalseIfTheEntryDoesntExist
+.
+TYPO3\Flow\Tests\Unit\Cache\Backend\PdoBackendTest::itIsPossibleToOverwriteAnEntryInTheCache
+.
+TYPO3\Flow\Tests\Unit\Cache\Backend\PdoBackendTest::itIsPossibleToRemoveEntryFromCache
+.
+TYPO3\Flow\Tests\Unit\Cache\Backend\PdoBackendTest::itIsPossibleToSetAndCheckExistenceInCache
+.
+TYPO3\Flow\Tests\Unit\Cache\Backend\PdoBackendTest::itIsPossibleToSetAndGetEntry
+.
+TYPO3\Flow\Tests\Unit\Cache\Backend\PdoBackendTest::removeReturnsFalseIfTheEntryDoesntExist
+.
+TYPO3\Flow\Tests\Unit\Cache\Backend\PdoBackendTest::setRemovesTagsFromPreviousSet
+.
+TYPO3\Flow\Tests\Unit\Cache\Backend\PdoBackendTest::setThrowsExceptionIfNoFrontEndHasBeenSet
+.
+TYPO3\Flow\Tests\Unit\Cache\Backend\RedisBackendTest::findIdentifiersByTagInvokesRedis
+S
+TYPO3\Flow\Tests\Unit\Cache\Backend\RedisBackendTest::freezeInvokesRedis
+S
+TYPO3\Flow\Tests\Unit\Cache\Backend\RedisBackendTest::getInvokesRedis
+S
+TYPO3\Flow\Tests\Unit\Cache\Backend\RedisBackendTest::hasInvokesRedis
+S
+TYPO3\Flow\Tests\Unit\Cache\Backend\RedisBackendTest::setAddsEntryToRedis
+S
+TYPO3\Flow\Tests\Unit\Cache\Backend\RedisBackendTest::setUsesDefaultLifetimeIfNotProvided
+S
+TYPO3\Flow\Tests\Unit\Cache\Backend\RedisBackendTest::setUsesProvidedLifetime
+S
+TYPO3\Flow\Tests\Unit\Cache\Backend\RedisBackendTest::writingOperationsThrowAnExceptionIfCacheIsFrozen with data set #0
+S
+TYPO3\Flow\Tests\Unit\Cache\Backend\RedisBackendTest::writingOperationsThrowAnExceptionIfCacheIsFrozen with data set #1
+S
+TYPO3\Flow\Tests\Unit\Cache\Backend\RedisBackendTest::writingOperationsThrowAnExceptionIfCacheIsFrozen with data set #2
+S
+TYPO3\Flow\Tests\Unit\Cache\Backend\RedisBackendTest::writingOperationsThrowAnExceptionIfCacheIsFrozen with data set #3
+S
+TYPO3\Flow\Tests\Unit\Cache\Backend\TransientMemoryBackendTest::findIdentifiersByTagFindsCacheEntriesWithSpecifiedTag
+.
+TYPO3\Flow\Tests\Unit\Cache\Backend\TransientMemoryBackendTest::flushByTagRemovesCacheEntriesWithSpecifiedTag
+.
+TYPO3\Flow\Tests\Unit\Cache\Backend\TransientMemoryBackendTest::flushRemovesAllCacheEntries
+.
+TYPO3\Flow\Tests\Unit\Cache\Backend\TransientMemoryBackendTest::hasReturnsFalseIfTheEntryDoesntExist
+.
+TYPO3\Flow\Tests\Unit\Cache\Backend\TransientMemoryBackendTest::itIsPossibleToOverwriteAnEntryInTheCache
+.
+TYPO3\Flow\Tests\Unit\Cache\Backend\TransientMemoryBackendTest::itIsPossibleToRemoveEntryFromCache
+.
+TYPO3\Flow\Tests\Unit\Cache\Backend\TransientMemoryBackendTest::itIsPossibleToSetAndCheckExistenceInCache
+.
+TYPO3\Flow\Tests\Unit\Cache\Backend\TransientMemoryBackendTest::itIsPossibleToSetAndGetEntry
+.
+TYPO3\Flow\Tests\Unit\Cache\Backend\TransientMemoryBackendTest::removeReturnsFalseIfTheEntryDoesntExist
+.
+TYPO3\Flow\Tests\Unit\Cache\Backend\TransientMemoryBackendTest::setThrowsExceptionIfNoFrontEndHasBeenSet
+.
+TYPO3\Flow\Tests\Unit\Cache\CacheFactoryTest::createInjectsAnInstanceOfTheSpecifiedBackendIntoTheCacheFrontend
+.
+TYPO3\Flow\Tests\Unit\Cache\CacheFactoryTest::createRegistersTheCacheAtTheCacheManager
+.
+TYPO3\Flow\Tests\Unit\Cache\CacheFactoryTest::createReturnsInstanceOfTheSpecifiedCacheFrontend
+.
+TYPO3\Flow\Tests\Unit\Cache\CacheManagerTest::flushCachesByTagCallsTheFlushByTagMethodOfAllRegisteredCaches
+.
+TYPO3\Flow\Tests\Unit\Cache\CacheManagerTest::flushCachesCallsTheFlushMethodOfAllRegisteredCaches
+.
+TYPO3\Flow\Tests\Unit\Cache\CacheManagerTest::flushSystemCachesByChangedFilesDoesNotFlushI18nCacheIfNoTranslationFileHasBeenModified
+.
+TYPO3\Flow\Tests\Unit\Cache\CacheManagerTest::flushSystemCachesByChangedFilesDoesNotFlushPolicyCacheIfNoPolicyFileHasBeenModified
+.
+TYPO3\Flow\Tests\Unit\Cache\CacheManagerTest::flushSystemCachesByChangedFilesDoesNotFlushRoutingCacheIfNoRoutesFileHasBeenModified
+.
+TYPO3\Flow\Tests\Unit\Cache\CacheManagerTest::flushSystemCachesByChangedFilesFlushesI18nCacheIfATranslationFileHasBeenModified
+.
+TYPO3\Flow\Tests\Unit\Cache\CacheManagerTest::flushSystemCachesByChangedFilesFlushesPolicyAndDoctrineCachesIfAPolicyFileHasBeenModified
+.
+TYPO3\Flow\Tests\Unit\Cache\CacheManagerTest::flushSystemCachesByChangedFilesFlushesRoutingCacheIfACustomSubRoutesFileHasBeenModified
+.
+TYPO3\Flow\Tests\Unit\Cache\CacheManagerTest::flushSystemCachesByChangedFilesFlushesRoutingCacheIfARoutesFileHasBeenModified
+.
+TYPO3\Flow\Tests\Unit\Cache\CacheManagerTest::flushSystemCachesByChangedFilesTriggersAopProxyClassRebuild
+.
+TYPO3\Flow\Tests\Unit\Cache\CacheManagerTest::flushSystemCachesByChangedFilesWithChangedClassFileRemovesCacheEntryFromObjectClassesCache
+.
+TYPO3\Flow\Tests\Unit\Cache\CacheManagerTest::flushSystemCachesByChangedFilesWithChangedTestFileRemovesCacheEntryFromObjectClassesCache
+.
+TYPO3\Flow\Tests\Unit\Cache\CacheManagerTest::getCacheThrowsExceptionForNonExistingIdentifier
+.
+TYPO3\Flow\Tests\Unit\Cache\CacheManagerTest::hasCacheReturnsCorrectResult
+.
+TYPO3\Flow\Tests\Unit\Cache\CacheManagerTest::managerReturnsThePreviouslyRegisteredCached
+.
+TYPO3\Flow\Tests\Unit\Cache\CacheManagerTest::managerThrowsExceptionOnCacheRegistrationWithAlreadyExistingIdentifier
+.
+TYPO3\Flow\Tests\Unit\Cache\Frontend\AbstractFrontendTest::collectGarbageCallsBackend
+.
+TYPO3\Flow\Tests\Unit\Cache\Frontend\AbstractFrontendTest::flushByTagCallsBackendIfItIsATaggableBackend
+.
+TYPO3\Flow\Tests\Unit\Cache\Frontend\AbstractFrontendTest::flushByTagRejectsInvalidTags
+.
+TYPO3\Flow\Tests\Unit\Cache\Frontend\AbstractFrontendTest::flushCallsBackend
+.
+TYPO3\Flow\Tests\Unit\Cache\Frontend\AbstractFrontendTest::getClassTagRendersTagWhichCanBeUsedToTagACacheEntryWithACertainClass
+.
+TYPO3\Flow\Tests\Unit\Cache\Frontend\AbstractFrontendTest::invalidEntryIdentifiersAreRecognizedAsInvalid
+.
+TYPO3\Flow\Tests\Unit\Cache\Frontend\AbstractFrontendTest::invalidTagsAreRecognizedAsInvalid
+.
+TYPO3\Flow\Tests\Unit\Cache\Frontend\AbstractFrontendTest::theConstructorAcceptsValidIdentifiers
+.
+TYPO3\Flow\Tests\Unit\Cache\Frontend\AbstractFrontendTest::theConstructorRejectsInvalidIdentifiers
+.
+TYPO3\Flow\Tests\Unit\Cache\Frontend\AbstractFrontendTest::validEntryIdentifiersAreRecognizedAsValid
+.
+TYPO3\Flow\Tests\Unit\Cache\Frontend\AbstractFrontendTest::validTagsAreRecognizedAsValid
+.
+TYPO3\Flow\Tests\Unit\Cache\Frontend\PhpFrontendTest::requireOnceCallsTheBackendsRequireOnceMethod
+.
+TYPO3\Flow\Tests\Unit\Cache\Frontend\PhpFrontendTest::setChecksIfTheIdentifierIsValid
+.
+TYPO3\Flow\Tests\Unit\Cache\Frontend\PhpFrontendTest::setPassesPhpSourceCodeTagsAndLifetimeToBackend
+.
+TYPO3\Flow\Tests\Unit\Cache\Frontend\PhpFrontendTest::setThrowsInvalidDataExceptionOnNonStringValues
+.
+TYPO3\Flow\Tests\Unit\Cache\Frontend\StringFrontendTest::getByTagCallsBackendAndReturnsIdentifiersAndValuesOfEntries
+.
+TYPO3\Flow\Tests\Unit\Cache\Frontend\StringFrontendTest::getByTagRejectsInvalidTags
+.
+TYPO3\Flow\Tests\Unit\Cache\Frontend\StringFrontendTest::getFetchesStringValueFromBackend
+.
+TYPO3\Flow\Tests\Unit\Cache\Frontend\StringFrontendTest::hasReturnsResultFromBackend
+.
+TYPO3\Flow\Tests\Unit\Cache\Frontend\StringFrontendTest::removeCallsBackend
+.
+TYPO3\Flow\Tests\Unit\Cache\Frontend\StringFrontendTest::setChecksIfTheIdentifierIsValid
+.
+TYPO3\Flow\Tests\Unit\Cache\Frontend\StringFrontendTest::setPassesLifetimeToBackend
+.
+TYPO3\Flow\Tests\Unit\Cache\Frontend\StringFrontendTest::setPassesStringToBackend
+.
+TYPO3\Flow\Tests\Unit\Cache\Frontend\StringFrontendTest::setThrowsInvalidDataExceptionOnNonStringValues
+.
+TYPO3\Flow\Tests\Unit\Cache\Frontend\VariableFrontendTest::getByTagCallsBackendAndReturnsIdentifiersAndValuesOfEntries
+.
+TYPO3\Flow\Tests\Unit\Cache\Frontend\VariableFrontendTest::getByTagRejectsInvalidTags
+.
+TYPO3\Flow\Tests\Unit\Cache\Frontend\VariableFrontendTest::getByTagUsesIgBinaryIfAvailable
+S
+TYPO3\Flow\Tests\Unit\Cache\Frontend\VariableFrontendTest::getFetchesArrayValueFromBackend
+.
+TYPO3\Flow\Tests\Unit\Cache\Frontend\VariableFrontendTest::getFetchesFalseBooleanValueFromBackend
+.
+TYPO3\Flow\Tests\Unit\Cache\Frontend\VariableFrontendTest::getFetchesStringValueFromBackend
+.
+TYPO3\Flow\Tests\Unit\Cache\Frontend\VariableFrontendTest::getUsesIgBinaryIfAvailable
+S
+TYPO3\Flow\Tests\Unit\Cache\Frontend\VariableFrontendTest::hasReturnsResultFromBackend
+.
+TYPO3\Flow\Tests\Unit\Cache\Frontend\VariableFrontendTest::removeCallsBackend
+.
+TYPO3\Flow\Tests\Unit\Cache\Frontend\VariableFrontendTest::setChecksIfTheIdentifierIsValid
+.
+TYPO3\Flow\Tests\Unit\Cache\Frontend\VariableFrontendTest::setPassesLifetimeToBackend
+.
+TYPO3\Flow\Tests\Unit\Cache\Frontend\VariableFrontendTest::setPassesSerializedArrayToBackend
+.
+TYPO3\Flow\Tests\Unit\Cache\Frontend\VariableFrontendTest::setPassesSerializedStringToBackend
+.
+TYPO3\Flow\Tests\Unit\Cache\Frontend\VariableFrontendTest::setUsesIgBinarySerializeIfAvailable
+S
+TYPO3\Flow\Tests\Unit\Cli\CommandManagerTest::getAvailableCommandsReturnsAllAvailableCommands
+.
+TYPO3\Flow\Tests\Unit\Cli\CommandManagerTest::getCommandByIdentifierAllowsThePackageKeyToOnlyContainTheLastPartOfThePackageNamespaceIfCommandsAreUnambiguous
+.
+TYPO3\Flow\Tests\Unit\Cli\CommandManagerTest::getCommandByIdentifierReturnsCommandIfIdentifierIsEqual
+.
+TYPO3\Flow\Tests\Unit\Cli\CommandManagerTest::getCommandByIdentifierThrowsExceptionIfMoreThanOneMatchingCommandWasFound
+.
+TYPO3\Flow\Tests\Unit\Cli\CommandManagerTest::getCommandByIdentifierThrowsExceptionIfNoMatchingCommandWasFound
+.
+TYPO3\Flow\Tests\Unit\Cli\CommandManagerTest::getCommandByIdentifierThrowsExceptionIfOnlyPackageKeyIsSpecifiedAndContainsMoreThanOneCommand
+.
+TYPO3\Flow\Tests\Unit\Cli\CommandManagerTest::getCommandByIdentifierWorksCaseInsensitive
+.
+TYPO3\Flow\Tests\Unit\Cli\CommandManagerTest::getCommandsByIdentifierReturnsAllCommandsOfTheSpecifiedPackage
+.
+TYPO3\Flow\Tests\Unit\Cli\CommandManagerTest::getCommandsByIdentifierReturnsAnEmptyArrayIfNoCommandMatches
+.
+TYPO3\Flow\Tests\Unit\Cli\CommandManagerTest::getShortestIdentifierForCommandAlwaysReturnsShortNameForFlowHelpCommand
+.
+TYPO3\Flow\Tests\Unit\Cli\CommandManagerTest::getShortestIdentifierForCommandReturnsCompleteCommandIdentifierForCommandsWithTheSameControllerAndCommandName
+.
+TYPO3\Flow\Tests\Unit\Cli\CommandManagerTest::getShortestIdentifierForCommandReturnsShortestUnambiguousCommandIdentifiers
+.
+TYPO3\Flow\Tests\Unit\Cli\CommandManagerTest::getShortestIdentifierForCommandReturnsTheCompleteIdentifiersForCustomHelpCommands
+.
+TYPO3\Flow\Tests\Unit\Cli\CommandTest::constructRendersACommandIdentifierByTheGivenControllerAndCommandName with data set #0
+.
+TYPO3\Flow\Tests\Unit\Cli\CommandTest::constructRendersACommandIdentifierByTheGivenControllerAndCommandName with data set #1
+.
+TYPO3\Flow\Tests\Unit\Cli\CommandTest::constructRendersACommandIdentifierByTheGivenControllerAndCommandName with data set #2
+.
+TYPO3\Flow\Tests\Unit\Cli\CommandTest::getArgumentDefinitionsReturnsArrayOfArgumentDefinitionIfCommandExpectsArguments
+.
+TYPO3\Flow\Tests\Unit\Cli\CommandTest::getArgumentDefinitionsReturnsEmptyArrayIfCommandExpectsNoArguments
+.
+TYPO3\Flow\Tests\Unit\Cli\CommandTest::hasArgumentsReturnsFalseIfCommandExpectsNoArguments
+.
+TYPO3\Flow\Tests\Unit\Cli\CommandTest::hasArgumentsReturnsTrueIfCommandExpectsArguments
+.
+TYPO3\Flow\Tests\Unit\Cli\RequestBuilderTest::CliAccesWithArgumentsWithAndWithoutValuesBuildsCorrectRequest
+.
+TYPO3\Flow\Tests\Unit\Cli\RequestBuilderTest::CliAccesWithShortArgumentsBuildsCorrectRequest
+.
+TYPO3\Flow\Tests\Unit\Cli\RequestBuilderTest::afterAllRequiredArgumentsUnnamedParametersAreStoredAsExceedingArguments
+.
+TYPO3\Flow\Tests\Unit\Cli\RequestBuilderTest::argumentWithValueSeparatedByEqualSignBuildsCorrectRequest
+.
+TYPO3\Flow\Tests\Unit\Cli\RequestBuilderTest::argumentsAreDetectedAfterOptions
+.
+TYPO3\Flow\Tests\Unit\Cli\RequestBuilderTest::booleanOptionsAreConsideredEvenIfAnUnnamedArgumentFollows
+.
+TYPO3\Flow\Tests\Unit\Cli\RequestBuilderTest::booleanOptionsCanHaveOnlyCertainValuesIfTheValueIsAssignedWithoutEqualSign
+.
+TYPO3\Flow\Tests\Unit\Cli\RequestBuilderTest::checkIfCliAccesWithPackageControllerActionAndArgumentsToleratesSpaces
+.
+TYPO3\Flow\Tests\Unit\Cli\RequestBuilderTest::cliAccessWithPackageControllerActionAndArgumentsBuildsCorrectRequest
+.
+TYPO3\Flow\Tests\Unit\Cli\RequestBuilderTest::cliAccessWithPackageControllerAndActionNameBuildsCorrectRequest
+.
+TYPO3\Flow\Tests\Unit\Cli\RequestBuilderTest::exceedingArgumentsMayBeSpecified
+.
+TYPO3\Flow\Tests\Unit\Cli\RequestBuilderTest::ifCommandCantBeResolvedTheHelpScreenIsShown
+.
+TYPO3\Flow\Tests\Unit\Cli\RequestBuilderTest::ifNamedArgumentsAreUsedAllRequiredArgumentsMustBeNamed
+.
+TYPO3\Flow\Tests\Unit\Cli\RequestBuilderTest::ifUnnamedArgumentsAreUsedAllRequiredArgumentsMustBeUnnamed
+.
+TYPO3\Flow\Tests\Unit\Cli\RequestBuilderTest::insteadOfNamedArgumentsTheArgumentsCanBePassedUnnamedInTheCorrectOrder
+.
+TYPO3\Flow\Tests\Unit\Cli\RequestBuilderTest::optionsAreNotMappedToCommandArgumentsIfTheyAreUnnamed
+.
+TYPO3\Flow\Tests\Unit\Cli\RequestBuilderTest::quotedArgumentValuesAreCorrectlyParsedWhenPassingTheCommandAsString with data set #0
+.
+TYPO3\Flow\Tests\Unit\Cli\RequestBuilderTest::quotedArgumentValuesAreCorrectlyParsedWhenPassingTheCommandAsString with data set #1
+.
+TYPO3\Flow\Tests\Unit\Cli\RequestBuilderTest::quotedArgumentValuesAreCorrectlyParsedWhenPassingTheCommandAsString with data set #2
+.
+TYPO3\Flow\Tests\Unit\Cli\RequestBuilderTest::quotedArgumentValuesAreCorrectlyParsedWhenPassingTheCommandAsString with data set #3
+.
+TYPO3\Flow\Tests\Unit\Cli\RequestBuilderTest::quotedArgumentValuesAreCorrectlyParsedWhenPassingTheCommandAsString with data set #4
+.
+TYPO3\Flow\Tests\Unit\Cli\RequestBuilderTest::quotedArgumentValuesAreCorrectlyParsedWhenPassingTheCommandAsString with data set #5
+.
+TYPO3\Flow\Tests\Unit\Cli\RequestBuilderTest::quotedArgumentValuesAreCorrectlyParsedWhenPassingTheCommandAsString with data set #6
+.
+TYPO3\Flow\Tests\Unit\Cli\RequestBuilderTest::quotedArgumentValuesAreCorrectlyParsedWhenPassingTheCommandAsString with data set #7
+.
+TYPO3\Flow\Tests\Unit\Cli\RequestBuilderTest::quotedArgumentValuesAreCorrectlyParsedWhenPassingTheCommandAsString with data set #8
+.
+TYPO3\Flow\Tests\Unit\Cli\RequestBuilderTest::quotedArgumentValuesAreCorrectlyParsedWhenPassingTheCommandAsString with data set #9
+.
+TYPO3\Flow\Tests\Unit\Cli\RequestTest::getCommandReturnsTheCommandObjectReflectingTheRequestInformation
+.
+TYPO3\Flow\Tests\Unit\Cli\RequestTest::setControllerObjectNameAndSetControllerCommandNameUnsetTheBuiltCommandObject
+.
+TYPO3\Flow\Tests\Unit\Configuration\ConfigurationManagerTest::buildSubrouteConfigurationsCorrectlyMergesRoutes
+.
+TYPO3\Flow\Tests\Unit\Configuration\ConfigurationManagerTest::buildSubrouteConfigurationsMergesSubRoutesAndProcessesPlaceholders
+.
+TYPO3\Flow\Tests\Unit\Configuration\ConfigurationManagerTest::getConfigurationForCustomConfigurationUsingSettingsProcessingReturnsRespectiveConfigurationArray
+.
+TYPO3\Flow\Tests\Unit\Configuration\ConfigurationManagerTest::getConfigurationForRoutesAndCachesLoadsConfigurationIfNecessary
+.
+TYPO3\Flow\Tests\Unit\Configuration\ConfigurationManagerTest::getConfigurationForRoutesAndCachesReturnsRespectiveConfigurationArray
+.
+TYPO3\Flow\Tests\Unit\Configuration\ConfigurationManagerTest::getConfigurationForSettingsLoadsConfigurationIfNecessary
+.
+TYPO3\Flow\Tests\Unit\Configuration\ConfigurationManagerTest::getConfigurationForTypeObjectLoadsConfiguration
+.
+TYPO3\Flow\Tests\Unit\Configuration\ConfigurationManagerTest::getConfigurationForTypeSettingsLoadsConfigurationIfNecessary
+.
+TYPO3\Flow\Tests\Unit\Configuration\ConfigurationManagerTest::getConfigurationForTypeSettingsReturnsRespectiveConfigurationArray
+.
+TYPO3\Flow\Tests\Unit\Configuration\ConfigurationManagerTest::getConfigurationThrowsExceptionOnInvalidConfigurationType
+.
+TYPO3\Flow\Tests\Unit\Configuration\ConfigurationManagerTest::gettingUnregisteredConfigurationTypeFails
+.
+TYPO3\Flow\Tests\Unit\Configuration\ConfigurationManagerTest::loadConfigurationCacheLoadsConfigurationsFromCacheIfACacheFileExists
+.
+TYPO3\Flow\Tests\Unit\Configuration\ConfigurationManagerTest::loadConfigurationCorrectlyMergesSettings
+.
+TYPO3\Flow\Tests\Unit\Configuration\ConfigurationManagerTest::loadConfigurationForCachesOverridesConfigurationByContext
+.
+TYPO3\Flow\Tests\Unit\Configuration\ConfigurationManagerTest::loadConfigurationForObjectsOverridesConfigurationByContext
+.
+TYPO3\Flow\Tests\Unit\Configuration\ConfigurationManagerTest::loadConfigurationForRoutesLoadsContextSpecificRoutesFirst
+.
+TYPO3\Flow\Tests\Unit\Configuration\ConfigurationManagerTest::loadConfigurationForRoutesLoadsSubRoutesRecursively
+.
+TYPO3\Flow\Tests\Unit\Configuration\ConfigurationManagerTest::loadConfigurationForRoutesThrowsExceptionIfSubRoutesContainCircularReferences
+.
+TYPO3\Flow\Tests\Unit\Configuration\ConfigurationManagerTest::loadConfigurationForViewsLoadsAppendsAllConfigurations
+.
+TYPO3\Flow\Tests\Unit\Configuration\ConfigurationManagerTest::loadConfigurationOverridesGlobalSettingsByContext
+.
+TYPO3\Flow\Tests\Unit\Configuration\ConfigurationManagerTest::loadConfigurationOverridesSettingsByContext
+.
+TYPO3\Flow\Tests\Unit\Configuration\ConfigurationManagerTest::mergeRoutesWithSubRoutesRespectsSuffixSubRouteOption
+.
+TYPO3\Flow\Tests\Unit\Configuration\ConfigurationManagerTest::mergeRoutesWithSubRoutesThrowsExceptionIfRouteRefersToNonExistingOrInactivePackages
+.
+TYPO3\Flow\Tests\Unit\Configuration\ConfigurationManagerTest::postProcessConfigurationMaintainsConstantTypeIfOnlyValue
+.
+TYPO3\Flow\Tests\Unit\Configuration\ConfigurationManagerTest::postProcessConfigurationReplacesClassConstantMarkersWithApproppriateConstants
+.
+TYPO3\Flow\Tests\Unit\Configuration\ConfigurationManagerTest::postProcessConfigurationReplacesConstantMarkersByRealGlobalConstants
+.
+TYPO3\Flow\Tests\Unit\Configuration\ConfigurationManagerTest::registerConfigurationTypeThrowsExceptionOnInvalidConfigurationProcessingType
+.
+TYPO3\Flow\Tests\Unit\Configuration\ConfigurationManagerTest::saveConfigurationCacheSavesTheCurrentConfigurationAsPhpCode
+.
+TYPO3\Flow\Tests\Unit\Configuration\Source\YamlSourceTest::optionSetInTheConfigurationFileReallyEndsUpInTheArray
+.
+TYPO3\Flow\Tests\Unit\Configuration\Source\YamlSourceTest::returnsEmptyArrayOnNonExistingFile
+.
+TYPO3\Flow\Tests\Unit\Configuration\Source\YamlSourceTest::saveWritesArrayToGivenFileAsYAML
+.
+TYPO3\Flow\Tests\Unit\Configuration\Source\YamlSourceTest::saveWritesDoesNotOverwriteExistingHeaderCommentsIfFileExists
+.
+TYPO3\Flow\Tests\Unit\Configuration\Source\YamlSourceTest::splitConfigurationFilesAreMergedAsExpected
+.
+TYPO3\Flow\Tests\Unit\Configuration\Source\YamlSourceTest::yamlFileIsParsedToArray
+.
+TYPO3\Flow\Tests\Unit\Core\ApplicationContextTest::constructorThrowsExceptionIfMainContextIsForbidden with data set #0
+.
+TYPO3\Flow\Tests\Unit\Core\ApplicationContextTest::constructorThrowsExceptionIfMainContextIsForbidden with data set #1
+.
+TYPO3\Flow\Tests\Unit\Core\ApplicationContextTest::constructorThrowsExceptionIfMainContextIsForbidden with data set #2
+.
+TYPO3\Flow\Tests\Unit\Core\ApplicationContextTest::constructorThrowsExceptionIfMainContextIsForbidden with data set #3
+.
+TYPO3\Flow\Tests\Unit\Core\ApplicationContextTest::contextMethodsReturnTheCorrectValues with data set "Development"
+.
+TYPO3\Flow\Tests\Unit\Core\ApplicationContextTest::contextMethodsReturnTheCorrectValues with data set "Development/YourSpecialContext"
+.
+TYPO3\Flow\Tests\Unit\Core\ApplicationContextTest::contextMethodsReturnTheCorrectValues with data set "Production"
+.
+TYPO3\Flow\Tests\Unit\Core\ApplicationContextTest::contextMethodsReturnTheCorrectValues with data set "Production/MySpecialContext"
+.
+TYPO3\Flow\Tests\Unit\Core\ApplicationContextTest::contextMethodsReturnTheCorrectValues with data set "Testing"
+.
+TYPO3\Flow\Tests\Unit\Core\ApplicationContextTest::contextMethodsReturnTheCorrectValues with data set "Testing/MySpecialContext"
+.
+TYPO3\Flow\Tests\Unit\Core\ApplicationContextTest::contextStringCanBeSetInConstructorAndReadByCallingToString with data set #0
+.
+TYPO3\Flow\Tests\Unit\Core\ApplicationContextTest::contextStringCanBeSetInConstructorAndReadByCallingToString with data set #1
+.
+TYPO3\Flow\Tests\Unit\Core\ApplicationContextTest::contextStringCanBeSetInConstructorAndReadByCallingToString with data set #2
+.
+TYPO3\Flow\Tests\Unit\Core\ApplicationContextTest::contextStringCanBeSetInConstructorAndReadByCallingToString with data set #3
+.
+TYPO3\Flow\Tests\Unit\Core\ApplicationContextTest::contextStringCanBeSetInConstructorAndReadByCallingToString with data set #4
+.
+TYPO3\Flow\Tests\Unit\Core\ApplicationContextTest::contextStringCanBeSetInConstructorAndReadByCallingToString with data set #5
+.
+TYPO3\Flow\Tests\Unit\Core\ApplicationContextTest::parentContextIsConnectedRecursively
+.
+TYPO3\Flow\Tests\Unit\Core\Booting\ScriptsTest::subProcessCommandEvaluatesIniFileUsageSettingCorrectly
+.
+TYPO3\Flow\Tests\Unit\Core\Booting\ScriptsTest::subProcessCommandEvaluatesSubRequestIniEntriesCorrectly
+.
+TYPO3\Flow\Tests\Unit\Core\BootstrapTest::isCompileTimeCommandControllerChecksIfTheGivenCommandIdentifierRefersToACompileTimeController with data set #0
+.
+TYPO3\Flow\Tests\Unit\Core\BootstrapTest::isCompileTimeCommandControllerChecksIfTheGivenCommandIdentifierRefersToACompileTimeController with data set #1
+.
+TYPO3\Flow\Tests\Unit\Core\BootstrapTest::isCompileTimeCommandControllerChecksIfTheGivenCommandIdentifierRefersToACompileTimeController with data set #2
+.
+TYPO3\Flow\Tests\Unit\Core\BootstrapTest::isCompileTimeCommandControllerChecksIfTheGivenCommandIdentifierRefersToACompileTimeController with data set #3
+.
+TYPO3\Flow\Tests\Unit\Core\BootstrapTest::isCompileTimeCommandControllerChecksIfTheGivenCommandIdentifierRefersToACompileTimeController with data set #4
+.
+TYPO3\Flow\Tests\Unit\Core\BootstrapTest::isCompileTimeCommandControllerChecksIfTheGivenCommandIdentifierRefersToACompileTimeController with data set #5
+.
+TYPO3\Flow\Tests\Unit\Core\BootstrapTest::isCompileTimeCommandControllerChecksIfTheGivenCommandIdentifierRefersToACompileTimeController with data set #6
+.
+TYPO3\Flow\Tests\Unit\Core\BootstrapTest::isCompileTimeCommandControllerChecksIfTheGivenCommandIdentifierRefersToACompileTimeController with data set #7
+.
+TYPO3\Flow\Tests\Unit\Core\BootstrapTest::isCompileTimeCommandControllerChecksIfTheGivenCommandIdentifierRefersToACompileTimeController with data set #8
+.
+TYPO3\Flow\Tests\Unit\Core\ClassLoaderTest::classesFromDeeplyNestedSubDirectoriesAreLoaded
+.
+TYPO3\Flow\Tests\Unit\Core\ClassLoaderTest::classesFromFunctionalTestsDirectoriesAreLoaded
+.
+TYPO3\Flow\Tests\Unit\Core\ClassLoaderTest::classesFromInactivePackagesAreNotLoaded
+.
+TYPO3\Flow\Tests\Unit\Core\ClassLoaderTest::classesFromPsr4PackagesAreLoaded
+.
+TYPO3\Flow\Tests\Unit\Core\ClassLoaderTest::classesFromSubDirectoriesAreLoaded
+.
+TYPO3\Flow\Tests\Unit\Core\ClassLoaderTest::classesFromSubMatchingPackagesAreLoaded
+.
+TYPO3\Flow\Tests\Unit\Core\ClassLoaderTest::classesWithLeadingBackslashAreLoaded
+.
+TYPO3\Flow\Tests\Unit\Core\ClassLoaderTest::classesWithOnlyUnderscoresAreLoaded
+.
+TYPO3\Flow\Tests\Unit\Core\ClassLoaderTest::classesWithUnderscoresAreLoaded
+.
+TYPO3\Flow\Tests\Unit\Core\ClassLoaderTest::namespaceWithUnderscoresAreLoaded
+.
+TYPO3\Flow\Tests\Unit\Error\AbstractExceptionHandlerTest::handleExceptionDoesNotLogInformationAboutTheExceptionInTheSystemLogIfLogExceptionWasTurnedOff
+.
+TYPO3\Flow\Tests\Unit\Error\AbstractExceptionHandlerTest::handleExceptionLogsInformationAboutTheExceptionInTheSystemLog
+.
+TYPO3\Flow\Tests\Unit\Error\DebugExceptionHandlerTest::splitExceptionMessageTests with data set #0
+.
+TYPO3\Flow\Tests\Unit\Error\DebugExceptionHandlerTest::splitExceptionMessageTests with data set #1
+.
+TYPO3\Flow\Tests\Unit\Error\DebugExceptionHandlerTest::splitExceptionMessageTests with data set #10
+.
+TYPO3\Flow\Tests\Unit\Error\DebugExceptionHandlerTest::splitExceptionMessageTests with data set #11
+.
+TYPO3\Flow\Tests\Unit\Error\DebugExceptionHandlerTest::splitExceptionMessageTests with data set #2
+.
+TYPO3\Flow\Tests\Unit\Error\DebugExceptionHandlerTest::splitExceptionMessageTests with data set #3
+.
+TYPO3\Flow\Tests\Unit\Error\DebugExceptionHandlerTest::splitExceptionMessageTests with data set #4
+.
+TYPO3\Flow\Tests\Unit\Error\DebugExceptionHandlerTest::splitExceptionMessageTests with data set #5
+.
+TYPO3\Flow\Tests\Unit\Error\DebugExceptionHandlerTest::splitExceptionMessageTests with data set #6
+.
+TYPO3\Flow\Tests\Unit\Error\DebugExceptionHandlerTest::splitExceptionMessageTests with data set #7
+.
+TYPO3\Flow\Tests\Unit\Error\DebugExceptionHandlerTest::splitExceptionMessageTests with data set #8
+.
+TYPO3\Flow\Tests\Unit\Error\DebugExceptionHandlerTest::splitExceptionMessageTests with data set #9
+.
+TYPO3\Flow\Tests\Unit\Error\DebuggerTest::considersProxyClassWhenIsProxyPropertyIsPresent
+.
+TYPO3\Flow\Tests\Unit\Error\DebuggerTest::renderingClosuresWorksWithoutThrowingException
+.
+TYPO3\Flow\Tests\Unit\Error\ErrorTest::theConstructorSetsTheErrorCodeCorrectly
+.
+TYPO3\Flow\Tests\Unit\Error\ErrorTest::theConstructorSetsTheErrorMessageCorrectly
+.
+TYPO3\Flow\Tests\Unit\Error\MessageTest::constructorSetsArguments
+.
+TYPO3\Flow\Tests\Unit\Error\MessageTest::constructorSetsCode
+.
+TYPO3\Flow\Tests\Unit\Error\MessageTest::constructorSetsMessage
+.
+TYPO3\Flow\Tests\Unit\Error\MessageTest::convertingTheMessageToStringRendersIt
+.
+TYPO3\Flow\Tests\Unit\Error\MessageTest::renderReplacesArgumentsInTheMessageText
+.
+TYPO3\Flow\Tests\Unit\Error\MessageTest::renderReturnsTheMessageTextIfNoArgumentsAreSpecified
+.
+TYPO3\Flow\Tests\Unit\Error\ResultTest::addedMessagesShouldBeRetrievableAgain with data set #0
+.
+TYPO3\Flow\Tests\Unit\Error\ResultTest::addedMessagesShouldBeRetrievableAgain with data set #1
+.
+TYPO3\Flow\Tests\Unit\Error\ResultTest::addedMessagesShouldBeRetrievableAgain with data set #2
+.
+TYPO3\Flow\Tests\Unit\Error\ResultTest::forPropertyShouldReturnSubResult
+.
+TYPO3\Flow\Tests\Unit\Error\ResultTest::forPropertyWithEmptyStringShouldReturnSelf
+.
+TYPO3\Flow\Tests\Unit\Error\ResultTest::forPropertyWithNullShouldReturnSelf
+.
+TYPO3\Flow\Tests\Unit\Error\ResultTest::getFirstMessageShouldReturnFirstMessage with data set #0
+.
+TYPO3\Flow\Tests\Unit\Error\ResultTest::getFirstMessageShouldReturnFirstMessage with data set #1
+.
+TYPO3\Flow\Tests\Unit\Error\ResultTest::getFirstMessageShouldReturnFirstMessage with data set #2
+.
+TYPO3\Flow\Tests\Unit\Error\ResultTest::getFlattenedMessagesShouldNotContainEmptyResults with data set #0
+.
+TYPO3\Flow\Tests\Unit\Error\ResultTest::getFlattenedMessagesShouldNotContainEmptyResults with data set #1
+.
+TYPO3\Flow\Tests\Unit\Error\ResultTest::getFlattenedMessagesShouldNotContainEmptyResults with data set #2
+.
+TYPO3\Flow\Tests\Unit\Error\ResultTest::getFlattenedMessagesShouldReturnAllSubMessages with data set #0
+.
+TYPO3\Flow\Tests\Unit\Error\ResultTest::getFlattenedMessagesShouldReturnAllSubMessages with data set #1
+.
+TYPO3\Flow\Tests\Unit\Error\ResultTest::getFlattenedMessagesShouldReturnAllSubMessages with data set #2
+.
+TYPO3\Flow\Tests\Unit\Error\ResultTest::getMessageShouldNotBeRecursive with data set #0
+.
+TYPO3\Flow\Tests\Unit\Error\ResultTest::getMessageShouldNotBeRecursive with data set #1
+.
+TYPO3\Flow\Tests\Unit\Error\ResultTest::getMessageShouldNotBeRecursive with data set #2
+.
+TYPO3\Flow\Tests\Unit\Error\ResultTest::hasMessagesShouldReturnFalseIfSubObjectHasNoErrors with data set #0
+.
+TYPO3\Flow\Tests\Unit\Error\ResultTest::hasMessagesShouldReturnFalseIfSubObjectHasNoErrors with data set #1
+.
+TYPO3\Flow\Tests\Unit\Error\ResultTest::hasMessagesShouldReturnFalseIfSubObjectHasNoErrors with data set #2
+.
+TYPO3\Flow\Tests\Unit\Error\ResultTest::hasMessagesShouldReturnTrueIfTopLevelObjectHasMessages with data set #0
+.
+TYPO3\Flow\Tests\Unit\Error\ResultTest::hasMessagesShouldReturnTrueIfTopLevelObjectHasMessages with data set #1
+.
+TYPO3\Flow\Tests\Unit\Error\ResultTest::hasMessagesShouldReturnTrueIfTopLevelObjectHasMessages with data set #2
+.
+TYPO3\Flow\Tests\Unit\Error\ResultTest::hasMessageshouldReturnTrueIfSubObjectHasErrors with data set #0
+.
+TYPO3\Flow\Tests\Unit\Error\ResultTest::hasMessageshouldReturnTrueIfSubObjectHasErrors with data set #1
+.
+TYPO3\Flow\Tests\Unit\Error\ResultTest::hasMessageshouldReturnTrueIfSubObjectHasErrors with data set #2
+.
+TYPO3\Flow\Tests\Unit\Error\ResultTest::mergeShouldMergeTwoResults
+.
+TYPO3\Flow\Tests\Unit\Http\AbstractMessageTest::aHeaderCanBeSetAndRetrieved
+.
+TYPO3\Flow\Tests\Unit\Http\AbstractMessageTest::byDefaultHeadersOfTheSameNameAreReplaced
+.
+TYPO3\Flow\Tests\Unit\Http\AbstractMessageTest::contentCanBeSetAndRetrieved
+.
+TYPO3\Flow\Tests\Unit\Http\AbstractMessageTest::cookieConvenienceMethodsUseMethodsOfHeadersObject
+.
+TYPO3\Flow\Tests\Unit\Http\AbstractMessageTest::getHeaderReturnsAStringOrAnArray
+.
+TYPO3\Flow\Tests\Unit\Http\AbstractMessageTest::multipleHeadersOfTheSameNameMayBeDefined
+.
+TYPO3\Flow\Tests\Unit\Http\AbstractMessageTest::setCharsetAlsoUpdatesContentTypeHeaderIfSpaceIsMissing
+.
+TYPO3\Flow\Tests\Unit\Http\AbstractMessageTest::setCharsetSetsTheCharsetAndAlsoUpdatesContentTypeHeader
+.
+TYPO3\Flow\Tests\Unit\Http\AbstractMessageTest::setCharsetUpdatesContentTypeHeaderAndLeavesAdditionalInformationIntact
+.
+TYPO3\Flow\Tests\Unit\Http\AbstractMessageTest::setHeaderAddsCharsetToMediaTypeIfNoneWasSpecifiedAndTypeIsText
+.
+TYPO3\Flow\Tests\Unit\Http\AbstractMessageTest::setterMethodsAreChainable
+.
+TYPO3\Flow\Tests\Unit\Http\AbstractMessageTest::theDefaultCharacterSetIsUtf8
+.
+TYPO3\Flow\Tests\Unit\Http\BrowserTest::automaticHeadersAreSetOnEachRequest
+.
+TYPO3\Flow\Tests\Unit\Http\BrowserTest::automaticHeadersCanBeRemovedAgain
+.
+TYPO3\Flow\Tests\Unit\Http\BrowserTest::browserDoesNotRedirectOnLocationHeaderButNot3xxResponseCode
+.
+TYPO3\Flow\Tests\Unit\Http\BrowserTest::browserFollowsRedirectionIfResponseTellsSo
+.
+TYPO3\Flow\Tests\Unit\Http\BrowserTest::browserHaltsOnAttemptedInfiniteRedirectionLoop
+.
+TYPO3\Flow\Tests\Unit\Http\BrowserTest::browserHaltsOnExceedingMaximumRedirections
+.
+TYPO3\Flow\Tests\Unit\Http\BrowserTest::requestingUriQueriesRequestEngine
+.
+TYPO3\Flow\Tests\Unit\Http\Component\ComponentChainFactoryTest::createInitializesComponentsInTheRightOrderAccordingToThePositionDirective
+.
+TYPO3\Flow\Tests\Unit\Http\Component\ComponentChainFactoryTest::createThrowsExceptionIfComponentClassNameDoesNotImplementComponentInterface
+.
+TYPO3\Flow\Tests\Unit\Http\Component\ComponentChainFactoryTest::createThrowsExceptionIfComponentClassNameIsNotConfigured
+.
+TYPO3\Flow\Tests\Unit\Http\Component\ComponentChainTest::handleProcessesConfiguredComponents
+.
+TYPO3\Flow\Tests\Unit\Http\Component\ComponentChainTest::handleResetsTheCancelParameterIfItWasTrue
+.
+TYPO3\Flow\Tests\Unit\Http\Component\ComponentChainTest::handleReturnsIfNoComponentsAreConfigured
+.
+TYPO3\Flow\Tests\Unit\Http\Component\ComponentChainTest::handleStopsProcessingIfAComponentCancelsTheCurrentChain
+.
+TYPO3\Flow\Tests\Unit\Http\Component\ComponentContextTest::getHttpRequestReturnsTheCurrentRequest
+.
+TYPO3\Flow\Tests\Unit\Http\Component\ComponentContextTest::getHttpResponseReturnsTheCurrentResponse
+.
+TYPO3\Flow\Tests\Unit\Http\Component\ComponentContextTest::getParameterReturnsNullIfTheSpecifiedParameterIsNotDefined
+.
+TYPO3\Flow\Tests\Unit\Http\Component\ComponentContextTest::replaceHttpRequestReplacesTheCurrentRequest
+.
+TYPO3\Flow\Tests\Unit\Http\Component\ComponentContextTest::replaceHttpResponseReplacesTheCurrentResponse
+.
+TYPO3\Flow\Tests\Unit\Http\Component\ComponentContextTest::setParameterStoresTheGivenParameter
+.
+TYPO3\Flow\Tests\Unit\Http\Component\StandardsComplianceComponentTest::handleCallsMakeStandardsCompliantOnTheCurrentResponse
+.
+TYPO3\Flow\Tests\Unit\Http\CookieTest::constructorAcceptsValidCookieNames with data set #0
+.
+TYPO3\Flow\Tests\Unit\Http\CookieTest::constructorAcceptsValidCookieNames with data set #1
+.
+TYPO3\Flow\Tests\Unit\Http\CookieTest::constructorAcceptsValidCookieNames with data set #2
+.
+TYPO3\Flow\Tests\Unit\Http\CookieTest::constructorAcceptsValidCookieNames with data set #3
+.
+TYPO3\Flow\Tests\Unit\Http\CookieTest::constructorAcceptsValidCookieNames with data set #4
+.
+TYPO3\Flow\Tests\Unit\Http\CookieTest::constructorAcceptsValidCookieNames with data set #5
+.
+TYPO3\Flow\Tests\Unit\Http\CookieTest::constructorAcceptsValidCookieNames with data set #6
+.
+TYPO3\Flow\Tests\Unit\Http\CookieTest::constructorThrowsExceptionOnInvalidCookieNames with data set #0
+.
+TYPO3\Flow\Tests\Unit\Http\CookieTest::constructorThrowsExceptionOnInvalidCookieNames with data set #1
+.
+TYPO3\Flow\Tests\Unit\Http\CookieTest::constructorThrowsExceptionOnInvalidCookieNames with data set #10
+.
+TYPO3\Flow\Tests\Unit\Http\CookieTest::constructorThrowsExceptionOnInvalidCookieNames with data set #11
+.
+TYPO3\Flow\Tests\Unit\Http\CookieTest::constructorThrowsExceptionOnInvalidCookieNames with data set #12
+.
+TYPO3\Flow\Tests\Unit\Http\CookieTest::constructorThrowsExceptionOnInvalidCookieNames with data set #2
+.
+TYPO3\Flow\Tests\Unit\Http\CookieTest::constructorThrowsExceptionOnInvalidCookieNames with data set #3
+.
+TYPO3\Flow\Tests\Unit\Http\CookieTest::constructorThrowsExceptionOnInvalidCookieNames with data set #4
+.
+TYPO3\Flow\Tests\Unit\Http\CookieTest::constructorThrowsExceptionOnInvalidCookieNames with data set #5
+.
+TYPO3\Flow\Tests\Unit\Http\CookieTest::constructorThrowsExceptionOnInvalidCookieNames with data set #6
+.
+TYPO3\Flow\Tests\Unit\Http\CookieTest::constructorThrowsExceptionOnInvalidCookieNames with data set #7
+.
+TYPO3\Flow\Tests\Unit\Http\CookieTest::constructorThrowsExceptionOnInvalidCookieNames with data set #8
+.
+TYPO3\Flow\Tests\Unit\Http\CookieTest::constructorThrowsExceptionOnInvalidCookieNames with data set #9
+.
+TYPO3\Flow\Tests\Unit\Http\CookieTest::constructorThrowsExceptionOnInvalidDomain with data set #0
+.
+TYPO3\Flow\Tests\Unit\Http\CookieTest::constructorThrowsExceptionOnInvalidDomain with data set #1
+.
+TYPO3\Flow\Tests\Unit\Http\CookieTest::constructorThrowsExceptionOnInvalidDomain with data set #2
+.
+TYPO3\Flow\Tests\Unit\Http\CookieTest::constructorThrowsExceptionOnInvalidDomain with data set #3
+.
+TYPO3\Flow\Tests\Unit\Http\CookieTest::constructorThrowsExceptionOnInvalidDomain with data set #4
+.
+TYPO3\Flow\Tests\Unit\Http\CookieTest::constructorThrowsExceptionOnInvalidDomain with data set #5
+.
+TYPO3\Flow\Tests\Unit\Http\CookieTest::constructorThrowsExceptionOnInvalidExpiresParameter with data set #0
+.
+TYPO3\Flow\Tests\Unit\Http\CookieTest::constructorThrowsExceptionOnInvalidExpiresParameter with data set #1
+.
+TYPO3\Flow\Tests\Unit\Http\CookieTest::constructorThrowsExceptionOnInvalidExpiresParameter with data set #2
+.
+TYPO3\Flow\Tests\Unit\Http\CookieTest::constructorThrowsExceptionOnInvalidExpiresParameter with data set #3
+.
+TYPO3\Flow\Tests\Unit\Http\CookieTest::constructorThrowsExceptionOnInvalidMaximumAgeParameter
+.
+TYPO3\Flow\Tests\Unit\Http\CookieTest::constructorThrowsExceptionOnInvalidPath with data set #0
+.
+TYPO3\Flow\Tests\Unit\Http\CookieTest::constructorThrowsExceptionOnInvalidPath with data set #1
+.
+TYPO3\Flow\Tests\Unit\Http\CookieTest::constructorThrowsExceptionOnInvalidPath with data set #2
+.
+TYPO3\Flow\Tests\Unit\Http\CookieTest::constructorThrowsExceptionOnInvalidPath with data set #3
+.
+TYPO3\Flow\Tests\Unit\Http\CookieTest::createCookieFromRawAssumesDefaultPathIfNoLeadingSlashIsPresent
+.
+TYPO3\Flow\Tests\Unit\Http\CookieTest::createCookieFromRawAssumesExpiryDateZeroIfItCannotBeParsed
+.
+TYPO3\Flow\Tests\Unit\Http\CookieTest::createCookieFromRawDoesntCareAboutUnkownAttributeValues
+.
+TYPO3\Flow\Tests\Unit\Http\CookieTest::createCookieFromRawIgnoresDomainAttributeIfValueIsEmpty
+.
+TYPO3\Flow\Tests\Unit\Http\CookieTest::createCookieFromRawIgnoresMaxAgeIfInvalid
+.
+TYPO3\Flow\Tests\Unit\Http\CookieTest::createCookieFromRawLowerCasesDomainName
+.
+TYPO3\Flow\Tests\Unit\Http\CookieTest::createCookieFromRawParsesExpiryDateCorrectly
+.
+TYPO3\Flow\Tests\Unit\Http\CookieTest::createCookieFromRawParsesMaxAgeCorrectly
+.
+TYPO3\Flow\Tests\Unit\Http\CookieTest::createCookieFromRawRemovesLeadingDotForDomainIfPresent
+.
+TYPO3\Flow\Tests\Unit\Http\CookieTest::createCookieFromRawReturnsNullIfBasicNameOrValueAreNotSatisfied
+.
+TYPO3\Flow\Tests\Unit\Http\CookieTest::createCookieFromRawSetsHttpOnlyIfPresent
+.
+TYPO3\Flow\Tests\Unit\Http\CookieTest::createCookieFromRawSetsSecureIfPresent
+.
+TYPO3\Flow\Tests\Unit\Http\CookieTest::createCookieFromRawUsesPathCorrectly
+.
+TYPO3\Flow\Tests\Unit\Http\CookieTest::getDomainReturnsDomain
+.
+TYPO3\Flow\Tests\Unit\Http\CookieTest::getExpiresAlwaysReturnsAUnixTimestamp
+.
+TYPO3\Flow\Tests\Unit\Http\CookieTest::getMaximumAgeReturnsTheMaximumAge
+.
+TYPO3\Flow\Tests\Unit\Http\CookieTest::getPathReturnsPath
+.
+TYPO3\Flow\Tests\Unit\Http\CookieTest::getValueReturnsTheSetValue
+.
+TYPO3\Flow\Tests\Unit\Http\CookieTest::isExpiredTellsIfTheCookieIsExpired
+.
+TYPO3\Flow\Tests\Unit\Http\CookieTest::isHttpOnlyReturnsHttpOnlyFlag
+.
+TYPO3\Flow\Tests\Unit\Http\CookieTest::isSecureReturnsSecureFlag
+.
+TYPO3\Flow\Tests\Unit\Http\CookieTest::stringRepresentationOfCookieIsValidSetCookieFieldValue with data set #0
+.
+TYPO3\Flow\Tests\Unit\Http\CookieTest::stringRepresentationOfCookieIsValidSetCookieFieldValue with data set #1
+.
+TYPO3\Flow\Tests\Unit\Http\CookieTest::stringRepresentationOfCookieIsValidSetCookieFieldValue with data set #10
+.
+TYPO3\Flow\Tests\Unit\Http\CookieTest::stringRepresentationOfCookieIsValidSetCookieFieldValue with data set #11
+.
+TYPO3\Flow\Tests\Unit\Http\CookieTest::stringRepresentationOfCookieIsValidSetCookieFieldValue with data set #12
+.
+TYPO3\Flow\Tests\Unit\Http\CookieTest::stringRepresentationOfCookieIsValidSetCookieFieldValue with data set #13
+.
+TYPO3\Flow\Tests\Unit\Http\CookieTest::stringRepresentationOfCookieIsValidSetCookieFieldValue with data set #14
+.
+TYPO3\Flow\Tests\Unit\Http\CookieTest::stringRepresentationOfCookieIsValidSetCookieFieldValue with data set #15
+.
+TYPO3\Flow\Tests\Unit\Http\CookieTest::stringRepresentationOfCookieIsValidSetCookieFieldValue with data set #2
+.
+TYPO3\Flow\Tests\Unit\Http\CookieTest::stringRepresentationOfCookieIsValidSetCookieFieldValue with data set #3
+.
+TYPO3\Flow\Tests\Unit\Http\CookieTest::stringRepresentationOfCookieIsValidSetCookieFieldValue with data set #4
+.
+TYPO3\Flow\Tests\Unit\Http\CookieTest::stringRepresentationOfCookieIsValidSetCookieFieldValue with data set #5
+.
+TYPO3\Flow\Tests\Unit\Http\CookieTest::stringRepresentationOfCookieIsValidSetCookieFieldValue with data set #6
+.
+TYPO3\Flow\Tests\Unit\Http\CookieTest::stringRepresentationOfCookieIsValidSetCookieFieldValue with data set #7
+.
+TYPO3\Flow\Tests\Unit\Http\CookieTest::stringRepresentationOfCookieIsValidSetCookieFieldValue with data set #8
+.
+TYPO3\Flow\Tests\Unit\Http\CookieTest::stringRepresentationOfCookieIsValidSetCookieFieldValue with data set #9
+.
+TYPO3\Flow\Tests\Unit\Http\HeadersTest::cacheControlHeaderPassedToSetIsParsedCorrectly with data set #0
+.
+TYPO3\Flow\Tests\Unit\Http\HeadersTest::cacheControlHeaderPassedToSetIsParsedCorrectly with data set #1
+.
+TYPO3\Flow\Tests\Unit\Http\HeadersTest::cacheControlHeaderPassedToSetIsParsedCorrectly with data set #2
+.
+TYPO3\Flow\Tests\Unit\Http\HeadersTest::cacheControlHeaderPassedToSetIsParsedCorrectly with data set #3
+.
+TYPO3\Flow\Tests\Unit\Http\HeadersTest::cacheControlHeaderPassedToSetIsParsedCorrectly with data set #4
+.
+TYPO3\Flow\Tests\Unit\Http\HeadersTest::cacheControlHeaderPassedToSetIsParsedCorrectly with data set #5
+.
+TYPO3\Flow\Tests\Unit\Http\HeadersTest::cacheControlHeaderPassedToSetIsParsedCorrectly with data set #6
+.
+TYPO3\Flow\Tests\Unit\Http\HeadersTest::cacheControlHeaderPassedToSetIsParsedCorrectly with data set #7
+.
+TYPO3\Flow\Tests\Unit\Http\HeadersTest::cookiesCanBeRemoved
+.
+TYPO3\Flow\Tests\Unit\Http\HeadersTest::cookiesCanBeSetThroughTheCookieHeader
+.
+TYPO3\Flow\Tests\Unit\Http\HeadersTest::cookiesWithEmptyNameAreIgnored
+.
+TYPO3\Flow\Tests\Unit\Http\HeadersTest::createFromServerCreatesFieldsFromSpecifiedServerSuperglobal
+.
+TYPO3\Flow\Tests\Unit\Http\HeadersTest::createFromServerSimulatesAuthorizationHeaderIfPHPAuthVariablesArePresent
+.
+TYPO3\Flow\Tests\Unit\Http\HeadersTest::getAllAddsCacheControlHeaderIfCacheDirectivesHaveBeenSet
+.
+TYPO3\Flow\Tests\Unit\Http\HeadersTest::getAllReturnsAllHeaderFields
+.
+TYPO3\Flow\Tests\Unit\Http\HeadersTest::getCacheControlDirectiveReturnsTheSpecifiedDirectiveValueIfPresent with data set #0
+.
+TYPO3\Flow\Tests\Unit\Http\HeadersTest::getCacheControlDirectiveReturnsTheSpecifiedDirectiveValueIfPresent with data set #1
+.
+TYPO3\Flow\Tests\Unit\Http\HeadersTest::getCacheControlDirectiveReturnsTheSpecifiedDirectiveValueIfPresent with data set #10
+.
+TYPO3\Flow\Tests\Unit\Http\HeadersTest::getCacheControlDirectiveReturnsTheSpecifiedDirectiveValueIfPresent with data set #11
+.
+TYPO3\Flow\Tests\Unit\Http\HeadersTest::getCacheControlDirectiveReturnsTheSpecifiedDirectiveValueIfPresent with data set #12
+.
+TYPO3\Flow\Tests\Unit\Http\HeadersTest::getCacheControlDirectiveReturnsTheSpecifiedDirectiveValueIfPresent with data set #2
+.
+TYPO3\Flow\Tests\Unit\Http\HeadersTest::getCacheControlDirectiveReturnsTheSpecifiedDirectiveValueIfPresent with data set #3
+.
+TYPO3\Flow\Tests\Unit\Http\HeadersTest::getCacheControlDirectiveReturnsTheSpecifiedDirectiveValueIfPresent with data set #4
+.
+TYPO3\Flow\Tests\Unit\Http\HeadersTest::getCacheControlDirectiveReturnsTheSpecifiedDirectiveValueIfPresent with data set #5
+.
+TYPO3\Flow\Tests\Unit\Http\HeadersTest::getCacheControlDirectiveReturnsTheSpecifiedDirectiveValueIfPresent with data set #6
+.
+TYPO3\Flow\Tests\Unit\Http\HeadersTest::getCacheControlDirectiveReturnsTheSpecifiedDirectiveValueIfPresent with data set #7
+.
+TYPO3\Flow\Tests\Unit\Http\HeadersTest::getCacheControlDirectiveReturnsTheSpecifiedDirectiveValueIfPresent with data set #8
+.
+TYPO3\Flow\Tests\Unit\Http\HeadersTest::getCacheControlDirectiveReturnsTheSpecifiedDirectiveValueIfPresent with data set #9
+.
+TYPO3\Flow\Tests\Unit\Http\HeadersTest::getCookiesReturnsAllCookies
+.
+TYPO3\Flow\Tests\Unit\Http\HeadersTest::getReturnsNullForNonExistingHeader
+.
+TYPO3\Flow\Tests\Unit\Http\HeadersTest::headerFieldsCanBeReplaced
+.
+TYPO3\Flow\Tests\Unit\Http\HeadersTest::headerFieldsCanBeSpecifiedToTheConstructor
+.
+TYPO3\Flow\Tests\Unit\Http\HeadersTest::headerFieldsCanExistMultipleTimes
+.
+TYPO3\Flow\Tests\Unit\Http\HeadersTest::maxAgeAndSMaxAgeIsRenderedCorrectly
+.
+TYPO3\Flow\Tests\Unit\Http\HeadersTest::mustRevalidateAndProxyRevalidateAreRenderedCorrectly
+.
+TYPO3\Flow\Tests\Unit\Http\HeadersTest::noStoreCacheDirectiveCanBeSetAndRemoved
+.
+TYPO3\Flow\Tests\Unit\Http\HeadersTest::noTransformCacheDirectiveIsRenderedCorrectly
+.
+TYPO3\Flow\Tests\Unit\Http\HeadersTest::removeCacheControlDirectiveRemovesVisibilityCorrectly
+.
+TYPO3\Flow\Tests\Unit\Http\HeadersTest::removeRemovesTheSpecifiedHeader
+.
+TYPO3\Flow\Tests\Unit\Http\HeadersTest::setCacheControlDirectiveSetsVisibilityCorrectly
+.
+TYPO3\Flow\Tests\Unit\Http\HeadersTest::setGetAndGetAllConvertDatesFromDateObjectsToStringAndViceVersa
+.
+TYPO3\Flow\Tests\Unit\Http\HeadersTest::setOverridesAnyPreviouslyDefinedCacheControlDirectives
+.
+TYPO3\Flow\Tests\Unit\Http\HeadersTest::singleCookieCanBeSetAndRetrieved
+.
+TYPO3\Flow\Tests\Unit\Http\RequestTest::constructRecognizesSslSessionIdAsIndicatorForSsl
+.
+TYPO3\Flow\Tests\Unit\Http\RequestTest::constructorCorrectlyStripsOffIndexPhpFromRequestUri with data set #0
+.
+TYPO3\Flow\Tests\Unit\Http\RequestTest::constructorCorrectlyStripsOffIndexPhpFromRequestUri with data set #1
+.
+TYPO3\Flow\Tests\Unit\Http\RequestTest::constructorCorrectlyStripsOffIndexPhpFromRequestUri with data set #2
+.
+TYPO3\Flow\Tests\Unit\Http\RequestTest::constructorCorrectlyStripsOffIndexPhpFromRequestUri with data set #3
+.
+TYPO3\Flow\Tests\Unit\Http\RequestTest::constructorCorrectlyStripsOffIndexPhpFromRequestUri with data set #4
+.
+TYPO3\Flow\Tests\Unit\Http\RequestTest::createActionRequestCreatesAnMvcRequestConnectedToTheParentRequest
+.
+TYPO3\Flow\Tests\Unit\Http\RequestTest::createFromEnvironmentCreatesAReasonableRequestObjectFromTheSuperGlobals
+.
+TYPO3\Flow\Tests\Unit\Http\RequestTest::createFromEnvironmentWithEmptyServerVariableWorks
+.
+TYPO3\Flow\Tests\Unit\Http\RequestTest::createSetsTheContentTypeHeaderToFormUrlEncodedByDefaultIfRequestMethodSuggestsIt
+.
+TYPO3\Flow\Tests\Unit\Http\RequestTest::createUsesReasonableDefaultsForCreatingANewRequest
+.
+TYPO3\Flow\Tests\Unit\Http\RequestTest::forwardHeaderTests with data set #0
+.
+TYPO3\Flow\Tests\Unit\Http\RequestTest::forwardHeaderTests with data set #1
+.
+TYPO3\Flow\Tests\Unit\Http\RequestTest::forwardHeaderTests with data set #10
+.
+TYPO3\Flow\Tests\Unit\Http\RequestTest::forwardHeaderTests with data set #11
+.
+TYPO3\Flow\Tests\Unit\Http\RequestTest::forwardHeaderTests with data set #12
+.
+TYPO3\Flow\Tests\Unit\Http\RequestTest::forwardHeaderTests with data set #13
+.
+TYPO3\Flow\Tests\Unit\Http\RequestTest::forwardHeaderTests with data set #14
+.
+TYPO3\Flow\Tests\Unit\Http\RequestTest::forwardHeaderTests with data set #2
+.
+TYPO3\Flow\Tests\Unit\Http\RequestTest::forwardHeaderTests with data set #3
+.
+TYPO3\Flow\Tests\Unit\Http\RequestTest::forwardHeaderTests with data set #4
+.
+TYPO3\Flow\Tests\Unit\Http\RequestTest::forwardHeaderTests with data set #5
+.
+TYPO3\Flow\Tests\Unit\Http\RequestTest::forwardHeaderTests with data set #6
+.
+TYPO3\Flow\Tests\Unit\Http\RequestTest::forwardHeaderTests with data set #7
+.
+TYPO3\Flow\Tests\Unit\Http\RequestTest::forwardHeaderTests with data set #8
+.
+TYPO3\Flow\Tests\Unit\Http\RequestTest::forwardHeaderTests with data set #9
+.
+TYPO3\Flow\Tests\Unit\Http\RequestTest::getAcceptedMediaTypesReturnsAnOrderedListOfMediaTypesDefinedInTheAcceptHeader with data set #0
+.
+TYPO3\Flow\Tests\Unit\Http\RequestTest::getAcceptedMediaTypesReturnsAnOrderedListOfMediaTypesDefinedInTheAcceptHeader with data set #1
+.
+TYPO3\Flow\Tests\Unit\Http\RequestTest::getAcceptedMediaTypesReturnsAnOrderedListOfMediaTypesDefinedInTheAcceptHeader with data set #2
+.
+TYPO3\Flow\Tests\Unit\Http\RequestTest::getAcceptedMediaTypesReturnsAnOrderedListOfMediaTypesDefinedInTheAcceptHeader with data set #3
+.
+TYPO3\Flow\Tests\Unit\Http\RequestTest::getAcceptedMediaTypesReturnsAnOrderedListOfMediaTypesDefinedInTheAcceptHeader with data set #4
+.
+TYPO3\Flow\Tests\Unit\Http\RequestTest::getAcceptedMediaTypesReturnsAnOrderedListOfMediaTypesDefinedInTheAcceptHeader with data set #5
+.
+TYPO3\Flow\Tests\Unit\Http\RequestTest::getAcceptedMediaTypesReturnsAnOrderedListOfMediaTypesDefinedInTheAcceptHeader with data set #6
+.
+TYPO3\Flow\Tests\Unit\Http\RequestTest::getAcceptedMediaTypesReturnsAnOrderedListOfMediaTypesDefinedInTheAcceptHeader with data set #7
+.
+TYPO3\Flow\Tests\Unit\Http\RequestTest::getArgumentsReturnsGetAndPostArguments with data set #0
+.
+TYPO3\Flow\Tests\Unit\Http\RequestTest::getArgumentsReturnsGetAndPostArguments with data set #1
+.
+TYPO3\Flow\Tests\Unit\Http\RequestTest::getArgumentsReturnsGetAndPostArguments with data set #2
+.
+TYPO3\Flow\Tests\Unit\Http\RequestTest::getBaseUriReturnsTheDetectedBaseUri
+.
+TYPO3\Flow\Tests\Unit\Http\RequestTest::getBaseUriReturnsThePresetBaseUriIfItHasBeenSet
+.
+TYPO3\Flow\Tests\Unit\Http\RequestTest::getClientIpAddressReturnsTheIpAddressDerivedFromSeveralServerEnvironmentVariables with data set #0
+.
+TYPO3\Flow\Tests\Unit\Http\RequestTest::getClientIpAddressReturnsTheIpAddressDerivedFromSeveralServerEnvironmentVariables with data set #1
+.
+TYPO3\Flow\Tests\Unit\Http\RequestTest::getClientIpAddressReturnsTheIpAddressDerivedFromSeveralServerEnvironmentVariables with data set #10
+.
+TYPO3\Flow\Tests\Unit\Http\RequestTest::getClientIpAddressReturnsTheIpAddressDerivedFromSeveralServerEnvironmentVariables with data set #11
+.
+TYPO3\Flow\Tests\Unit\Http\RequestTest::getClientIpAddressReturnsTheIpAddressDerivedFromSeveralServerEnvironmentVariables with data set #12
+.
+TYPO3\Flow\Tests\Unit\Http\RequestTest::getClientIpAddressReturnsTheIpAddressDerivedFromSeveralServerEnvironmentVariables with data set #2
+.
+TYPO3\Flow\Tests\Unit\Http\RequestTest::getClientIpAddressReturnsTheIpAddressDerivedFromSeveralServerEnvironmentVariables with data set #3
+.
+TYPO3\Flow\Tests\Unit\Http\RequestTest::getClientIpAddressReturnsTheIpAddressDerivedFromSeveralServerEnvironmentVariables with data set #4
+.
+TYPO3\Flow\Tests\Unit\Http\RequestTest::getClientIpAddressReturnsTheIpAddressDerivedFromSeveralServerEnvironmentVariables with data set #5
+.
+TYPO3\Flow\Tests\Unit\Http\RequestTest::getClientIpAddressReturnsTheIpAddressDerivedFromSeveralServerEnvironmentVariables with data set #6
+.
+TYPO3\Flow\Tests\Unit\Http\RequestTest::getClientIpAddressReturnsTheIpAddressDerivedFromSeveralServerEnvironmentVariables with data set #7
+.
+TYPO3\Flow\Tests\Unit\Http\RequestTest::getClientIpAddressReturnsTheIpAddressDerivedFromSeveralServerEnvironmentVariables with data set #8
+.
+TYPO3\Flow\Tests\Unit\Http\RequestTest::getClientIpAddressReturnsTheIpAddressDerivedFromSeveralServerEnvironmentVariables with data set #9
+.
+TYPO3\Flow\Tests\Unit\Http\RequestTest::getContentReturnsTheRequestBodyContent
+.
+TYPO3\Flow\Tests\Unit\Http\RequestTest::getContentReturnsTheRequestBodyContentAsResourcePointerIfRequested
+.
+TYPO3\Flow\Tests\Unit\Http\RequestTest::getContentThrowsAnExceptionOnTryingToRetrieveContentAsResourceAlthoughItHasBeenRetrievedPreviously
+.
+TYPO3\Flow\Tests\Unit\Http\RequestTest::getNegotiatedMediaTypeReturnsMediaTypeBasedOnContentNegotiation with data set #0
+.
+TYPO3\Flow\Tests\Unit\Http\RequestTest::getNegotiatedMediaTypeReturnsMediaTypeBasedOnContentNegotiation with data set #1
+.
+TYPO3\Flow\Tests\Unit\Http\RequestTest::getNegotiatedMediaTypeReturnsMediaTypeBasedOnContentNegotiation with data set #2
+.
+TYPO3\Flow\Tests\Unit\Http\RequestTest::getNegotiatedMediaTypeReturnsMediaTypeBasedOnContentNegotiation with data set #3
+.
+TYPO3\Flow\Tests\Unit\Http\RequestTest::getNegotiatedMediaTypeReturnsMediaTypeBasedOnContentNegotiation with data set #4
+.
+TYPO3\Flow\Tests\Unit\Http\RequestTest::getNegotiatedMediaTypeReturnsMediaTypeBasedOnContentNegotiation with data set #5
+.
+TYPO3\Flow\Tests\Unit\Http\RequestTest::getRelativePathCorrectlyTrimsBaseUri
+.
+TYPO3\Flow\Tests\Unit\Http\RequestTest::getRelativePathReturnsEmptyStringForHomepage
+.
+TYPO3\Flow\Tests\Unit\Http\RequestTest::getReturnsTheRequestUri
+.
+TYPO3\Flow\Tests\Unit\Http\RequestTest::httpHostIsNotAppendedByColonIfNoExplicitPortIsGiven
+.
+TYPO3\Flow\Tests\Unit\Http\RequestTest::isMethodSafeReturnsTrueIfTheRequestMethodIsGetOrHead
+.
+TYPO3\Flow\Tests\Unit\Http\RequestTest::isSecureReturnsFalseIfTheRequestWasForwardedAndOriginallyWasHttp
+.
+TYPO3\Flow\Tests\Unit\Http\RequestTest::isSecureReturnsTrueEvenIfTheSchemeIsHttpButTheRequestWasForwardedAndOriginallyWasHttps
+.
+TYPO3\Flow\Tests\Unit\Http\RequestTest::methodCanBeOverridden with data set #0
+.
+TYPO3\Flow\Tests\Unit\Http\RequestTest::methodCanBeOverridden with data set #1
+.
+TYPO3\Flow\Tests\Unit\Http\RequestTest::methodCanBeOverridden with data set #2
+.
+TYPO3\Flow\Tests\Unit\Http\RequestTest::methodCanBeOverridden with data set #3
+.
+TYPO3\Flow\Tests\Unit\Http\RequestTest::methodCanBeOverridden with data set #4
+.
+TYPO3\Flow\Tests\Unit\Http\RequestTest::methodCanBeOverridden with data set #5
+.
+TYPO3\Flow\Tests\Unit\Http\RequestTest::nonStandardHttpsPortIsAddedToHttpHost
+.
+TYPO3\Flow\Tests\Unit\Http\RequestTest::nonStandardHttpsPortIsAddedToServerPort
+.
+TYPO3\Flow\Tests\Unit\Http\RequestTest::nonStandardPortIsAddedToServerPort
+.
+TYPO3\Flow\Tests\Unit\Http\RequestTest::nonStandardPortIsRecognizedCorrectly
+.
+TYPO3\Flow\Tests\Unit\Http\RequestTest::parseContentNegotiationQualityValuesReturnsNormalizedAndOrderListOfPreferredValues with data set #0
+.
+TYPO3\Flow\Tests\Unit\Http\RequestTest::parseContentNegotiationQualityValuesReturnsNormalizedAndOrderListOfPreferredValues with data set #1
+.
+TYPO3\Flow\Tests\Unit\Http\RequestTest::parseContentNegotiationQualityValuesReturnsNormalizedAndOrderListOfPreferredValues with data set #2
+.
+TYPO3\Flow\Tests\Unit\Http\RequestTest::parseContentNegotiationQualityValuesReturnsNormalizedAndOrderListOfPreferredValues with data set #3
+.
+TYPO3\Flow\Tests\Unit\Http\RequestTest::parseContentNegotiationQualityValuesReturnsNormalizedAndOrderListOfPreferredValues with data set #4
+.
+TYPO3\Flow\Tests\Unit\Http\RequestTest::parseContentNegotiationQualityValuesReturnsNormalizedAndOrderListOfPreferredValues with data set #5
+.
+TYPO3\Flow\Tests\Unit\Http\RequestTest::portInProxyHeaderIsAcknowledged
+.
+TYPO3\Flow\Tests\Unit\Http\RequestTest::renderHeadersReturnsRawHttpHeadersAccordingToTheRequestProperties
+.
+TYPO3\Flow\Tests\Unit\Http\RequestTest::setContentAlsoAcceptsAFileHandleAsInput
+.
+TYPO3\Flow\Tests\Unit\Http\RequestTest::setContentAlsoAcceptsAStreamAsInputAndSetsContentLengthAndTypeAccordingly
+.
+TYPO3\Flow\Tests\Unit\Http\RequestTest::setMethodAcceptsAnyRequestMethod with data set #0
+.
+TYPO3\Flow\Tests\Unit\Http\RequestTest::setMethodAcceptsAnyRequestMethod with data set #1
+.
+TYPO3\Flow\Tests\Unit\Http\RequestTest::setMethodAcceptsAnyRequestMethod with data set #2
+.
+TYPO3\Flow\Tests\Unit\Http\RequestTest::setMethodAcceptsAnyRequestMethod with data set #3
+.
+TYPO3\Flow\Tests\Unit\Http\RequestTest::settingVersionHasExpectedImplications
+.
+TYPO3\Flow\Tests\Unit\Http\RequestTest::singleArgumentsCanBeCheckedAndRetrieved
+.
+TYPO3\Flow\Tests\Unit\Http\RequestTest::standardHttpsPortIsRecognizedCorrectly
+.
+TYPO3\Flow\Tests\Unit\Http\RequestTest::standardPortsAreRecognizedCorrectly
+.
+TYPO3\Flow\Tests\Unit\Http\RequestTest::toStringReturnsRawHttpRequestAccordingToTheRequestProperties
+.
+TYPO3\Flow\Tests\Unit\Http\RequestTest::untangleFilesArrayDoesNotChangeArgumentsIfNoFileWasUploaded
+.
+TYPO3\Flow\Tests\Unit\Http\RequestTest::untangleFilesArrayTransformsTheFilesSuperglobalIntoAMangeableForm
+.
+TYPO3\Flow\Tests\Unit\Http\ResponseTest::additionalHeadersCanBeSetAndRetrieved
+.
+TYPO3\Flow\Tests\Unit\Http\ResponseTest::contentCanBeSetAppendedAndRetrieved
+.
+TYPO3\Flow\Tests\Unit\Http\ResponseTest::contentTypeHeaderWithMediaTypeTextHtmlIsAddedByDefault
+.
+TYPO3\Flow\Tests\Unit\Http\ResponseTest::createFromRawSetsCookiesCorrectly
+.
+TYPO3\Flow\Tests\Unit\Http\ResponseTest::createFromRawSetsHeadersAndStatusCodeCorrectly with data set #0
+.
+TYPO3\Flow\Tests\Unit\Http\ResponseTest::createFromRawSetsHeadersAndStatusCodeCorrectly with data set #1
+.
+TYPO3\Flow\Tests\Unit\Http\ResponseTest::createFromRawThrowsExceptionOnFirstLine
+.
+TYPO3\Flow\Tests\Unit\Http\ResponseTest::getAgeReturnsTheTimePassedSinceTimeSpecifiedInDateHeader
+.
+TYPO3\Flow\Tests\Unit\Http\ResponseTest::getAgeReturnsTimeSpecifiedInAgeHeaderIfExists
+.
+TYPO3\Flow\Tests\Unit\Http\ResponseTest::getParentResponseReturnsResponseSetInConstructor
+.
+TYPO3\Flow\Tests\Unit\Http\ResponseTest::getStatusCodeSolelyReturnsTheStatusCode
+.
+TYPO3\Flow\Tests\Unit\Http\ResponseTest::getStatusReturnsTheStatusCodeAndMessage
+.
+TYPO3\Flow\Tests\Unit\Http\ResponseTest::itIsPossibleToSetTheHttpStatusCodeAndMessage
+.
+TYPO3\Flow\Tests\Unit\Http\ResponseTest::makeStandardsCompliantRemovesBodyContentIfStatusCodeImpliesIt
+.
+TYPO3\Flow\Tests\Unit\Http\ResponseTest::makeStandardsCompliantRemovesMaxAgeDireciveIfExpiresHeaderIsPresent
+.
+TYPO3\Flow\Tests\Unit\Http\ResponseTest::makeStandardsCompliantRemovesMaxAgeIfNoCacheExists
+.
+TYPO3\Flow\Tests\Unit\Http\ResponseTest::makeStandardsCompliantRemovesTheContentLengthHeaderIfTransferLengthIsDifferent
+.
+TYPO3\Flow\Tests\Unit\Http\ResponseTest::makeStandardsCompliantReturns304ResponseIfResourceWasNotModified
+.
+TYPO3\Flow\Tests\Unit\Http\ResponseTest::makeStandardsCompliantReturns412StatusIfUnmodifiedSinceDoesNotMatch
+.
+TYPO3\Flow\Tests\Unit\Http\ResponseTest::makeStandardsCompliantSetsAContentLengthHeaderIfNotPresent
+.
+TYPO3\Flow\Tests\Unit\Http\ResponseTest::makeStandardsCompliantSetsBodyAndContentLengthForHeadRequests
+.
+TYPO3\Flow\Tests\Unit\Http\ResponseTest::responseMustContainDateHeaderAndThusHasOneByDefault
+.
+TYPO3\Flow\Tests\Unit\Http\ResponseTest::setAndGetExpiresSetsAndRetrievesTheExpiresHeader
+.
+TYPO3\Flow\Tests\Unit\Http\ResponseTest::setAndGetLastModifiedSetsTheLastModifiedHeader
+.
+TYPO3\Flow\Tests\Unit\Http\ResponseTest::setAndGetMaximumAgeSetsAndReturnsTheMaxAgeCacheControlDirective
+.
+TYPO3\Flow\Tests\Unit\Http\ResponseTest::setAndGetSharedMaximumAgeSetsAndReturnsTheSMaxAgeCacheControlDirective
+.
+TYPO3\Flow\Tests\Unit\Http\ResponseTest::setDateAndGetDateSetAndGetTheDateHeader
+.
+TYPO3\Flow\Tests\Unit\Http\ResponseTest::setNowSetsTheTimeReferenceInGmt
+.
+TYPO3\Flow\Tests\Unit\Http\ResponseTest::setPrivateSetsTheRespectiveCacheControlDirective
+.
+TYPO3\Flow\Tests\Unit\Http\ResponseTest::setPublicSetsTheRespectiveCacheControlDirective
+.
+TYPO3\Flow\Tests\Unit\Http\ResponseTest::setStatusReturnsUnknownStatusMessageOnInvalidCode
+.
+TYPO3\Flow\Tests\Unit\Http\ResponseTest::setStatusThrowsExceptionOnNonNumericCode
+.
+TYPO3\Flow\Tests\Unit\Http\ResponseTest::setterMethodsAreChainable
+.
+TYPO3\Flow\Tests\Unit\Http\ResponseTest::settingVersionHasExpectedImplications
+.
+TYPO3\Flow\Tests\Unit\Http\ResponseTest::startLineEqualsStatusLine
+.
+TYPO3\Flow\Tests\Unit\Http\ResponseTest::theDefaultStatusHeaderIs200OK
+.
+TYPO3\Flow\Tests\Unit\Http\ResponseTest::toStringAlwaysReturnsAStringRepresentationOfContent with data set #0
+.
+TYPO3\Flow\Tests\Unit\Http\ResponseTest::toStringAlwaysReturnsAStringRepresentationOfContent with data set #1
+.
+TYPO3\Flow\Tests\Unit\Http\ResponseTest::toStringAlwaysReturnsAStringRepresentationOfContent with data set #2
+.
+TYPO3\Flow\Tests\Unit\Http\ResponseTest::toStringAlwaysReturnsAStringRepresentationOfContent with data set #3
+.
+TYPO3\Flow\Tests\Unit\Http\ResponseTest::toStringAlwaysReturnsAStringRepresentationOfContent with data set #4
+.
+TYPO3\Flow\Tests\Unit\Http\UriTemplateTest::uriTemplatesAreExpandedCorrectly with data set #0
+.
+TYPO3\Flow\Tests\Unit\Http\UriTemplateTest::uriTemplatesAreExpandedCorrectly with data set #1
+.
+TYPO3\Flow\Tests\Unit\Http\UriTemplateTest::uriTemplatesAreExpandedCorrectly with data set #10
+.
+TYPO3\Flow\Tests\Unit\Http\UriTemplateTest::uriTemplatesAreExpandedCorrectly with data set #11
+.
+TYPO3\Flow\Tests\Unit\Http\UriTemplateTest::uriTemplatesAreExpandedCorrectly with data set #12
+.
+TYPO3\Flow\Tests\Unit\Http\UriTemplateTest::uriTemplatesAreExpandedCorrectly with data set #13
+.
+TYPO3\Flow\Tests\Unit\Http\UriTemplateTest::uriTemplatesAreExpandedCorrectly with data set #14
+.
+TYPO3\Flow\Tests\Unit\Http\UriTemplateTest::uriTemplatesAreExpandedCorrectly with data set #15
+.
+TYPO3\Flow\Tests\Unit\Http\UriTemplateTest::uriTemplatesAreExpandedCorrectly with data set #16
+.
+TYPO3\Flow\Tests\Unit\Http\UriTemplateTest::uriTemplatesAreExpandedCorrectly with data set #17
+.
+TYPO3\Flow\Tests\Unit\Http\UriTemplateTest::uriTemplatesAreExpandedCorrectly with data set #18
+.
+TYPO3\Flow\Tests\Unit\Http\UriTemplateTest::uriTemplatesAreExpandedCorrectly with data set #19
+.
+TYPO3\Flow\Tests\Unit\Http\UriTemplateTest::uriTemplatesAreExpandedCorrectly with data set #2
+.
+TYPO3\Flow\Tests\Unit\Http\UriTemplateTest::uriTemplatesAreExpandedCorrectly with data set #20
+.
+TYPO3\Flow\Tests\Unit\Http\UriTemplateTest::uriTemplatesAreExpandedCorrectly with data set #21
+.
+TYPO3\Flow\Tests\Unit\Http\UriTemplateTest::uriTemplatesAreExpandedCorrectly with data set #22
+.
+TYPO3\Flow\Tests\Unit\Http\UriTemplateTest::uriTemplatesAreExpandedCorrectly with data set #23
+.
+TYPO3\Flow\Tests\Unit\Http\UriTemplateTest::uriTemplatesAreExpandedCorrectly with data set #24
+.
+TYPO3\Flow\Tests\Unit\Http\UriTemplateTest::uriTemplatesAreExpandedCorrectly with data set #25
+.
+TYPO3\Flow\Tests\Unit\Http\UriTemplateTest::uriTemplatesAreExpandedCorrectly with data set #26
+.
+TYPO3\Flow\Tests\Unit\Http\UriTemplateTest::uriTemplatesAreExpandedCorrectly with data set #27
+.
+TYPO3\Flow\Tests\Unit\Http\UriTemplateTest::uriTemplatesAreExpandedCorrectly with data set #28
+.
+TYPO3\Flow\Tests\Unit\Http\UriTemplateTest::uriTemplatesAreExpandedCorrectly with data set #29
+.
+TYPO3\Flow\Tests\Unit\Http\UriTemplateTest::uriTemplatesAreExpandedCorrectly with data set #3
+.
+TYPO3\Flow\Tests\Unit\Http\UriTemplateTest::uriTemplatesAreExpandedCorrectly with data set #30
+.
+TYPO3\Flow\Tests\Unit\Http\UriTemplateTest::uriTemplatesAreExpandedCorrectly with data set #31
+.
+TYPO3\Flow\Tests\Unit\Http\UriTemplateTest::uriTemplatesAreExpandedCorrectly with data set #32
+.
+TYPO3\Flow\Tests\Unit\Http\UriTemplateTest::uriTemplatesAreExpandedCorrectly with data set #33
+.
+TYPO3\Flow\Tests\Unit\Http\UriTemplateTest::uriTemplatesAreExpandedCorrectly with data set #34
+.
+TYPO3\Flow\Tests\Unit\Http\UriTemplateTest::uriTemplatesAreExpandedCorrectly with data set #35
+.
+TYPO3\Flow\Tests\Unit\Http\UriTemplateTest::uriTemplatesAreExpandedCorrectly with data set #36
+.
+TYPO3\Flow\Tests\Unit\Http\UriTemplateTest::uriTemplatesAreExpandedCorrectly with data set #37
+.
+TYPO3\Flow\Tests\Unit\Http\UriTemplateTest::uriTemplatesAreExpandedCorrectly with data set #38
+.
+TYPO3\Flow\Tests\Unit\Http\UriTemplateTest::uriTemplatesAreExpandedCorrectly with data set #39
+.
+TYPO3\Flow\Tests\Unit\Http\UriTemplateTest::uriTemplatesAreExpandedCorrectly with data set #4
+.
+TYPO3\Flow\Tests\Unit\Http\UriTemplateTest::uriTemplatesAreExpandedCorrectly with data set #40
+.
+TYPO3\Flow\Tests\Unit\Http\UriTemplateTest::uriTemplatesAreExpandedCorrectly with data set #41
+.
+TYPO3\Flow\Tests\Unit\Http\UriTemplateTest::uriTemplatesAreExpandedCorrectly with data set #42
+.
+TYPO3\Flow\Tests\Unit\Http\UriTemplateTest::uriTemplatesAreExpandedCorrectly with data set #43
+.
+TYPO3\Flow\Tests\Unit\Http\UriTemplateTest::uriTemplatesAreExpandedCorrectly with data set #44
+.
+TYPO3\Flow\Tests\Unit\Http\UriTemplateTest::uriTemplatesAreExpandedCorrectly with data set #45
+.
+TYPO3\Flow\Tests\Unit\Http\UriTemplateTest::uriTemplatesAreExpandedCorrectly with data set #46
+.
+TYPO3\Flow\Tests\Unit\Http\UriTemplateTest::uriTemplatesAreExpandedCorrectly with data set #47
+.
+TYPO3\Flow\Tests\Unit\Http\UriTemplateTest::uriTemplatesAreExpandedCorrectly with data set #48
+.
+TYPO3\Flow\Tests\Unit\Http\UriTemplateTest::uriTemplatesAreExpandedCorrectly with data set #49
+.
+TYPO3\Flow\Tests\Unit\Http\UriTemplateTest::uriTemplatesAreExpandedCorrectly with data set #5
+.
+TYPO3\Flow\Tests\Unit\Http\UriTemplateTest::uriTemplatesAreExpandedCorrectly with data set #50
+.
+TYPO3\Flow\Tests\Unit\Http\UriTemplateTest::uriTemplatesAreExpandedCorrectly with data set #51
+.
+TYPO3\Flow\Tests\Unit\Http\UriTemplateTest::uriTemplatesAreExpandedCorrectly with data set #52
+.
+TYPO3\Flow\Tests\Unit\Http\UriTemplateTest::uriTemplatesAreExpandedCorrectly with data set #53
+.
+TYPO3\Flow\Tests\Unit\Http\UriTemplateTest::uriTemplatesAreExpandedCorrectly with data set #54
+.
+TYPO3\Flow\Tests\Unit\Http\UriTemplateTest::uriTemplatesAreExpandedCorrectly with data set #55
+.
+TYPO3\Flow\Tests\Unit\Http\UriTemplateTest::uriTemplatesAreExpandedCorrectly with data set #56
+.
+TYPO3\Flow\Tests\Unit\Http\UriTemplateTest::uriTemplatesAreExpandedCorrectly with data set #57
+.
+TYPO3\Flow\Tests\Unit\Http\UriTemplateTest::uriTemplatesAreExpandedCorrectly with data set #58
+.
+TYPO3\Flow\Tests\Unit\Http\UriTemplateTest::uriTemplatesAreExpandedCorrectly with data set #59
+.
+TYPO3\Flow\Tests\Unit\Http\UriTemplateTest::uriTemplatesAreExpandedCorrectly with data set #6
+.
+TYPO3\Flow\Tests\Unit\Http\UriTemplateTest::uriTemplatesAreExpandedCorrectly with data set #60
+.
+TYPO3\Flow\Tests\Unit\Http\UriTemplateTest::uriTemplatesAreExpandedCorrectly with data set #61
+.
+TYPO3\Flow\Tests\Unit\Http\UriTemplateTest::uriTemplatesAreExpandedCorrectly with data set #62
+.
+TYPO3\Flow\Tests\Unit\Http\UriTemplateTest::uriTemplatesAreExpandedCorrectly with data set #63
+.
+TYPO3\Flow\Tests\Unit\Http\UriTemplateTest::uriTemplatesAreExpandedCorrectly with data set #64
+.
+TYPO3\Flow\Tests\Unit\Http\UriTemplateTest::uriTemplatesAreExpandedCorrectly with data set #65
+.
+TYPO3\Flow\Tests\Unit\Http\UriTemplateTest::uriTemplatesAreExpandedCorrectly with data set #66
+.
+TYPO3\Flow\Tests\Unit\Http\UriTemplateTest::uriTemplatesAreExpandedCorrectly with data set #67
+.
+TYPO3\Flow\Tests\Unit\Http\UriTemplateTest::uriTemplatesAreExpandedCorrectly with data set #68
+.
+TYPO3\Flow\Tests\Unit\Http\UriTemplateTest::uriTemplatesAreExpandedCorrectly with data set #69
+.
+TYPO3\Flow\Tests\Unit\Http\UriTemplateTest::uriTemplatesAreExpandedCorrectly with data set #7
+.
+TYPO3\Flow\Tests\Unit\Http\UriTemplateTest::uriTemplatesAreExpandedCorrectly with data set #70
+.
+TYPO3\Flow\Tests\Unit\Http\UriTemplateTest::uriTemplatesAreExpandedCorrectly with data set #71
+.
+TYPO3\Flow\Tests\Unit\Http\UriTemplateTest::uriTemplatesAreExpandedCorrectly with data set #72
+.
+TYPO3\Flow\Tests\Unit\Http\UriTemplateTest::uriTemplatesAreExpandedCorrectly with data set #73
+.
+TYPO3\Flow\Tests\Unit\Http\UriTemplateTest::uriTemplatesAreExpandedCorrectly with data set #74
+.
+TYPO3\Flow\Tests\Unit\Http\UriTemplateTest::uriTemplatesAreExpandedCorrectly with data set #75
+.
+TYPO3\Flow\Tests\Unit\Http\UriTemplateTest::uriTemplatesAreExpandedCorrectly with data set #8
+.
+TYPO3\Flow\Tests\Unit\Http\UriTemplateTest::uriTemplatesAreExpandedCorrectly with data set #9
+.
+TYPO3\Flow\Tests\Unit\Http\UriTest::constructingWithNotAStringThrowsException
+.
+TYPO3\Flow\Tests\Unit\Http\UriTest::constructorParsesAFullBlownUriStringCorrectly
+.
+TYPO3\Flow\Tests\Unit\Http\UriTest::constructorParsesArgumentsWithSpecialCharactersCorrectly
+.
+TYPO3\Flow\Tests\Unit\Http\UriTest::constructorParsesHostCorrectly with data set #0
+.
+TYPO3\Flow\Tests\Unit\Http\UriTest::constructorParsesHostCorrectly with data set #1
+.
+TYPO3\Flow\Tests\Unit\Http\UriTest::settingInvalidHostThrowsException
+.
+TYPO3\Flow\Tests\Unit\Http\UriTest::settingSchemeAndHostOnUriDoesNotConfuseToString
+.
+TYPO3\Flow\Tests\Unit\Http\UriTest::settingValidHostPassesRegexCheck with data set #0
+.
+TYPO3\Flow\Tests\Unit\Http\UriTest::settingValidHostPassesRegexCheck with data set #1
+.
+TYPO3\Flow\Tests\Unit\Http\UriTest::stringRepresentationIsCorrect
+.
+TYPO3\Flow\Tests\Unit\Http\UriTest::toStringOmitsStandardPorts
+.
+TYPO3\Flow\Tests\Unit\Http\UriTest::unparsableUriStringThrowsException
+.
+TYPO3\Flow\Tests\Unit\Http\UriTest::urisCanBeConvertedForthAndBackWithoutLoss with data set #0
+.
+TYPO3\Flow\Tests\Unit\Http\UriTest::urisCanBeConvertedForthAndBackWithoutLoss with data set #1
+.
+TYPO3\Flow\Tests\Unit\Http\UriTest::urisCanBeConvertedForthAndBackWithoutLoss with data set #2
+.
+TYPO3\Flow\Tests\Unit\Http\UriTest::urisCanBeConvertedForthAndBackWithoutLoss with data set #3
+.
+TYPO3\Flow\Tests\Unit\Http\UriTest::urisCanBeConvertedForthAndBackWithoutLoss with data set #4
+.
+TYPO3\Flow\Tests\Unit\Http\UriTest::urisCanBeConvertedForthAndBackWithoutLoss with data set #5
+.
+TYPO3\Flow\Tests\Unit\I18n\AbstractXmlParserTest::invokesDoParsingFromRootMethodForActualParsing
+.
+TYPO3\Flow\Tests\Unit\I18n\AbstractXmlParserTest::throwsExceptionWhenBadFilenameGiven
+.
+TYPO3\Flow\Tests\Unit\I18n\Cldr\CldrModelTest::getRawArrayAlwaysReturnsArrayOrFalse
+.
+TYPO3\Flow\Tests\Unit\I18n\Cldr\CldrModelTest::mergesMultipleFilesAndResolvesAliasesCorrectly
+.
+TYPO3\Flow\Tests\Unit\I18n\Cldr\CldrModelTest::returnsAttributeValueCorrectly
+.
+TYPO3\Flow\Tests\Unit\I18n\Cldr\CldrModelTest::returnsElementCorrectly
+.
+TYPO3\Flow\Tests\Unit\I18n\Cldr\CldrModelTest::returnsNodeNameCorrectly
+.
+TYPO3\Flow\Tests\Unit\I18n\Cldr\CldrModelTest::returnsRawArrayCorrectly
+.
+TYPO3\Flow\Tests\Unit\I18n\Cldr\CldrParserTest::parsesCldrDataCorrectly
+.
+TYPO3\Flow\Tests\Unit\I18n\Cldr\CldrRepositoryTest::modelIsReturnedCorrectlyForGroupOfFiles
+.
+TYPO3\Flow\Tests\Unit\I18n\Cldr\CldrRepositoryTest::modelIsReturnedCorrectlyForSingleFile
+.
+TYPO3\Flow\Tests\Unit\I18n\Cldr\Reader\DatesReaderTest::dateTimeFormatIsParsedCorrectly
+.
+TYPO3\Flow\Tests\Unit\I18n\Cldr\Reader\DatesReaderTest::formatIsCorrectlyReadFromCldr
+.
+TYPO3\Flow\Tests\Unit\I18n\Cldr\Reader\DatesReaderTest::formatStringsAreParsedCorrectly with data set #0
+.
+TYPO3\Flow\Tests\Unit\I18n\Cldr\Reader\DatesReaderTest::formatStringsAreParsedCorrectly with data set #1
+.
+TYPO3\Flow\Tests\Unit\I18n\Cldr\Reader\DatesReaderTest::formatStringsAreParsedCorrectly with data set #2
+.
+TYPO3\Flow\Tests\Unit\I18n\Cldr\Reader\DatesReaderTest::formatStringsAreParsedCorrectly with data set #3
+.
+TYPO3\Flow\Tests\Unit\I18n\Cldr\Reader\DatesReaderTest::formatStringsAreParsedCorrectly with data set #4
+.
+TYPO3\Flow\Tests\Unit\I18n\Cldr\Reader\DatesReaderTest::formatStringsAreParsedCorrectly with data set #5
+.
+TYPO3\Flow\Tests\Unit\I18n\Cldr\Reader\DatesReaderTest::formatStringsAreParsedCorrectly with data set #6
+.
+TYPO3\Flow\Tests\Unit\I18n\Cldr\Reader\DatesReaderTest::localizedLiteralsAreCorrectlyReadFromCldr
+.
+TYPO3\Flow\Tests\Unit\I18n\Cldr\Reader\NumbersReaderTest::formatIsCorrectlyReadFromCldr
+.
+TYPO3\Flow\Tests\Unit\I18n\Cldr\Reader\NumbersReaderTest::formatStringsAreParsedCorrectly with data set #0
+.
+TYPO3\Flow\Tests\Unit\I18n\Cldr\Reader\NumbersReaderTest::formatStringsAreParsedCorrectly with data set #1
+.
+TYPO3\Flow\Tests\Unit\I18n\Cldr\Reader\NumbersReaderTest::formatStringsAreParsedCorrectly with data set #2
+.
+TYPO3\Flow\Tests\Unit\I18n\Cldr\Reader\NumbersReaderTest::formatStringsAreParsedCorrectly with data set #3
+.
+TYPO3\Flow\Tests\Unit\I18n\Cldr\Reader\NumbersReaderTest::throwsExceptionWhenUnsupportedFormatsEncountered with data set #0
+.
+TYPO3\Flow\Tests\Unit\I18n\Cldr\Reader\NumbersReaderTest::throwsExceptionWhenUnsupportedFormatsEncountered with data set #1
+.
+TYPO3\Flow\Tests\Unit\I18n\Cldr\Reader\NumbersReaderTest::throwsExceptionWhenUnsupportedFormatsEncountered with data set #2
+.
+TYPO3\Flow\Tests\Unit\I18n\Cldr\Reader\NumbersReaderTest::throwsExceptionWhenUnsupportedFormatsEncountered with data set #3
+.
+TYPO3\Flow\Tests\Unit\I18n\Cldr\Reader\PluralsReaderTest::returnsCorrectPluralForm with data set #0
+.
+TYPO3\Flow\Tests\Unit\I18n\Cldr\Reader\PluralsReaderTest::returnsCorrectPluralForm with data set #1
+.
+TYPO3\Flow\Tests\Unit\I18n\Cldr\Reader\PluralsReaderTest::returnsCorrectPluralForm with data set #2
+.
+TYPO3\Flow\Tests\Unit\I18n\Cldr\Reader\PluralsReaderTest::returnsCorrectPluralForm with data set #3
+.
+TYPO3\Flow\Tests\Unit\I18n\Cldr\Reader\PluralsReaderTest::returnsCorrectPluralForm with data set #4
+.
+TYPO3\Flow\Tests\Unit\I18n\DetectorTest::detectingBestMatchingLocaleFromHttpAcceptLanguageHeaderWorksCorrectly with data set #0
+.
+TYPO3\Flow\Tests\Unit\I18n\DetectorTest::detectingBestMatchingLocaleFromHttpAcceptLanguageHeaderWorksCorrectly with data set #1
+.
+TYPO3\Flow\Tests\Unit\I18n\DetectorTest::detectingBestMatchingLocaleFromHttpAcceptLanguageHeaderWorksCorrectly with data set #2
+.
+TYPO3\Flow\Tests\Unit\I18n\DetectorTest::detectingBestMatchingLocaleFromLocaleIdentifierWorksCorrectly with data set #0
+.
+TYPO3\Flow\Tests\Unit\I18n\DetectorTest::detectingBestMatchingLocaleFromLocaleIdentifierWorksCorrectly with data set #1
+.
+TYPO3\Flow\Tests\Unit\I18n\DetectorTest::detectingBestMatchingLocaleFromLocaleIdentifierWorksCorrectly with data set #2
+.
+TYPO3\Flow\Tests\Unit\I18n\FormatResolverTest::fullyQualifiedFormatterIsCorrectlyBeingUsed
+.
+TYPO3\Flow\Tests\Unit\I18n\FormatResolverTest::fullyQualifiedFormatterWithLowercaseVendorNameIsCorrectlyBeingUsed
+.
+TYPO3\Flow\Tests\Unit\I18n\FormatResolverTest::namedPlaceholdersAreResolvedCorrectly
+.
+TYPO3\Flow\Tests\Unit\I18n\FormatResolverTest::placeholdersAreResolvedCorrectly
+.
+TYPO3\Flow\Tests\Unit\I18n\FormatResolverTest::returnsStringCastedArgumentWhenFormatterNameIsNotSet
+.
+TYPO3\Flow\Tests\Unit\I18n\FormatResolverTest::throwsExceptionWhenFormatterDoesNotExist
+.
+TYPO3\Flow\Tests\Unit\I18n\FormatResolverTest::throwsExceptionWhenFormatterDoesNotImplementFormatterInterface
+.
+TYPO3\Flow\Tests\Unit\I18n\FormatResolverTest::throwsExceptionWhenInsufficientNumberOfArgumentsProvided
+.
+TYPO3\Flow\Tests\Unit\I18n\FormatResolverTest::throwsExceptionWhenInvalidPlaceholderEncountered
+.
+TYPO3\Flow\Tests\Unit\I18n\Formatter\DatetimeFormatterTest::formatMethodsAreChoosenCorrectly
+.
+TYPO3\Flow\Tests\Unit\I18n\Formatter\DatetimeFormatterTest::formattingUsingCustomPatternWorks with data set #0
+.
+TYPO3\Flow\Tests\Unit\I18n\Formatter\DatetimeFormatterTest::parsedFormatsAreUsedCorrectly with data set #0
+.
+TYPO3\Flow\Tests\Unit\I18n\Formatter\DatetimeFormatterTest::parsedFormatsAreUsedCorrectly with data set #1
+.
+TYPO3\Flow\Tests\Unit\I18n\Formatter\DatetimeFormatterTest::parsedFormatsAreUsedCorrectly with data set #2
+.
+TYPO3\Flow\Tests\Unit\I18n\Formatter\DatetimeFormatterTest::parsedFormatsAreUsedCorrectly with data set #3
+.
+TYPO3\Flow\Tests\Unit\I18n\Formatter\DatetimeFormatterTest::parsedFormatsAreUsedCorrectly with data set #4
+.
+TYPO3\Flow\Tests\Unit\I18n\Formatter\DatetimeFormatterTest::parsedFormatsAreUsedCorrectly with data set #5
+.
+TYPO3\Flow\Tests\Unit\I18n\Formatter\DatetimeFormatterTest::parsedFormatsAreUsedCorrectly with data set #6
+.
+TYPO3\Flow\Tests\Unit\I18n\Formatter\DatetimeFormatterTest::specificFormattingMethodsWork with data set #0
+.
+TYPO3\Flow\Tests\Unit\I18n\Formatter\DatetimeFormatterTest::specificFormattingMethodsWork with data set #1
+.
+TYPO3\Flow\Tests\Unit\I18n\Formatter\DatetimeFormatterTest::specificFormattingMethodsWork with data set #2
+.
+TYPO3\Flow\Tests\Unit\I18n\Formatter\NumberFormatterTest::formatMethodsAreChoosenCorrectly
+.
+TYPO3\Flow\Tests\Unit\I18n\Formatter\NumberFormatterTest::formattingUsingCustomPatternWorks with data set #0
+.
+TYPO3\Flow\Tests\Unit\I18n\Formatter\NumberFormatterTest::formattingUsingCustomPatternWorks with data set #1
+.
+TYPO3\Flow\Tests\Unit\I18n\Formatter\NumberFormatterTest::formattingUsingCustomPatternWorks with data set #2
+.
+TYPO3\Flow\Tests\Unit\I18n\Formatter\NumberFormatterTest::parsedFormatsAreUsedCorrectly with data set #0
+.
+TYPO3\Flow\Tests\Unit\I18n\Formatter\NumberFormatterTest::parsedFormatsAreUsedCorrectly with data set #1
+.
+TYPO3\Flow\Tests\Unit\I18n\Formatter\NumberFormatterTest::parsedFormatsAreUsedCorrectly with data set #2
+.
+TYPO3\Flow\Tests\Unit\I18n\Formatter\NumberFormatterTest::specificFormattingMethodsWork with data set #0
+.
+TYPO3\Flow\Tests\Unit\I18n\Formatter\NumberFormatterTest::specificFormattingMethodsWork with data set #1
+.
+TYPO3\Flow\Tests\Unit\I18n\Formatter\NumberFormatterTest::specificFormattingMethodsWork with data set #2
+.
+TYPO3\Flow\Tests\Unit\I18n\Formatter\NumberFormatterTest::specificFormattingMethodsWork with data set #3
+.
+TYPO3\Flow\Tests\Unit\I18n\Formatter\NumberFormatterTest::specificFormattingMethodsWork with data set #4
+.
+TYPO3\Flow\Tests\Unit\I18n\Formatter\NumberFormatterTest::specificFormattingMethodsWork with data set #5
+.
+TYPO3\Flow\Tests\Unit\I18n\LocaleCollectionTest::bestMatchingLocalesAreFoundCorrectly
+.
+TYPO3\Flow\Tests\Unit\I18n\LocaleCollectionTest::existingLocaleIsNotAddedToTheCollection
+.
+TYPO3\Flow\Tests\Unit\I18n\LocaleCollectionTest::localesAreAddedToTheCollectionCorrectlyWithHierarchyRelation
+.
+TYPO3\Flow\Tests\Unit\I18n\LocaleCollectionTest::returnsNullWhenNoParentLocaleCouldBeFound
+.
+TYPO3\Flow\Tests\Unit\I18n\LocaleTest::producesCorrectLocaleIdentifierWhenStringCasted
+.
+TYPO3\Flow\Tests\Unit\I18n\LocaleTest::theConstructorRecognizesTheMostImportantValidLocaleIdentifiers
+.
+TYPO3\Flow\Tests\Unit\I18n\LocaleTest::theConstructorThrowsAnExceptionOnPassingAInvalidLocaleIdentifiers with data set #0
+.
+TYPO3\Flow\Tests\Unit\I18n\LocaleTest::theConstructorThrowsAnExceptionOnPassingAInvalidLocaleIdentifiers with data set #1
+.
+TYPO3\Flow\Tests\Unit\I18n\LocaleTest::theConstructorThrowsAnExceptionOnPassingAInvalidLocaleIdentifiers with data set #2
+.
+TYPO3\Flow\Tests\Unit\I18n\LocaleTypeConverterTest::canConvertFromShouldReturnTrue
+.
+TYPO3\Flow\Tests\Unit\I18n\LocaleTypeConverterTest::checkMetadata
+.
+TYPO3\Flow\Tests\Unit\I18n\LocaleTypeConverterTest::convertFromShouldReturnLocale
+.
+TYPO3\Flow\Tests\Unit\I18n\LocaleTypeConverterTest::getSourceChildPropertiesToBeConvertedShouldReturnEmptyArray
+.
+TYPO3\Flow\Tests\Unit\I18n\Parser\DatetimeParserTest::lenientParsingWorksCorrectlyForEasyDatetimes with data set #0
+.
+TYPO3\Flow\Tests\Unit\I18n\Parser\DatetimeParserTest::lenientParsingWorksCorrectlyForEasyDatetimes with data set #1
+.
+TYPO3\Flow\Tests\Unit\I18n\Parser\DatetimeParserTest::lenientParsingWorksCorrectlyForEasyDatetimes with data set #2
+.
+TYPO3\Flow\Tests\Unit\I18n\Parser\DatetimeParserTest::lenientParsingWorksCorrectlyForHardDatetimes with data set #0
+.
+TYPO3\Flow\Tests\Unit\I18n\Parser\DatetimeParserTest::lenientParsingWorksCorrectlyForHardDatetimes with data set #1
+.
+TYPO3\Flow\Tests\Unit\I18n\Parser\DatetimeParserTest::lenientParsingWorksCorrectlyForHardDatetimes with data set #2
+.
+TYPO3\Flow\Tests\Unit\I18n\Parser\DatetimeParserTest::strictParsingReturnsFalseForHardDatetimes with data set #0
+.
+TYPO3\Flow\Tests\Unit\I18n\Parser\DatetimeParserTest::strictParsingReturnsFalseForHardDatetimes with data set #1
+.
+TYPO3\Flow\Tests\Unit\I18n\Parser\DatetimeParserTest::strictParsingReturnsFalseForHardDatetimes with data set #2
+.
+TYPO3\Flow\Tests\Unit\I18n\Parser\DatetimeParserTest::strictParsingWorksCorrectlyForEasyDatetimes with data set #0
+.
+TYPO3\Flow\Tests\Unit\I18n\Parser\DatetimeParserTest::strictParsingWorksCorrectlyForEasyDatetimes with data set #1
+.
+TYPO3\Flow\Tests\Unit\I18n\Parser\DatetimeParserTest::strictParsingWorksCorrectlyForEasyDatetimes with data set #2
+.
+TYPO3\Flow\Tests\Unit\I18n\Parser\NumberParserTest::lenientParsingWorksCorrectlyForEasyNumbers with data set #0
+.
+TYPO3\Flow\Tests\Unit\I18n\Parser\NumberParserTest::lenientParsingWorksCorrectlyForEasyNumbers with data set #1
+.
+TYPO3\Flow\Tests\Unit\I18n\Parser\NumberParserTest::lenientParsingWorksCorrectlyForEasyNumbers with data set #2
+.
+TYPO3\Flow\Tests\Unit\I18n\Parser\NumberParserTest::lenientParsingWorksCorrectlyForEasyNumbers with data set #3
+.
+TYPO3\Flow\Tests\Unit\I18n\Parser\NumberParserTest::lenientParsingWorksCorrectlyForEasyNumbers with data set #4
+.
+TYPO3\Flow\Tests\Unit\I18n\Parser\NumberParserTest::lenientParsingWorksCorrectlyForEasyNumbers with data set #5
+.
+TYPO3\Flow\Tests\Unit\I18n\Parser\NumberParserTest::lenientParsingWorksCorrectlyForEasyNumbers with data set #6
+.
+TYPO3\Flow\Tests\Unit\I18n\Parser\NumberParserTest::lenientParsingWorksCorrectlyForEasyNumbers with data set #7
+.
+TYPO3\Flow\Tests\Unit\I18n\Parser\NumberParserTest::lenientParsingWorksCorrectlyForHardNumbers with data set #0
+.
+TYPO3\Flow\Tests\Unit\I18n\Parser\NumberParserTest::lenientParsingWorksCorrectlyForHardNumbers with data set #1
+.
+TYPO3\Flow\Tests\Unit\I18n\Parser\NumberParserTest::lenientParsingWorksCorrectlyForHardNumbers with data set #2
+.
+TYPO3\Flow\Tests\Unit\I18n\Parser\NumberParserTest::lenientParsingWorksCorrectlyForHardNumbers with data set #3
+.
+TYPO3\Flow\Tests\Unit\I18n\Parser\NumberParserTest::parsingUsingCustomPatternWorks with data set #0
+.
+TYPO3\Flow\Tests\Unit\I18n\Parser\NumberParserTest::parsingUsingCustomPatternWorks with data set #1
+.
+TYPO3\Flow\Tests\Unit\I18n\Parser\NumberParserTest::parsingUsingCustomPatternWorks with data set #2
+.
+TYPO3\Flow\Tests\Unit\I18n\Parser\NumberParserTest::parsingUsingCustomPatternWorks with data set #3
+.
+TYPO3\Flow\Tests\Unit\I18n\Parser\NumberParserTest::parsingUsingCustomPatternWorks with data set #4
+.
+TYPO3\Flow\Tests\Unit\I18n\Parser\NumberParserTest::parsingUsingCustomPatternWorks with data set #5
+.
+TYPO3\Flow\Tests\Unit\I18n\Parser\NumberParserTest::parsingUsingCustomPatternWorks with data set #6
+.
+TYPO3\Flow\Tests\Unit\I18n\Parser\NumberParserTest::parsingUsingCustomPatternWorks with data set #7
+.
+TYPO3\Flow\Tests\Unit\I18n\Parser\NumberParserTest::specificFormattingMethodsWork with data set #0
+.
+TYPO3\Flow\Tests\Unit\I18n\Parser\NumberParserTest::specificFormattingMethodsWork with data set #1
+.
+TYPO3\Flow\Tests\Unit\I18n\Parser\NumberParserTest::specificFormattingMethodsWork with data set #2
+.
+TYPO3\Flow\Tests\Unit\I18n\Parser\NumberParserTest::specificFormattingMethodsWork with data set #3
+.
+TYPO3\Flow\Tests\Unit\I18n\Parser\NumberParserTest::specificFormattingMethodsWork with data set #4
+.
+TYPO3\Flow\Tests\Unit\I18n\Parser\NumberParserTest::specificFormattingMethodsWork with data set #5
+.
+TYPO3\Flow\Tests\Unit\I18n\Parser\NumberParserTest::specificFormattingMethodsWork with data set #6
+.
+TYPO3\Flow\Tests\Unit\I18n\Parser\NumberParserTest::specificFormattingMethodsWork with data set #7
+.
+TYPO3\Flow\Tests\Unit\I18n\Parser\NumberParserTest::strictParsingReturnsFalseForHardNumbers with data set #0
+.
+TYPO3\Flow\Tests\Unit\I18n\Parser\NumberParserTest::strictParsingReturnsFalseForHardNumbers with data set #1
+.
+TYPO3\Flow\Tests\Unit\I18n\Parser\NumberParserTest::strictParsingReturnsFalseForHardNumbers with data set #2
+.
+TYPO3\Flow\Tests\Unit\I18n\Parser\NumberParserTest::strictParsingReturnsFalseForHardNumbers with data set #3
+.
+TYPO3\Flow\Tests\Unit\I18n\Parser\NumberParserTest::strictParsingWorksCorrectlyForEasyNumbers with data set #0
+.
+TYPO3\Flow\Tests\Unit\I18n\Parser\NumberParserTest::strictParsingWorksCorrectlyForEasyNumbers with data set #1
+.
+TYPO3\Flow\Tests\Unit\I18n\Parser\NumberParserTest::strictParsingWorksCorrectlyForEasyNumbers with data set #2
+.
+TYPO3\Flow\Tests\Unit\I18n\Parser\NumberParserTest::strictParsingWorksCorrectlyForEasyNumbers with data set #3
+.
+TYPO3\Flow\Tests\Unit\I18n\Parser\NumberParserTest::strictParsingWorksCorrectlyForEasyNumbers with data set #4
+.
+TYPO3\Flow\Tests\Unit\I18n\Parser\NumberParserTest::strictParsingWorksCorrectlyForEasyNumbers with data set #5
+.
+TYPO3\Flow\Tests\Unit\I18n\Parser\NumberParserTest::strictParsingWorksCorrectlyForEasyNumbers with data set #6
+.
+TYPO3\Flow\Tests\Unit\I18n\Parser\NumberParserTest::strictParsingWorksCorrectlyForEasyNumbers with data set #7
+.
+TYPO3\Flow\Tests\Unit\I18n\ServiceTest::getLocalizedFilenameIgnoresDotsInFilePath
+.
+TYPO3\Flow\Tests\Unit\I18n\ServiceTest::getLocalizedFilenameReturnsCorrectFilenameIfExtensionIsMissing
+.
+TYPO3\Flow\Tests\Unit\I18n\ServiceTest::getLocalizedFilenameReturnsCorrectFilenameInStrictMode
+.
+TYPO3\Flow\Tests\Unit\I18n\ServiceTest::getLocalizedFilenameReturnsCorrectlyLocalizedFilename
+.
+TYPO3\Flow\Tests\Unit\I18n\ServiceTest::getLocalizedFilenameReturnsOriginalFilenameIfNoLocalizedFileExists
+.
+TYPO3\Flow\Tests\Unit\I18n\ServiceTest::getLocalizedFilenameReturnsOriginalFilenameInStrictModeIfNoLocalizedFileExists
+.
+TYPO3\Flow\Tests\Unit\I18n\ServiceTest::initializeCorrectlyGeneratesAvailableLocales
+.
+TYPO3\Flow\Tests\Unit\I18n\TranslationProvider\XliffTranslationProviderTest::getModelSetsCorrectLocaleInModel
+.
+TYPO3\Flow\Tests\Unit\I18n\TranslationProvider\XliffTranslationProviderTest::getTranslationByIdThrowsExceptionWhenInvalidPluralFormProvided
+.
+TYPO3\Flow\Tests\Unit\I18n\TranslationProvider\XliffTranslationProviderTest::getTranslationByOriginalLabelThrowsExceptionWhenInvalidPluralFormProvided
+.
+TYPO3\Flow\Tests\Unit\I18n\TranslationProvider\XliffTranslationProviderTest::returnsTranslatedLabelWhenLabelIdProvided
+.
+TYPO3\Flow\Tests\Unit\I18n\TranslationProvider\XliffTranslationProviderTest::returnsTranslatedLabelWhenOriginalLabelProvided
+.
+TYPO3\Flow\Tests\Unit\I18n\TranslatorTest::returnsIdWhenTranslationNotAvailable
+.
+TYPO3\Flow\Tests\Unit\I18n\TranslatorTest::returnsOriginalLabelWhenTranslationNotAvailable
+.
+TYPO3\Flow\Tests\Unit\I18n\TranslatorTest::translateByIdReturnsTranslationIfOneNumericArgumentIsGiven
+.
+TYPO3\Flow\Tests\Unit\I18n\TranslatorTest::translateByIdReturnsTranslationWhenNoArgumentsAreGiven
+.
+TYPO3\Flow\Tests\Unit\I18n\TranslatorTest::translateByOriginalLabelReturnsTranslationIfOneNumericArgumentIsGiven
+.
+TYPO3\Flow\Tests\Unit\I18n\TranslatorTest::translatingIsDoneCorrectly
+.
+TYPO3\Flow\Tests\Unit\I18n\UtilityTest::httpAcceptLanguageHeadersAreParsedCorrectly with data set #0
+.
+TYPO3\Flow\Tests\Unit\I18n\UtilityTest::httpAcceptLanguageHeadersAreParsedCorrectly with data set #1
+.
+TYPO3\Flow\Tests\Unit\I18n\UtilityTest::httpAcceptLanguageHeadersAreParsedCorrectly with data set #2
+.
+TYPO3\Flow\Tests\Unit\I18n\UtilityTest::httpAcceptLanguageHeadersAreParsedCorrectly with data set #3
+.
+TYPO3\Flow\Tests\Unit\I18n\UtilityTest::localeIdentifiersAreCorrectlyExtractedFromFilename with data set #0
+.
+TYPO3\Flow\Tests\Unit\I18n\UtilityTest::localeIdentifiersAreCorrectlyExtractedFromFilename with data set #1
+.
+TYPO3\Flow\Tests\Unit\I18n\UtilityTest::localeIdentifiersAreCorrectlyExtractedFromFilename with data set #2
+.
+TYPO3\Flow\Tests\Unit\I18n\UtilityTest::localeIdentifiersAreCorrectlyExtractedFromFilename with data set #3
+.
+TYPO3\Flow\Tests\Unit\I18n\UtilityTest::localeIdentifiersAreCorrectlyExtractedFromFilename with data set #4
+.
+TYPO3\Flow\Tests\Unit\I18n\UtilityTest::localeIdentifiersAreCorrectlyExtractedFromFilename with data set #5
+.
+TYPO3\Flow\Tests\Unit\I18n\UtilityTest::localeIdentifiersAreCorrectlyExtractedFromFilename with data set #6
+.
+TYPO3\Flow\Tests\Unit\I18n\UtilityTest::stringIsFoundAtBeginningOfAnotherString with data set #0
+.
+TYPO3\Flow\Tests\Unit\I18n\UtilityTest::stringIsFoundAtBeginningOfAnotherString with data set #1
+.
+TYPO3\Flow\Tests\Unit\I18n\UtilityTest::stringIsFoundAtBeginningOfAnotherString with data set #2
+.
+TYPO3\Flow\Tests\Unit\I18n\UtilityTest::stringIsFoundAtBeginningOfAnotherString with data set #3
+.
+TYPO3\Flow\Tests\Unit\I18n\UtilityTest::stringIsFoundAtBeginningOfAnotherString with data set #4
+.
+TYPO3\Flow\Tests\Unit\I18n\UtilityTest::stringIsFoundAtEndingOfAnotherString with data set #0
+.
+TYPO3\Flow\Tests\Unit\I18n\UtilityTest::stringIsFoundAtEndingOfAnotherString with data set #1
+.
+TYPO3\Flow\Tests\Unit\I18n\UtilityTest::stringIsFoundAtEndingOfAnotherString with data set #2
+.
+TYPO3\Flow\Tests\Unit\I18n\UtilityTest::stringIsFoundAtEndingOfAnotherString with data set #3
+.
+TYPO3\Flow\Tests\Unit\I18n\UtilityTest::stringIsFoundAtEndingOfAnotherString with data set #4
+.
+TYPO3\Flow\Tests\Unit\I18n\Xliff\XliffModelTest::getTargetBySourceLogsSilentlyIfNoTransUnitsArePresent
+.
+TYPO3\Flow\Tests\Unit\I18n\Xliff\XliffModelTest::sourceIsReturnedWhenIdProvidedAndSourceEqualsTargetLanguage
+.
+TYPO3\Flow\Tests\Unit\I18n\Xliff\XliffModelTest::targetIsReturnedCorrectlyWhenIdProvided
+.
+TYPO3\Flow\Tests\Unit\I18n\Xliff\XliffModelTest::targetIsReturnedCorrectlyWhenSourceProvided
+.
+TYPO3\Flow\Tests\Unit\I18n\Xliff\XliffParserTest::missingIdInPluralTransUnitCausesException
+.
+TYPO3\Flow\Tests\Unit\I18n\Xliff\XliffParserTest::missingIdInSingularTransUnitCausesException
+.
+TYPO3\Flow\Tests\Unit\I18n\Xliff\XliffParserTest::parsesXliffFileCorrectly
+.
+TYPO3\Flow\Tests\Unit\Log\Backend\AbstractBackendTest::theConstructorCallsSetterMethodsForAllSpecifiedOptions
+.
+TYPO3\Flow\Tests\Unit\Log\Backend\FileBackendTest::appendIgnoresMessagesAboveTheSeverityThreshold
+.
+TYPO3\Flow\Tests\Unit\Log\Backend\FileBackendTest::appendRendersALogEntryAndAppendsItToTheLogfile
+.
+TYPO3\Flow\Tests\Unit\Log\Backend\FileBackendTest::appendRendersALogEntryWithRemoteIpAddressAndAppendsItToTheLogfile
+.
+TYPO3\Flow\Tests\Unit\Log\Backend\FileBackendTest::logFileIsRotatedIfMaximumSizeIsExceeded
+S
+TYPO3\Flow\Tests\Unit\Log\Backend\FileBackendTest::openCreatesParentDirectoriesIfTheOptionSaysSo
+.
+TYPO3\Flow\Tests\Unit\Log\Backend\FileBackendTest::openDoesNotCreateParentDirectoriesByDefault
+.
+TYPO3\Flow\Tests\Unit\Log\Backend\FileBackendTest::theLogFileIsOpenedWithOpen
+.
+TYPO3\Flow\Tests\Unit\Log\LoggerTest::addBackendAllowsForAddingMultipleBackends
+.
+TYPO3\Flow\Tests\Unit\Log\LoggerTest::addBackendRunsTheBackendsOpenMethod
+.
+TYPO3\Flow\Tests\Unit\Log\LoggerTest::logPassesItsArgumentsToTheBackendsAppendMethod
+.
+TYPO3\Flow\Tests\Unit\Log\LoggerTest::removeBackendRunsTheBackendsCloseMethodAndRemovesItFromTheLogger
+.
+TYPO3\Flow\Tests\Unit\Log\LoggerTest::removeThrowsAnExceptionOnTryingToRemoveABackendNotPreviouslyAdded
+.
+TYPO3\Flow\Tests\Unit\Log\LoggerTest::theShutdownMethodRunsCloseOnAllRegisteredBackends
+.
+TYPO3\Flow\Tests\Unit\Monitor\ChangeDetectionStrategy\ModificationTimeStrategyTest::getFileStatusDetectsADeletedFile
+.
+TYPO3\Flow\Tests\Unit\Monitor\ChangeDetectionStrategy\ModificationTimeStrategyTest::getFileStatusDetectsANewlyCreatedFile
+.
+TYPO3\Flow\Tests\Unit\Monitor\ChangeDetectionStrategy\ModificationTimeStrategyTest::getFileStatusReturnsStatusChangedIfTheFileExistedEarlierButTheModificationTimeHasChangedSinceThen
+.
+TYPO3\Flow\Tests\Unit\Monitor\ChangeDetectionStrategy\ModificationTimeStrategyTest::getFileStatusReturnsStatusUnchangedIfFileDoesNotExistAndDidNotExistEarlier
+.
+TYPO3\Flow\Tests\Unit\Monitor\ChangeDetectionStrategy\ModificationTimeStrategyTest::getFileStatusReturnsStatusUnchangedIfFileExistedAndTheModificationTimeDidNotChange
+.
+TYPO3\Flow\Tests\Unit\Monitor\FileMonitorTest::aDirectoryAppearsOnlyOnceInTheListOfMonitoredDirectories
+.
+TYPO3\Flow\Tests\Unit\Monitor\FileMonitorTest::aFileAppearsOnlyOnceInTheListOfMonitoredFiles
+.
+TYPO3\Flow\Tests\Unit\Monitor\FileMonitorTest::detectChangedFilesFetchesTheStatusOfGivenFilesAndReturnsAListOfChangeFilesAndTheirStatus
+.
+TYPO3\Flow\Tests\Unit\Monitor\FileMonitorTest::detectChangesAddsCreatedFilesOfMonitoredDirectoriesToStoredDirectories
+.
+TYPO3\Flow\Tests\Unit\Monitor\FileMonitorTest::detectChangesDetectsChangesInFilesOfMonitoredDirectories
+.
+TYPO3\Flow\Tests\Unit\Monitor\FileMonitorTest::detectChangesDetectsChangesInFilesOfMonitoredDirectoriesIfPatternIsMatched
+.
+TYPO3\Flow\Tests\Unit\Monitor\FileMonitorTest::detectChangesDetectsChangesInMonitoredFiles
+.
+TYPO3\Flow\Tests\Unit\Monitor\FileMonitorTest::detectChangesDetectsCreatedFilesOfMonitoredDirectoriesOnlyIfPatternIsMatched
+.
+TYPO3\Flow\Tests\Unit\Monitor\FileMonitorTest::detectChangesDetectsDeletedFilesOfMonitoredDirectoriesIfPatternIsMatched
+.
+TYPO3\Flow\Tests\Unit\Monitor\FileMonitorTest::detectChangesDetectsNewlyCreatedFilesInMonitoredDirectories
+.
+TYPO3\Flow\Tests\Unit\Monitor\FileMonitorTest::detectChangesEmitsDirectoryChangedSignalAndMemorizesDirectoryIfDirectoryHasNotBeenMonitoredPreviously
+.
+TYPO3\Flow\Tests\Unit\Monitor\FileMonitorTest::detectChangesEmitsDirectoryChangedSignalIfDirectoryHasBeenRemoved
+.
+TYPO3\Flow\Tests\Unit\Monitor\FileMonitorTest::detectChangesEmitsFilesHaveChangedSignalIfFilesHaveChanged
+.
+TYPO3\Flow\Tests\Unit\Monitor\FileMonitorTest::fileMonitorCachesTheListOfKnownDirectoriesAndFiles
+.
+TYPO3\Flow\Tests\Unit\Monitor\FileMonitorTest::monitorDirectoryRegistersAWholeDirectoryForMonitoring
+.
+TYPO3\Flow\Tests\Unit\Monitor\FileMonitorTest::monitorFileRegistersAFileForMonitoring
+.
+TYPO3\Flow\Tests\Unit\Mvc\ActionRequestTest::aSingleArgumentCanBeSetWithSetArgumentAndRetrievedWithGetArgument
+.
+TYPO3\Flow\Tests\Unit\Mvc\ActionRequestTest::allArgumentsCanBeSetOrRetrievedAtOnce
+.
+TYPO3\Flow\Tests\Unit\Mvc\ActionRequestTest::anHttpRequestOrActionRequestIsRequiredAsParentRequest
+.
+TYPO3\Flow\Tests\Unit\Mvc\ActionRequestTest::argumentNamespaceCanBeSpecified
+.
+TYPO3\Flow\Tests\Unit\Mvc\ActionRequestTest::cloneResetsTheStatusToNotDispatched
+.
+TYPO3\Flow\Tests\Unit\Mvc\ActionRequestTest::constructorThrowsAnExceptionIfNoValidRequestIsPassed
+.
+TYPO3\Flow\Tests\Unit\Mvc\ActionRequestTest::getControllerNameExtractsTheControllerNameFromTheControllerObjectNameToAssureTheCorrectCase
+.
+TYPO3\Flow\Tests\Unit\Mvc\ActionRequestTest::getControllerNameReturnsTheUnknownCasesControllerNameIfNoControllerObjectNameCouldBeDetermined
+.
+TYPO3\Flow\Tests\Unit\Mvc\ActionRequestTest::getControllerObjectNameReturnsAnEmptyStringIfTheResolvedControllerDoesNotExist
+.
+TYPO3\Flow\Tests\Unit\Mvc\ActionRequestTest::getControllerObjectNameReturnsObjectNameDerivedFromPreviouslySetControllerInformation
+.
+TYPO3\Flow\Tests\Unit\Mvc\ActionRequestTest::getControllerSubpackageKeyExtractsTheSubpackageKeyFromTheControllerObjectNameToAssureTheCorrectCase
+.
+TYPO3\Flow\Tests\Unit\Mvc\ActionRequestTest::getControllerSubpackageKeyReturnsNullIfNoSubpackageKeyIsSet
+.
+TYPO3\Flow\Tests\Unit\Mvc\ActionRequestTest::getControllerSubpackageKeyReturnsTheUnknownCasesPackageKeyIfNoControllerObjectNameCouldBeDetermined
+.
+TYPO3\Flow\Tests\Unit\Mvc\ActionRequestTest::getHttpRequestReturnsTheHttpRequestWhichIsTheRootOfAllActionRequests
+.
+TYPO3\Flow\Tests\Unit\Mvc\ActionRequestTest::getMainRequestReturnsTheTopLevelActionRequestWhoseParentIsTheHttpRequest
+.
+TYPO3\Flow\Tests\Unit\Mvc\ActionRequestTest::getReferringRequestThrowsAnExceptionIfTheHmacOfTheArgumentsCouldNotBeValid
+.
+TYPO3\Flow\Tests\Unit\Mvc\ActionRequestTest::internalArgumentsAreHandledSeparately
+.
+TYPO3\Flow\Tests\Unit\Mvc\ActionRequestTest::internalArgumentsMayHaveObjectValues
+.
+TYPO3\Flow\Tests\Unit\Mvc\ActionRequestTest::internalArgumentsOfActionRequestOverruleThoseOfTheHttpRequest
+.
+TYPO3\Flow\Tests\Unit\Mvc\ActionRequestTest::isMainRequestChecksIfTheParentRequestIsNotAnHttpRequest
+.
+TYPO3\Flow\Tests\Unit\Mvc\ActionRequestTest::pluginArgumentsAreHandledSeparately
+.
+TYPO3\Flow\Tests\Unit\Mvc\ActionRequestTest::pluginArgumentsOfActionRequestOverruleThoseOfTheHttpRequest
+.
+TYPO3\Flow\Tests\Unit\Mvc\ActionRequestTest::requestIsDispatchable
+.
+TYPO3\Flow\Tests\Unit\Mvc\ActionRequestTest::setArgumentDoesNotAllowObjectValuesForRegularArguments
+.
+TYPO3\Flow\Tests\Unit\Mvc\ActionRequestTest::setArgumentThrowsAnExceptionOnInvalidArgumentNames
+.
+TYPO3\Flow\Tests\Unit\Mvc\ActionRequestTest::setControllerActionNameThrowsExceptionOnInvalidActionNames with data set #0
+.
+TYPO3\Flow\Tests\Unit\Mvc\ActionRequestTest::setControllerActionNameThrowsExceptionOnInvalidActionNames with data set #1
+.
+TYPO3\Flow\Tests\Unit\Mvc\ActionRequestTest::setControllerActionNameThrowsExceptionOnInvalidActionNames with data set #2
+.
+TYPO3\Flow\Tests\Unit\Mvc\ActionRequestTest::setControllerNameThrowsExceptionOnInvalidControllerNames with data set #0
+.
+TYPO3\Flow\Tests\Unit\Mvc\ActionRequestTest::setControllerNameThrowsExceptionOnInvalidControllerNames with data set #1
+.
+TYPO3\Flow\Tests\Unit\Mvc\ActionRequestTest::setControllerNameThrowsExceptionOnInvalidControllerNames with data set #2
+.
+TYPO3\Flow\Tests\Unit\Mvc\ActionRequestTest::setControllerObjectNameSplitsTheGivenObjectNameIntoItsParts with data set #0
+.
+TYPO3\Flow\Tests\Unit\Mvc\ActionRequestTest::setControllerObjectNameSplitsTheGivenObjectNameIntoItsParts with data set #1
+.
+TYPO3\Flow\Tests\Unit\Mvc\ActionRequestTest::setControllerObjectNameSplitsTheGivenObjectNameIntoItsParts with data set #2
+.
+TYPO3\Flow\Tests\Unit\Mvc\ActionRequestTest::setControllerObjectNameSplitsTheGivenObjectNameIntoItsParts with data set #3
+.
+TYPO3\Flow\Tests\Unit\Mvc\ActionRequestTest::setControllerObjectNameSplitsTheGivenObjectNameIntoItsParts with data set #4
+.
+TYPO3\Flow\Tests\Unit\Mvc\ActionRequestTest::setControllerObjectNameThrowsExceptionOnUnknownObjectName
+.
+TYPO3\Flow\Tests\Unit\Mvc\ActionRequestTest::setControllerPackageKeyWithLowercasePackageKeyResolvesCorrectly
+.
+TYPO3\Flow\Tests\Unit\Mvc\ActionRequestTest::setDispatchedEmitsSignalIfDispatched
+.
+TYPO3\Flow\Tests\Unit\Mvc\ActionRequestTest::theActionNameCanBeSetAndRetrieved
+.
+TYPO3\Flow\Tests\Unit\Mvc\ActionRequestTest::theActionNamesCaseIsFixedIfItIsAllLowerCaseAndTheControllerObjectNameIsKnown
+.
+TYPO3\Flow\Tests\Unit\Mvc\ActionRequestTest::theRepresentationFormatCanBeSetAndRetrieved
+.
+TYPO3\Flow\Tests\Unit\Mvc\Controller\AbstractControllerTest::addFlashMessageTests with data set #0
+.
+TYPO3\Flow\Tests\Unit\Mvc\Controller\AbstractControllerTest::addFlashMessageTests with data set #1
+.
+TYPO3\Flow\Tests\Unit\Mvc\Controller\AbstractControllerTest::addFlashMessageTests with data set #2
+.
+TYPO3\Flow\Tests\Unit\Mvc\Controller\AbstractControllerTest::addFlashMessageTests with data set #3
+.
+TYPO3\Flow\Tests\Unit\Mvc\Controller\AbstractControllerTest::addFlashMessageTests with data set #4
+.
+TYPO3\Flow\Tests\Unit\Mvc\Controller\AbstractControllerTest::addFlashMessageThrowsExceptionOnInvalidMessageBody
+.
+TYPO3\Flow\Tests\Unit\Mvc\Controller\AbstractControllerTest::forwardConvertsObjectsFoundInArgumentsIntoIdentifiersBeforePassingThemToRequest
+.
+TYPO3\Flow\Tests\Unit\Mvc\Controller\AbstractControllerTest::forwardResetsControllerArguments
+.
+TYPO3\Flow\Tests\Unit\Mvc\Controller\AbstractControllerTest::forwardSetsAndResetsSubpackageKeyIfNeeded
+.
+TYPO3\Flow\Tests\Unit\Mvc\Controller\AbstractControllerTest::forwardSetsControllerAndArgumentsAtTheRequestObjectIfTheyAreSpecified
+.
+TYPO3\Flow\Tests\Unit\Mvc\Controller\AbstractControllerTest::initializeControllerInitializesRequestUriBuilderArgumentsAndContext
+.
+TYPO3\Flow\Tests\Unit\Mvc\Controller\AbstractControllerTest::initializeControllerWillThrowAnExceptionIfTheGivenRequestIsNotSupported
+.
+TYPO3\Flow\Tests\Unit\Mvc\Controller\AbstractControllerTest::mapRequestArgumentsToControllerArgumentsDoesJustThat
+.
+TYPO3\Flow\Tests\Unit\Mvc\Controller\AbstractControllerTest::mapRequestArgumentsToControllerArgumentsThrowsExceptionIfRequiredArgumentWasNotSet
+.
+TYPO3\Flow\Tests\Unit\Mvc\Controller\AbstractControllerTest::redirectRedirectsToTheSpecifiedAction
+.
+TYPO3\Flow\Tests\Unit\Mvc\Controller\AbstractControllerTest::redirectToUriDoesNotSetLocationHeaderIfDelayIsNotZero
+.
+TYPO3\Flow\Tests\Unit\Mvc\Controller\AbstractControllerTest::redirectToUriSetsLocationHeader
+.
+TYPO3\Flow\Tests\Unit\Mvc\Controller\AbstractControllerTest::redirectToUriSetsStatus
+.
+TYPO3\Flow\Tests\Unit\Mvc\Controller\AbstractControllerTest::redirectToUriThrowsStopActionException
+.
+TYPO3\Flow\Tests\Unit\Mvc\Controller\AbstractControllerTest::redirectUsesRequestFormatAsDefaultAndUnsetsSubPackageKeyIfNecessary
+.
+TYPO3\Flow\Tests\Unit\Mvc\Controller\AbstractControllerTest::throwStatusSetsTheSpecifiedStatusHeaderAndStopsTheCurrentAction
+.
+TYPO3\Flow\Tests\Unit\Mvc\Controller\AbstractControllerTest::throwStatusSetsTheStatusMessageAsContentIfNoFurtherContentIsProvided
+.
+TYPO3\Flow\Tests\Unit\Mvc\Controller\AbstractControllerTest::throwStatusSetsThrowsStopActionException
+.
+TYPO3\Flow\Tests\Unit\Mvc\Controller\ActionControllerTest::initializeActionMethodValidatorsDoesNotAddValidatorForIgnoredArgumentsWithoutEvaluation with data set #0
+.
+TYPO3\Flow\Tests\Unit\Mvc\Controller\ActionControllerTest::initializeActionMethodValidatorsDoesNotAddValidatorForIgnoredArgumentsWithoutEvaluation with data set #1
+.
+TYPO3\Flow\Tests\Unit\Mvc\Controller\ActionControllerTest::processRequestInjectsControllerContextToView
+.
+TYPO3\Flow\Tests\Unit\Mvc\Controller\ActionControllerTest::processRequestInjectsSettingsToView
+.
+TYPO3\Flow\Tests\Unit\Mvc\Controller\ActionControllerTest::processRequestThrowsExceptionIfRequestedActionIsNotCallable
+.
+TYPO3\Flow\Tests\Unit\Mvc\Controller\ActionControllerTest::processRequestThrowsExceptionIfRequestedActionIsNotPublic
+.
+TYPO3\Flow\Tests\Unit\Mvc\Controller\ActionControllerTest::resolveViewObjectNameRespectsViewFormatToObjectNameMap
+.
+TYPO3\Flow\Tests\Unit\Mvc\Controller\ActionControllerTest::resolveViewObjectNameReturnsObjectNameOfCustomViewWithFormatSuffixIfItExists
+.
+TYPO3\Flow\Tests\Unit\Mvc\Controller\ActionControllerTest::resolveViewObjectNameReturnsObjectNameOfCustomViewWithoutFormatSuffixIfItExists
+.
+TYPO3\Flow\Tests\Unit\Mvc\Controller\ActionControllerTest::resolveViewReturnsDefaultViewIfNoViewObjectNameCouldBeResolved
+.
+TYPO3\Flow\Tests\Unit\Mvc\Controller\ActionControllerTest::resolveViewReturnsViewResolvedByResolveViewObjectName
+.
+TYPO3\Flow\Tests\Unit\Mvc\Controller\ActionControllerTest::resolveViewThrowsExceptionIfResolvedViewDoesNotImplementViewInterface
+.
+TYPO3\Flow\Tests\Unit\Mvc\Controller\ActionControllerTest::resolveViewThrowsExceptionIfViewCouldNotBeResolved
+.
+TYPO3\Flow\Tests\Unit\Mvc\Controller\ArgumentTest::constructingArgumentWithInvalidNameThrowsException
+.
+TYPO3\Flow\Tests\Unit\Mvc\Controller\ArgumentTest::constructingArgumentWithoutNameThrowsException
+.
+TYPO3\Flow\Tests\Unit\Mvc\Controller\ArgumentTest::defaultPropertyMappingConfigurationDoesNotAllowCreationOrModificationOfObjects
+.
+TYPO3\Flow\Tests\Unit\Mvc\Controller\ArgumentTest::passingDataTypeToConstructorReallySetsTheDataType
+.
+TYPO3\Flow\Tests\Unit\Mvc\Controller\ArgumentTest::setDataTypeProvidesFluentInterfaceAndReallySetsDataType
+.
+TYPO3\Flow\Tests\Unit\Mvc\Controller\ArgumentTest::setDefaultValueShouldProvideFluentInterfaceAndReallySetDefaultValue
+.
+TYPO3\Flow\Tests\Unit\Mvc\Controller\ArgumentTest::setRequiredShouldProvideFluentInterfaceAndReallySetRequiredState
+.
+TYPO3\Flow\Tests\Unit\Mvc\Controller\ArgumentTest::setShortHelpMessageShouldProvideFluentInterfaceAndReallySetShortHelpMessage
+.
+TYPO3\Flow\Tests\Unit\Mvc\Controller\ArgumentTest::setShortHelpMessageShouldThrowExceptionIfMessageIsNoString
+.
+TYPO3\Flow\Tests\Unit\Mvc\Controller\ArgumentTest::setShortNameProvidesFluentInterface
+.
+TYPO3\Flow\Tests\Unit\Mvc\Controller\ArgumentTest::setValidatorShouldProvideFluentInterfaceAndReallySetValidator
+.
+TYPO3\Flow\Tests\Unit\Mvc\Controller\ArgumentTest::setValueProvidesFluentInterface
+.
+TYPO3\Flow\Tests\Unit\Mvc\Controller\ArgumentTest::setValueShouldBeFluentInterface
+.
+TYPO3\Flow\Tests\Unit\Mvc\Controller\ArgumentTest::setValueShouldCallPropertyMapperCorrectlyAndStoreResultInValue
+.
+TYPO3\Flow\Tests\Unit\Mvc\Controller\ArgumentTest::setValueShouldSetValidationErrorsIfValidatorIsSetAndValidationFailed
+.
+TYPO3\Flow\Tests\Unit\Mvc\Controller\ArgumentTest::setValueUsesMatchingInstanceAsIs
+.
+TYPO3\Flow\Tests\Unit\Mvc\Controller\ArgumentTest::setValueUsesNullAsIs
+.
+TYPO3\Flow\Tests\Unit\Mvc\Controller\ArgumentTest::shortNameCanBeRetrievedAgain
+.
+TYPO3\Flow\Tests\Unit\Mvc\Controller\ArgumentTest::shortNameShouldThrowExceptionIfInvalid with data set #0
+.
+TYPO3\Flow\Tests\Unit\Mvc\Controller\ArgumentTest::shortNameShouldThrowExceptionIfInvalid with data set #1
+.
+TYPO3\Flow\Tests\Unit\Mvc\Controller\ArgumentTest::shortNameShouldThrowExceptionIfInvalid with data set #2
+.
+TYPO3\Flow\Tests\Unit\Mvc\Controller\ArgumentsTest::addNewArgumentCanAddArgumentsMarkedAsOptionalWithDefaultValues
+.
+TYPO3\Flow\Tests\Unit\Mvc\Controller\ArgumentsTest::addNewArgumentCanAddArgumentsMarkedAsRequired
+.
+TYPO3\Flow\Tests\Unit\Mvc\Controller\ArgumentsTest::addNewArgumentCreatesAndAddsNewArgument
+.
+TYPO3\Flow\Tests\Unit\Mvc\Controller\ArgumentsTest::addingAnArgumentManuallyWorks
+.
+TYPO3\Flow\Tests\Unit\Mvc\Controller\ArgumentsTest::addingAnArgumentReplacesArgumentWithSameName
+.
+TYPO3\Flow\Tests\Unit\Mvc\Controller\ArgumentsTest::addingAnArgumentUsesStringAsDataTypeDefault
+.
+TYPO3\Flow\Tests\Unit\Mvc\Controller\ArgumentsTest::addingArgumentThroughArrayAccessWorks
+.
+TYPO3\Flow\Tests\Unit\Mvc\Controller\ArgumentsTest::callingInvalidMethodThrowsException
+.
+TYPO3\Flow\Tests\Unit\Mvc\Controller\ArgumentsTest::getArgumentNamesReturnsNamesOfAddedArguments
+.
+TYPO3\Flow\Tests\Unit\Mvc\Controller\ArgumentsTest::getArgumentShortNamesReturnsShortNamesOfAddedArguments
+.
+TYPO3\Flow\Tests\Unit\Mvc\Controller\ArgumentsTest::getArgumentWithNonExistingArgumentNameThrowsException
+.
+TYPO3\Flow\Tests\Unit\Mvc\Controller\ArgumentsTest::getValidationResultsShouldFetchAllValidationResltsFromArguments
+.
+TYPO3\Flow\Tests\Unit\Mvc\Controller\ArgumentsTest::issetReturnsCorrectResult
+.
+TYPO3\Flow\Tests\Unit\Mvc\Controller\ArgumentsTest::removeAllClearsAllArguments
+.
+TYPO3\Flow\Tests\Unit\Mvc\Controller\ArgumentsTest::retrievingArgumentThroughArrayAccessWorks
+.
+TYPO3\Flow\Tests\Unit\Mvc\Controller\CommandControllerTest::outputReplacesArgumentsInGivenString
+.
+TYPO3\Flow\Tests\Unit\Mvc\Controller\CommandControllerTest::outputWritesGivenStringToTheConsoleOutput
+.
+TYPO3\Flow\Tests\Unit\Mvc\Controller\CommandControllerTest::processRequestMarksRequestDispatched
+.
+TYPO3\Flow\Tests\Unit\Mvc\Controller\CommandControllerTest::processRequestResetsCommandMethodArguments
+.
+TYPO3\Flow\Tests\Unit\Mvc\Controller\CommandControllerTest::processRequestThrowsExceptionIfGivenRequestIsNoCliRequest
+.
+TYPO3\Flow\Tests\Unit\Mvc\Controller\FlashMessageContainerTest::addedFlashMessageCanBeReadOutAgain
+.
+TYPO3\Flow\Tests\Unit\Mvc\Controller\FlashMessageContainerTest::flushResetsFlashMessages
+.
+TYPO3\Flow\Tests\Unit\Mvc\Controller\FlashMessageContainerTest::getMessagesAndFlushCanAlsoFilterBySeverity
+.
+TYPO3\Flow\Tests\Unit\Mvc\Controller\FlashMessageContainerTest::getMessagesAndFlushFetchesAllEntriesAndFlushesTheFlashMessages
+.
+TYPO3\Flow\Tests\Unit\Mvc\Controller\FlashMessageContainerTest::messagesCanBeFilteredBySeverity
+.
+TYPO3\Flow\Tests\Unit\Mvc\Controller\MvcPropertyMappingConfigurationServiceTest::generateTrustedPropertiesTokenGeneratesTheCorrectHashesInNormalOperation with data set "Recursion with un-named fields at the end (...[]). There, they should be made explicit by increasing the counter"
+.
+TYPO3\Flow\Tests\Unit\Mvc\Controller\MvcPropertyMappingConfigurationServiceTest::generateTrustedPropertiesTokenGeneratesTheCorrectHashesInNormalOperation with data set "Recursion"
+.
+TYPO3\Flow\Tests\Unit\Mvc\Controller\MvcPropertyMappingConfigurationServiceTest::generateTrustedPropertiesTokenGeneratesTheCorrectHashesInNormalOperation with data set "Simple Case - Empty"
+.
+TYPO3\Flow\Tests\Unit\Mvc\Controller\MvcPropertyMappingConfigurationServiceTest::generateTrustedPropertiesTokenGeneratesTheCorrectHashesInNormalOperation with data set "Simple Case - Single Value"
+.
+TYPO3\Flow\Tests\Unit\Mvc\Controller\MvcPropertyMappingConfigurationServiceTest::generateTrustedPropertiesTokenGeneratesTheCorrectHashesInNormalOperation with data set "Simple Case - Two Values"
+.
+TYPO3\Flow\Tests\Unit\Mvc\Controller\MvcPropertyMappingConfigurationServiceTest::generateTrustedPropertiesTokenGeneratesTheCorrectHashesInNormalOperation with data set "recursion with duplicated field name"
+.
+TYPO3\Flow\Tests\Unit\Mvc\Controller\MvcPropertyMappingConfigurationServiceTest::generateTrustedPropertiesTokenThrowsExceptionInWrongCases with data set "Empty [] not as last argument"
+.
+TYPO3\Flow\Tests\Unit\Mvc\Controller\MvcPropertyMappingConfigurationServiceTest::generateTrustedPropertiesTokenThrowsExceptionInWrongCases with data set "Overriding form fields (array overridden by string) - 1"
+.
+TYPO3\Flow\Tests\Unit\Mvc\Controller\MvcPropertyMappingConfigurationServiceTest::generateTrustedPropertiesTokenThrowsExceptionInWrongCases with data set "Overriding form fields (array overridden by string) - 2"
+.
+TYPO3\Flow\Tests\Unit\Mvc\Controller\MvcPropertyMappingConfigurationServiceTest::generateTrustedPropertiesTokenThrowsExceptionInWrongCases with data set "Overriding form fields (string overridden by array) - 1"
+.
+TYPO3\Flow\Tests\Unit\Mvc\Controller\MvcPropertyMappingConfigurationServiceTest::generateTrustedPropertiesTokenThrowsExceptionInWrongCases with data set "Overriding form fields (string overridden by array) - 2"
+.
+TYPO3\Flow\Tests\Unit\Mvc\Controller\MvcPropertyMappingConfigurationServiceTest::initializePropertyMappingConfigurationDoesNothingIfTrustedPropertiesAreNotSet
+.
+TYPO3\Flow\Tests\Unit\Mvc\Controller\MvcPropertyMappingConfigurationServiceTest::initializePropertyMappingConfigurationReturnsEarlyIfArgumentIsUnknown
+.
+TYPO3\Flow\Tests\Unit\Mvc\Controller\MvcPropertyMappingConfigurationServiceTest::initializePropertyMappingConfigurationReturnsEarlyIfNoTrustedPropertiesAreSet
+.
+TYPO3\Flow\Tests\Unit\Mvc\Controller\MvcPropertyMappingConfigurationServiceTest::initializePropertyMappingConfigurationSetsAllowedFields
+.
+TYPO3\Flow\Tests\Unit\Mvc\Controller\MvcPropertyMappingConfigurationServiceTest::initializePropertyMappingConfigurationSetsAllowedFieldsRecursively
+.
+TYPO3\Flow\Tests\Unit\Mvc\Controller\MvcPropertyMappingConfigurationServiceTest::initializePropertyMappingConfigurationSetsCreationAllowedIfIdentityPropertyIsNotSet
+.
+TYPO3\Flow\Tests\Unit\Mvc\Controller\MvcPropertyMappingConfigurationServiceTest::initializePropertyMappingConfigurationSetsModificationAllowedIfIdentityPropertyIsSet
+.
+TYPO3\Flow\Tests\Unit\Mvc\Controller\MvcPropertyMappingConfigurationServiceTest::serializeAndHashFormFieldArrayWorks
+.
+TYPO3\Flow\Tests\Unit\Mvc\Controller\MvcPropertyMappingConfigurationTest::respectiveMethodsProvideFluentInterface with data set #0
+.
+TYPO3\Flow\Tests\Unit\Mvc\Controller\MvcPropertyMappingConfigurationTest::respectiveMethodsProvideFluentInterface with data set #1
+.
+TYPO3\Flow\Tests\Unit\Mvc\Controller\MvcPropertyMappingConfigurationTest::respectiveMethodsProvideFluentInterface with data set #2
+.
+TYPO3\Flow\Tests\Unit\Mvc\Controller\MvcPropertyMappingConfigurationTest::respectiveMethodsProvideFluentInterface with data set #3
+.
+TYPO3\Flow\Tests\Unit\Mvc\DispatchComponentTest::handleDispatchesTheRequest
+.
+TYPO3\Flow\Tests\Unit\Mvc\DispatchComponentTest::handleDoesNotSetDefaultControllerAndActionNameIfTheyAreSetAlready
+.
+TYPO3\Flow\Tests\Unit\Mvc\DispatchComponentTest::handleMergesArgumentsWithRoutingMatchResults with data set #0
+.
+TYPO3\Flow\Tests\Unit\Mvc\DispatchComponentTest::handleMergesArgumentsWithRoutingMatchResults with data set #1
+.
+TYPO3\Flow\Tests\Unit\Mvc\DispatchComponentTest::handleMergesArgumentsWithRoutingMatchResults with data set #2
+.
+TYPO3\Flow\Tests\Unit\Mvc\DispatchComponentTest::handleMergesArgumentsWithRoutingMatchResults with data set #3
+.
+TYPO3\Flow\Tests\Unit\Mvc\DispatchComponentTest::handleMergesArgumentsWithRoutingMatchResults with data set #4
+.
+TYPO3\Flow\Tests\Unit\Mvc\DispatchComponentTest::handleMergesArgumentsWithRoutingMatchResults with data set #5
+.
+TYPO3\Flow\Tests\Unit\Mvc\DispatchComponentTest::handleMergesInternalArgumentsWithRoutingMatchResults
+.
+TYPO3\Flow\Tests\Unit\Mvc\DispatchComponentTest::handleSetsActionRequestArgumentsIfARouteMatches
+.
+TYPO3\Flow\Tests\Unit\Mvc\DispatchComponentTest::handleSetsDefaultControllerAndActionNameIfTheyAreNotSetYet
+.
+TYPO3\Flow\Tests\Unit\Mvc\DispatchComponentTest::handleSetsRequestInSecurityContext
+.
+TYPO3\Flow\Tests\Unit\Mvc\DispatchComponentTest::handleStoresTheActionRequestInTheComponentContext
+.
+TYPO3\Flow\Tests\Unit\Mvc\DispatcherTest::dispatchCallsStartAuthenticationOnAllActiveEntryPoints
+.
+TYPO3\Flow\Tests\Unit\Mvc\DispatcherTest::dispatchCallsTheControllersProcessRequestMethodUntilTheIsDispatchedFlagInTheRequestObjectIsSet
+.
+TYPO3\Flow\Tests\Unit\Mvc\DispatcherTest::dispatchCatchesStopExceptionOfActionRequestsAndRollsBackToTheParentRequest
+.
+TYPO3\Flow\Tests\Unit\Mvc\DispatcherTest::dispatchContinuesWithNextRequestFoundInAForwardException
+.
+TYPO3\Flow\Tests\Unit\Mvc\DispatcherTest::dispatchDoesNotBlockCliRequests
+.
+TYPO3\Flow\Tests\Unit\Mvc\DispatcherTest::dispatchDoesNotBlockRequestsIfAuthorizationChecksAreDisabled
+.
+TYPO3\Flow\Tests\Unit\Mvc\DispatcherTest::dispatchDoesNotSetInterceptedRequestIfAuthenticationTokensContainNoEntryPoint
+.
+TYPO3\Flow\Tests\Unit\Mvc\DispatcherTest::dispatchIgnoresStopExceptionsForFirstLevelActionRequests
+.
+TYPO3\Flow\Tests\Unit\Mvc\DispatcherTest::dispatchInterceptsActionRequestsByDefault
+.
+TYPO3\Flow\Tests\Unit\Mvc\DispatcherTest::dispatchRethrowsAccessDeniedException
+.
+TYPO3\Flow\Tests\Unit\Mvc\DispatcherTest::dispatchRethrowsAuthenticationRequiredExceptionIfSecurityContextDoesNotContainAnyAuthenticationToken
+.
+TYPO3\Flow\Tests\Unit\Mvc\DispatcherTest::dispatchSetsInterceptedRequestIfSecurityContextContainsAuthenticationTokensWithEntryPoints
+.
+TYPO3\Flow\Tests\Unit\Mvc\DispatcherTest::dispatchThrowsAnInfiniteLoopExceptionIfTheRequestCouldNotBeDispachedAfter99Iterations
+.
+TYPO3\Flow\Tests\Unit\Mvc\DispatcherTest::resolveControllerReturnsTheControllerSpecifiedInTheRequest
+.
+TYPO3\Flow\Tests\Unit\Mvc\DispatcherTest::resolveControllerThrowsAnInvalidControllerExceptionIfTheResolvedControllerDoesNotExist
+.
+TYPO3\Flow\Tests\Unit\Mvc\DispatcherTest::resolveControllerThrowsAnInvalidControllerExceptionIfTheResolvedControllerDoesNotImplementTheControllerInterface
+.
+TYPO3\Flow\Tests\Unit\Mvc\ResponseTest::toStringReturnsContentOfResponse
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\DynamicRoutePartTest::dynamicRouteDoesNotMatchRequestPathWithMoreThanOneSegmentIfSplitStringIsNotFound
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\DynamicRoutePartTest::dynamicRouteDoesNotMatchRequestPathWithMoreThanOneSegmentIfSplitStringIsNotSet
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\DynamicRoutePartTest::dynamicRouteMatchesRequestPathWithOnlyOneSegmentIfSplitStringIsNotFound
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\DynamicRoutePartTest::dynamicRouteMatchesRequestPathWithOnlyOneSegmentIfSplitStringIsNotSet
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\DynamicRoutePartTest::dynamicRoutePartDoesNotChangeCaseOfValueIfLowerCaseIsFale
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\DynamicRoutePartTest::dynamicRoutePartDoesNotMatchEmptyRequestPathEvenIfDefaultValueIsSet
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\DynamicRoutePartTest::dynamicRoutePartDoesNotMatchIfNameIsNotSet
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\DynamicRoutePartTest::dynamicRoutePartDoesNotMatchIfRequestPathIsNullOrEmpty
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\DynamicRoutePartTest::dynamicRoutePartDoesNotMatchIfSplitStringIsAtFirstPosition
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\DynamicRoutePartTest::dynamicRoutePartDoesNotResolveEmptyArray
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\DynamicRoutePartTest::dynamicRoutePartDoesNotResolveEmptyArrayEvenIfDefaultValueIsSet
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\DynamicRoutePartTest::dynamicRoutePartDoesNotResolveIfNameIsNotSet
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\DynamicRoutePartTest::dynamicRoutePartLowerCasesValueWhenCallingResolveByDefault
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\DynamicRoutePartTest::dynamicRoutePartMatchesIfSplitStringContainsMultipleCharactersThatAreFoundInRequestPath
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\DynamicRoutePartTest::dynamicRoutePartResolvesSimpleValueArray
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\DynamicRoutePartTest::dynamicRoutePartUrlEncodesValues
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\DynamicRoutePartTest::resolveDoesNotChangeRouteValuesOnUnsuccessfulResolve
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\DynamicRoutePartTest::resolveRecursivelyUnsetsCurrentRouteValueOnSuccessfulResolve
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\DynamicRoutePartTest::resolveReturnsFalseIfNoCorrespondingValueIsGiven
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\DynamicRoutePartTest::resolveUnsetsCurrentRouteValueOnSuccessfulResolve
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\DynamicRoutePartTest::resolveValueReturnsFalseIfTheValueToBeResolvedIsAnObjectThatIsUnknownToThePersistenceManager
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\DynamicRoutePartTest::resolveValueReturnsFalseIfTheValueToBeResolvedIsAnObjectWithAMultiValueIdentifier
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\DynamicRoutePartTest::resolveValueReturnsTrueAndSetTheValueToTheCorrectlyCasedIdentifierIfTheValueToBeResolvedIsAnObjectAndLowerCaseIsFalse
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\DynamicRoutePartTest::resolveValueReturnsTrueAndSetTheValueToTheLowerCasedIdentifierIfTheValueToBeResolvedIsAnObject
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\DynamicRoutePartTest::resolveValueReturnsTrueIfTheValueToBeResolvedIsAnObjectWithANumericIdentifier
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\DynamicRoutePartTest::routePartValueIsNullAfterUnsuccessfulResolve
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\DynamicRoutePartTest::routePathIsShortenedByOneSegmentAfterSuccessfulMatch
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\DynamicRoutePartTest::valueIsNullAfterUnsuccessfulMatch
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\DynamicRoutePartTest::valueIsUrlDecodedAfterSuccessfulMatch
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\DynamicRoutePartTest::valueMatchesFirstRequestPathSegmentAfterSuccessfulMatch
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\IdentityRoutePartTest::createPathSegmentForObjectTests with data set #0
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\IdentityRoutePartTest::createPathSegmentForObjectTests with data set #1
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\IdentityRoutePartTest::createPathSegmentForObjectTests with data set #2
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\IdentityRoutePartTest::createPathSegmentForObjectTests with data set #3
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\IdentityRoutePartTest::createPathSegmentForObjectTests with data set #4
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\IdentityRoutePartTest::createPathSegmentForObjectTests with data set #5
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\IdentityRoutePartTest::createPathSegmentForObjectTests with data set #6
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\IdentityRoutePartTest::createPathSegmentForObjectTests with data set #7
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\IdentityRoutePartTest::createPathSegmentForObjectTests with data set #8
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\IdentityRoutePartTest::createPathSegmentForObjectTests with data set #9
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\IdentityRoutePartTest::createPathSegmentForObjectThrowsInvalidUriPatterExceptionIfItSpecifiedPropertiesContainObjects
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\IdentityRoutePartTest::findValueToMatchReturnsAnEmptyStringIfTheCalculatedUriPatternIsEmpty
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\IdentityRoutePartTest::findValueToMatchReturnsAnEmptyStringIfTheRoutePathIsEmpty
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\IdentityRoutePartTest::findValueToMatchReturnsAnEmptyStringIfTheSpecifiedSplitStringCantBeFoundInTheRoutePath
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\IdentityRoutePartTest::findValueToMatchTests with data set #0
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\IdentityRoutePartTest::findValueToMatchTests with data set #1
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\IdentityRoutePartTest::findValueToMatchTests with data set #2
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\IdentityRoutePartTest::findValueToMatchTests with data set #3
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\IdentityRoutePartTest::findValueToMatchTests with data set #4
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\IdentityRoutePartTest::findValueToMatchTests with data set #5
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\IdentityRoutePartTest::findValueToMatchTests with data set #6
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\IdentityRoutePartTest::findValueToMatchTests with data set #7
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\IdentityRoutePartTest::findValueToMatchTests with data set #8
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\IdentityRoutePartTest::findValueToMatchTests with data set #9
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\IdentityRoutePartTest::getUriPatternReturnsAnEmptyStringIfObjectTypeHasNotIdentityPropertiesAndNoPatternWasSpecified
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\IdentityRoutePartTest::getUriPatternReturnsBasedOnTheIdentityPropertiesOfTheObjectTypeIfNoPatternWasSpecified
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\IdentityRoutePartTest::getUriPatternReturnsTheSpecifiedUriPatternIfItsNotEmpty
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\IdentityRoutePartTest::matchValueReturnsFalseIfNoObjectPathMappingCouldBeFound
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\IdentityRoutePartTest::matchValueReturnsFalseIfTheGivenValueIsEmptyOrNull
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\IdentityRoutePartTest::matchValueSetsCaseSensitiveFlagIfLowerCaseIsFalse
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\IdentityRoutePartTest::matchValueSetsTheIdentifierOfTheObjectPathMappingAndReturnsTrueIfAMatchingObjectPathMappingWasFound
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\IdentityRoutePartTest::matchValueSetsTheRouteValueToTheUrlDecodedPathSegmentIfNoUriPatternIsSpecified
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\IdentityRoutePartTest::resolveValueAcceptsIdentityArrays
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\IdentityRoutePartTest::resolveValueAppendsCounterIfCreatedPathSegmentIsEmpty
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\IdentityRoutePartTest::resolveValueAppendsCounterIfNoMatchingObjectPathMappingWasFoundAndCreatedPathSegmentIsNotUnique
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\IdentityRoutePartTest::resolveValueConvertsCaseOfResolvedPathSegmentIfLowerCaseIsTrue
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\IdentityRoutePartTest::resolveValueCreatesAndStoresANewObjectPathMappingIfNoMatchingObjectPathMappingWasFound
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\IdentityRoutePartTest::resolveValueDoesNotAcceptObjectsWithMultiValueIdentifiers
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\IdentityRoutePartTest::resolveValueKeepsCaseOfResolvedPathSegmentIfLowerCaseIsTrue
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\IdentityRoutePartTest::resolveValueReturnsFalseIfTheGivenValueIsNotOfTheSpecifiedType
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\IdentityRoutePartTest::resolveValueSetsCaseSensitiveFlagIfLowerCaseIsFalse
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\IdentityRoutePartTest::resolveValueSetsTheRouteValueToTheUrlEncodedIdentifierIfNoUriPatternIsSpecified
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\IdentityRoutePartTest::resolveValueSetsTheValueToThePathSegmentOfTheObjectPathMappingAndReturnsTrueIfAMatchingObjectPathMappingWasFound
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\IdentityRoutePartTest::resolveValueThrowsInfiniteLoopExceptionIfNoUniquePathSegmentCantBeFound
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouteTest::byDefaultRouteDoesNotResolveIfUriPatternContainsLessValuesThanAreSpecified
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouteTest::compareAndRemoveMatchingDefaultValuesTests with data set #0
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouteTest::compareAndRemoveMatchingDefaultValuesTests with data set #1
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouteTest::compareAndRemoveMatchingDefaultValuesTests with data set #10
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouteTest::compareAndRemoveMatchingDefaultValuesTests with data set #2
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouteTest::compareAndRemoveMatchingDefaultValuesTests with data set #3
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouteTest::compareAndRemoveMatchingDefaultValuesTests with data set #4
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouteTest::compareAndRemoveMatchingDefaultValuesTests with data set #5
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouteTest::compareAndRemoveMatchingDefaultValuesTests with data set #6
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouteTest::compareAndRemoveMatchingDefaultValuesTests with data set #7
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouteTest::compareAndRemoveMatchingDefaultValuesTests with data set #8
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouteTest::compareAndRemoveMatchingDefaultValuesTests with data set #9
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouteTest::defaultValuesAreSetForUriPatternSegmentsWithMultipleOptionalRouteParts
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouteTest::getMatchResultsReturnsCorrectResultsAfterSuccessfulMatch
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouteTest::httpMethodConstraintsCanBeSetAndRetrieved
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouteTest::ifAnObjectTypeIsSpecifiedTheIdentityRoutePartHandlerIsInstantiated
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouteTest::matchesRecursivelyMergesMatchResults
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouteTest::matchesThrowsExceptionIfRoutePartValueContainsObjects with data set #0
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouteTest::matchesThrowsExceptionIfRoutePartValueContainsObjects with data set #1
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouteTest::matchesThrowsExceptionIfRoutePartValueContainsObjects with data set #2
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouteTest::matchesThrowsExceptionIfRoutePartValueContainsObjects with data set #3
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouteTest::matchesThrowsExceptionIfRoutePartValueContainsObjects with data set #4
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouteTest::matchesThrowsExceptionIfRoutePartValueContainsObjects with data set #5
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouteTest::matchingRouteIsProperlyResolved
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouteTest::parseSetsDefaultValueOfRouteParts
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouteTest::parseSetsDefaultValueOfRoutePartsRecursively
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouteTest::parseSetsUriPatternOfIdentityRoutePartIfSpecified
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouteTest::registeredRoutePartHandlerIsInvokedWhenCallingMatch
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouteTest::registeredRoutePartHandlerIsInvokedWhenCallingResolve
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouteTest::resolvedUriPathIsNullAfterUnsuccessfulResolve
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouteTest::resolvesAppendsDefaultValuesOfOptionalUriPartsToResolvedUriPath
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouteTest::resolvesAppendsRemainingRouteValuesToResolvedUriPathIfAppendExceedingArgumentsIsTrue
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouteTest::resolvesCallsCompareAndRemoveMatchingDefaultValues
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouteTest::resolvesConvertsDomainObjectsToIdentityArrays
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouteTest::resolvesKeepsCaseOfResolvedUriIfToLowerCaseIsFalse
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouteTest::resolvesLowerCasesResolvedUriPathByDefault
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouteTest::resolvesReturnsFalseIfNotAllRouteValuesCanBeResolved
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouteTest::resolvesReturnsTrueIfTargetControllerExists
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouteTest::resolvesThrowsExceptionIfRoutePartDefaultValueIsNoString
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouteTest::resolvesThrowsExceptionIfRoutePartValueIsNoString
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouteTest::routeAlwaysAppendsExceedingInternalArguments
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouteTest::routeAlwaysAppendsExceedingInternalArgumentsRecursively
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouteTest::routeAppendsAllAdditionalQueryParametersIfUriPatternContainsLessValuesThanAreSpecifiedIfAppendExceedingArgumentsIsTrue
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouteTest::routeCanBeResolvedIfAComplexValueIsEqualToItsDefaultValue
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouteTest::routeCanBeResolvedIfASpecifiedValueIsEqualToItsDefaultValue
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouteTest::routeCantBeResolvedIfASpecifiedValueIsNotEqualToItsDefaultValue
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouteTest::routeDoesNotMatchEmptyRequestPathIfUriPatternContainsOneOptionalDynamicRoutePartWithoutDefaultValue
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouteTest::routeDoesNotMatchEmptyRequestPathIfUriPatternIsNotSet
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouteTest::routeDoesNotMatchIfOneSegmentOfRequestPathIsDifferentFromItsRespectiveStaticUriPatternSegment
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouteTest::routeDoesNotMatchIfRequestMethodIsNotAccepted
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouteTest::routeDoesNotMatchIfRequestPathIsDifferentFromStaticUriPattern
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouteTest::routeDoesNotMatchIfRequestPathIsEqualToStaticUriPatternWithoutSlashes
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouteTest::routeDoesNotMatchIfRoutePartDoesNotMatchAndDefaultValueIsSet
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouteTest::routeDoesNotMatchIfRoutePartDoesNotMatchAndIsOptionalButHasNoDefault
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouteTest::routeDoesNotMatchRequestPathContainingNoneOfTheOptionalRoutePartsIfNoDefaultsAreSet
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouteTest::routeDoesNotMatchRequestPathContainingOnlySomeOfTheOptionalRouteParts
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouteTest::routeDoesNotMatchRequestPathWithAllPartsIfUriPatternEndsWithTwoSuccessiveOptionalRouteParts
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouteTest::routeDoesNotMatchRequestPathWithOnlyOneOptionalPartIfUriPatternContainsTwoSuccessiveOptionalRouteParts
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouteTest::routeDoesNotMatchRequestPathWithOnlyOneOptionalPartIfUriPatternStartsWithTwoSuccessiveOptionalRouteParts
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouteTest::routeDoesNotMatchRequestPathWithRequiredAndOnlyOneOptionalPartsIfUriPatternEndsWithTwoSuccessiveOptionalRouteParts
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouteTest::routeDoesNotResolveIfRouteValuesContainAnIdentityForAnArgumentThatIsNotPartOfTheRoute
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouteTest::routeMatchesEmptyRequestPathIfUriPatternContainsOneOptionalDynamicRoutePartWithDefaultValue
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouteTest::routeMatchesEmptyRequestPathIfUriPatternContainsOneOptionalStaticRoutePart
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouteTest::routeMatchesEmptyRequestPathIfUriPatternIsEmpty
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouteTest::routeMatchesIfRequestMethodIsAccepted
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouteTest::routeMatchesIfRequestPathIsEqualToStaticUriPattern
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouteTest::routeMatchesIfRoutePartDoesNotMatchButIsOptionalAndHasDefault
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouteTest::routeMatchesIfStaticSegmentsMatchAndASegmentExistsForAllDynamicUriPartSegments
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouteTest::routeMatchesRequestPathContainingAllOfTheOptionalRouteParts
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouteTest::routeMatchesRequestPathContainingNoneOfTheOptionalRouteParts
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouteTest::routeMatchesRequestPathWithAllPartsIfUriPatternContainsOneOptionalAndOneRequiredStaticRoutePart
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouteTest::routeMatchesRequestPathWithAllPartsIfUriPatternContainsTwoOptionalAndOneRequiredStaticRoutePart
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouteTest::routeMatchesRequestPathWithAllPartsIfUriPatternContainsTwoSuccessiveOptionalRouteParts
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouteTest::routeMatchesRequestPathWithAllPartsIfUriPatternStartsWithTwoSuccessiveOptionalRouteParts
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouteTest::routeMatchesRequestPathWithOnlyRequiredPartsIfUriPatternContainsOneOptionalAndOneRequiredStaticRoutePart
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouteTest::routeMatchesRequestPathWithOnlyRequiredPartsIfUriPatternContainsOneRequiredAndOneOptionalStaticRoutePart
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouteTest::routeMatchesRequestPathWithOnlyRequiredPartsIfUriPatternContainsTwoOptionalAndOneRequiredStaticRoutePart
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouteTest::routeMatchesRequestPathWithOnlyRequiredPartsIfUriPatternContainsTwoSuccessiveOptionalRouteParts
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouteTest::routeMatchesRequestPathWithOnlyRequiredPartsIfUriPatternEndsWithTwoSuccessiveOptionalRouteParts
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouteTest::routeMatchesRequestPathWithOnlyRequiredPartsIfUriPatternStartsWithTwoSuccessiveOptionalRouteParts
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouteTest::routePartHandlerIsInstantiated
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouteTest::setDefaultsAllowsToSetTheDefaultPackageControllerAndActionName
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouteTest::setNameCorrectlySetsRouteName
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouteTest::settingInvalidRoutePartHandlerThrowsException
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouteTest::settingUriPatternResetsRoute
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouteTest::staticAndDynamicRoutesCanBeMixedInAnyOrder
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouteTest::uriPatternSegmentCanContainTwoDynamicRouteParts
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouteTest::uriPatternSegmentsCanContainMultipleDynamicRouteParts
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouteTest::uriPatternWithLeadingSlashThrowsException
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouteTest::uriPatternWithSuccessiveDynamicRoutepartsThrowsException
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouteTest::uriPatternWithSuccessiveOptionalSectionsThrowsException
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouteTest::uriPatternWithTrailingSlashThrowsException
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouteTest::uriPatternWithUnopenedOptionalSectionsThrowsException
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouteTest::uriPatternWithUnterminatedOptionalSectionsThrowsException
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouterCachingServiceTest::containsObjectDetectsObjectsInVariousSituations with data set #0
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouterCachingServiceTest::containsObjectDetectsObjectsInVariousSituations with data set #1
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouterCachingServiceTest::containsObjectDetectsObjectsInVariousSituations with data set #2
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouterCachingServiceTest::containsObjectDetectsObjectsInVariousSituations with data set #3
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouterCachingServiceTest::containsObjectDetectsObjectsInVariousSituations with data set #4
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouterCachingServiceTest::containsObjectDetectsObjectsInVariousSituations with data set #5
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouterCachingServiceTest::containsObjectDetectsObjectsInVariousSituations with data set #6
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouterCachingServiceTest::flushCachesResetsBothRoutingCaches
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouterCachingServiceTest::getCachedMatchResultsReturnsCachedMatchResultsIfFoundInCache
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouterCachingServiceTest::getCachedMatchResultsReturnsFalseIfNotFoundInCache
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouterCachingServiceTest::getCachedResolvedUriPathReturnsCachedResolvedUriPathIfFoundInCache
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouterCachingServiceTest::getCachedResolvedUriPathSkipsCacheIfRouteValuesContainObjectsThatCantBeConvertedToHashes
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouterCachingServiceTest::storeMatchExtractsUuidsToCacheTags
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouterCachingServiceTest::storeMatchResultsDoesNotStoreMatchResultsInCacheIfTheyContainObjects
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouterCachingServiceTest::storeResolvedUriPathConvertsObjectsImplementingCacheAwareInterfaceToCacheEntryIdentifier
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouterCachingServiceTest::storeResolvedUriPathConvertsObjectsToHashesToGenerateCacheIdentifier
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouterCachingServiceTest::storeResolvedUriPathExtractsUuidsToCacheTags
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouterTest::createRoutesFromConfigurationParsesTheGivenConfigurationAndBuildsRouteObjectsFromIt
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouterTest::createRoutesFromConfigurationThrowsExceptionIfOnlySomeRoutesWithTheSameUriPatternHaveHttpMethodConstraints
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouterTest::getLastMatchedRouteReturnsNullByDefault
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouterTest::getLastResolvedRouteReturnsNullByDefault
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouterTest::resolveCallsCreateRoutesFromConfiguration
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouterTest::resolveDoesNotStoreResolvedUriPathInCacheIfItsNull
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouterTest::resolveIteratesOverTheRegisteredRoutesAndReturnsTheResolvedUriPathIfAny
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouterTest::resolveReturnsCachedResolvedUriPathIfFoundInCache
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouterTest::resolveSetsLastResolvedRoute
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouterTest::resolveStoresResolvedUriPathInCacheIfNotFoundInCache
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouterTest::resolveThrowsExceptionIfNoMatchingRouteWasFound
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouterTest::routeDoesNotStoreMatchResultsInCacheIfTheyAreNull
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouterTest::routeReturnsCachedMatchResultsIfFoundInCache
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouterTest::routeSetsLastMatchedRoute
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RouterTest::routeStoresMatchResultsInCacheIfNotFoundInCache
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RoutingComponentTest::handleDoesNotInitializeRouterIfTheSkipRouterInitializationParameterIsSet
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RoutingComponentTest::handleInitializesRouterByDefault
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\RoutingComponentTest::handleStoresRouterMatchResultsInTheComponentContext
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\StaticRoutePartTest::matchResetsValueBeforeProcessingTheRoutePath
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\StaticRoutePartTest::routePathIsNotModifiedAfterUnsuccessfulMatch
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\StaticRoutePartTest::routePathIsShortenedByMatchingPartOnSuccessfulMatch
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\StaticRoutePartTest::staticRoutePartCanResolveEmptyArray
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\StaticRoutePartTest::staticRoutePartCanResolveNonEmptyArray
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\StaticRoutePartTest::staticRoutePartDoesNotAlterCaseIfLowerCaseIsFalse
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\StaticRoutePartTest::staticRoutePartDoesNotAlterRouteValuesWhenCallingResolve
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\StaticRoutePartTest::staticRoutePartDoesNotMatchIfCaseOfRequestPathIsNotEqualToTheName
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\StaticRoutePartTest::staticRoutePartDoesNotMatchIfNameIsNotEqualToBeginningOfRequestPath
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\StaticRoutePartTest::staticRoutePartDoesNotMatchIfRequestPathIsEmptyEvenIfDefaultValueIsSet
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\StaticRoutePartTest::staticRoutePartDoesNotMatchIfRequestPathIsNullOrEmpty
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\StaticRoutePartTest::staticRoutePartDoesNotMatchIfUnnamed
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\StaticRoutePartTest::staticRoutePartDoesNotResolveIfUnnamed
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\StaticRoutePartTest::staticRoutePartLowerCasesValueByDefault
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\StaticRoutePartTest::staticRoutePartMatchesIfNameIsEqualToBeginningOfRequestPath
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\StaticRoutePartTest::valueIsNullAfterUnsuccessfulMatch
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\UriBuilderTest::buildAddsActionNameFromRootRequestIfRequestIsOfTypeSubRequest
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\UriBuilderTest::buildAddsControllerNameFromRootRequestIfRequestIsOfTypeSubRequest
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\UriBuilderTest::buildAddsPackageKeyFromRootRequestIfRequestIsOfTypeSubRequest
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\UriBuilderTest::buildAddsSubpackageKeyFromRootRequestIfRequestIsOfTypeSubRequest
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\UriBuilderTest::buildAppendsSectionIfSectionIsSpecified
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\UriBuilderTest::buildDoesNotMergeArgumentsWithRequestArgumentsByDefault
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\UriBuilderTest::buildDoesNotMergeRootRequestArgumentsWithTheCurrentArgumentNamespaceIfRequestIsOfTypeSubRequest
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\UriBuilderTest::buildDoesNotMergeRootRequestArgumentsWithTheCurrentArgumentNamespaceIfRequestIsOfTypeSubRequestAndHasAParentSubRequest
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\UriBuilderTest::buildDoesNotPrependsScriptRequestPathIfCreateRelativePathsCompatibilityFlagIsTrue
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\UriBuilderTest::buildKeepsArgumentsBelongingToNamespacedSubRequestsIfAddQueryStringIsSet
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\UriBuilderTest::buildKeepsArgumentsBelongingToNamespacedSubSubRequestsIfAddQueryStringIsSet
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\UriBuilderTest::buildMergesArgumentsOfTheParentRequestIfRequestIsOfTypeSubRequestAndHasAParentSubRequest
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\UriBuilderTest::buildMergesArgumentsWithRequestArgumentsIfAddQueryStringIsSet
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\UriBuilderTest::buildMergesArgumentsWithRequestArgumentsOfCurrentRequestIfAddQueryStringIsSetAndRequestIsOfTypeSubRequest
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\UriBuilderTest::buildMergesArgumentsWithRootRequestArgumentsIfRequestIsOfTypeSubRequest
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\UriBuilderTest::buildPrependsBaseUriIfCreateAbsoluteUriIsSet
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\UriBuilderTest::buildPrependsIndexFileIfRewriteUrlsIsOff
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\UriBuilderTest::buildPrependsScriptRequestPathByDefaultIfCreateAbsoluteUriIsFalse
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\UriBuilderTest::buildRemovesArgumentsBelongingToNamespacedSubRequests
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\UriBuilderTest::buildRemovesArgumentsBelongingToNamespacedSubSubRequests
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\UriBuilderTest::buildRemovesSpecifiedQueryParametersIfArgumentsToBeExcludedFromQueryStringIsSet
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\UriBuilderTest::buildRemovesSpecifiedQueryParametersInCurrentNamespaceIfArgumentsToBeExcludedFromQueryStringIsSetAndRequestIsOfTypeSubRequest
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\UriBuilderTest::resetSetsAllOptionsToTheirDefaultValue
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\UriBuilderTest::setArgumentsSetsNonPrefixedArgumentsByDefault
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\UriBuilderTest::setRequestResetsUriBuilder
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\UriBuilderTest::settersAndGettersWorkAsExpected
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\UriBuilderTest::uriForDoesNotUseSubpackageKeyFromRequestIfOnlyThePackageIsSet
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\UriBuilderTest::uriForInSubRequestWithExplicitEmptySubpackageKeyDoesNotUseRequestSubpackageKey
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\UriBuilderTest::uriForPrefixesControllerArgumentsForMultipleNamespacedSubRequest
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\UriBuilderTest::uriForPrefixesControllerArgumentsWithSubRequestArgumentNamespaceIfNotEmpty
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\UriBuilderTest::uriForPrefixesControllerArgumentsWithSubRequestArgumentNamespaceOfParentRequestIfCurrentRequestHasNoNamespace
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\UriBuilderTest::uriForRecursivelyMergesAndOverrulesControllerArgumentsWithArguments
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\UriBuilderTest::uriForSetsControllerFromRequestIfControllerIsNotSet
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\UriBuilderTest::uriForSetsFormatArgumentIfSpecified
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\UriBuilderTest::uriForSetsPackageKeyFromRequestIfPackageKeyIsNotSet
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\UriBuilderTest::uriForSetsSubpackageKeyFromRequestIfPackageKeyAndSubpackageKeyAreNotSet
+.
+TYPO3\Flow\Tests\Unit\Mvc\Routing\UriBuilderTest::uriForThrowsExceptionIfActionNameIsNotSpecified
+.
+TYPO3\Flow\Tests\Unit\Mvc\View\AbstractViewTest::assignAddsValueToInternalVariableCollection
+.
+TYPO3\Flow\Tests\Unit\Mvc\View\AbstractViewTest::assignCanOverridePreviouslyAssignedValues
+.
+TYPO3\Flow\Tests\Unit\Mvc\View\AbstractViewTest::assignMultipleAddsValuesToInternalVariableCollection
+.
+TYPO3\Flow\Tests\Unit\Mvc\View\AbstractViewTest::assignMultipleCanOverridePreviouslyAssignedValues
+.
+TYPO3\Flow\Tests\Unit\Mvc\View\JsonViewTest::descendAllKeepsArrayIndexes
+.
+TYPO3\Flow\Tests\Unit\Mvc\View\JsonViewTest::renderCanRenderMultipleComplexObjects
+.
+TYPO3\Flow\Tests\Unit\Mvc\View\JsonViewTest::renderCanRenderPlainArray
+.
+TYPO3\Flow\Tests\Unit\Mvc\View\JsonViewTest::renderOnlyRendersVariableWithTheNameValue
+.
+TYPO3\Flow\Tests\Unit\Mvc\View\JsonViewTest::renderRendersMultipleValuesIfTheyAreSpecifiedAsVariablesToRender
+.
+TYPO3\Flow\Tests\Unit\Mvc\View\JsonViewTest::renderReturnsJsonRepresentationOfAssignedArray
+.
+TYPO3\Flow\Tests\Unit\Mvc\View\JsonViewTest::renderReturnsJsonRepresentationOfAssignedObject
+.
+TYPO3\Flow\Tests\Unit\Mvc\View\JsonViewTest::renderReturnsJsonRepresentationOfAssignedSimpleValue
+.
+TYPO3\Flow\Tests\Unit\Mvc\View\JsonViewTest::renderReturnsNullIfNameOfAssignedVariableIsNotEqualToValue
+.
+TYPO3\Flow\Tests\Unit\Mvc\View\JsonViewTest::renderSetsContentTypeHeader
+.
+TYPO3\Flow\Tests\Unit\Mvc\View\JsonViewTest::renderTransformsJsonSerializableValues
+.
+TYPO3\Flow\Tests\Unit\Mvc\View\JsonViewTest::setVariablesToRenderOverridesValueToRender
+.
+TYPO3\Flow\Tests\Unit\Mvc\View\JsonViewTest::testTransformValue with data set #0
+.
+TYPO3\Flow\Tests\Unit\Mvc\View\JsonViewTest::testTransformValue with data set #1
+.
+TYPO3\Flow\Tests\Unit\Mvc\View\JsonViewTest::testTransformValue with data set #10
+.
+TYPO3\Flow\Tests\Unit\Mvc\View\JsonViewTest::testTransformValue with data set #11
+.
+TYPO3\Flow\Tests\Unit\Mvc\View\JsonViewTest::testTransformValue with data set #2
+.
+TYPO3\Flow\Tests\Unit\Mvc\View\JsonViewTest::testTransformValue with data set #3
+.
+TYPO3\Flow\Tests\Unit\Mvc\View\JsonViewTest::testTransformValue with data set #4
+.
+TYPO3\Flow\Tests\Unit\Mvc\View\JsonViewTest::testTransformValue with data set #5
+.
+TYPO3\Flow\Tests\Unit\Mvc\View\JsonViewTest::testTransformValue with data set #6
+.
+TYPO3\Flow\Tests\Unit\Mvc\View\JsonViewTest::testTransformValue with data set #7
+.
+TYPO3\Flow\Tests\Unit\Mvc\View\JsonViewTest::testTransformValue with data set #8
+.
+TYPO3\Flow\Tests\Unit\Mvc\View\JsonViewTest::testTransformValue with data set #9
+.
+TYPO3\Flow\Tests\Unit\Mvc\View\JsonViewTest::testTransformValueWithObjectIdentifierExposure with data set #0
+.
+TYPO3\Flow\Tests\Unit\Mvc\View\JsonViewTest::testTransformValueWithObjectIdentifierExposure with data set #1
+.
+TYPO3\Flow\Tests\Unit\Mvc\View\JsonViewTest::viewAcceptsJsonEncodingOptions
+.
+TYPO3\Flow\Tests\Unit\Mvc\View\JsonViewTest::viewExposesClassNameFullyIfConfiguredSo with data set #0
+.
+TYPO3\Flow\Tests\Unit\Mvc\View\JsonViewTest::viewExposesClassNameFullyIfConfiguredSo with data set #1
+.
+TYPO3\Flow\Tests\Unit\Mvc\View\JsonViewTest::viewExposesClassNameFullyIfConfiguredSo with data set #2
+.
+TYPO3\Flow\Tests\Unit\Object\CompileTimeObjectManagerTest::flowPackageClassesAreNotFilteredFromObjectManagementByDefault
+.
+TYPO3\Flow\Tests\Unit\Object\CompileTimeObjectManagerTest::flowPackageClassesForNonMatchingIncludesAreRemoved
+.
+TYPO3\Flow\Tests\Unit\Object\CompileTimeObjectManagerTest::nonFlowPackageClassesAreFilteredFromObjectManagementByDefault
+.
+TYPO3\Flow\Tests\Unit\Object\CompileTimeObjectManagerTest::nonFlowPackageClassesCanBeIncludedInObjectManagementByConfiguration
+.
+TYPO3\Flow\Tests\Unit\Object\CompileTimeObjectManagerTest::nonFlowPackageClassesExcludedAndIncludedWillNotBeIncluded
+.
+TYPO3\Flow\Tests\Unit\Object\Configuration\ConfigurationBuilderTest::allBasicOptionsAreSetCorrectly
+.
+TYPO3\Flow\Tests\Unit\Object\Configuration\ConfigurationBuilderTest::argumentsOfTypeObjectCanSpecifyAdditionalObjectConfigurationOptions
+.
+TYPO3\Flow\Tests\Unit\Object\Configuration\ConfigurationBuilderTest::errorOnGetClassMethodsThrowsException
+.
+TYPO3\Flow\Tests\Unit\Object\Configuration\ConfigurationBuilderTest::invalidOptionResultsInException
+.
+TYPO3\Flow\Tests\Unit\Object\Configuration\ConfigurationBuilderTest::itIsPossibleToPassArraysAsStraightArgumentOrPropertyValues
+.
+TYPO3\Flow\Tests\Unit\Object\Configuration\ConfigurationBuilderTest::parseConfigurationArrayBuildsConfigurationArgumentForInjectedSetting
+.
+TYPO3\Flow\Tests\Unit\Object\Configuration\ConfigurationBuilderTest::parseConfigurationArrayBuildsConfigurationPropertyForInjectedSetting
+.
+TYPO3\Flow\Tests\Unit\Object\Configuration\ConfigurationBuilderTest::privatePropertyAnnotatedForInjectionThrowsException
+.
+TYPO3\Flow\Tests\Unit\Object\Configuration\ConfigurationBuilderTest::propertiesOfTypeObjectCanSpecifyAdditionalObjectConfigurationOptions
+.
+TYPO3\Flow\Tests\Unit\Object\Configuration\ConfigurationTest::passingAnEmptyArrayToSetArgumentsRemovesAllExistingArguments
+.
+TYPO3\Flow\Tests\Unit\Object\Configuration\ConfigurationTest::passingAnEmptyArrayToSetPropertiesRemovesAllExistingproperties
+.
+TYPO3\Flow\Tests\Unit\Object\Configuration\ConfigurationTest::setArgumentsOnlyAcceptsValidValues
+.
+TYPO3\Flow\Tests\Unit\Object\Configuration\ConfigurationTest::setFactoryMethodNameAcceptsValidStrings
+.
+TYPO3\Flow\Tests\Unit\Object\Configuration\ConfigurationTest::setFactoryMethodNameRejectsAnythingElseThanAString
+.
+TYPO3\Flow\Tests\Unit\Object\Configuration\ConfigurationTest::setFactoryObjectNameAcceptsValidClassNames
+.
+TYPO3\Flow\Tests\Unit\Object\Configuration\ConfigurationTest::setPropertiesOnlyAcceptsValidValues
+.
+TYPO3\Flow\Tests\Unit\Object\Configuration\ConfigurationTest::theDefaultFactoryMethodNameIsCreate
+.
+TYPO3\Flow\Tests\Unit\Object\DependencyInject\DependencyProxyTest::getClassNameReturnsTheNameOfTheProxiedDependencyClass
+.
+TYPO3\Flow\Tests\Unit\Object\ObjectSerializerTest::buildStorageArrayCreatesTheCorrectArrayForAnArrayProperty
+.
+TYPO3\Flow\Tests\Unit\Object\ObjectSerializerTest::buildStorageArrayCreatesTheCorrectArrayForAnArrayPropertyWithContainingObject
+.
+TYPO3\Flow\Tests\Unit\Object\ObjectSerializerTest::deserializeObjectsArrayCallsReconstituteObjectWithTheCorrectObjectData
+.
+TYPO3\Flow\Tests\Unit\Object\ObjectSerializerTest::deserializeObjectsArraySetsTheInternalObjectsAsArrayPropertyCorrectly
+.
+TYPO3\Flow\Tests\Unit\Object\ObjectSerializerTest::reconstituteArrayWorks
+.
+TYPO3\Flow\Tests\Unit\Object\ObjectSerializerTest::reconstituteArrayWorksWithCollectionInTheArray
+.
+TYPO3\Flow\Tests\Unit\Object\ObjectSerializerTest::reconstituteArrayWorksWithObjectsInTheArray
+.
+TYPO3\Flow\Tests\Unit\Object\ObjectSerializerTest::reconstituteArrayWorksWithPersistenceObjectsInTheArray
+.
+TYPO3\Flow\Tests\Unit\Object\ObjectSerializerTest::reconstituteArrayWorksWithSplObjectStorageInTheArray
+.
+TYPO3\Flow\Tests\Unit\Object\ObjectSerializerTest::reconstituteCollectionWorks
+.
+TYPO3\Flow\Tests\Unit\Object\ObjectSerializerTest::reconstituteObjectCallsTheCorrectReconstitutePropertyTypeFunctionsAndSetsTheValuesInTheObject
+.
+TYPO3\Flow\Tests\Unit\Object\ObjectSerializerTest::reconstitutePersistenceObjectRetrievesTheObjectCorrectlyFromThePersistenceFramework
+.
+TYPO3\Flow\Tests\Unit\Object\ObjectSerializerTest::reconstituteSplObjectStorageWorks
+.
+TYPO3\Flow\Tests\Unit\Object\ObjectSerializerTest::serializeObjectAsPropertyArrayForDoctrineCollectionPropertyBuildsTheCorrectArrayStructureAndStoresEveryObjectInsideSeparately
+.
+TYPO3\Flow\Tests\Unit\Object\ObjectSerializerTest::serializeObjectAsPropertyArrayForSplObjectStoragePropertyBuildsTheCorrectArrayStructureAndStoresEveryObjectInsideSeparately
+.
+TYPO3\Flow\Tests\Unit\Object\ObjectSerializerTest::serializeObjectAsPropertyArraySerializesArrayObjectPropertiesCorrectly
+.
+TYPO3\Flow\Tests\Unit\Object\ObjectSerializerTest::serializeObjectAsPropertyArraySerializesArrayPropertiesCorrectly
+.
+TYPO3\Flow\Tests\Unit\Object\ObjectSerializerTest::serializeObjectAsPropertyArraySerializesObjectPropertiesCorrectly
+.
+TYPO3\Flow\Tests\Unit\Object\ObjectSerializerTest::serializeObjectAsPropertyArraySerializesOnlyTheUuidOfEntityObjectsIfTheyAreNotMarkedAsNew
+.
+TYPO3\Flow\Tests\Unit\Object\ObjectSerializerTest::serializeObjectAsPropertyArraySerializesTheCorrectPropertyArrayUnderTheCorrectObjectName
+.
+TYPO3\Flow\Tests\Unit\Object\ObjectSerializerTest::serializeObjectAsPropertyArraySerializessOnlyTheUuidOfPersistenceValueobjectsIfTheyAreNotMarkedAsNew
+.
+TYPO3\Flow\Tests\Unit\Object\ObjectSerializerTest::serializeObjectAsPropertyArraySkipsObjectPropertiesThatAreScopeSingleton
+.
+TYPO3\Flow\Tests\Unit\Object\ObjectSerializerTest::serializeObjectAsPropertyArraySkipsPropertiesThatAreAnnotatedToBeTransient
+.
+TYPO3\Flow\Tests\Unit\Object\ObjectSerializerTest::serializeObjectSerializesObjectInstancesOnlyOnceToPreventRecursion
+.
+TYPO3\Flow\Tests\Unit\Object\Proxy\CompilerTest::renderAnnotationRendersCorrectly with data set #0
+.
+TYPO3\Flow\Tests\Unit\Object\Proxy\CompilerTest::renderAnnotationRendersCorrectly with data set #1
+.
+TYPO3\Flow\Tests\Unit\Object\Proxy\CompilerTest::renderAnnotationRendersCorrectly with data set #10
+.
+TYPO3\Flow\Tests\Unit\Object\Proxy\CompilerTest::renderAnnotationRendersCorrectly with data set #11
+.
+TYPO3\Flow\Tests\Unit\Object\Proxy\CompilerTest::renderAnnotationRendersCorrectly with data set #2
+.
+TYPO3\Flow\Tests\Unit\Object\Proxy\CompilerTest::renderAnnotationRendersCorrectly with data set #3
+.
+TYPO3\Flow\Tests\Unit\Object\Proxy\CompilerTest::renderAnnotationRendersCorrectly with data set #4
+.
+TYPO3\Flow\Tests\Unit\Object\Proxy\CompilerTest::renderAnnotationRendersCorrectly with data set #5
+.
+TYPO3\Flow\Tests\Unit\Object\Proxy\CompilerTest::renderAnnotationRendersCorrectly with data set #6
+.
+TYPO3\Flow\Tests\Unit\Object\Proxy\CompilerTest::renderAnnotationRendersCorrectly with data set #7
+.
+TYPO3\Flow\Tests\Unit\Object\Proxy\CompilerTest::renderAnnotationRendersCorrectly with data set #8
+.
+TYPO3\Flow\Tests\Unit\Object\Proxy\CompilerTest::renderAnnotationRendersCorrectly with data set #9
+.
+TYPO3\Flow\Tests\Unit\Object\Proxy\CompilerTest::stripOpeningPhpTagCorrectlyStripsPhpTagTests with data set #0
+.
+TYPO3\Flow\Tests\Unit\Object\Proxy\CompilerTest::stripOpeningPhpTagCorrectlyStripsPhpTagTests with data set #1
+.
+TYPO3\Flow\Tests\Unit\Object\Proxy\CompilerTest::stripOpeningPhpTagCorrectlyStripsPhpTagTests with data set #10
+.
+TYPO3\Flow\Tests\Unit\Object\Proxy\CompilerTest::stripOpeningPhpTagCorrectlyStripsPhpTagTests with data set #2
+.
+TYPO3\Flow\Tests\Unit\Object\Proxy\CompilerTest::stripOpeningPhpTagCorrectlyStripsPhpTagTests with data set #3
+.
+TYPO3\Flow\Tests\Unit\Object\Proxy\CompilerTest::stripOpeningPhpTagCorrectlyStripsPhpTagTests with data set #4
+.
+TYPO3\Flow\Tests\Unit\Object\Proxy\CompilerTest::stripOpeningPhpTagCorrectlyStripsPhpTagTests with data set #5
+.
+TYPO3\Flow\Tests\Unit\Object\Proxy\CompilerTest::stripOpeningPhpTagCorrectlyStripsPhpTagTests with data set #6
+.
+TYPO3\Flow\Tests\Unit\Object\Proxy\CompilerTest::stripOpeningPhpTagCorrectlyStripsPhpTagTests with data set #7
+.
+TYPO3\Flow\Tests\Unit\Object\Proxy\CompilerTest::stripOpeningPhpTagCorrectlyStripsPhpTagTests with data set #8
+.
+TYPO3\Flow\Tests\Unit\Object\Proxy\CompilerTest::stripOpeningPhpTagCorrectlyStripsPhpTagTests with data set #9
+.
+TYPO3\Flow\Tests\Unit\Object\Proxy\ProxyClassTest::renderWorksAsExpected with data set #0
+.
+TYPO3\Flow\Tests\Unit\Object\Proxy\ProxyClassTest::renderWorksAsExpected with data set #1
+.
+TYPO3\Flow\Tests\Unit\Object\Proxy\ProxyClassTest::renderWorksAsExpected with data set #2
+.
+TYPO3\Flow\Tests\Unit\Object\Proxy\ProxyMethodTest::buildMethodDocumentationAddsAllExpectedAnnotations
+.
+TYPO3\Flow\Tests\Unit\Object\Proxy\ProxyMethodTest::buildMethodParametersCodeOmitsTypeHintsAndDefaultValuesIfToldSo
+.
+TYPO3\Flow\Tests\Unit\Object\Proxy\ProxyMethodTest::buildMethodParametersCodeRendersParametersCodeWithCorrectTypeHintsAndDefaultValues
+.
+TYPO3\Flow\Tests\Unit\Object\Proxy\ProxyMethodTest::buildMethodParametersCodeReturnsAnEmptyStringIfTheClassNameIsNULL
+.
+TYPO3\Flow\Tests\Unit\Package\DocumentationTest::constructSetsPackageNameAndPathToDocumentation
+.
+TYPO3\Flow\Tests\Unit\Package\DocumentationTest::getDocumentationFormatsScansDocumentationDirectoryAndReturnsDocumentationFormatObjectsIndexedByFormatName
+.
+TYPO3\Flow\Tests\Unit\Package\Documentation\FormatTest::constructSetsNameAndPathToFormat
+.
+TYPO3\Flow\Tests\Unit\Package\Documentation\FormatTest::getLanguagesScansFormatDirectoryAndReturnsLanguagesAsStrings
+.
+TYPO3\Flow\Tests\Unit\Package\PackageManagerTest::activatePackageAndDeactivatePackageActivateAndDeactivateTheGivenPackage
+.
+TYPO3\Flow\Tests\Unit\Package\PackageManagerTest::availablePackagesAreSortedAfterTheirDependencies with data set #0
+.
+TYPO3\Flow\Tests\Unit\Package\PackageManagerTest::availablePackagesAreSortedAfterTheirDependencies with data set #1
+.
+TYPO3\Flow\Tests\Unit\Package\PackageManagerTest::createPackageActivatesTheNewlyCreatedPackage
+.
+TYPO3\Flow\Tests\Unit\Package\PackageManagerTest::createPackageCanChangePackageTypeInComposerManifest
+.
+TYPO3\Flow\Tests\Unit\Package\PackageManagerTest::createPackageCreatesCommonFolders
+.
+TYPO3\Flow\Tests\Unit\Package\PackageManagerTest::createPackageCreatesPackageFolderAndReturnsPackage with data set #0
+.
+TYPO3\Flow\Tests\Unit\Package\PackageManagerTest::createPackageCreatesPackageFolderAndReturnsPackage with data set #1
+.
+TYPO3\Flow\Tests\Unit\Package\PackageManagerTest::createPackageThrowsExceptionForExistingPackageKey
+.
+TYPO3\Flow\Tests\Unit\Package\PackageManagerTest::createPackageThrowsExceptionOnInvalidPackageKey
+.
+TYPO3\Flow\Tests\Unit\Package\PackageManagerTest::createPackageWritesAComposerManifestUsingTheGivenMetaObject
+.
+TYPO3\Flow\Tests\Unit\Package\PackageManagerTest::deactivatePackageThrowsAnExceptionIfPackageIsProtected
+.
+TYPO3\Flow\Tests\Unit\Package\PackageManagerTest::deletePackageRemovesPackageFromAvailableAndActivePackagesAndDeletesThePackageDirectory
+.
+TYPO3\Flow\Tests\Unit\Package\PackageManagerTest::deletePackageThrowsAnExceptionIfPackageIsProtected
+.
+TYPO3\Flow\Tests\Unit\Package\PackageManagerTest::deletePackageThrowsErrorIfPackageIsNotAvailable
+.
+TYPO3\Flow\Tests\Unit\Package\PackageManagerTest::getCaseSensitivePackageKeyReturnsTheUpperCamelCaseVersionOfAGivenPackageKeyIfThePackageIsRegistered
+.
+TYPO3\Flow\Tests\Unit\Package\PackageManagerTest::getPackageKeyFromComposerNameIgnoresCaseDifferences with data set #0
+.
+TYPO3\Flow\Tests\Unit\Package\PackageManagerTest::getPackageKeyFromComposerNameIgnoresCaseDifferences with data set #1
+.
+TYPO3\Flow\Tests\Unit\Package\PackageManagerTest::getPackageKeyFromComposerNameIgnoresCaseDifferences with data set #2
+.
+TYPO3\Flow\Tests\Unit\Package\PackageManagerTest::getPackageKeyFromComposerNameIgnoresCaseDifferences with data set #3
+.
+TYPO3\Flow\Tests\Unit\Package\PackageManagerTest::getPackageOfObjectAssumesParentClassIfDoctrineProxyClassGiven
+.
+TYPO3\Flow\Tests\Unit\Package\PackageManagerTest::getPackageOfObjectDoesNotGivePackageWithShorterPathPrematurely
+.
+TYPO3\Flow\Tests\Unit\Package\PackageManagerTest::getPackageOfObjectGetsPackageByGivenObject
+.
+TYPO3\Flow\Tests\Unit\Package\PackageManagerTest::getPackageOfObjectReturnsNullIfPackageCouldNotBeResolved
+.
+TYPO3\Flow\Tests\Unit\Package\PackageManagerTest::getPackageReturnsTheSpecifiedPackage
+.
+TYPO3\Flow\Tests\Unit\Package\PackageManagerTest::getPackageThrowsExceptionOnUnknownPackage
+.
+TYPO3\Flow\Tests\Unit\Package\PackageManagerTest::packageStatesConfigurationContainsRelativePaths
+.
+TYPO3\Flow\Tests\Unit\Package\PackageManagerTest::registeringTheSamePackageKeyWithDifferentCaseShouldThrowException
+.
+TYPO3\Flow\Tests\Unit\Package\PackageManagerTest::scanAvailablePackagesKeepsExistingPackageConfiguration
+F
+TYPO3\Flow\Tests\Unit\Package\PackageManagerTest::scanAvailablePackagesTraversesThePackagesDirectoryAndRegistersPackagesItFinds
+.
+TYPO3\Flow\Tests\Unit\Package\PackageTest::aPackageCanBeFlaggedAsProtected
+.
+TYPO3\Flow\Tests\Unit\Package\PackageTest::constructAcceptsValidPackageKeys with data set #0
+.
+TYPO3\Flow\Tests\Unit\Package\PackageTest::constructAcceptsValidPackageKeys with data set #1
+.
+TYPO3\Flow\Tests\Unit\Package\PackageTest::constructAcceptsValidPackageKeys with data set #2
+.
+TYPO3\Flow\Tests\Unit\Package\PackageTest::constructAcceptsValidPackageKeys with data set #3
+.
+TYPO3\Flow\Tests\Unit\Package\PackageTest::constructAcceptsValidPackageKeys with data set #4
+.
+TYPO3\Flow\Tests\Unit\Package\PackageTest::constructRejectsInvalidPackageKeys with data set #0
+.
+TYPO3\Flow\Tests\Unit\Package\PackageTest::constructRejectsInvalidPackageKeys with data set #1
+.
+TYPO3\Flow\Tests\Unit\Package\PackageTest::constructRejectsInvalidPackageKeys with data set #2
+.
+TYPO3\Flow\Tests\Unit\Package\PackageTest::constructorSetsTheClassesPathAccordingToThePsr0MappingIfItExists
+.
+TYPO3\Flow\Tests\Unit\Package\PackageTest::constructorSetsTheClassesPathAccordingToThePsr4MappingIfItExists
+.
+TYPO3\Flow\Tests\Unit\Package\PackageTest::constructorSetsTheClassesPathAsSpecifiedIfNoPsrMappingExists
+.
+TYPO3\Flow\Tests\Unit\Package\PackageTest::constructorSetsTheClassesPathToFirstConfiguredPsr0Mapping
+.
+TYPO3\Flow\Tests\Unit\Package\PackageTest::constructorThrowsInvalidPackageKeyExceptionIfTheSpecifiedPackageKeyIsNotValid
+.
+TYPO3\Flow\Tests\Unit\Package\PackageTest::constructorThrowsInvalidPackageManifestExceptionIfNoComposerManifestWasFound
+.
+TYPO3\Flow\Tests\Unit\Package\PackageTest::constructorThrowsInvalidPackagePathExceptionIfTheSpecifiedClassesPathHasALeadingSlash
+.
+TYPO3\Flow\Tests\Unit\Package\PackageTest::constructorThrowsInvalidPackagePathExceptionIfTheSpecifiedPackagePathDoesHaveATrailingSlash
+.
+TYPO3\Flow\Tests\Unit\Package\PackageTest::constructorThrowsInvalidPackagePathExceptionIfTheSpecifiedPackagePathDoesNotExist
+.
+TYPO3\Flow\Tests\Unit\Package\PackageTest::getClassFilesReturnsAListOfClassFilesOfThePackage
+.
+TYPO3\Flow\Tests\Unit\Package\PackageTest::getClassesPathReturnsNormalizedPathToClasses
+.
+TYPO3\Flow\Tests\Unit\Package\PackageTest::getClassesPathReturnsPathToClasses
+.
+TYPO3\Flow\Tests\Unit\Package\PackageTest::getDocumentationPathReturnsPathToDocumentationDirectory
+.
+TYPO3\Flow\Tests\Unit\Package\PackageTest::getMetaPathReturnsPathToMetaDirectory
+.
+TYPO3\Flow\Tests\Unit\Package\PackageTest::getNamespaceReturnsPsr4NamespaceIfNoPsr0MappingIsDefined
+.
+TYPO3\Flow\Tests\Unit\Package\PackageTest::getNamespaceReturnsTheFirstPsr0NamespaceIfMultiplePsr0MappingsAreDefined
+.
+TYPO3\Flow\Tests\Unit\Package\PackageTest::getNamespaceReturnsTheFirstPsr4NamespaceIfMultiplePsr4MappingsAreDefined
+.
+TYPO3\Flow\Tests\Unit\Package\PackageTest::getNamespaceReturnsThePhpNamespaceCorrespondingToThePackageKeyIfNoPsrMappingIsDefined
+.
+TYPO3\Flow\Tests\Unit\Package\PackageTest::getNamespaceReturnsThePsr0NamespaceIfAPsr0MappingIsDefined
+.
+TYPO3\Flow\Tests\Unit\Package\PackageTest::getPackageDocumentationsReturnsEmptyArrayIfDocumentationDirectoryDoesntExist
+.
+TYPO3\Flow\Tests\Unit\Package\PackageTest::isObjectManagementEnabledTellsIfObjectManagementShouldBeEnabledForPackages
+.
+TYPO3\Flow\Tests\Unit\Package\PackageTest::packageMetaDataContainsPackageType
+.
+TYPO3\Flow\Tests\Unit\Persistence\AbstractPersistenceManagerTest::convertObjectToIdentityArrayConvertsAnObject
+.
+TYPO3\Flow\Tests\Unit\Persistence\AbstractPersistenceManagerTest::convertObjectToIdentityArrayThrowsExceptionIfIdentityForTheGivenObjectCantBeDetermined
+.
+TYPO3\Flow\Tests\Unit\Persistence\AbstractPersistenceManagerTest::convertObjectsToIdentityArraysConvertsObjectsInIterators
+.
+TYPO3\Flow\Tests\Unit\Persistence\AbstractPersistenceManagerTest::convertObjectsToIdentityArraysRecursivelyConvertsObjects
+.
+TYPO3\Flow\Tests\Unit\Persistence\Aspect\PersistenceMagicAspectTest::cloneObjectMarksTheObjectAsCloned
+.
+TYPO3\Flow\Tests\Unit\Persistence\Aspect\PersistenceMagicAspectTest::generateUuidGeneratesUuidAndRegistersProxyAsNewObject
+.
+TYPO3\Flow\Tests\Unit\Persistence\Doctrine\EntityManagerFactoryTest::dqlCustomDateTimeFunctionCanCorrectlyBeAppliedToConfiguration
+.
+TYPO3\Flow\Tests\Unit\Persistence\Doctrine\EntityManagerFactoryTest::dqlCustomNumericFunctionCanCorrectlyBeAppliedToConfiguration
+.
+TYPO3\Flow\Tests\Unit\Persistence\Doctrine\EntityManagerFactoryTest::dqlCustomStringFunctionCanCorrectlyBeAppliedToConfiguration
+.
+TYPO3\Flow\Tests\Unit\Persistence\Doctrine\Mapping\Driver\FlowAnnotationDriverTest::getMaxIdentifierLengthAsksDoctrineForValue
+.
+TYPO3\Flow\Tests\Unit\Persistence\Doctrine\Mapping\Driver\FlowAnnotationDriverTest::testInferJoinTableNameFromClassAndPropertyName with data set #0
+.
+TYPO3\Flow\Tests\Unit\Persistence\Doctrine\Mapping\Driver\FlowAnnotationDriverTest::testInferJoinTableNameFromClassAndPropertyName with data set #1
+.
+TYPO3\Flow\Tests\Unit\Persistence\Doctrine\Mapping\Driver\FlowAnnotationDriverTest::testInferJoinTableNameFromClassAndPropertyName with data set #2
+.
+TYPO3\Flow\Tests\Unit\Persistence\Doctrine\Mapping\Driver\FlowAnnotationDriverTest::testInferJoinTableNameFromClassAndPropertyName with data set #3
+.
+TYPO3\Flow\Tests\Unit\Persistence\Doctrine\Mapping\Driver\FlowAnnotationDriverTest::testInferJoinTableNameFromClassAndPropertyName with data set #4
+.
+TYPO3\Flow\Tests\Unit\Persistence\Doctrine\Mapping\Driver\FlowAnnotationDriverTest::testInferJoinTableNameFromClassAndPropertyName with data set #5
+.
+TYPO3\Flow\Tests\Unit\Persistence\Doctrine\Mapping\Driver\FlowAnnotationDriverTest::testInferJoinTableNameFromClassAndPropertyName with data set #6
+.
+TYPO3\Flow\Tests\Unit\Persistence\Doctrine\Mapping\Driver\FlowAnnotationDriverTest::testInferTableNameFromClassName with data set #0
+.
+TYPO3\Flow\Tests\Unit\Persistence\Doctrine\Mapping\Driver\FlowAnnotationDriverTest::testInferTableNameFromClassName with data set #1
+.
+TYPO3\Flow\Tests\Unit\Persistence\Doctrine\Mapping\Driver\FlowAnnotationDriverTest::testInferTableNameFromClassName with data set #2
+.
+TYPO3\Flow\Tests\Unit\Persistence\Doctrine\Mapping\Driver\FlowAnnotationDriverTest::testInferTableNameFromClassName with data set #3
+.
+TYPO3\Flow\Tests\Unit\Persistence\Doctrine\Mapping\Driver\FlowAnnotationDriverTest::testInferTableNameFromClassName with data set #4
+.
+TYPO3\Flow\Tests\Unit\Persistence\Doctrine\PersistenceManagerTest::getIdentifierByObjectUsesUnitOfWorkIdentityWithEmptyFlowPersistenceIdentifier
+.
+TYPO3\Flow\Tests\Unit\Persistence\Doctrine\PersistenceManagerTest::persistAllAbortsIfConnectionIsClosed
+.
+TYPO3\Flow\Tests\Unit\Persistence\Doctrine\PersistenceManagerTest::persistAllEmitsAllObjectsPersistedSignal
+.
+TYPO3\Flow\Tests\Unit\Persistence\Doctrine\PersistenceManagerTest::persistAllReconnectsConnectionOnFailure
+.
+TYPO3\Flow\Tests\Unit\Persistence\Doctrine\PersistenceManagerTest::persistAllRespectsObjectWhitelistIfOnlyWhitelistedObjectsFlagIsTrue
+.
+TYPO3\Flow\Tests\Unit\Persistence\Doctrine\PersistenceManagerTest::persistAllThrowsExceptionIfTryingToPersistNonWhitelistedObjectsAndOnlyWhitelistedObjectsFlagIsTrue
+.
+TYPO3\Flow\Tests\Unit\Persistence\Doctrine\QueryResultTest::getQueryReturnsAClone
+.
+TYPO3\Flow\Tests\Unit\Persistence\Doctrine\QueryResultTest::getQueryReturnsQueryObject
+.
+TYPO3\Flow\Tests\Unit\Persistence\Doctrine\QueryResultTest::offsetGetReturnsNullIfOffsetDoesNotExist
+.
+TYPO3\Flow\Tests\Unit\Persistence\Generic\Backend\AbstractBackendTest::arrayContainsObjectReturnsFalseForClone
+.
+TYPO3\Flow\Tests\Unit\Persistence\Generic\Backend\AbstractBackendTest::arrayContainsObjectReturnsFalseForDifferentObject
+.
+TYPO3\Flow\Tests\Unit\Persistence\Generic\Backend\AbstractBackendTest::arrayContainsObjectReturnsTrueForSameObject
+.
+TYPO3\Flow\Tests\Unit\Persistence\Generic\Backend\AbstractBackendTest::commitDelegatesToPersistObjectsAndProcessDeletedObjects
+.
+TYPO3\Flow\Tests\Unit\Persistence\Generic\Backend\AbstractBackendTest::getTypeNormalizesDoubleToFloat
+.
+TYPO3\Flow\Tests\Unit\Persistence\Generic\Backend\AbstractBackendTest::getTypeReturnsClassNameForObjects
+.
+TYPO3\Flow\Tests\Unit\Persistence\Generic\Backend\AbstractBackendTest::persistObjectsPassesObjectsToPersistObject
+.
+TYPO3\Flow\Tests\Unit\Persistence\Generic\Backend\AbstractBackendTest::processDeletedObjectsPassesObjectsToRemoveEntity
+.
+TYPO3\Flow\Tests\Unit\Persistence\Generic\Backend\AbstractBackendTest::processDeletedObjectsPassesOnlyKnownObjectsToRemoveEntity
+.
+TYPO3\Flow\Tests\Unit\Persistence\Generic\DataMapperTest::mapArrayCreatesExpectedArray
+.
+TYPO3\Flow\Tests\Unit\Persistence\Generic\DataMapperTest::mapArrayMapsNestedArray
+.
+TYPO3\Flow\Tests\Unit\Persistence\Generic\DataMapperTest::mapDateTimeCreatesDateTimeFromTimestamp
+.
+TYPO3\Flow\Tests\Unit\Persistence\Generic\DataMapperTest::mapSplObjectStorageCreatesSplObjectStorage
+.
+TYPO3\Flow\Tests\Unit\Persistence\Generic\DataMapperTest::mapToObjectReconstitutesExpectedObjectAndRegistersItWithIdentityMapToObjects
+.
+TYPO3\Flow\Tests\Unit\Persistence\Generic\DataMapperTest::mapToObjectReturnsObjectFromIdentityMapIfAvailable
+.
+TYPO3\Flow\Tests\Unit\Persistence\Generic\DataMapperTest::mapToObjectThrowsExceptionOnEmptyInput
+.
+TYPO3\Flow\Tests\Unit\Persistence\Generic\DataMapperTest::mapToObjectsMapsArrayToObjectByCallingMapToObject
+.
+TYPO3\Flow\Tests\Unit\Persistence\Generic\DataMapperTest::thawPropertiesAssignsMetadataToTheProxyIfItExists
+.
+TYPO3\Flow\Tests\Unit\Persistence\Generic\DataMapperTest::thawPropertiesAssignsTheUuidToTheProxy
+.
+TYPO3\Flow\Tests\Unit\Persistence\Generic\DataMapperTest::thawPropertiesDelegatesHandlingOfArraysAndObjects
+.
+TYPO3\Flow\Tests\Unit\Persistence\Generic\DataMapperTest::thawPropertiesFollowsOrderOfGivenObjectData
+S
+TYPO3\Flow\Tests\Unit\Persistence\Generic\DataMapperTest::thawPropertiesSetsPropertyValues
+.
+TYPO3\Flow\Tests\Unit\Persistence\Generic\DataMapperTest::thawPropertiesSkipsPropertiesNoLongerInClassSchema
+.
+TYPO3\Flow\Tests\Unit\Persistence\Generic\PersistenceManagerTest::addActuallyAddsAnObjectToTheInternalObjectsArray
+.
+TYPO3\Flow\Tests\Unit\Persistence\Generic\PersistenceManagerTest::clearStateForgetsAboutNewObjects
+.
+TYPO3\Flow\Tests\Unit\Persistence\Generic\PersistenceManagerTest::getIdentifierByObjectReturnsIdentifierFromSession
+.
+TYPO3\Flow\Tests\Unit\Persistence\Generic\PersistenceManagerTest::getObjectByIdentifierReturnsNullForUnknownObject
+.
+TYPO3\Flow\Tests\Unit\Persistence\Generic\PersistenceManagerTest::getObjectByIdentifierReturnsObjectFromPersistenceIfAvailable
+.
+TYPO3\Flow\Tests\Unit\Persistence\Generic\PersistenceManagerTest::getObjectByIdentifierReturnsObjectFromSessionIfAvailable
+.
+TYPO3\Flow\Tests\Unit\Persistence\Generic\PersistenceManagerTest::initializeInitializesBackendWithBackendOptions
+.
+TYPO3\Flow\Tests\Unit\Persistence\Generic\PersistenceManagerTest::persistAllPassesAddedObjectsToBackend
+.
+TYPO3\Flow\Tests\Unit\Persistence\Generic\PersistenceManagerTest::persistAllPassesRemovedObjectsToBackend
+.
+TYPO3\Flow\Tests\Unit\Persistence\Generic\PersistenceManagerTest::removeActuallyRemovesAnObjectFromTheInternalObjectsArray
+.
+TYPO3\Flow\Tests\Unit\Persistence\Generic\PersistenceManagerTest::removeRemovesTheRightObjectEvenIfItHasBeenModifiedSinceItsAddition
+.
+TYPO3\Flow\Tests\Unit\Persistence\Generic\PersistenceManagerTest::removeRetainsObjectForObjectsNotInCurrentSession
+.
+TYPO3\Flow\Tests\Unit\Persistence\Generic\PersistenceManagerTest::tearDownWithBackendNotSupportingTearDownDoesNothing
+.
+TYPO3\Flow\Tests\Unit\Persistence\Generic\PersistenceManagerTest::tearDownWithBackendSupportingTearDownDelegatesCallToBackend
+.
+TYPO3\Flow\Tests\Unit\Persistence\Generic\PersistenceManagerTest::updateSchedulesAnObjectForPersistence
+I
+TYPO3\Flow\Tests\Unit\Persistence\Generic\QueryResultTest::countCallsGetObjectCountByQueryOnPersistenceManager
+.
+TYPO3\Flow\Tests\Unit\Persistence\Generic\QueryResultTest::countDoesNotInitializeProxy
+.
+TYPO3\Flow\Tests\Unit\Persistence\Generic\QueryResultTest::getFirstMapsAndReturnsFirstResultIfQueryIsNotInitialized
+.
+TYPO3\Flow\Tests\Unit\Persistence\Generic\QueryResultTest::getFirstReturnsFirstResultIfQueryIsInitialized
+.
+TYPO3\Flow\Tests\Unit\Persistence\Generic\QueryResultTest::getFirstReturnsNullIfResultSetIsEmptyAndQueryIsInitialized
+.
+TYPO3\Flow\Tests\Unit\Persistence\Generic\QueryResultTest::getFirstReturnsNullIfResultSetIsEmptyAndQueryIsNotInitialized
+.
+TYPO3\Flow\Tests\Unit\Persistence\Generic\QueryResultTest::getQueryReturnsAClone
+.
+TYPO3\Flow\Tests\Unit\Persistence\Generic\QueryResultTest::getQueryReturnsQueryObject
+.
+TYPO3\Flow\Tests\Unit\Persistence\Generic\QueryResultTest::initializeExecutesQueryWithArrayFetchMode
+.
+TYPO3\Flow\Tests\Unit\Persistence\Generic\QueryResultTest::iteratorMethodsAreCorrectlyImplemented
+.
+TYPO3\Flow\Tests\Unit\Persistence\Generic\QueryResultTest::offsetExistsWorksAsExpected
+.
+TYPO3\Flow\Tests\Unit\Persistence\Generic\QueryResultTest::offsetGetWorksAsExpected
+.
+TYPO3\Flow\Tests\Unit\Persistence\Generic\QueryResultTest::offsetSetWorksAsExpected
+.
+TYPO3\Flow\Tests\Unit\Persistence\Generic\QueryResultTest::offsetUnsetWorksAsExpected
+.
+TYPO3\Flow\Tests\Unit\Persistence\Generic\QueryTest::executeReturnsQueryResultInstance
+.
+TYPO3\Flow\Tests\Unit\Persistence\Generic\QueryTest::setLimitAcceptsOnlyIntegers
+.
+TYPO3\Flow\Tests\Unit\Persistence\Generic\QueryTest::setLimitRejectsIntegersLessThanOne
+.
+TYPO3\Flow\Tests\Unit\Persistence\Generic\QueryTest::setOffsetAcceptsOnlyIntegers
+.
+TYPO3\Flow\Tests\Unit\Persistence\Generic\QueryTest::setOffsetRejectsIntegersLessThanZero
+.
+TYPO3\Flow\Tests\Unit\Persistence\Generic\SessionTest::getCleanStateOfPropertyReturnsNullIfObjectWasNotReconstituted
+.
+TYPO3\Flow\Tests\Unit\Persistence\Generic\SessionTest::getCleanStateOfPropertyReturnsNullIfPropertyWasNotInObjectData
+.
+TYPO3\Flow\Tests\Unit\Persistence\Generic\SessionTest::getCleanStateOfPropertyReturnsPropertyData
+.
+TYPO3\Flow\Tests\Unit\Persistence\Generic\SessionTest::getIdentifierByObjectReturnsHashForObjectBeingAOPProxy
+.
+TYPO3\Flow\Tests\Unit\Persistence\Generic\SessionTest::getIdentifierByObjectReturnsNullForUnknownObjectBeingAOPProxy
+.
+TYPO3\Flow\Tests\Unit\Persistence\Generic\SessionTest::getIdentifierByObjectReturnsRegisteredUUIDForObject
+.
+TYPO3\Flow\Tests\Unit\Persistence\Generic\SessionTest::getIdentifierByObjectReturnsUUIDForKnownObject
+.
+TYPO3\Flow\Tests\Unit\Persistence\Generic\SessionTest::getIdentifierByObjectReturnsUuidForObjectBeingAOPProxy
+.
+TYPO3\Flow\Tests\Unit\Persistence\Generic\SessionTest::getIdentifierByObjectReturnsValueOfPropertyTaggedWithId
+.
+TYPO3\Flow\Tests\Unit\Persistence\Generic\SessionTest::getObjectByIdentifierReturnsRegisteredObjectForUUID
+.
+TYPO3\Flow\Tests\Unit\Persistence\Generic\SessionTest::hasIdentifierReturnsTrueForRegisteredObject
+.
+TYPO3\Flow\Tests\Unit\Persistence\Generic\SessionTest::hasObjectReturnsTrueForRegisteredObject
+.
+TYPO3\Flow\Tests\Unit\Persistence\Generic\SessionTest::isDirtyAsksIsPropertyDirtyForChangedLiterals
+.
+TYPO3\Flow\Tests\Unit\Persistence\Generic\SessionTest::isDirtyReturnsFalseForCleanArrays
+.
+TYPO3\Flow\Tests\Unit\Persistence\Generic\SessionTest::isDirtyReturnsFalseForCleanNestedArrays
+.
+TYPO3\Flow\Tests\Unit\Persistence\Generic\SessionTest::isDirtyReturnsFalseForNullInBothCurrentAndCleanValue
+.
+TYPO3\Flow\Tests\Unit\Persistence\Generic\SessionTest::isDirtyReturnsFalseForUnactivatedLazyObjects
+.
+TYPO3\Flow\Tests\Unit\Persistence\Generic\SessionTest::isDirtyReturnsTrueForArraysWhoseContainedObjectsDiffer
+.
+TYPO3\Flow\Tests\Unit\Persistence\Generic\SessionTest::isDirtyReturnsTrueForArraysWithNewMembers
+.
+TYPO3\Flow\Tests\Unit\Persistence\Generic\SessionTest::isDirtyReturnsTrueForNestedArrayWhoseCountDiffers
+.
+TYPO3\Flow\Tests\Unit\Persistence\Generic\SessionTest::isDirtyReturnsTrueForSplObjectStorageWhoseContainedObjectsDiffer
+.
+TYPO3\Flow\Tests\Unit\Persistence\Generic\SessionTest::isDirtyReturnsTrueForTraversablesWhoseCountDiffers
+.
+TYPO3\Flow\Tests\Unit\Persistence\Generic\SessionTest::isDirtyReturnsTrueForUnregisteredReconstitutedEntities
+.
+TYPO3\Flow\Tests\Unit\Persistence\Generic\SessionTest::isSingleValuedPropertyDirtyWorksAsExpected with data set #0
+.
+TYPO3\Flow\Tests\Unit\Persistence\Generic\SessionTest::isSingleValuedPropertyDirtyWorksAsExpected with data set #1
+.
+TYPO3\Flow\Tests\Unit\Persistence\Generic\SessionTest::isSingleValuedPropertyDirtyWorksAsExpected with data set #10
+.
+TYPO3\Flow\Tests\Unit\Persistence\Generic\SessionTest::isSingleValuedPropertyDirtyWorksAsExpected with data set #11
+.
+TYPO3\Flow\Tests\Unit\Persistence\Generic\SessionTest::isSingleValuedPropertyDirtyWorksAsExpected with data set #12
+.
+TYPO3\Flow\Tests\Unit\Persistence\Generic\SessionTest::isSingleValuedPropertyDirtyWorksAsExpected with data set #13
+.
+TYPO3\Flow\Tests\Unit\Persistence\Generic\SessionTest::isSingleValuedPropertyDirtyWorksAsExpected with data set #2
+.
+TYPO3\Flow\Tests\Unit\Persistence\Generic\SessionTest::isSingleValuedPropertyDirtyWorksAsExpected with data set #3
+.
+TYPO3\Flow\Tests\Unit\Persistence\Generic\SessionTest::isSingleValuedPropertyDirtyWorksAsExpected with data set #4
+.
+TYPO3\Flow\Tests\Unit\Persistence\Generic\SessionTest::isSingleValuedPropertyDirtyWorksAsExpected with data set #5
+.
+TYPO3\Flow\Tests\Unit\Persistence\Generic\SessionTest::isSingleValuedPropertyDirtyWorksAsExpected with data set #6
+.
+TYPO3\Flow\Tests\Unit\Persistence\Generic\SessionTest::isSingleValuedPropertyDirtyWorksAsExpected with data set #7
+.
+TYPO3\Flow\Tests\Unit\Persistence\Generic\SessionTest::isSingleValuedPropertyDirtyWorksAsExpected with data set #8
+.
+TYPO3\Flow\Tests\Unit\Persistence\Generic\SessionTest::isSingleValuedPropertyDirtyWorksAsExpected with data set #9
+.
+TYPO3\Flow\Tests\Unit\Persistence\Generic\SessionTest::newObjectsAreConsideredDirty
+.
+TYPO3\Flow\Tests\Unit\Persistence\Generic\SessionTest::objectRegisteredWithRegisterReconstitutedEntityCanBeRetrievedWithGetReconstitutedEntities
+.
+TYPO3\Flow\Tests\Unit\Persistence\Generic\SessionTest::unregisterObjectRemovesRegisteredObject
+.
+TYPO3\Flow\Tests\Unit\Persistence\Generic\SessionTest::unregisterReconstitutedEntityRemovesObjectFromSession
+.
+TYPO3\Flow\Tests\Unit\Persistence\RepositoryTest::abstractRepositoryImplementsRepositoryInterface
+.
+TYPO3\Flow\Tests\Unit\Persistence\RepositoryTest::addChecksObjectType
+.
+TYPO3\Flow\Tests\Unit\Persistence\RepositoryTest::addDelegatesToPersistenceManager
+.
+TYPO3\Flow\Tests\Unit\Persistence\RepositoryTest::constructSetsObjectTypeFromClassConstant
+.
+TYPO3\Flow\Tests\Unit\Persistence\RepositoryTest::constructSetsObjectTypeFromClassName with data set #0
+.
+TYPO3\Flow\Tests\Unit\Persistence\RepositoryTest::constructSetsObjectTypeFromClassName with data set #1
+.
+TYPO3\Flow\Tests\Unit\Persistence\RepositoryTest::constructSetsObjectTypeFromClassName with data set #2
+.
+TYPO3\Flow\Tests\Unit\Persistence\RepositoryTest::createQueryCallsPersistenceManagerWithExpectedClassName
+.
+TYPO3\Flow\Tests\Unit\Persistence\RepositoryTest::createQuerySetsDefaultOrderingIfDefined
+.
+TYPO3\Flow\Tests\Unit\Persistence\RepositoryTest::findAllCreatesQueryAndReturnsResultOfExecuteCall
+.
+TYPO3\Flow\Tests\Unit\Persistence\RepositoryTest::findByidentifierReturnsResultOfGetObjectByIdentifierCall
+.
+TYPO3\Flow\Tests\Unit\Persistence\RepositoryTest::magicCallMethodAcceptsCountBySomethingCallsAndExecutesAQueryWithThatCriteria
+.
+TYPO3\Flow\Tests\Unit\Persistence\RepositoryTest::magicCallMethodAcceptsFindBySomethingCallsAndExecutesAQueryWithThatCriteria
+.
+TYPO3\Flow\Tests\Unit\Persistence\RepositoryTest::magicCallMethodAcceptsFindOneBySomethingCallsAndExecutesAQueryWithThatCriteria
+.
+TYPO3\Flow\Tests\Unit\Persistence\RepositoryTest::magicCallMethodTriggersAnErrorIfUnknownMethodsAreCalled
+.
+TYPO3\Flow\Tests\Unit\Persistence\RepositoryTest::removeChecksObjectType
+.
+TYPO3\Flow\Tests\Unit\Persistence\RepositoryTest::removeDelegatesToPersistenceManager
+.
+TYPO3\Flow\Tests\Unit\Persistence\RepositoryTest::updateChecksObjectType
+.
+TYPO3\Flow\Tests\Unit\Persistence\RepositoryTest::updateDelegatesToPersistenceManager
+.
+TYPO3\Flow\Tests\Unit\Property\PropertyMapperTest::convertCallsCanConvertFromWithTheFullNormalizedTargetType with data set #0
+.
+TYPO3\Flow\Tests\Unit\Property\PropertyMapperTest::convertCallsCanConvertFromWithTheFullNormalizedTargetType with data set #1
+.
+TYPO3\Flow\Tests\Unit\Property\PropertyMapperTest::convertCallsCanConvertFromWithTheFullNormalizedTargetType with data set #2
+.
+TYPO3\Flow\Tests\Unit\Property\PropertyMapperTest::convertCallsCanConvertFromWithTheFullNormalizedTargetType with data set #3
+.
+TYPO3\Flow\Tests\Unit\Property\PropertyMapperTest::convertCallsCanConvertFromWithTheFullNormalizedTargetType with data set #4
+.
+TYPO3\Flow\Tests\Unit\Property\PropertyMapperTest::convertDoesNotCatchSecurityExceptions
+.
+TYPO3\Flow\Tests\Unit\Property\PropertyMapperTest::convertShouldAskConfigurationBuilderForDefaultConfiguration
+.
+TYPO3\Flow\Tests\Unit\Property\PropertyMapperTest::convertSkipsPropertiesIfConfiguredTo
+.
+TYPO3\Flow\Tests\Unit\Property\PropertyMapperTest::convertSkipsUnknownPropertiesIfConfiguredTo
+.
+TYPO3\Flow\Tests\Unit\Property\PropertyMapperTest::doMappingReturnsSourceUnchangedIfAlreadyConverted
+.
+TYPO3\Flow\Tests\Unit\Property\PropertyMapperTest::doMappingReturnsSourceUnchangedIfAlreadyConvertedToCompositeType
+.
+TYPO3\Flow\Tests\Unit\Property\PropertyMapperTest::findFirstEligibleTypeConverterInObjectHierarchyShouldReturnNullIfSourceTypeIsUnknown
+.
+TYPO3\Flow\Tests\Unit\Property\PropertyMapperTest::findTypeConverterShouldReturnConverterForTargetObjectIfItExists with data set #0
+.
+TYPO3\Flow\Tests\Unit\Property\PropertyMapperTest::findTypeConverterShouldReturnConverterForTargetObjectIfItExists with data set #1
+.
+TYPO3\Flow\Tests\Unit\Property\PropertyMapperTest::findTypeConverterShouldReturnConverterForTargetObjectIfItExists with data set #2
+.
+TYPO3\Flow\Tests\Unit\Property\PropertyMapperTest::findTypeConverterShouldReturnConverterForTargetObjectIfItExists with data set #3
+.
+TYPO3\Flow\Tests\Unit\Property\PropertyMapperTest::findTypeConverterShouldReturnConverterForTargetObjectIfItExists with data set #4
+.
+TYPO3\Flow\Tests\Unit\Property\PropertyMapperTest::findTypeConverterShouldReturnConverterForTargetObjectIfItExists with data set #5
+.
+TYPO3\Flow\Tests\Unit\Property\PropertyMapperTest::findTypeConverterShouldReturnConverterForTargetObjectIfItExists with data set #6
+.
+TYPO3\Flow\Tests\Unit\Property\PropertyMapperTest::findTypeConverterShouldReturnConverterForTargetObjectIfItExists with data set #7
+.
+TYPO3\Flow\Tests\Unit\Property\PropertyMapperTest::findTypeConverterShouldReturnConverterForTargetObjectIfItExists with data set #8
+.
+TYPO3\Flow\Tests\Unit\Property\PropertyMapperTest::findTypeConverterShouldReturnHighestPriorityTypeConverterForSimpleType with data set #0
+.
+TYPO3\Flow\Tests\Unit\Property\PropertyMapperTest::findTypeConverterShouldReturnHighestPriorityTypeConverterForSimpleType with data set #1
+.
+TYPO3\Flow\Tests\Unit\Property\PropertyMapperTest::findTypeConverterShouldReturnHighestPriorityTypeConverterForSimpleType with data set #2
+.
+TYPO3\Flow\Tests\Unit\Property\PropertyMapperTest::findTypeConverterShouldReturnHighestPriorityTypeConverterForSimpleType with data set #3
+.
+TYPO3\Flow\Tests\Unit\Property\PropertyMapperTest::findTypeConverterShouldReturnTypeConverterFromConfigurationIfItIsSet
+.
+TYPO3\Flow\Tests\Unit\Property\PropertyMapperTest::sourceTypeCanBeCorrectlyDetermined with data set #0
+.
+TYPO3\Flow\Tests\Unit\Property\PropertyMapperTest::sourceTypeCanBeCorrectlyDetermined with data set #1
+.
+TYPO3\Flow\Tests\Unit\Property\PropertyMapperTest::sourceTypeCanBeCorrectlyDetermined with data set #2
+.
+TYPO3\Flow\Tests\Unit\Property\PropertyMapperTest::sourceTypeCanBeCorrectlyDetermined with data set #3
+.
+TYPO3\Flow\Tests\Unit\Property\PropertyMapperTest::sourceTypeCanBeCorrectlyDetermined with data set #4
+.
+TYPO3\Flow\Tests\Unit\Property\PropertyMapperTest::sourceTypeCanBeCorrectlyDetermined with data set #5
+.
+TYPO3\Flow\Tests\Unit\Property\PropertyMapperTest::sourceWhichIsNoSimpleTypeOrObjectThrowsException with data set #0
+.
+TYPO3\Flow\Tests\Unit\Property\PropertyMappingConfigurationBuilderTest::getTargetPropertyNameShouldReturnTheUnmodifiedPropertyNameWithoutConfiguration
+.
+TYPO3\Flow\Tests\Unit\Property\PropertyMappingConfigurationTest::forPropertyWithAsteriskAllowsArbitraryPropertyNamesWithForProperty
+.
+TYPO3\Flow\Tests\Unit\Property\PropertyMappingConfigurationTest::forPropertyWithAsteriskAllowsArbitraryPropertyNamesWithGetConfigurationFor
+.
+TYPO3\Flow\Tests\Unit\Property\PropertyMappingConfigurationTest::forPropertyWithAsteriskAllowsArbitraryPropertyNamesWithShouldMap
+.
+TYPO3\Flow\Tests\Unit\Property\PropertyMappingConfigurationTest::getTargetPropertyNameShouldRespectMapping
+.
+TYPO3\Flow\Tests\Unit\Property\PropertyMappingConfigurationTest::getTargetPropertyNameShouldReturnTheUnmodifiedPropertyNameWithoutConfiguration
+.
+TYPO3\Flow\Tests\Unit\Property\PropertyMappingConfigurationTest::getTypeConverterReturnsNullIfNoTypeConverterSet
+.
+TYPO3\Flow\Tests\Unit\Property\PropertyMappingConfigurationTest::getTypeConverterReturnsTypeConverterIfItHasBeenSet
+.
+TYPO3\Flow\Tests\Unit\Property\PropertyMappingConfigurationTest::nonexistentTypeConverterOptionsReturnNull
+.
+TYPO3\Flow\Tests\Unit\Property\PropertyMappingConfigurationTest::respectiveMethodsProvideFluentInterface with data set #0
+.
+TYPO3\Flow\Tests\Unit\Property\PropertyMappingConfigurationTest::respectiveMethodsProvideFluentInterface with data set #1
+.
+TYPO3\Flow\Tests\Unit\Property\PropertyMappingConfigurationTest::respectiveMethodsProvideFluentInterface with data set #2
+.
+TYPO3\Flow\Tests\Unit\Property\PropertyMappingConfigurationTest::respectiveMethodsProvideFluentInterface with data set #3
+.
+TYPO3\Flow\Tests\Unit\Property\PropertyMappingConfigurationTest::respectiveMethodsProvideFluentInterface with data set #4
+.
+TYPO3\Flow\Tests\Unit\Property\PropertyMappingConfigurationTest::respectiveMethodsProvideFluentInterface with data set #5
+.
+TYPO3\Flow\Tests\Unit\Property\PropertyMappingConfigurationTest::respectiveMethodsProvideFluentInterface with data set #6
+.
+TYPO3\Flow\Tests\Unit\Property\PropertyMappingConfigurationTest::setTypeConverterOptionShouldOverrideAlreadySetOptions
+.
+TYPO3\Flow\Tests\Unit\Property\PropertyMappingConfigurationTest::setTypeConverterOptionsCanBeRetrievedAgain
+.
+TYPO3\Flow\Tests\Unit\Property\PropertyMappingConfigurationTest::setTypeConverterOptionsShouldOverrideAlreadySetOptions
+.
+TYPO3\Flow\Tests\Unit\Property\PropertyMappingConfigurationTest::shouldMapReturnsFalseByDefault
+.
+TYPO3\Flow\Tests\Unit\Property\PropertyMappingConfigurationTest::shouldMapReturnsFalseForBlacklistedProperties
+.
+TYPO3\Flow\Tests\Unit\Property\PropertyMappingConfigurationTest::shouldMapReturnsTrueForAllowedProperties
+.
+TYPO3\Flow\Tests\Unit\Property\PropertyMappingConfigurationTest::shouldMapReturnsTrueIfConfigured
+.
+TYPO3\Flow\Tests\Unit\Property\PropertyMappingConfigurationTest::shouldSkipReturnsFalseByDefault
+.
+TYPO3\Flow\Tests\Unit\Property\PropertyMappingConfigurationTest::shouldSkipReturnsTrueIfConfigured
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\ArrayConverterTest::canConvertFromStringToArray with data set #0
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\ArrayConverterTest::canConvertFromStringToArray with data set #1
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\ArrayConverterTest::canConvertFromStringToArray with data set #2
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\ArrayConverterTest::canConvertFromStringToArray with data set #3
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\ArrayConverterTest::checkMetadata
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\ArrayConverterTest::convertFromDoesNotModifyTheSourceArray
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\BooleanConverterTest::checkMetadata
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\BooleanConverterTest::convertFromCastsNumericSourceStringToBoolean
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\BooleanConverterTest::convertFromCastsSourceStringToBoolean
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\BooleanConverterTest::convertFromDoesNotModifyTheBooleanSource
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\BooleanConverterTest::convertFromTests with data set #0
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\BooleanConverterTest::convertFromTests with data set #1
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\BooleanConverterTest::convertFromTests with data set #10
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\BooleanConverterTest::convertFromTests with data set #11
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\BooleanConverterTest::convertFromTests with data set #12
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\BooleanConverterTest::convertFromTests with data set #13
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\BooleanConverterTest::convertFromTests with data set #14
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\BooleanConverterTest::convertFromTests with data set #15
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\BooleanConverterTest::convertFromTests with data set #16
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\BooleanConverterTest::convertFromTests with data set #17
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\BooleanConverterTest::convertFromTests with data set #2
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\BooleanConverterTest::convertFromTests with data set #3
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\BooleanConverterTest::convertFromTests with data set #4
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\BooleanConverterTest::convertFromTests with data set #5
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\BooleanConverterTest::convertFromTests with data set #6
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\BooleanConverterTest::convertFromTests with data set #7
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\BooleanConverterTest::convertFromTests with data set #8
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\BooleanConverterTest::convertFromTests with data set #9
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\CollectionConverterTest::checkMetadata
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\CollectionConverterTest::getTypeOfChildPropertyReturnsElementTypeFromTargetTypeIfGiven
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\CollectionConverterTest::getTypeOfChildPropertyReturnsEmptyStringForElementTypeIfNotGivenInTargetType
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\DateTimeConverterTest::canConvertFromReturnsFalseIfTargetTypeIsNotDateTime
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\DateTimeConverterTest::canConvertFromReturnsTrueIfSourceTypeIsAString
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\DateTimeConverterTest::canConvertFromReturnsTrueIfSourceTypeIsAnArray
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\DateTimeConverterTest::canConvertFromReturnsTrueIfSourceTypeIsAnEmptyString
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\DateTimeConverterTest::checkMetadata
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\DateTimeConverterTest::convertFromAllowsToOverrideTheTime
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\DateTimeConverterTest::convertFromAllowsToOverrideTheTimezone
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\DateTimeConverterTest::convertFromArrayReturnsNullForEmptyDate
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\DateTimeConverterTest::convertFromArrayTests with data set #0
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\DateTimeConverterTest::convertFromArrayTests with data set #1
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\DateTimeConverterTest::convertFromArrayTests with data set #2
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\DateTimeConverterTest::convertFromArrayTests with data set #3
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\DateTimeConverterTest::convertFromArrayTests with data set #4
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\DateTimeConverterTest::convertFromArrayTests with data set #5
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\DateTimeConverterTest::convertFromArrayTests with data set #6
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\DateTimeConverterTest::convertFromArrayTests with data set #7
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\DateTimeConverterTest::convertFromArrayTests with data set #8
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\DateTimeConverterTest::convertFromArrayTests with data set #9
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\DateTimeConverterTest::convertFromArrayThrowsExceptionForEmptyArray
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\DateTimeConverterTest::convertFromEmptyStringReturnsNull
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\DateTimeConverterTest::convertFromIntegerOrDigitStringInArrayWithoutConfigurationTests with data set #0
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\DateTimeConverterTest::convertFromIntegerOrDigitStringInArrayWithoutConfigurationTests with data set #1
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\DateTimeConverterTest::convertFromIntegerOrDigitStringWithoutConfigurationTests with data set #0
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\DateTimeConverterTest::convertFromIntegerOrDigitStringWithoutConfigurationTests with data set #1
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\DateTimeConverterTest::convertFromProperlyConvertsArrayWithDateAsArray
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\DateTimeConverterTest::convertFromProperlyConvertsArrayWithDefaultDateFormat
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\DateTimeConverterTest::convertFromProperlyConvertsStringWithDefaultDateFormat
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\DateTimeConverterTest::convertFromReturnsErrorIfGivenArrayCantBeConverted
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\DateTimeConverterTest::convertFromReturnsErrorIfGivenStringCantBeConverted
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\DateTimeConverterTest::convertFromStringTests with data set #0
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\DateTimeConverterTest::convertFromStringTests with data set #1
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\DateTimeConverterTest::convertFromStringTests with data set #2
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\DateTimeConverterTest::convertFromStringTests with data set #3
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\DateTimeConverterTest::convertFromStringTests with data set #4
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\DateTimeConverterTest::convertFromStringTests with data set #5
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\DateTimeConverterTest::convertFromStringTests with data set #6
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\DateTimeConverterTest::convertFromStringTests with data set #7
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\DateTimeConverterTest::convertFromSupportsDateTimeSubClasses
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\DateTimeConverterTest::convertFromThrowsExceptionIfDatePartKeysHaveInvalidValuesSpecified with data set #0
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\DateTimeConverterTest::convertFromThrowsExceptionIfDatePartKeysHaveInvalidValuesSpecified with data set #1
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\DateTimeConverterTest::convertFromThrowsExceptionIfDatePartKeysHaveInvalidValuesSpecified with data set #2
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\DateTimeConverterTest::convertFromThrowsExceptionIfDatePartKeysHaveInvalidValuesSpecified with data set #3
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\DateTimeConverterTest::convertFromThrowsExceptionIfDatePartKeysHaveInvalidValuesSpecified with data set #4
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\DateTimeConverterTest::convertFromThrowsExceptionIfDatePartKeysHaveInvalidValuesSpecified with data set #5
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\DateTimeConverterTest::convertFromThrowsExceptionIfGivenArrayDoesNotSpecifyTheDate
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\DateTimeConverterTest::convertFromThrowsExceptionIfSpecifiedTimezoneIsInvalid
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\DateTimeConverterTest::convertFromUsesDefaultDateFormatIfItIsNotConfigured
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\FloatConverterTest::canConvertFromShouldReturnTrue
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\FloatConverterTest::canConvertFromShouldReturnTrueForANullValue
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\FloatConverterTest::canConvertFromShouldReturnTrueForAnEmptyValue
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\FloatConverterTest::checkMetadata
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\FloatConverterTest::convertFromReturnsAnErrorIfSpecifiedStringIsNotNumeric
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\FloatConverterTest::convertFromReturnsNullIfEmptyStringSpecified
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\FloatConverterTest::convertFromShouldAcceptIntegers
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\FloatConverterTest::convertFromShouldCastTheStringToFloat
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\FloatConverterTest::getSourceChildPropertiesToBeConvertedShouldReturnEmptyArray
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\IntegerConverterTest::canConvertFromShouldReturnTrueForADateTimeValue
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\IntegerConverterTest::canConvertFromShouldReturnTrueForANullValue
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\IntegerConverterTest::canConvertFromShouldReturnTrueForANumericStringSource
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\IntegerConverterTest::canConvertFromShouldReturnTrueForAnEmptyValue
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\IntegerConverterTest::canConvertFromShouldReturnTrueForAnIntegerSource
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\IntegerConverterTest::checkMetadata
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\IntegerConverterTest::convertFromCastsDateTimeToInteger
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\IntegerConverterTest::convertFromCastsStringToInteger
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\IntegerConverterTest::convertFromDoesNotModifyIntegers
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\IntegerConverterTest::convertFromReturnsAnErrorIfSpecifiedStringIsNotNumeric
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\IntegerConverterTest::convertFromReturnsNullIfEmptyStringSpecified
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\IntegerConverterTest::getSourceChildPropertiesToBeConvertedShouldReturnEmptyArray
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\MediaTypeConverterTest::convertExpectsJsonAsDefault
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\MediaTypeConverterTest::convertReturnsEmptyArrayIfBodyCantBeParsed
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\MediaTypeConverterTest::convertReturnsEmptyArrayIfGivenMediaTypeIsInvalid
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\MediaTypeConverterTest::convertTests with data set #0
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\MediaTypeConverterTest::convertTests with data set #1
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\MediaTypeConverterTest::convertTests with data set #10
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\MediaTypeConverterTest::convertTests with data set #2
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\MediaTypeConverterTest::convertTests with data set #3
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\MediaTypeConverterTest::convertTests with data set #4
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\MediaTypeConverterTest::convertTests with data set #5
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\MediaTypeConverterTest::convertTests with data set #6
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\MediaTypeConverterTest::convertTests with data set #7
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\MediaTypeConverterTest::convertTests with data set #8
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\MediaTypeConverterTest::convertTests with data set #9
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\ObjectConverterTest::canConvertFromReturnsTrueIfClassIsTaggedWithEntityOrValueObject with data set #0
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\ObjectConverterTest::canConvertFromReturnsTrueIfClassIsTaggedWithEntityOrValueObject with data set #1
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\ObjectConverterTest::canConvertFromReturnsTrueIfClassIsTaggedWithEntityOrValueObject with data set #2
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\ObjectConverterTest::checkMetadata
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\ObjectConverterTest::getTypeOfChildPropertyShouldUseReflectionServiceToDetermineType
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\PersistentObjectConverterTest::canConvertFromReturnsTrueIfClassIsTaggedWithEntityOrValueObject with data set #0
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\PersistentObjectConverterTest::canConvertFromReturnsTrueIfClassIsTaggedWithEntityOrValueObject with data set #1
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\PersistentObjectConverterTest::canConvertFromReturnsTrueIfClassIsTaggedWithEntityOrValueObject with data set #2
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\PersistentObjectConverterTest::checkMetadata
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\PersistentObjectConverterTest::convertFromShouldCreateObject
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\PersistentObjectConverterTest::convertFromShouldCreateObjectWhenThereAreConstructorParameters
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\PersistentObjectConverterTest::convertFromShouldCreateObjectWhenThereAreOptionalConstructorParameters
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\PersistentObjectConverterTest::convertFromShouldFetchObjectFromPersistenceIfNonUuidStringIsGiven
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\PersistentObjectConverterTest::convertFromShouldFetchObjectFromPersistenceIfOnlyIdentityArrayGiven
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\PersistentObjectConverterTest::convertFromShouldFetchObjectFromPersistenceIfUuidStringIsGiven
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\PersistentObjectConverterTest::convertFromShouldReturnFirstMatchingObjectIfMultipleIdentityPropertiesExist
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\PersistentObjectConverterTest::convertFromShouldReturnNullForEmptyString
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\PersistentObjectConverterTest::convertFromShouldReturnTargetNotFoundErrorIfNoMatchingObjectWasFound
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\PersistentObjectConverterTest::convertFromShouldThrowExceptionIfIdentityIsOfInvalidType
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\PersistentObjectConverterTest::convertFromShouldThrowExceptionIfMoreThanOneObjectWasFound
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\PersistentObjectConverterTest::convertFromShouldThrowExceptionIfObjectNeedsToBeCreatedButConfigurationIsNotSet
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\PersistentObjectConverterTest::convertFromShouldThrowExceptionIfObjectNeedsToBeModifiedButConfigurationIsNotSet
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\PersistentObjectConverterTest::convertFromShouldThrowExceptionIfPropertyOnTargetObjectCouldNotBeSet
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\PersistentObjectConverterTest::convertFromShouldThrowExceptionIfRequiredConstructorParameterWasNotFound
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\PersistentObjectConverterTest::getSourceChildPropertiesToBeConvertedReturnsAllPropertiesExceptTheIdentityProperty
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\PersistentObjectConverterTest::getTypeOfChildPropertyShouldConsiderSetters
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\PersistentObjectConverterTest::getTypeOfChildPropertyShouldUseConfiguredTypeIfItWasSet
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\PersistentObjectConverterTest::getTypeOfChildPropertyShouldUseReflectionServiceToDetermineType
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\StringConverterTest::canConvertFromShouldReturnTrue
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\StringConverterTest::canConvertFromStringToArray with data set #0
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\StringConverterTest::canConvertFromStringToArray with data set #1
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\StringConverterTest::canConvertFromStringToArray with data set #2
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\StringConverterTest::canConvertFromStringToArray with data set #3
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\StringConverterTest::checkMetadata
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\StringConverterTest::convertFromShouldReturnSourceString
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\StringConverterTest::getSourceChildPropertiesToBeConvertedShouldReturnEmptyArray
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\TypedArrayConverterTest::canConvertFromTests with data set #0
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\TypedArrayConverterTest::canConvertFromTests with data set #1
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\TypedArrayConverterTest::canConvertFromTests with data set #2
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\TypedArrayConverterTest::canConvertFromTests with data set #3
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\TypedArrayConverterTest::canConvertFromTests with data set #4
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\TypedArrayConverterTest::checkMetadata
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\UriTypeConverterTest::sourceTypeIsStringOnly
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\UriTypeConverterTest::targetTypeIsUri
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\UriTypeConverterTest::typeConverterReturnsErrorOnMalformedUri
+.
+TYPO3\Flow\Tests\Unit\Property\TypeConverter\UriTypeConverterTest::typeConverterReturnsUriOnValidUri
+.
+TYPO3\Flow\Tests\Unit\Reflection\ClassReflectionTest::getConstructorReturnsFlowsMethodReflection
+.
+TYPO3\Flow\Tests\Unit\Reflection\ClassReflectionTest::getInterfacesReturnsFlowsClassReflection
+.
+TYPO3\Flow\Tests\Unit\Reflection\ClassReflectionTest::getMethodReturnsFlowsMethodReflection
+.
+TYPO3\Flow\Tests\Unit\Reflection\ClassReflectionTest::getMethodsReturnsArrayWithNumericIndex
+.
+TYPO3\Flow\Tests\Unit\Reflection\ClassReflectionTest::getMethodsReturnsFlowsMethodReflection
+.
+TYPO3\Flow\Tests\Unit\Reflection\ClassReflectionTest::getParentClassReturnsFlowsClassReflection
+.
+TYPO3\Flow\Tests\Unit\Reflection\ClassReflectionTest::getPropertiesReturnsFlowsPropertyReflection
+.
+TYPO3\Flow\Tests\Unit\Reflection\ClassReflectionTest::getPropertyReturnsFlowsPropertyReflection
+.
+TYPO3\Flow\Tests\Unit\Reflection\ClassSchemaTest::addPropertyAcceptsValidPropertyTypes with data set #0
+.
+TYPO3\Flow\Tests\Unit\Reflection\ClassSchemaTest::addPropertyAcceptsValidPropertyTypes with data set #1
+.
+TYPO3\Flow\Tests\Unit\Reflection\ClassSchemaTest::addPropertyAcceptsValidPropertyTypes with data set #10
+.
+TYPO3\Flow\Tests\Unit\Reflection\ClassSchemaTest::addPropertyAcceptsValidPropertyTypes with data set #11
+.
+TYPO3\Flow\Tests\Unit\Reflection\ClassSchemaTest::addPropertyAcceptsValidPropertyTypes with data set #12
+.
+TYPO3\Flow\Tests\Unit\Reflection\ClassSchemaTest::addPropertyAcceptsValidPropertyTypes with data set #13
+.
+TYPO3\Flow\Tests\Unit\Reflection\ClassSchemaTest::addPropertyAcceptsValidPropertyTypes with data set #14
+.
+TYPO3\Flow\Tests\Unit\Reflection\ClassSchemaTest::addPropertyAcceptsValidPropertyTypes with data set #15
+.
+TYPO3\Flow\Tests\Unit\Reflection\ClassSchemaTest::addPropertyAcceptsValidPropertyTypes with data set #2
+.
+TYPO3\Flow\Tests\Unit\Reflection\ClassSchemaTest::addPropertyAcceptsValidPropertyTypes with data set #3
+.
+TYPO3\Flow\Tests\Unit\Reflection\ClassSchemaTest::addPropertyAcceptsValidPropertyTypes with data set #4
+.
+TYPO3\Flow\Tests\Unit\Reflection\ClassSchemaTest::addPropertyAcceptsValidPropertyTypes with data set #5
+.
+TYPO3\Flow\Tests\Unit\Reflection\ClassSchemaTest::addPropertyAcceptsValidPropertyTypes with data set #6
+.
+TYPO3\Flow\Tests\Unit\Reflection\ClassSchemaTest::addPropertyAcceptsValidPropertyTypes with data set #7
+.
+TYPO3\Flow\Tests\Unit\Reflection\ClassSchemaTest::addPropertyAcceptsValidPropertyTypes with data set #8
+.
+TYPO3\Flow\Tests\Unit\Reflection\ClassSchemaTest::addPropertyAcceptsValidPropertyTypes with data set #9
+.
+TYPO3\Flow\Tests\Unit\Reflection\ClassSchemaTest::addPropertyRejectsInvalidPropertyTypes with data set #0
+.
+TYPO3\Flow\Tests\Unit\Reflection\ClassSchemaTest::addPropertyRejectsInvalidPropertyTypes with data set #1
+.
+TYPO3\Flow\Tests\Unit\Reflection\ClassSchemaTest::addPropertyRejectsInvalidPropertyTypes with data set #2
+.
+TYPO3\Flow\Tests\Unit\Reflection\ClassSchemaTest::addPropertyRejectsInvalidPropertyTypes with data set #3
+.
+TYPO3\Flow\Tests\Unit\Reflection\ClassSchemaTest::addPropertyStoresElementTypesForCollectionProperties
+.
+TYPO3\Flow\Tests\Unit\Reflection\ClassSchemaTest::getIdentityPropertiesReturnsNamesAndTypes
+.
+TYPO3\Flow\Tests\Unit\Reflection\ClassSchemaTest::getPropertiesReturnsAddedProperties
+.
+TYPO3\Flow\Tests\Unit\Reflection\ClassSchemaTest::hasPropertyReturnsTrueOnlyForExistingProperties
+.
+TYPO3\Flow\Tests\Unit\Reflection\ClassSchemaTest::isMultiValuedPropertyReturnsTrueForCollectionTypes with data set #0
+.
+TYPO3\Flow\Tests\Unit\Reflection\ClassSchemaTest::isMultiValuedPropertyReturnsTrueForCollectionTypes with data set #1
+.
+TYPO3\Flow\Tests\Unit\Reflection\ClassSchemaTest::isMultiValuedPropertyReturnsTrueForCollectionTypes with data set #2
+.
+TYPO3\Flow\Tests\Unit\Reflection\ClassSchemaTest::isMultiValuedPropertyReturnsTrueForCollectionTypes with data set #3
+.
+TYPO3\Flow\Tests\Unit\Reflection\ClassSchemaTest::isPropertyLazyReturnsAttributeForAddedProperties
+.
+TYPO3\Flow\Tests\Unit\Reflection\ClassSchemaTest::isPropertyTransientReturnsAttributeForAddedProperties
+.
+TYPO3\Flow\Tests\Unit\Reflection\ClassSchemaTest::markAsIdentityPropertyRejectsLazyLoadedProperties
+.
+TYPO3\Flow\Tests\Unit\Reflection\ClassSchemaTest::markAsIdentityPropertyRejectsUnknownProperties
+.
+TYPO3\Flow\Tests\Unit\Reflection\ClassSchemaTest::markAsIdentityPropertyThrowsExceptionForValueObjects
+.
+TYPO3\Flow\Tests\Unit\Reflection\ClassSchemaTest::setModelTypeResetsIdentityPropertiesAndAggregateRootForValueObjects
+.
+TYPO3\Flow\Tests\Unit\Reflection\DocCommentParserTest::descriptionWithOneLineIsParsedCorrectly
+.
+TYPO3\Flow\Tests\Unit\Reflection\DocCommentParserTest::eolCharacterCanBeNewlineOrCarriageReturn
+.
+TYPO3\Flow\Tests\Unit\Reflection\MethodReflectionTest::getDeclaringClassReturnsFlowsClassReflection
+.
+TYPO3\Flow\Tests\Unit\Reflection\MethodReflectionTest::getParametersReturnsFlowsParameterReflection
+.
+TYPO3\Flow\Tests\Unit\Reflection\ObjectAccessTest::accessorCacheIsNotUsedForStdClass
+.
+TYPO3\Flow\Tests\Unit\Reflection\ObjectAccessTest::getGettablePropertiesReturnsPropertiesOfStdClass
+.
+TYPO3\Flow\Tests\Unit\Reflection\ObjectAccessTest::getGettablePropertiesReturnsTheCorrectValuesForAllProperties
+.
+TYPO3\Flow\Tests\Unit\Reflection\ObjectAccessTest::getGettablePropertyNamesReturnsAllPropertiesWhichAreAvailable
+.
+TYPO3\Flow\Tests\Unit\Reflection\ObjectAccessTest::getPropertyCallsCustomGettersOfObjectsImplementingArrayAccess
+.
+TYPO3\Flow\Tests\Unit\Reflection\ObjectAccessTest::getPropertyCallsGettersBeforeCheckingViaArrayAccess
+.
+TYPO3\Flow\Tests\Unit\Reflection\ObjectAccessTest::getPropertyCanAccessNullPropertyOfAnArray
+.
+TYPO3\Flow\Tests\Unit\Reflection\ObjectAccessTest::getPropertyCanAccessPropertiesOfAnArray
+.
+TYPO3\Flow\Tests\Unit\Reflection\ObjectAccessTest::getPropertyCanAccessPropertiesOfAnArrayObject
+.
+TYPO3\Flow\Tests\Unit\Reflection\ObjectAccessTest::getPropertyCanAccessPropertiesOfAnObjectImplementingArrayAccess
+.
+TYPO3\Flow\Tests\Unit\Reflection\ObjectAccessTest::getPropertyDoesNotTryArrayAccessOnSplObjectStorageSubject
+.
+TYPO3\Flow\Tests\Unit\Reflection\ObjectAccessTest::getPropertyPathCanAccessPropertiesOfAnArray
+.
+TYPO3\Flow\Tests\Unit\Reflection\ObjectAccessTest::getPropertyPathCanAccessPropertiesOfAnObjectImplementingArrayAccess
+.
+TYPO3\Flow\Tests\Unit\Reflection\ObjectAccessTest::getPropertyPathCanRecursivelyGetPropertiesOfAnObject
+.
+TYPO3\Flow\Tests\Unit\Reflection\ObjectAccessTest::getPropertyPathReturnsNullForNonExistingPropertyPath
+.
+TYPO3\Flow\Tests\Unit\Reflection\ObjectAccessTest::getPropertyPathReturnsNullIfSubjectIsNoObject
+.
+TYPO3\Flow\Tests\Unit\Reflection\ObjectAccessTest::getPropertyPathReturnsNullIfSubjectOnPathIsNoObject
+.
+TYPO3\Flow\Tests\Unit\Reflection\ObjectAccessTest::getPropertyRespectsForceDirectAccessForArrayAccess
+.
+TYPO3\Flow\Tests\Unit\Reflection\ObjectAccessTest::getPropertyReturnsExpectedValueForGetterProperty
+.
+TYPO3\Flow\Tests\Unit\Reflection\ObjectAccessTest::getPropertyReturnsExpectedValueForPublicProperty
+.
+TYPO3\Flow\Tests\Unit\Reflection\ObjectAccessTest::getPropertyReturnsExpectedValueForUnexposedPropertyIfForceDirectAccessIsTrue
+.
+TYPO3\Flow\Tests\Unit\Reflection\ObjectAccessTest::getPropertyReturnsExpectedValueForUnknownPropertyIfForceDirectAccessIsTrue
+.
+TYPO3\Flow\Tests\Unit\Reflection\ObjectAccessTest::getPropertyReturnsPropertyNotAccessibleExceptionForNotExistingPropertyIfForceDirectAccessIsTrue
+.
+TYPO3\Flow\Tests\Unit\Reflection\ObjectAccessTest::getPropertyReturnsThrowsExceptionIfArrayKeyDoesNotExist
+.
+TYPO3\Flow\Tests\Unit\Reflection\ObjectAccessTest::getPropertyReturnsThrowsExceptionIfPropertyDoesNotExist
+.
+TYPO3\Flow\Tests\Unit\Reflection\ObjectAccessTest::getPropertyThrowsExceptionIfArrayObjectDoesNotContainMatchingKeyNorGetter
+.
+TYPO3\Flow\Tests\Unit\Reflection\ObjectAccessTest::getPropertyThrowsExceptionIfThePropertyNameIsNotAString
+.
+TYPO3\Flow\Tests\Unit\Reflection\ObjectAccessTest::getPropertyTriesToCallABooleanHasGetterMethodIfItExists
+.
+TYPO3\Flow\Tests\Unit\Reflection\ObjectAccessTest::getPropertyTriesToCallABooleanIsGetterMethodIfItExists
+.
+TYPO3\Flow\Tests\Unit\Reflection\ObjectAccessTest::getSettablePropertyNamesReturnsAllPropertiesWhichAreAvailable
+.
+TYPO3\Flow\Tests\Unit\Reflection\ObjectAccessTest::getSettablePropertyNamesReturnsPropertyNamesOfStdClass
+.
+TYPO3\Flow\Tests\Unit\Reflection\ObjectAccessTest::isPropertyGettableTellsIfAPropertyCanBeRetrieved
+.
+TYPO3\Flow\Tests\Unit\Reflection\ObjectAccessTest::isPropertyGettableWorksOnArrayAccessObjects
+.
+TYPO3\Flow\Tests\Unit\Reflection\ObjectAccessTest::isPropertyGettableWorksOnStdClass
+.
+TYPO3\Flow\Tests\Unit\Reflection\ObjectAccessTest::isPropertySettableTellsIfAPropertyCanBeSet
+.
+TYPO3\Flow\Tests\Unit\Reflection\ObjectAccessTest::isPropertySettableWorksOnStdClass
+.
+TYPO3\Flow\Tests\Unit\Reflection\ObjectAccessTest::setPropertyCallsASetterMethodToSetThePropertyValueIfOneIsAvailable
+.
+TYPO3\Flow\Tests\Unit\Reflection\ObjectAccessTest::setPropertyCanDirectlySetValuesInAnArrayObjectOrArray
+.
+TYPO3\Flow\Tests\Unit\Reflection\ObjectAccessTest::setPropertyReturnsFalseIfPropertyIsNotAccessible
+.
+TYPO3\Flow\Tests\Unit\Reflection\ObjectAccessTest::setPropertySetsValueIfPropertyDoesNotExistWhenForceDirectAccessIsTrue
+.
+TYPO3\Flow\Tests\Unit\Reflection\ObjectAccessTest::setPropertySetsValueIfPropertyIsNotAccessibleWhenForceDirectAccessIsTrue
+.
+TYPO3\Flow\Tests\Unit\Reflection\ObjectAccessTest::setPropertyThrowsExceptionIfThePropertyNameIsNotAString
+.
+TYPO3\Flow\Tests\Unit\Reflection\ObjectAccessTest::setPropertyWorksIfThePropertyNameIsAnInteger
+.
+TYPO3\Flow\Tests\Unit\Reflection\ObjectAccessTest::setPropertyWorksWithPublicProperty
+.
+TYPO3\Flow\Tests\Unit\Reflection\ParameterReflectionTest::getClassReturnsFlowsClassReflection
+.
+TYPO3\Flow\Tests\Unit\Reflection\ParameterReflectionTest::getDeclaringClassReturnsFlowsClassReflection
+.
+TYPO3\Flow\Tests\Unit\Reflection\PropertyReflectionTest::getValueEvenReturnsValueOfAPrivateProperty
+.
+TYPO3\Flow\Tests\Unit\Reflection\PropertyReflectionTest::getValueEvenReturnsValueOfAProtectedProperty
+.
+TYPO3\Flow\Tests\Unit\Reflection\PropertyReflectionTest::getValueReturnsValueOfAPrivatePropertyEvenIfItIsAnObject
+.
+TYPO3\Flow\Tests\Unit\Reflection\PropertyReflectionTest::getValueReturnsValueOfAProtectedPropertyEvenIfItIsAnObject
+.
+TYPO3\Flow\Tests\Unit\Reflection\PropertyReflectionTest::getValueReturnsValueOfAPublicProperty
+.
+TYPO3\Flow\Tests\Unit\Reflection\PropertyReflectionTest::getValueThrowsAnExceptionOnReflectingANonObject
+.
+TYPO3\Flow\Tests\Unit\Reflection\PropertyReflectionTest::setValueEvenSetsValueOfAPublicProperty
+.
+TYPO3\Flow\Tests\Unit\Reflection\ReflectionServiceTest::isTagIgnoredReturnsFalseForTagsThatAreNotConfigured
+.
+TYPO3\Flow\Tests\Unit\Reflection\ReflectionServiceTest::isTagIgnoredReturnsFalseForTagsThatAreNotIgnored
+.
+TYPO3\Flow\Tests\Unit\Reflection\ReflectionServiceTest::isTagIgnoredReturnsTrueForIgnoredTags
+.
+TYPO3\Flow\Tests\Unit\Reflection\ReflectionServiceTest::isTagIgnoredWorksWithOldConfiguration
+.
+TYPO3\Flow\Tests\Unit\Reflection\ReflectionServiceTest::reflectClassThrowsExceptionForClassesWithNoMatchingFilename
+.
+TYPO3\Flow\Tests\Unit\Reflection\ReflectionServiceTest::reflectClassThrowsExceptionForFilesWithNoClass
+.
+TYPO3\Flow\Tests\Unit\Reflection\ReflectionServiceTest::reflectClassThrowsExceptionForNonExistingClasses
+.
+TYPO3\Flow\Tests\Unit\Resource\ResourceTest::getMediaTypeReturnsMediaTypeBasedOnFileExtension
+.
+TYPO3\Flow\Tests\Unit\Resource\ResourceTest::setFilenameDoesNotAppendFileExtensionIfItIsEmpty
+.
+TYPO3\Flow\Tests\Unit\Resource\ResourceTest::setFilenameSetsTheMediaType
+.
+TYPO3\Flow\Tests\Unit\Resource\ResourceTest::setFilenameStoresTheFileExtensionInLowerCase
+.
+TYPO3\Flow\Tests\Unit\Resource\ResourceTypeConverterTest::canConvertFromReturnsTrueIfSourceTypeIsAnArrayWithErrorSet
+.
+TYPO3\Flow\Tests\Unit\Resource\ResourceTypeConverterTest::canConvertFromReturnsTrueIfSourceTypeIsAnArrayWithSubmittedFileSet
+.
+TYPO3\Flow\Tests\Unit\Resource\ResourceTypeConverterTest::checkMetadata
+.
+TYPO3\Flow\Tests\Unit\Resource\ResourceTypeConverterTest::convertFromAddsSystemLogEntryIfFileUploadFailedDueToAServerError
+.
+TYPO3\Flow\Tests\Unit\Resource\ResourceTypeConverterTest::convertFromImportsResourceIfFileUploadSucceeded
+.
+TYPO3\Flow\Tests\Unit\Resource\ResourceTypeConverterTest::convertFromReturnsAnErrorIfFileUploadFailed
+.
+TYPO3\Flow\Tests\Unit\Resource\ResourceTypeConverterTest::convertFromReturnsAnErrorIfTheUploadedFileCantBeImported
+.
+TYPO3\Flow\Tests\Unit\Resource\ResourceTypeConverterTest::convertFromReturnsNullIfNoFileWasUploaded
+.
+TYPO3\Flow\Tests\Unit\Resource\ResourceTypeConverterTest::convertFromReturnsNullIfSourceArrayIsEmpty
+.
+TYPO3\Flow\Tests\Unit\Resource\ResourceTypeConverterTest::convertFromReturnsNullIfSpecifiedResourceCantBeFound
+.
+TYPO3\Flow\Tests\Unit\Resource\ResourceTypeConverterTest::convertFromReturnsPreviouslyUploadedResourceIfNoNewFileWasUploaded
+.
+TYPO3\Flow\Tests\Unit\Resource\Streams\StreamWrapperAdapterTest::dir_closedirTest
+.
+TYPO3\Flow\Tests\Unit\Resource\Streams\StreamWrapperAdapterTest::dir_opendirTest
+.
+TYPO3\Flow\Tests\Unit\Resource\Streams\StreamWrapperAdapterTest::dir_readdirTest
+.
+TYPO3\Flow\Tests\Unit\Resource\Streams\StreamWrapperAdapterTest::dir_rewinddirTest
+.
+TYPO3\Flow\Tests\Unit\Resource\Streams\StreamWrapperAdapterTest::getRegisteredStreamWrappersReturnsRegisteredStreamWrappers
+.
+TYPO3\Flow\Tests\Unit\Resource\Streams\StreamWrapperAdapterTest::mkdirTest
+.
+TYPO3\Flow\Tests\Unit\Resource\Streams\StreamWrapperAdapterTest::renameTest
+.
+TYPO3\Flow\Tests\Unit\Resource\Streams\StreamWrapperAdapterTest::rmdirTest
+.
+TYPO3\Flow\Tests\Unit\Resource\Streams\StreamWrapperAdapterTest::stream_castTest
+S
+TYPO3\Flow\Tests\Unit\Resource\Streams\StreamWrapperAdapterTest::stream_closeTest
+.
+TYPO3\Flow\Tests\Unit\Resource\Streams\StreamWrapperAdapterTest::stream_eofTest
+.
+TYPO3\Flow\Tests\Unit\Resource\Streams\StreamWrapperAdapterTest::stream_flushTest
+.
+TYPO3\Flow\Tests\Unit\Resource\Streams\StreamWrapperAdapterTest::stream_lockTest
+.
+TYPO3\Flow\Tests\Unit\Resource\Streams\StreamWrapperAdapterTest::stream_openTest
+.
+TYPO3\Flow\Tests\Unit\Resource\Streams\StreamWrapperAdapterTest::stream_readTest
+.
+TYPO3\Flow\Tests\Unit\Resource\Streams\StreamWrapperAdapterTest::stream_seekTest
+.
+TYPO3\Flow\Tests\Unit\Resource\Streams\StreamWrapperAdapterTest::stream_seekTest2
+.
+TYPO3\Flow\Tests\Unit\Resource\Streams\StreamWrapperAdapterTest::stream_set_optionTest
+S
+TYPO3\Flow\Tests\Unit\Resource\Streams\StreamWrapperAdapterTest::stream_statTest
+.
+TYPO3\Flow\Tests\Unit\Resource\Streams\StreamWrapperAdapterTest::stream_tellTest
+.
+TYPO3\Flow\Tests\Unit\Resource\Streams\StreamWrapperAdapterTest::stream_unlockTest
+.
+TYPO3\Flow\Tests\Unit\Resource\Streams\StreamWrapperAdapterTest::stream_writeTest
+.
+TYPO3\Flow\Tests\Unit\Resource\Streams\StreamWrapperAdapterTest::unlinkTest
+.
+TYPO3\Flow\Tests\Unit\Resource\Streams\StreamWrapperAdapterTest::url_statTest
+.
+TYPO3\Flow\Tests\Unit\Security\AccountTest::addRoleAddsRoleToAccountIfNotAssigned
+.
+TYPO3\Flow\Tests\Unit\Security\AccountTest::addRoleSkipsRoleIfAssigned
+.
+TYPO3\Flow\Tests\Unit\Security\AccountTest::callingGetPartyInvokesPartyDomainServiceWithAccountAndReturnsItsValue
+.
+TYPO3\Flow\Tests\Unit\Security\AccountTest::callingGetPartyWithoutIdentifierThrowsException
+.
+TYPO3\Flow\Tests\Unit\Security\AccountTest::callingSetPartyInvokesPartyDomainServiceWithAccountIdentifier
+.
+TYPO3\Flow\Tests\Unit\Security\AccountTest::callingSetPartyWithoutIdentifierThrowsException
+.
+TYPO3\Flow\Tests\Unit\Security\AccountTest::expirationDateCanBeSetNull
+.
+TYPO3\Flow\Tests\Unit\Security\AccountTest::getRolesReturnsOnlyExistingRoles
+.
+TYPO3\Flow\Tests\Unit\Security\AccountTest::hasRoleReturnsFalseForAssignedButNonExistentRole
+.
+TYPO3\Flow\Tests\Unit\Security\AccountTest::hasRoleWorks
+.
+TYPO3\Flow\Tests\Unit\Security\AccountTest::isActiveReturnsFalseIfTheAccountHasAnExpirationDateInThePast
+.
+TYPO3\Flow\Tests\Unit\Security\AccountTest::isActiveReturnsTrueIfTheAccountHasAnExpirationDateInTheFuture
+.
+TYPO3\Flow\Tests\Unit\Security\AccountTest::isActiveReturnsTrueIfTheAccountHasNoExpirationDate
+.
+TYPO3\Flow\Tests\Unit\Security\AccountTest::removeRoleRemovesRoleFromAccountIfAssigned
+.
+TYPO3\Flow\Tests\Unit\Security\AccountTest::removeRoleSkipsRemovalIfRoleNotAssigned
+.
+TYPO3\Flow\Tests\Unit\Security\AccountTest::setRolesWorks
+.
+TYPO3\Flow\Tests\Unit\Security\Aspect\PolicyEnforcementAspectTest::enforcePolicyCallsTheAdviceChainCorrectly
+.
+TYPO3\Flow\Tests\Unit\Security\Aspect\PolicyEnforcementAspectTest::enforcePolicyCallsThePolicyEnforcementInterceptorCorrectly
+.
+TYPO3\Flow\Tests\Unit\Security\Aspect\PolicyEnforcementAspectTest::enforcePolicyCallsTheTheAfterInvocationInterceptorCorrectly
+S
+TYPO3\Flow\Tests\Unit\Security\Aspect\PolicyEnforcementAspectTest::enforcePolicyDoesNotInvokeInterceptorIfAuthorizationChecksAreDisabled
+.
+TYPO3\Flow\Tests\Unit\Security\Aspect\PolicyEnforcementAspectTest::enforcePolicyPassesTheGivenJoinPointOverToTheAfterInvocationInterceptor
+S
+TYPO3\Flow\Tests\Unit\Security\Aspect\PolicyEnforcementAspectTest::enforcePolicyPassesTheGivenJoinPointOverToThePolicyEnforcementInterceptor
+.
+TYPO3\Flow\Tests\Unit\Security\Aspect\PolicyEnforcementAspectTest::enforcePolicyPassesTheReturnValueOfTheInterceptedMethodOverToTheAfterInvocationInterceptor
+S
+TYPO3\Flow\Tests\Unit\Security\Aspect\PolicyEnforcementAspectTest::enforcePolicyReturnsTheResultOfTheOriginalMethodCorrectly
+.
+TYPO3\Flow\Tests\Unit\Security\Authentication\AuthenticationProviderManagerTest::anExceptionIsThrownIfTheConfiguredProviderDoesNotExist
+.
+TYPO3\Flow\Tests\Unit\Security\Authentication\AuthenticationProviderManagerTest::authenticateAuthenticatesOnlyTokensWithStatusAuthenticationNeeded
+.
+TYPO3\Flow\Tests\Unit\Security\Authentication\AuthenticationProviderManagerTest::authenticateDelegatesAuthenticationToTheCorrectProvidersInTheCorrectOrder
+.
+TYPO3\Flow\Tests\Unit\Security\Authentication\AuthenticationProviderManagerTest::authenticateTagsSessionWithAccountIdentifier
+.
+TYPO3\Flow\Tests\Unit\Security\Authentication\AuthenticationProviderManagerTest::authenticateThrowsAnExceptionIfAuthenticateAllTokensIsTrueButATokenCouldNotBeAuthenticated
+.
+TYPO3\Flow\Tests\Unit\Security\Authentication\AuthenticationProviderManagerTest::authenticateThrowsAnExceptionIfNoTokenCouldBeAuthenticated
+.
+TYPO3\Flow\Tests\Unit\Security\Authentication\AuthenticationProviderManagerTest::isAuthenticatedReturnsFalseIfNoTokenIsAuthenticated
+.
+TYPO3\Flow\Tests\Unit\Security\Authentication\AuthenticationProviderManagerTest::isAuthenticatedReturnsFalseIfNoTokenIsAuthenticatedWithStrategyAnyToken
+.
+TYPO3\Flow\Tests\Unit\Security\Authentication\AuthenticationProviderManagerTest::isAuthenticatedReturnsTrueIfAnTokenCouldBeAuthenticated
+.
+TYPO3\Flow\Tests\Unit\Security\Authentication\AuthenticationProviderManagerTest::isAuthenticatedReturnsTrueIfAtLeastOneTokenIsAuthenticated
+.
+TYPO3\Flow\Tests\Unit\Security\Authentication\AuthenticationProviderManagerTest::isAuthenticatedReturnsTrueIfOneTokenIsAuthenticatedWithStrategyAnyToken
+.
+TYPO3\Flow\Tests\Unit\Security\Authentication\AuthenticationProviderManagerTest::logoutDestroysSessionIfStarted
+.
+TYPO3\Flow\Tests\Unit\Security\Authentication\AuthenticationProviderManagerTest::logoutDoesNotDestroySessionIfNotStarted
+.
+TYPO3\Flow\Tests\Unit\Security\Authentication\AuthenticationProviderManagerTest::logoutEmitsLoggedOutSignalBeforeDestroyingSession
+.
+TYPO3\Flow\Tests\Unit\Security\Authentication\AuthenticationProviderManagerTest::logoutResetsSecurityContextHash
+.
+TYPO3\Flow\Tests\Unit\Security\Authentication\AuthenticationProviderManagerTest::logoutReturnsIfNoAccountIsAuthenticated
+.
+TYPO3\Flow\Tests\Unit\Security\Authentication\AuthenticationProviderManagerTest::logoutSetsTheAuthenticationStatusOfAllActiveAuthenticationTokensToNoCredentialsGiven
+.
+TYPO3\Flow\Tests\Unit\Security\Authentication\AuthenticationProviderManagerTest::noTokensAndProvidersAreBuiltIfTheConfigurationArrayIsEmpty
+.
+TYPO3\Flow\Tests\Unit\Security\Authentication\AuthenticationProviderResolverTest::resolveProviderObjectNameThrowsAnExceptionIfNoProviderIsAvailable
+.
+TYPO3\Flow\Tests\Unit\Security\Authentication\AuthenticationProviderResolverTest::resolveProviderReturnsTheCorrectProviderForACompleteClassName
+.
+TYPO3\Flow\Tests\Unit\Security\Authentication\AuthenticationProviderResolverTest::resolveProviderReturnsTheCorrectProviderForAShortName
+.
+TYPO3\Flow\Tests\Unit\Security\Authentication\EntryPoint\HttpBasicTest::startAuthenticationSetsTheCorrectValuesInTheResponseObject
+.
+TYPO3\Flow\Tests\Unit\Security\Authentication\EntryPoint\WebRedirectTest::startAuthenticationDoesNotPrefixAConfiguredUriIfItsAbsolute
+.
+TYPO3\Flow\Tests\Unit\Security\Authentication\EntryPoint\WebRedirectTest::startAuthenticationSetsTheCorrectValuesInTheResponseObjectIfRouteValuesAreSpecified
+.
+TYPO3\Flow\Tests\Unit\Security\Authentication\EntryPoint\WebRedirectTest::startAuthenticationSetsTheCorrectValuesInTheResponseObjectIfUriIsSpecified
+.
+TYPO3\Flow\Tests\Unit\Security\Authentication\EntryPoint\WebRedirectTest::startAuthenticationThrowsAnExceptionIfTheConfigurationOptionsAreMissing
+.
+TYPO3\Flow\Tests\Unit\Security\Authentication\EntryPoint\WebRedirectTest::startAuthenticationThrowsAnExceptionIfTheConfiguredRoutePartsAreInvalid
+.
+TYPO3\Flow\Tests\Unit\Security\Authentication\Provider\FileBasedSimpleKeyProviderTest::authenticatingAPasswordTokenChecksIfTheGivenClearTextPasswordMatchesThePersistedHashedPassword
+.
+TYPO3\Flow\Tests\Unit\Security\Authentication\Provider\FileBasedSimpleKeyProviderTest::authenticatingAnUnsupportedTokenThrowsAnException
+.
+TYPO3\Flow\Tests\Unit\Security\Authentication\Provider\FileBasedSimpleKeyProviderTest::authenticationAddsAnAccountHoldingTheConfiguredRoles
+.
+TYPO3\Flow\Tests\Unit\Security\Authentication\Provider\FileBasedSimpleKeyProviderTest::authenticationFailsWithWrongCredentialsInAPasswordToken
+.
+TYPO3\Flow\Tests\Unit\Security\Authentication\Provider\FileBasedSimpleKeyProviderTest::authenticationIsSkippedIfNoCredentialsInAPasswordToken
+.
+TYPO3\Flow\Tests\Unit\Security\Authentication\Provider\FileBasedSimpleKeyProviderTest::canAuthenticateReturnsTrueOnlyForAnTokenThatHasTheCorrectProviderNameSet
+.
+TYPO3\Flow\Tests\Unit\Security\Authentication\Provider\FileBasedSimpleKeyProviderTest::getTokenClassNameReturnsCorrectClassNames
+.
+TYPO3\Flow\Tests\Unit\Security\Authentication\Provider\PersistedUsernamePasswordProviderTest::authenticatingAnUnsupportedTokenThrowsAnException
+.
+TYPO3\Flow\Tests\Unit\Security\Authentication\Provider\PersistedUsernamePasswordProviderTest::authenticatingAnUsernamePasswordTokenChecksIfTheGivenClearTextPasswordMatchesThePersistedHashedPassword
+.
+TYPO3\Flow\Tests\Unit\Security\Authentication\Provider\PersistedUsernamePasswordProviderTest::authenticatingAnUsernamePasswordTokenFetchesAccountWithDisabledAuthorization
+.
+TYPO3\Flow\Tests\Unit\Security\Authentication\Provider\PersistedUsernamePasswordProviderTest::authenticationFailsWithWrongCredentialsInAnUsernamePasswordToken
+.
+TYPO3\Flow\Tests\Unit\Security\Authentication\Provider\PersistedUsernamePasswordProviderTest::canAuthenticateReturnsTrueOnlyForAnTokenThatHasTheCorrectProviderNameSet
+.
+TYPO3\Flow\Tests\Unit\Security\Authentication\Token\AbstractTokenTest::authenticationEntryPointCanBeSetAndRetrieved
+.
+TYPO3\Flow\Tests\Unit\Security\Authentication\Token\AbstractTokenTest::authenticationProviderNameCanBeSetAndRetrieved
+.
+TYPO3\Flow\Tests\Unit\Security\Authentication\Token\AbstractTokenTest::isAuthenticatedReturnsTheCorrectValueForAGivenStatus with data set #0
+.
+TYPO3\Flow\Tests\Unit\Security\Authentication\Token\AbstractTokenTest::isAuthenticatedReturnsTheCorrectValueForAGivenStatus with data set #1
+.
+TYPO3\Flow\Tests\Unit\Security\Authentication\Token\AbstractTokenTest::isAuthenticatedReturnsTheCorrectValueForAGivenStatus with data set #2
+.
+TYPO3\Flow\Tests\Unit\Security\Authentication\Token\AbstractTokenTest::isAuthenticatedReturnsTheCorrectValueForAGivenStatus with data set #3
+.
+TYPO3\Flow\Tests\Unit\Security\Authentication\Token\AbstractTokenTest::requestPatternsCanBeSetRetrievedAndChecked
+.
+TYPO3\Flow\Tests\Unit\Security\Authentication\Token\AbstractTokenTest::setAuthenticationStatusThrowsAnExceptionForAnInvalidStatus
+.
+TYPO3\Flow\Tests\Unit\Security\Authentication\Token\AbstractTokenTest::setRequestPatternsOnlyAcceptsRequestPatterns
+.
+TYPO3\Flow\Tests\Unit\Security\Authentication\Token\AbstractTokenTest::theAuthenticationStatusIsCorrectlyInitialized
+.
+TYPO3\Flow\Tests\Unit\Security\Authentication\Token\PasswordTokenTest::credentialsAreSetCorrectlyFromPostArguments
+.
+TYPO3\Flow\Tests\Unit\Security\Authentication\Token\PasswordTokenTest::updateCredentialsIgnoresAnythingOtherThanPostRequests
+.
+TYPO3\Flow\Tests\Unit\Security\Authentication\Token\PasswordTokenTest::updateCredentialsSetsTheCorrectAuthenticationStatusIfNewCredentialsArrived
+.
+TYPO3\Flow\Tests\Unit\Security\Authentication\Token\UsernamePasswordHttpBasicTest::credentialsAreSetCorrectlyForCGI
+.
+TYPO3\Flow\Tests\Unit\Security\Authentication\Token\UsernamePasswordHttpBasicTest::credentialsAreSetCorrectlyFromRequestHeadersArguments
+.
+TYPO3\Flow\Tests\Unit\Security\Authentication\Token\UsernamePasswordHttpBasicTest::updateCredentialsSetsTheCorrectAuthenticationStatusIfNoCredentialsArrived
+.
+TYPO3\Flow\Tests\Unit\Security\Authentication\Token\UsernamePasswordTest::credentialsAreSetCorrectlyFromPostArguments
+.
+TYPO3\Flow\Tests\Unit\Security\Authentication\Token\UsernamePasswordTest::tokenCanBeCastToString
+.
+TYPO3\Flow\Tests\Unit\Security\Authentication\Token\UsernamePasswordTest::updateCredentialsIgnoresAnythingOtherThanPostRequests
+.
+TYPO3\Flow\Tests\Unit\Security\Authentication\Token\UsernamePasswordTest::updateCredentialsSetsTheCorrectAuthenticationStatusIfNewCredentialsArrived
+.
+TYPO3\Flow\Tests\Unit\Security\Authorization\FilterFirewallTest::allConfiguredFiltersAreCalled
+.
+TYPO3\Flow\Tests\Unit\Security\Authorization\FilterFirewallTest::configuredFiltersAreCreatedCorrectly
+.
+TYPO3\Flow\Tests\Unit\Security\Authorization\FilterFirewallTest::ifRejectAllIsSetAndNoFilterExplicitlyAllowsTheRequestAPermissionDeniedExceptionIsThrown
+.
+TYPO3\Flow\Tests\Unit\Security\Authorization\InterceptorResolverTest::resolveInterceptorClassThrowsAnExceptionIfNoInterceptorIsAvailable
+.
+TYPO3\Flow\Tests\Unit\Security\Authorization\InterceptorResolverTest::resolveInterceptorReturnsTheCorrectInterceptorForACompleteClassName
+.
+TYPO3\Flow\Tests\Unit\Security\Authorization\InterceptorResolverTest::resolveInterceptorReturnsTheCorrectInterceptorForAShortName
+.
+TYPO3\Flow\Tests\Unit\Security\Authorization\Interceptor\AfterInvocationTest::invokeReturnsTheResultPreviouslySetBySetResultIfTheMethodIsNotIntercepted
+.
+TYPO3\Flow\Tests\Unit\Security\Authorization\Interceptor\PolicyEnforcementTest::invokeCallsTheAuthenticationManager
+.
+TYPO3\Flow\Tests\Unit\Security\Authorization\Interceptor\PolicyEnforcementTest::invokeCallsThePrivilegeManagerToDecideOnTheCurrentJoinPoint
+.
+TYPO3\Flow\Tests\Unit\Security\Authorization\Interceptor\RequireAuthenticationTest::invokeCallsTheAuthenticationManagerToPerformAuthentication
+.
+TYPO3\Flow\Tests\Unit\Security\Authorization\PrivilegeManagerTest::isGrantedDeniesAccessIfADenyPrivilegeWasConfiguredForOneOfTheRoles
+.
+TYPO3\Flow\Tests\Unit\Security\Authorization\PrivilegeManagerTest::isGrantedGrantsAccessIfAGrantPrivilegeAndNoDenyPrivilegeWasConfigured
+.
+TYPO3\Flow\Tests\Unit\Security\Authorization\PrivilegeManagerTest::isGrantedGrantsAccessIfNoPolicyEntryCouldBeFound
+.
+TYPO3\Flow\Tests\Unit\Security\Authorization\PrivilegeManagerTest::isGrantedGrantsAccessIfNoRolesAreAvailable
+.
+TYPO3\Flow\Tests\Unit\Security\Authorization\PrivilegeManagerTest::isGrantedGrantsIfNoPrivilegeWasConfigured
+.
+TYPO3\Flow\Tests\Unit\Security\Authorization\PrivilegeManagerTest::isPrivilegeTargetGrantedPrivilegeReturnsTrueIfAllVotersAbstainAndAllowAccessIfAllVotersAbstainIsTrue
+.
+TYPO3\Flow\Tests\Unit\Security\Authorization\PrivilegeManagerTest::isPrivilegeTargetGrantedReturnsFalseIfAllVotersAbstainAndAllowAccessIfAllVotersAbstainIsFalse
+.
+TYPO3\Flow\Tests\Unit\Security\Authorization\PrivilegeManagerTest::isPrivilegeTargetGrantedReturnsFalseIfOneVoterReturnsADenyVote
+.
+TYPO3\Flow\Tests\Unit\Security\Authorization\PrivilegeManagerTest::isPrivilegeTargetGrantedReturnsTrueIfThereIsNoDenyVoteAndOneGrantVote
+.
+TYPO3\Flow\Tests\Unit\Security\Authorization\RequestFilterTest::theFilterReturnsFalseIfThePatternDidNotMatch
+.
+TYPO3\Flow\Tests\Unit\Security\Authorization\RequestFilterTest::theFilterReturnsTrueIfThePatternMatched
+.
+TYPO3\Flow\Tests\Unit\Security\Authorization\RequestFilterTest::theSetIncerceptorIsCalledIfTheRequestPatternMatches
+.
+TYPO3\Flow\Tests\Unit\Security\Authorization\RequestFilterTest::theSetIncerceptorIsNotCalledIfTheRequestPatternDoesNotMatch
+.
+TYPO3\Flow\Tests\Unit\Security\ContextTest::authenticationStrategyIsSetCorrectlyFromConfiguration with data set #0
+.
+TYPO3\Flow\Tests\Unit\Security\ContextTest::authenticationStrategyIsSetCorrectlyFromConfiguration with data set #1
+.
+TYPO3\Flow\Tests\Unit\Security\ContextTest::authenticationStrategyIsSetCorrectlyFromConfiguration with data set #2
+.
+TYPO3\Flow\Tests\Unit\Security\ContextTest::authenticationStrategyIsSetCorrectlyFromConfiguration with data set #3
+.
+TYPO3\Flow\Tests\Unit\Security\ContextTest::authorizationChecksAreEnabledByDefault
+.
+TYPO3\Flow\Tests\Unit\Security\ContextTest::csrfProtectionStrategyIsSetCorrectlyFromConfiguration with data set #0
+.
+TYPO3\Flow\Tests\Unit\Security\ContextTest::csrfProtectionStrategyIsSetCorrectlyFromConfiguration with data set #1
+.
+TYPO3\Flow\Tests\Unit\Security\ContextTest::csrfProtectionStrategyIsSetCorrectlyFromConfiguration with data set #2
+.
+TYPO3\Flow\Tests\Unit\Security\ContextTest::currentRequestIsSetInTheSecurityContext
+.
+TYPO3\Flow\Tests\Unit\Security\ContextTest::getAccountByAuthenticationProviderNameReturnsNullIfNoAccountFound
+.
+TYPO3\Flow\Tests\Unit\Security\ContextTest::getAccountByAuthenticationProviderNameReturnsTheAuthenticatedAccountWithGivenProviderName
+.
+TYPO3\Flow\Tests\Unit\Security\ContextTest::getAccountReturnsTheAccountAttachedToTheFirstAuthenticatedToken
+.
+TYPO3\Flow\Tests\Unit\Security\ContextTest::getCsrfProtectionTokenReturnsANewTokenIfNoneIsPresentInTheContext
+.
+TYPO3\Flow\Tests\Unit\Security\ContextTest::getCsrfProtectionTokenReturnsANewTokenIfTheCsrfStrategyIsOnePerUri
+.
+TYPO3\Flow\Tests\Unit\Security\ContextTest::getPartyAsksTheCorrectAuthenticationTokenAndReturnsItsParty
+.
+TYPO3\Flow\Tests\Unit\Security\ContextTest::getPartyByTypeReturnsTheFirstAuthenticatedPartyWithGivenType
+.
+TYPO3\Flow\Tests\Unit\Security\ContextTest::getRolesReturnsTheAnonymousRoleIfNoTokenIsAuthenticated
+.
+TYPO3\Flow\Tests\Unit\Security\ContextTest::getRolesReturnsTheAuthenticatedUserRoleIfATokenIsAuthenticated
+.
+TYPO3\Flow\Tests\Unit\Security\ContextTest::getRolesReturnsTheCorrectRoles
+.
+TYPO3\Flow\Tests\Unit\Security\ContextTest::getRolesReturnsTheEverybodyRoleEvenIfNoTokenIsAuthenticated
+.
+TYPO3\Flow\Tests\Unit\Security\ContextTest::getRolesTakesInheritanceOfRolesIntoAccount
+.
+TYPO3\Flow\Tests\Unit\Security\ContextTest::hasRoleReturnsFalseForAnonymousRoleIfAuthenticated
+.
+TYPO3\Flow\Tests\Unit\Security\ContextTest::hasRoleReturnsTrueForAnonymousRoleIfNotAuthenticated
+.
+TYPO3\Flow\Tests\Unit\Security\ContextTest::hasRoleReturnsTrueForEverybodyRole
+.
+TYPO3\Flow\Tests\Unit\Security\ContextTest::hasRoleWorks
+.
+TYPO3\Flow\Tests\Unit\Security\ContextTest::hasRoleWorksWithRecursiveRoles
+.
+TYPO3\Flow\Tests\Unit\Security\ContextTest::initializeCallsUpdateCredentialsOnAllActiveTokens
+.
+TYPO3\Flow\Tests\Unit\Security\ContextTest::initializeSeparatesActiveAndInactiveTokens
+.
+TYPO3\Flow\Tests\Unit\Security\ContextTest::initializeUpdatesAndSeparatesActiveAndInactiveTokensCorrectly
+.
+TYPO3\Flow\Tests\Unit\Security\ContextTest::injectAuthenticationManagerSetsAReferenceToTheSecurityContextInTheAuthenticationManager
+.
+TYPO3\Flow\Tests\Unit\Security\ContextTest::invalidAuthenticationStrategyFromConfigurationThrowsException
+.
+TYPO3\Flow\Tests\Unit\Security\ContextTest::invalidCsrfProtectionStrategyFromConfigurationThrowsException
+.
+TYPO3\Flow\Tests\Unit\Security\ContextTest::isCsrfProtectionTokenValidChecksIfTheGivenTokenIsExistingInTheContext
+.
+TYPO3\Flow\Tests\Unit\Security\ContextTest::isCsrfProtectionTokenValidChecksIfTheGivenTokenIsExistingInTheContextAndUnsetsItIfTheCsrfStrategyIsOnePerUri
+.
+TYPO3\Flow\Tests\Unit\Security\ContextTest::securityContextCallsTheAuthenticationManagerToSetItsTokens
+.
+TYPO3\Flow\Tests\Unit\Security\ContextTest::securityContextIsNotInitializedAgainIfItHasBeenInitializedAlready
+.
+TYPO3\Flow\Tests\Unit\Security\ContextTest::securityContextIsSetToInitialized
+.
+TYPO3\Flow\Tests\Unit\Security\ContextTest::tokenFromAnAuthenticationManagerIsReplacedIfThereIsOneOfTheSameTypeInTheSession
+.
+TYPO3\Flow\Tests\Unit\Security\ContextTest::withoutAuthorizationChecksDisabledAuthorizationChecks
+.
+TYPO3\Flow\Tests\Unit\Security\ContextTest::withoutAuthorizationChecksReactivatesAuthorizationChecksAfterClosureInvocation
+.
+TYPO3\Flow\Tests\Unit\Security\ContextTest::withoutAuthorizationChecksReactivatesAuthorizationChecksAfterClosureInvocationIfClosureThrowsException
+.
+TYPO3\Flow\Tests\Unit\Security\Cryptography\AlgorithmsTest::pbkdf2TestVectorsAreCorrect with data set #0
+.
+TYPO3\Flow\Tests\Unit\Security\Cryptography\AlgorithmsTest::pbkdf2TestVectorsAreCorrect with data set #1
+.
+TYPO3\Flow\Tests\Unit\Security\Cryptography\AlgorithmsTest::pbkdf2TestVectorsAreCorrect with data set #2
+.
+TYPO3\Flow\Tests\Unit\Security\Cryptography\AlgorithmsTest::pbkdf2TestVectorsAreCorrect with data set #3
+.
+TYPO3\Flow\Tests\Unit\Security\Cryptography\AlgorithmsTest::pbkdf2TestVectorsAreCorrect with data set #4
+.
+TYPO3\Flow\Tests\Unit\Security\Cryptography\BCryptHashingStrategyTest::hashAndValidatePasswordWithDifferentCostsMatch
+.
+TYPO3\Flow\Tests\Unit\Security\Cryptography\BCryptHashingStrategyTest::hashAndValidatePasswordWithNotMatchingPasswordFails
+.
+TYPO3\Flow\Tests\Unit\Security\Cryptography\BCryptHashingStrategyTest::hashPasswordWithMatchingPasswordAndParametersSucceeds
+.
+TYPO3\Flow\Tests\Unit\Security\Cryptography\BCryptHashingStrategyTest::systemSupportsBlowfishCryptMethod
+.
+TYPO3\Flow\Tests\Unit\Security\Cryptography\BCryptHashingStrategyTest::validatePasswordWithInvalidHashFails
+.
+TYPO3\Flow\Tests\Unit\Security\Cryptography\HashServiceTest::appendHmacAppendsHmacToGivenString
+.
+TYPO3\Flow\Tests\Unit\Security\Cryptography\HashServiceTest::appendHmacThrowsExceptionIfNoStringGiven
+.
+TYPO3\Flow\Tests\Unit\Security\Cryptography\HashServiceTest::generateHmacReturnsDifferentHashStringsForDifferentInputStrings
+.
+TYPO3\Flow\Tests\Unit\Security\Cryptography\HashServiceTest::generateHmacReturnsHashStringIfStringIsGiven
+.
+TYPO3\Flow\Tests\Unit\Security\Cryptography\HashServiceTest::generateHmacReturnsHashStringWhichContainsSomeSalt
+.
+TYPO3\Flow\Tests\Unit\Security\Cryptography\HashServiceTest::generateHmacThrowsExceptionIfNoStringGiven
+.
+TYPO3\Flow\Tests\Unit\Security\Cryptography\HashServiceTest::generatedHashCanBeValidatedAgain
+.
+TYPO3\Flow\Tests\Unit\Security\Cryptography\HashServiceTest::generatedHashReturnsAHashOf40Characters
+.
+TYPO3\Flow\Tests\Unit\Security\Cryptography\HashServiceTest::generatedHashWillNotBeValidatedIfHashHasBeenChanged
+.
+TYPO3\Flow\Tests\Unit\Security\Cryptography\HashServiceTest::hashPasswordWillIncludeStrategyIdentifierInHashedPassword
+.
+TYPO3\Flow\Tests\Unit\Security\Cryptography\HashServiceTest::hashPasswordWithoutStrategyIdentifierUsesConfiguredDefaultStrategy
+.
+TYPO3\Flow\Tests\Unit\Security\Cryptography\HashServiceTest::validateAndStripHmacReturnsTheStringWithoutHmac
+.
+TYPO3\Flow\Tests\Unit\Security\Cryptography\HashServiceTest::validateAndStripHmacThrowsExceptionIfGivenStringHasNoHashAppended
+.
+TYPO3\Flow\Tests\Unit\Security\Cryptography\HashServiceTest::validateAndStripHmacThrowsExceptionIfGivenStringIsTooShort
+.
+TYPO3\Flow\Tests\Unit\Security\Cryptography\HashServiceTest::validateAndStripHmacThrowsExceptionIfNoStringGiven
+.
+TYPO3\Flow\Tests\Unit\Security\Cryptography\HashServiceTest::validateAndStripHmacThrowsExceptionIfTheAppendedHashIsInvalid
+.
+TYPO3\Flow\Tests\Unit\Security\Cryptography\HashServiceTest::validatePasswordWillUseStrategyIdentifierFromHashedPassword
+.
+TYPO3\Flow\Tests\Unit\Security\Cryptography\HashServiceTest::validatePasswordWithoutStrategyIdentifierAndConfiguredFallbackUsesFallbackStrategy
+.
+TYPO3\Flow\Tests\Unit\Security\Cryptography\Pbkdf2HashingStrategyTest::hashAndValidatePasswordWithNotMatchingPasswordOrParametersFails
+.
+TYPO3\Flow\Tests\Unit\Security\Cryptography\Pbkdf2HashingStrategyTest::hashPasswordWithMatchingPasswordAndParametersSucceeds
+.
+TYPO3\Flow\Tests\Unit\Security\Cryptography\RsaWalletServicePhpTest::checkRSAEncryptedPasswordReturnsFalseForAnIncorrectPassword
+.
+TYPO3\Flow\Tests\Unit\Security\Cryptography\RsaWalletServicePhpTest::checkRSAEncryptedPasswordReturnsTrueForACorrectPassword
+.
+TYPO3\Flow\Tests\Unit\Security\Cryptography\RsaWalletServicePhpTest::decryptingWithAKeypairUUIDMarkedForPasswordUsageThrowsAnException
+.
+TYPO3\Flow\Tests\Unit\Security\Cryptography\RsaWalletServicePhpTest::encryptingAndDecryptingBasicallyWorks
+.
+TYPO3\Flow\Tests\Unit\Security\Cryptography\RsaWalletServicePhpTest::getFingerprintByPublicKeyCalculatesCorrectFingerprint
+.
+TYPO3\Flow\Tests\Unit\Security\Cryptography\RsaWalletServicePhpTest::registerPublicKeyFromStringUsesFingerprintAsUuid
+.
+TYPO3\Flow\Tests\Unit\Security\Cryptography\RsaWalletServicePhpTest::shutdownDoesNotSavesKeysToKeystoreFileIfKeysWereNotModified
+.
+TYPO3\Flow\Tests\Unit\Security\Cryptography\RsaWalletServicePhpTest::shutdownSavesKeysToKeystoreFileIfKeysWereModified
+.
+TYPO3\Flow\Tests\Unit\Security\Cryptography\RsaWalletServicePhpTest::signAndVerifySignatureBasicallyWorks
+.
+TYPO3\Flow\Tests\Unit\Security\Policy\PolicyExpressionParserTest::parseMethodThrowsAnExceptionIfAnotherPrivilegeTargetIsReferencedInAnExpression
+.
+TYPO3\Flow\Tests\Unit\Security\Policy\RoleTest::setNameAndPackageKeyWorks with data set #0
+.
+TYPO3\Flow\Tests\Unit\Security\Policy\RoleTest::setNameAndPackageKeyWorks with data set #1
+.
+TYPO3\Flow\Tests\Unit\Security\Policy\RoleTest::setNameAndPackageKeyWorks with data set #2
+.
+TYPO3\Flow\Tests\Unit\Security\Policy\RoleTest::setParentRolesMakesSureThatParentRolesDontContainDuplicates
+.
+TYPO3\Flow\Tests\Unit\Security\RequestPatternResolverTest::resolveRequestPatternClassThrowsAnExceptionIfNoRequestPatternIsAvailable
+.
+TYPO3\Flow\Tests\Unit\Security\RequestPatternResolverTest::resolveRequestPatternReturnsTheCorrectRequestPatternForACompleteClassName
+.
+TYPO3\Flow\Tests\Unit\Security\RequestPatternResolverTest::resolveRequestPatternReturnsTheCorrectRequestPatternForAShortName
+.
+TYPO3\Flow\Tests\Unit\Security\RequestPattern\ControllerObjectNameTest::requestMatchingBasicallyWorks
+.
+TYPO3\Flow\Tests\Unit\Security\RequestPattern\CsrfProtectionTest::matchRequestReturnsFalseIfAuthorizationChecksAreDisabled
+.
+TYPO3\Flow\Tests\Unit\Security\RequestPattern\CsrfProtectionTest::matchRequestReturnsFalseIfNobodyIsAuthenticated
+.
+TYPO3\Flow\Tests\Unit\Security\RequestPattern\CsrfProtectionTest::matchRequestReturnsFalseIfRequestIsNoActionRequest
+.
+TYPO3\Flow\Tests\Unit\Security\RequestPattern\CsrfProtectionTest::matchRequestReturnsFalseIfRequestMethodIsSafe
+.
+TYPO3\Flow\Tests\Unit\Security\RequestPattern\CsrfProtectionTest::matchRequestReturnsFalseIfTheCsrfTokenIsPassedThroughAnHttpHeader
+.
+TYPO3\Flow\Tests\Unit\Security\RequestPattern\CsrfProtectionTest::matchRequestReturnsFalseIfTheTargetActionIsMentionedInThePolicyAndTheCsrfTokenIsValid
+.
+TYPO3\Flow\Tests\Unit\Security\RequestPattern\CsrfProtectionTest::matchRequestReturnsFalseIfTheTargetActionIsNotMentionedInThePolicy
+.
+TYPO3\Flow\Tests\Unit\Security\RequestPattern\CsrfProtectionTest::matchRequestReturnsFalseIfTheTargetActionIsTaggedWithSkipCsrfProtection
+.
+TYPO3\Flow\Tests\Unit\Security\RequestPattern\CsrfProtectionTest::matchRequestReturnsTrueIfTheTargetActionIsMentionedInThePolicyButNoCsrfTokenHasBeenSent
+.
+TYPO3\Flow\Tests\Unit\Security\RequestPattern\CsrfProtectionTest::matchRequestReturnsTrueIfTheTargetActionIsMentionedInThePolicyButTheCsrfTokenIsInvalid
+.
+TYPO3\Flow\Tests\Unit\Security\RequestPattern\UriTest::matchRequestTests with data set #0
+.
+TYPO3\Flow\Tests\Unit\Security\RequestPattern\UriTest::matchRequestTests with data set #1
+.
+TYPO3\Flow\Tests\Unit\Security\RequestPattern\UriTest::matchRequestTests with data set #2
+.
+TYPO3\Flow\Tests\Unit\Security\RequestPattern\UriTest::matchRequestTests with data set #3
+.
+TYPO3\Flow\Tests\Unit\Session\Aspect\LoggingAspectTest::logDestroyDoesNotRequireArgumentReason
+.
+TYPO3\Flow\Tests\Unit\Session\Aspect\LoggingAspectTest::logDestroyLogsSessionIdAndArgumentReason
+.
+TYPO3\Flow\Tests\Unit\Session\Aspect\SessionObjectMethodsPointcutFilterTest::reduceTargetClassNamesFiltersAllClassesNotBeeingConfiguredAsScopeSession
+.
+TYPO3\Flow\Tests\Unit\Session\SessionTest::aSessionCanBeTaggedAndBeRetrievedAgainByTheseTags
+.
+TYPO3\Flow\Tests\Unit\Session\SessionTest::addTagThrowsExceptionIfCalledOnNonStartedSession
+.
+TYPO3\Flow\Tests\Unit\Session\SessionTest::addTagThrowsExceptionIfTagIsNotValid
+.
+TYPO3\Flow\Tests\Unit\Session\SessionTest::autoExpireRemovesAllSessionDataOfTheExpiredSession
+.
+TYPO3\Flow\Tests\Unit\Session\SessionTest::autoExpireTriggersGarbageCollectionForExpiredSessions
+.
+TYPO3\Flow\Tests\Unit\Session\SessionTest::canBeResumedReturnsFalseIfNoSessionCookieExists
+.
+TYPO3\Flow\Tests\Unit\Session\SessionTest::canBeResumedReturnsFalseIfSessionIsExpiredAndExpiresASessionIfLastActivityIsOverTheLimit
+.
+TYPO3\Flow\Tests\Unit\Session\SessionTest::canBeResumedReturnsFalseIfTheSessionHasAlreadyBeenStarted
+.
+TYPO3\Flow\Tests\Unit\Session\SessionTest::closeAndShutdownObjectDoNotCloseARemoteSession
+.
+TYPO3\Flow\Tests\Unit\Session\SessionTest::closeFlagsTheSessionAsClosed
+.
+TYPO3\Flow\Tests\Unit\Session\SessionTest::constructCreatesARemoteSessionIfSessionIfIdentifierIsSpecified
+.
+TYPO3\Flow\Tests\Unit\Session\SessionTest::constructRequiresAStorageIdentifierIfASessionIdentifierWasGiven
+.
+TYPO3\Flow\Tests\Unit\Session\SessionTest::destroyRemovesAllSessionDataFromARemoteSession
+.
+TYPO3\Flow\Tests\Unit\Session\SessionTest::destroyRemovesAllSessionDataFromTheCurrentSessionButNotFromOtherSessions
+.
+TYPO3\Flow\Tests\Unit\Session\SessionTest::destroyThrowsExceptionIfSessionIsNotStarted
+.
+TYPO3\Flow\Tests\Unit\Session\SessionTest::garbageCollectionIsOmittedIfAnotherProcessIsAlreadyRunning
+.
+TYPO3\Flow\Tests\Unit\Session\SessionTest::garbageCollectionIsOmittedIfInactivityTimeoutIsSetToZero
+.
+TYPO3\Flow\Tests\Unit\Session\SessionTest::garbageCollectionOnlyRemovesTheDefinedMaximumNumberOfSessions
+.
+TYPO3\Flow\Tests\Unit\Session\SessionTest::getActiveSessionsReturnsAllActiveSessions
+.
+TYPO3\Flow\Tests\Unit\Session\SessionTest::getDataReturnsDataPreviouslySetWithPutData
+.
+TYPO3\Flow\Tests\Unit\Session\SessionTest::getDataThrowsExceptionIfSessionIsNotStarted
+.
+TYPO3\Flow\Tests\Unit\Session\SessionTest::getIdReturnsTheCurrentSessionIdentifier
+.
+TYPO3\Flow\Tests\Unit\Session\SessionTest::getLastActivityTimestampThrowsExceptionIfCalledOnNonStartedSession
+.
+TYPO3\Flow\Tests\Unit\Session\SessionTest::getTagsOnAResumedSessionReturnsTheTagsSetWithAddTag
+.
+TYPO3\Flow\Tests\Unit\Session\SessionTest::getTagsThrowsExceptionIfCalledOnNonStartedSession
+.
+TYPO3\Flow\Tests\Unit\Session\SessionTest::hasKeyThrowsExceptionIfCalledOnNonStartedSession
+.
+TYPO3\Flow\Tests\Unit\Session\SessionTest::isStartedReturnsFalseByDefault
+.
+TYPO3\Flow\Tests\Unit\Session\SessionTest::isStartedReturnsTrueAfterSessionHasBeenStarted
+.
+TYPO3\Flow\Tests\Unit\Session\SessionTest::lastActivityTimestampOfNewSessionIsSetAndStoredCorrectlyAndCanBeRetrieved
+.
+TYPO3\Flow\Tests\Unit\Session\SessionTest::putDataThrowsExceptionIfSessionIsNotStarted
+.
+TYPO3\Flow\Tests\Unit\Session\SessionTest::putDataThrowsExceptionIfTryingToPersistAResource
+.
+TYPO3\Flow\Tests\Unit\Session\SessionTest::remoteSessionUsesStorageIdentifierPassedToConstructor
+.
+TYPO3\Flow\Tests\Unit\Session\SessionTest::removeTagRemovesAPreviouslySetTag
+.
+TYPO3\Flow\Tests\Unit\Session\SessionTest::removeTagThrowsExceptionIfCalledOnNonStartedSession
+.
+TYPO3\Flow\Tests\Unit\Session\SessionTest::renewIdSetsANewSessionIdentifier
+.
+TYPO3\Flow\Tests\Unit\Session\SessionTest::renewIdThrowsExceptionIfCalledOnNonStartedSession
+.
+TYPO3\Flow\Tests\Unit\Session\SessionTest::renewIdThrowsExceptionIfCalledOnRemoteSession
+.
+TYPO3\Flow\Tests\Unit\Session\SessionTest::resumeOnAStartedSessionDoesNotDoAnyHarm
+.
+TYPO3\Flow\Tests\Unit\Session\SessionTest::resumeSetsSessionCookieInTheResponse
+.
+TYPO3\Flow\Tests\Unit\Session\SessionTest::sessionDataCanBeRetrievedEvenAfterSessionIdHasBeenRenewed
+.
+TYPO3\Flow\Tests\Unit\Session\SessionTest::sessionOnlyReusesTheSessionIdFromIncomingCookies
+.
+TYPO3\Flow\Tests\Unit\Session\SessionTest::shutdownChecksIfSessionStillExistsInStorageCacheBeforeWritingData
+.
+TYPO3\Flow\Tests\Unit\Session\SessionTest::shutdownCreatesSpecialDataEntryForSessionWithAuthenticatedAccounts
+.
+TYPO3\Flow\Tests\Unit\Session\SessionTest::startPutsACookieIntoTheHttpResponse
+.
+TYPO3\Flow\Tests\Unit\Session\SessionTest::startThrowsAnExceptionIfIncompatibleRequestHandlerIsUsed
+.
+TYPO3\Flow\Tests\Unit\Session\SessionTest::touchThrowsExceptionIfCalledOnNonStartedSession
+.
+TYPO3\Flow\Tests\Unit\Session\SessionTest::touchUpdatesLastActivityTimestampOfRemoteSession
+.
+TYPO3\Flow\Tests\Unit\Session\SessionTest::twoSessionsDontConflictIfUsingSameEntryIdentifiers
+.
+TYPO3\Flow\Tests\Unit\Session\TransientSessionTest::aSessionIdIsGeneratedOnStartingTheSession
+.
+TYPO3\Flow\Tests\Unit\Session\TransientSessionTest::allSessionDataCanBeFlushedByCallingDestroy
+.
+TYPO3\Flow\Tests\Unit\Session\TransientSessionTest::hasKeyReturnsTrueOrFalseAccordingToAvailableKeys
+.
+TYPO3\Flow\Tests\Unit\Session\TransientSessionTest::stringsCanBeStoredByCallingPutData
+.
+TYPO3\Flow\Tests\Unit\Session\TransientSessionTest::theTransientSessionImplementsTheSessionInterface
+.
+TYPO3\Flow\Tests\Unit\Session\TransientSessionTest::tryingToGetTheSessionIdWithoutStartingTheSessionThrowsAnException
+.
+TYPO3\Flow\Tests\Unit\SignalSlot\DispatcherTest::connectAllowsForConnectingASlotWithASignal
+.
+TYPO3\Flow\Tests\Unit\SignalSlot\DispatcherTest::connectAlsoAcceptsClosuresActingAsASlot
+.
+TYPO3\Flow\Tests\Unit\SignalSlot\DispatcherTest::connectAlsoAcceptsObjectsInPlaceOfTheClassName
+.
+TYPO3\Flow\Tests\Unit\SignalSlot\DispatcherTest::connectWithSignalNameStartingWithEmitShouldNotBeAllowed
+.
+TYPO3\Flow\Tests\Unit\SignalSlot\DispatcherTest::dispatchPassesArgumentContainingSlotInformationLastIfTheConnectionStatesSo
+.
+TYPO3\Flow\Tests\Unit\SignalSlot\DispatcherTest::dispatchPassesTheSignalArgumentsToTheSlotMethod
+.
+TYPO3\Flow\Tests\Unit\SignalSlot\DispatcherTest::dispatchPassesTheSignalArgumentsToTheStaticSlotMethod
+.
+TYPO3\Flow\Tests\Unit\SignalSlot\DispatcherTest::dispatchPassesTheSignalArgumentsToTheStaticSlotMethodIfNoObjectmanagerIsAvailable
+.
+TYPO3\Flow\Tests\Unit\SignalSlot\DispatcherTest::dispatchRetrievesSlotInstanceFromTheObjectManagerIfOnlyAClassNameWasSpecified
+.
+TYPO3\Flow\Tests\Unit\SignalSlot\DispatcherTest::dispatchThrowsAnExceptionIfTheSpecifiedClassOfASlotIsUnknown
+.
+TYPO3\Flow\Tests\Unit\SignalSlot\DispatcherTest::dispatchThrowsAnExceptionIfTheSpecifiedSlotMethodDoesNotExist
+.
+TYPO3\Flow\Tests\Unit\SignalSlot\SignalAspectTest::forwardSignalToDispatcherForwardsTheSignalsMethodArgumentsToTheDispatcher
+.
+TYPO3\Flow\Tests\Unit\Utility\AlgorithmsTest::generateRandomBytesGeneratesRandomBytes
+.
+TYPO3\Flow\Tests\Unit\Utility\AlgorithmsTest::generateRandomStringGeneratesAlnumCharactersPerDefault
+.
+TYPO3\Flow\Tests\Unit\Utility\AlgorithmsTest::generateRandomStringGeneratesOnlyDefinedCharactersRange with data set #0
+.
+TYPO3\Flow\Tests\Unit\Utility\AlgorithmsTest::generateRandomStringGeneratesOnlyDefinedCharactersRange with data set #1
+.
+TYPO3\Flow\Tests\Unit\Utility\AlgorithmsTest::generateRandomTokenGeneratesRandomToken
+.
+TYPO3\Flow\Tests\Unit\Utility\AlgorithmsTest::generateUUIDGeneratesAtLeastNotTheSameUuidOnSubsequentCalls
+.
+TYPO3\Flow\Tests\Unit\Utility\AlgorithmsTest::generateUUIDGeneratesLowercaseString
+.
+TYPO3\Flow\Tests\Unit\Utility\AlgorithmsTest::generateUUIDGeneratesUuidLikeString
+.
+TYPO3\Flow\Tests\Unit\Utility\ArraysTest::arrayMergeRecursiveCallbackConvertsSimpleValuesWithGivenClosure
+.
+TYPO3\Flow\Tests\Unit\Utility\ArraysTest::arrayMergeRecursiveCallbackConvertsSimpleValuesWithGivenClosureAndReturnedSimpleTypesOverwrite
+.
+TYPO3\Flow\Tests\Unit\Utility\ArraysTest::arrayMergeRecursiveOverruleMergesSimpleArrays with data set "empty array should override array (k2)"
+.
+TYPO3\Flow\Tests\Unit\Utility\ArraysTest::arrayMergeRecursiveOverruleMergesSimpleArrays with data set "empty array without emptyValuesOverride should add new key (k3)"
+.
+TYPO3\Flow\Tests\Unit\Utility\ArraysTest::arrayMergeRecursiveOverruleMergesSimpleArrays with data set "empty array without emptyValuesOverride should not override array (k2)"
+.
+TYPO3\Flow\Tests\Unit\Utility\ArraysTest::arrayMergeRecursiveOverruleMergesSimpleArrays with data set "empty array without emptyValuesOverride should not override existing key (k3)"
+.
+TYPO3\Flow\Tests\Unit\Utility\ArraysTest::arrayMergeRecursiveOverruleMergesSimpleArrays with data set "nested array with recursion"
+.
+TYPO3\Flow\Tests\Unit\Utility\ArraysTest::arrayMergeRecursiveOverruleMergesSimpleArrays with data set "null should override array (k2)"
+.
+TYPO3\Flow\Tests\Unit\Utility\ArraysTest::arrayMergeRecursiveOverruleMergesSimpleArrays with data set "simple type should override array (k2)"
+.
+TYPO3\Flow\Tests\Unit\Utility\ArraysTest::arrayMergeRecursiveOverruleMergesSimpleArrays with data set "simple usage with recursion"
+.
+TYPO3\Flow\Tests\Unit\Utility\ArraysTest::arrayMergeRecursiveOverruleMergesSimpleArrays with data set "simple usage"
+.
+TYPO3\Flow\Tests\Unit\Utility\ArraysTest::containsMultipleTypesReturnsFalseOnArrayWithIntegers
+.
+TYPO3\Flow\Tests\Unit\Utility\ArraysTest::containsMultipleTypesReturnsFalseOnArrayWithObjects
+.
+TYPO3\Flow\Tests\Unit\Utility\ArraysTest::containsMultipleTypesReturnsFalseOnEmptyArray
+.
+TYPO3\Flow\Tests\Unit\Utility\ArraysTest::containsMultipleTypesReturnsTrueOnMixedArray
+.
+TYPO3\Flow\Tests\Unit\Utility\ArraysTest::convertObjectToArrayConvertsNestedObjectsToArray
+.
+TYPO3\Flow\Tests\Unit\Utility\ArraysTest::getValueByPathReturnsNullIfThePathHasMoreSegmentsThanTheGivenArray
+.
+TYPO3\Flow\Tests\Unit\Utility\ArraysTest::getValueByPathReturnsNullIfTheSegementsOfThePathDontExist
+.
+TYPO3\Flow\Tests\Unit\Utility\ArraysTest::getValueByPathReturnsTheValueOfANestedArrayByFollowingTheGivenPath
+.
+TYPO3\Flow\Tests\Unit\Utility\ArraysTest::getValueByPathReturnsTheValueOfANestedArrayByFollowingTheGivenPathIfPathIsString
+.
+TYPO3\Flow\Tests\Unit\Utility\ArraysTest::getValueByPathReturnsTheValueOfANestedArrayByFollowingTheGivenSimplePath
+.
+TYPO3\Flow\Tests\Unit\Utility\ArraysTest::getValueByPathThrowsExceptionIfPathIsNoArrayOrString
+.
+TYPO3\Flow\Tests\Unit\Utility\ArraysTest::removeEmptyElementsRecursivelyRemovesEmptySubArrays
+.
+TYPO3\Flow\Tests\Unit\Utility\ArraysTest::removeEmptyElementsRecursivelyRemovesNullValues
+.
+TYPO3\Flow\Tests\Unit\Utility\ArraysTest::setValueByLeavesInputArrayUnchanged
+.
+TYPO3\Flow\Tests\Unit\Utility\ArraysTest::setValueByPathRecursivelyMergesAnArray
+.
+TYPO3\Flow\Tests\Unit\Utility\ArraysTest::setValueByPathSetsValueRecursivelyIfPathIsArray
+.
+TYPO3\Flow\Tests\Unit\Utility\ArraysTest::setValueByPathSetsValueRecursivelyIfPathIsString
+.
+TYPO3\Flow\Tests\Unit\Utility\ArraysTest::setValueByPathThrowsExceptionIfPathIsNoArrayOrString
+.
+TYPO3\Flow\Tests\Unit\Utility\ArraysTest::setValueByPathThrowsExceptionIfSubjectIsNoArray
+.
+TYPO3\Flow\Tests\Unit\Utility\ArraysTest::setValueByPathThrowsExceptionIfSubjectIsNoArrayAccess
+.
+TYPO3\Flow\Tests\Unit\Utility\ArraysTest::unsetValueByPathDoesNotModifyAnArrayIfThePathWasNotFound
+.
+TYPO3\Flow\Tests\Unit\Utility\ArraysTest::unsetValueByPathRemovesSpecifiedBranch
+.
+TYPO3\Flow\Tests\Unit\Utility\ArraysTest::unsetValueByPathRemovesSpecifiedKey
+.
+TYPO3\Flow\Tests\Unit\Utility\ArraysTest::unsetValueByPathRemovesSpecifiedKeyIfPathIsString
+.
+TYPO3\Flow\Tests\Unit\Utility\ArraysTest::unsetValueByPathThrowsExceptionIfPathIsNoArrayOrString
+.
+TYPO3\Flow\Tests\Unit\Utility\EnvironmentTest::getMaximumPathLengthReturnsCorrectValue
+.
+TYPO3\Flow\Tests\Unit\Utility\EnvironmentTest::getPathToTemporaryDirectoryReturnsAnExistingPath
+.
+TYPO3\Flow\Tests\Unit\Utility\EnvironmentTest::getPathToTemporaryDirectoryReturnsPathWithTrailingSlash
+.
+TYPO3\Flow\Tests\Unit\Utility\FilesTest::bytesToSizeStringTests with data set #0
+.
+TYPO3\Flow\Tests\Unit\Utility\FilesTest::bytesToSizeStringTests with data set #1
+.
+TYPO3\Flow\Tests\Unit\Utility\FilesTest::bytesToSizeStringTests with data set #10
+.
+TYPO3\Flow\Tests\Unit\Utility\FilesTest::bytesToSizeStringTests with data set #11
+.
+TYPO3\Flow\Tests\Unit\Utility\FilesTest::bytesToSizeStringTests with data set #12
+.
+TYPO3\Flow\Tests\Unit\Utility\FilesTest::bytesToSizeStringTests with data set #2
+.
+TYPO3\Flow\Tests\Unit\Utility\FilesTest::bytesToSizeStringTests with data set #3
+.
+TYPO3\Flow\Tests\Unit\Utility\FilesTest::bytesToSizeStringTests with data set #4
+.
+TYPO3\Flow\Tests\Unit\Utility\FilesTest::bytesToSizeStringTests with data set #5
+.
+TYPO3\Flow\Tests\Unit\Utility\FilesTest::bytesToSizeStringTests with data set #6
+.
+TYPO3\Flow\Tests\Unit\Utility\FilesTest::bytesToSizeStringTests with data set #7
+.
+TYPO3\Flow\Tests\Unit\Utility\FilesTest::bytesToSizeStringTests with data set #8
+.
+TYPO3\Flow\Tests\Unit\Utility\FilesTest::bytesToSizeStringTests with data set #9
+.
+TYPO3\Flow\Tests\Unit\Utility\FilesTest::concatenatePathsWorksForBrokenPaths
+.
+TYPO3\Flow\Tests\Unit\Utility\FilesTest::concatenatePathsWorksForEmptyPath
+.
+TYPO3\Flow\Tests\Unit\Utility\FilesTest::concatenatePathsWorksForEmptyPathArrayElements
+.
+TYPO3\Flow\Tests\Unit\Utility\FilesTest::concatenatePathsWorksForOnePath
+.
+TYPO3\Flow\Tests\Unit\Utility\FilesTest::concatenatePathsWorksForPathsWithLeadingAndTrailingSlash
+.
+TYPO3\Flow\Tests\Unit\Utility\FilesTest::concatenatePathsWorksForPathsWithLeadingSlash
+.
+TYPO3\Flow\Tests\Unit\Utility\FilesTest::concatenatePathsWorksForPathsWithTrailingSlash
+.
+TYPO3\Flow\Tests\Unit\Utility\FilesTest::concatenatePathsWorksForTwoPath
+.
+TYPO3\Flow\Tests\Unit\Utility\FilesTest::copyDirectoryRecursivelyCopiesDotFilesIfRequested
+.
+TYPO3\Flow\Tests\Unit\Utility\FilesTest::copyDirectoryRecursivelyCreatesTargetAsExpected
+.
+TYPO3\Flow\Tests\Unit\Utility\FilesTest::copyDirectoryRecursivelyKeepsExistingTargetFilesIfRequested
+.
+TYPO3\Flow\Tests\Unit\Utility\FilesTest::copyDirectoryRecursivelyOverwritesTargetFiles
+.
+TYPO3\Flow\Tests\Unit\Utility\FilesTest::emptyDirectoryRecursivelyThrowsExceptionIfSpecifiedPathDoesNotExist
+.
+TYPO3\Flow\Tests\Unit\Utility\FilesTest::getUnixStylePathWorksForPathWithBackwardSlashes
+.
+TYPO3\Flow\Tests\Unit\Utility\FilesTest::getUnixStylePathWorksForPathWithDriveLetterAndBackwardSlashes
+.
+TYPO3\Flow\Tests\Unit\Utility\FilesTest::getUnixStylePathWorksForPathWithForwardAndBackwardSlashes
+.
+TYPO3\Flow\Tests\Unit\Utility\FilesTest::getUnixStylePathWorksForPathWithForwardSlashes
+.
+TYPO3\Flow\Tests\Unit\Utility\FilesTest::getUnixStylePathWorksForPathWithProtocol with data set #0
+.
+TYPO3\Flow\Tests\Unit\Utility\FilesTest::getUnixStylePathWorksForPathWithProtocol with data set #1
+.
+TYPO3\Flow\Tests\Unit\Utility\FilesTest::getUnixStylePathWorksForPathWithProtocol with data set #2
+.
+TYPO3\Flow\Tests\Unit\Utility\FilesTest::getUnixStylePathWorksForPathWithoutSlashes
+.
+TYPO3\Flow\Tests\Unit\Utility\FilesTest::is_linkReturnsFalseForExistingDirectoryThatIsNoSymlink
+.
+TYPO3\Flow\Tests\Unit\Utility\FilesTest::is_linkReturnsFalseForExistingFileThatIsNoSymlink
+.
+TYPO3\Flow\Tests\Unit\Utility\FilesTest::is_linkReturnsFalseForNonExistingFiles
+.
+TYPO3\Flow\Tests\Unit\Utility\FilesTest::is_linkReturnsFalseForStreamWrapperPaths
+.
+TYPO3\Flow\Tests\Unit\Utility\FilesTest::is_linkReturnsTrueForExistingSymlink
+.
+TYPO3\Flow\Tests\Unit\Utility\FilesTest::is_linkReturnsTrueForExistingSymlinkDirectory
+.
+TYPO3\Flow\Tests\Unit\Utility\FilesTest::removeDirectoryRecursivelyThrowsExceptionIfSpecifiedPathDoesNotExist
+.
+TYPO3\Flow\Tests\Unit\Utility\FilesTest::removeEmptyDirectoriesOnPathAlsoRemovesOSXFinderFilesIfNecessary
+.
+TYPO3\Flow\Tests\Unit\Utility\FilesTest::removeEmptyDirectoriesOnPathDoesNotRemoveAnythingIfTopLevelPathContainsFile
+.
+TYPO3\Flow\Tests\Unit\Utility\FilesTest::removeEmptyDirectoriesOnPathRemovesAllDirectoriesOnPathIfTheyAreEmpty
+.
+TYPO3\Flow\Tests\Unit\Utility\FilesTest::removeEmptyDirectoriesOnPathRemovesOnlyDirectoriesBelowTheGivenBasePath
+.
+TYPO3\Flow\Tests\Unit\Utility\FilesTest::removeEmptyDirectoriesOnPathRemovesOnlyDirectoriesWhichAreEmpty
+.
+TYPO3\Flow\Tests\Unit\Utility\FilesTest::removeEmptyDirectoriesOnPathThrowsExceptionIfBasePathIsNotParentOfPath
+.
+TYPO3\Flow\Tests\Unit\Utility\FilesTest::sizeStringThrowsExceptionIfTheSpecifiedUnitIsUnknown
+.
+TYPO3\Flow\Tests\Unit\Utility\FilesTest::sizeStringToBytesTests with data set #0
+.
+TYPO3\Flow\Tests\Unit\Utility\FilesTest::sizeStringToBytesTests with data set #1
+.
+TYPO3\Flow\Tests\Unit\Utility\FilesTest::sizeStringToBytesTests with data set #10
+.
+TYPO3\Flow\Tests\Unit\Utility\FilesTest::sizeStringToBytesTests with data set #11
+.
+TYPO3\Flow\Tests\Unit\Utility\FilesTest::sizeStringToBytesTests with data set #2
+.
+TYPO3\Flow\Tests\Unit\Utility\FilesTest::sizeStringToBytesTests with data set #3
+.
+TYPO3\Flow\Tests\Unit\Utility\FilesTest::sizeStringToBytesTests with data set #4
+.
+TYPO3\Flow\Tests\Unit\Utility\FilesTest::sizeStringToBytesTests with data set #5
+.
+TYPO3\Flow\Tests\Unit\Utility\FilesTest::sizeStringToBytesTests with data set #6
+.
+TYPO3\Flow\Tests\Unit\Utility\FilesTest::sizeStringToBytesTests with data set #7
+.
+TYPO3\Flow\Tests\Unit\Utility\FilesTest::sizeStringToBytesTests with data set #8
+.
+TYPO3\Flow\Tests\Unit\Utility\FilesTest::sizeStringToBytesTests with data set #9
+.
+TYPO3\Flow\Tests\Unit\Utility\FilesTest::unlinkProperlyRemovesSymlinksPointingToDirectories
+.
+TYPO3\Flow\Tests\Unit\Utility\FilesTest::unlinkProperlyRemovesSymlinksPointingToFiles
+.
+TYPO3\Flow\Tests\Unit\Utility\FilesTest::unlinkReturnsFalseIfSpecifiedPathDoesNotExist
+.
+TYPO3\Flow\Tests\Unit\Utility\MediaTypesTest::getFilenameExtensionFromMediaTypeReturnsFirstFileExtensionFoundForThatMediaType with data set #0
+.
+TYPO3\Flow\Tests\Unit\Utility\MediaTypesTest::getFilenameExtensionFromMediaTypeReturnsFirstFileExtensionFoundForThatMediaType with data set #1
+.
+TYPO3\Flow\Tests\Unit\Utility\MediaTypesTest::getFilenameExtensionFromMediaTypeReturnsFirstFileExtensionFoundForThatMediaType with data set #2
+.
+TYPO3\Flow\Tests\Unit\Utility\MediaTypesTest::getFilenameExtensionFromMediaTypeReturnsFirstFileExtensionFoundForThatMediaType with data set #3
+.
+TYPO3\Flow\Tests\Unit\Utility\MediaTypesTest::getFilenameExtensionsFromMediaTypeReturnsAllFileExtensionForThatMediaType with data set #0
+.
+TYPO3\Flow\Tests\Unit\Utility\MediaTypesTest::getFilenameExtensionsFromMediaTypeReturnsAllFileExtensionForThatMediaType with data set #1
+.
+TYPO3\Flow\Tests\Unit\Utility\MediaTypesTest::getFilenameExtensionsFromMediaTypeReturnsAllFileExtensionForThatMediaType with data set #2
+.
+TYPO3\Flow\Tests\Unit\Utility\MediaTypesTest::getFilenameExtensionsFromMediaTypeReturnsAllFileExtensionForThatMediaType with data set #3
+.
+TYPO3\Flow\Tests\Unit\Utility\MediaTypesTest::getMediaTypeFromFilenameMapsFilenameOrExtensionToMediaType with data set #0
+.
+TYPO3\Flow\Tests\Unit\Utility\MediaTypesTest::getMediaTypeFromFilenameMapsFilenameOrExtensionToMediaType with data set #1
+.
+TYPO3\Flow\Tests\Unit\Utility\MediaTypesTest::getMediaTypeFromFilenameMapsFilenameOrExtensionToMediaType with data set #2
+.
+TYPO3\Flow\Tests\Unit\Utility\MediaTypesTest::getMediaTypeFromFilenameMapsFilenameOrExtensionToMediaType with data set #3
+.
+TYPO3\Flow\Tests\Unit\Utility\MediaTypesTest::getMediaTypeFromFilenameMapsFilenameOrExtensionToMediaType with data set #4
+.
+TYPO3\Flow\Tests\Unit\Utility\MediaTypesTest::getMediaTypeFromFilenameMapsFilenameOrExtensionToMediaType with data set #5
+.
+TYPO3\Flow\Tests\Unit\Utility\MediaTypesTest::getMediaTypeFromFilenameMapsFilenameOrExtensionToMediaType with data set #6
+.
+TYPO3\Flow\Tests\Unit\Utility\MediaTypesTest::getMediaTypeFromFilenameMapsFilenameOrExtensionToMediaType with data set #7
+.
+TYPO3\Flow\Tests\Unit\Utility\MediaTypesTest::getMediaTypeFromFilenameMapsFilenameOrExtensionToMediaType with data set #8
+.
+TYPO3\Flow\Tests\Unit\Utility\MediaTypesTest::mediaRangeMatchesChecksIfTheGivenMediaRangeMatchesTheGivenMediaType with data set #0
+.
+TYPO3\Flow\Tests\Unit\Utility\MediaTypesTest::mediaRangeMatchesChecksIfTheGivenMediaRangeMatchesTheGivenMediaType with data set #1
+.
+TYPO3\Flow\Tests\Unit\Utility\MediaTypesTest::mediaRangeMatchesChecksIfTheGivenMediaRangeMatchesTheGivenMediaType with data set #10
+.
+TYPO3\Flow\Tests\Unit\Utility\MediaTypesTest::mediaRangeMatchesChecksIfTheGivenMediaRangeMatchesTheGivenMediaType with data set #2
+.
+TYPO3\Flow\Tests\Unit\Utility\MediaTypesTest::mediaRangeMatchesChecksIfTheGivenMediaRangeMatchesTheGivenMediaType with data set #3
+.
+TYPO3\Flow\Tests\Unit\Utility\MediaTypesTest::mediaRangeMatchesChecksIfTheGivenMediaRangeMatchesTheGivenMediaType with data set #4
+.
+TYPO3\Flow\Tests\Unit\Utility\MediaTypesTest::mediaRangeMatchesChecksIfTheGivenMediaRangeMatchesTheGivenMediaType with data set #5
+.
+TYPO3\Flow\Tests\Unit\Utility\MediaTypesTest::mediaRangeMatchesChecksIfTheGivenMediaRangeMatchesTheGivenMediaType with data set #6
+.
+TYPO3\Flow\Tests\Unit\Utility\MediaTypesTest::mediaRangeMatchesChecksIfTheGivenMediaRangeMatchesTheGivenMediaType with data set #7
+.
+TYPO3\Flow\Tests\Unit\Utility\MediaTypesTest::mediaRangeMatchesChecksIfTheGivenMediaRangeMatchesTheGivenMediaType with data set #8
+.
+TYPO3\Flow\Tests\Unit\Utility\MediaTypesTest::mediaRangeMatchesChecksIfTheGivenMediaRangeMatchesTheGivenMediaType with data set #9
+.
+TYPO3\Flow\Tests\Unit\Utility\MediaTypesTest::parseMediaTypeReturnsAssociativeArrayWithIndividualPartsOfTheMediaType with data set #0
+.
+TYPO3\Flow\Tests\Unit\Utility\MediaTypesTest::parseMediaTypeReturnsAssociativeArrayWithIndividualPartsOfTheMediaType with data set #1
+.
+TYPO3\Flow\Tests\Unit\Utility\MediaTypesTest::parseMediaTypeReturnsAssociativeArrayWithIndividualPartsOfTheMediaType with data set #2
+.
+TYPO3\Flow\Tests\Unit\Utility\MediaTypesTest::trimMediaTypeReturnsJustTheTypeAndSubTypeWithoutParameters with data set #0
+.
+TYPO3\Flow\Tests\Unit\Utility\MediaTypesTest::trimMediaTypeReturnsJustTheTypeAndSubTypeWithoutParameters with data set #1
+.
+TYPO3\Flow\Tests\Unit\Utility\MediaTypesTest::trimMediaTypeReturnsJustTheTypeAndSubTypeWithoutParameters with data set #2
+.
+TYPO3\Flow\Tests\Unit\Utility\MediaTypesTest::trimMediaTypeReturnsJustTheTypeAndSubTypeWithoutParameters with data set #3
+.
+TYPO3\Flow\Tests\Unit\Utility\MediaTypesTest::trimMediaTypeReturnsJustTheTypeAndSubTypeWithoutParameters with data set #4
+.
+TYPO3\Flow\Tests\Unit\Utility\PositionalArraySorterTest::getSortedKeysTests with data set #0
+.
+TYPO3\Flow\Tests\Unit\Utility\PositionalArraySorterTest::getSortedKeysTests with data set #1
+.
+TYPO3\Flow\Tests\Unit\Utility\PositionalArraySorterTest::getSortedKeysTests with data set #10
+.
+TYPO3\Flow\Tests\Unit\Utility\PositionalArraySorterTest::getSortedKeysTests with data set #11
+.
+TYPO3\Flow\Tests\Unit\Utility\PositionalArraySorterTest::getSortedKeysTests with data set #12
+.
+TYPO3\Flow\Tests\Unit\Utility\PositionalArraySorterTest::getSortedKeysTests with data set #2
+.
+TYPO3\Flow\Tests\Unit\Utility\PositionalArraySorterTest::getSortedKeysTests with data set #3
+.
+TYPO3\Flow\Tests\Unit\Utility\PositionalArraySorterTest::getSortedKeysTests with data set #4
+.
+TYPO3\Flow\Tests\Unit\Utility\PositionalArraySorterTest::getSortedKeysTests with data set #5
+.
+TYPO3\Flow\Tests\Unit\Utility\PositionalArraySorterTest::getSortedKeysTests with data set #6
+.
+TYPO3\Flow\Tests\Unit\Utility\PositionalArraySorterTest::getSortedKeysTests with data set #7
+.
+TYPO3\Flow\Tests\Unit\Utility\PositionalArraySorterTest::getSortedKeysTests with data set #8
+.
+TYPO3\Flow\Tests\Unit\Utility\PositionalArraySorterTest::getSortedKeysTests with data set #9
+.
+TYPO3\Flow\Tests\Unit\Utility\PositionalArraySorterTest::toArraySortsNumericKeysIfNoPositionMetaDataIsSet
+.
+TYPO3\Flow\Tests\Unit\Utility\PositionalArraySorterTest::toArrayTests with data set #0
+.
+TYPO3\Flow\Tests\Unit\Utility\PositionalArraySorterTest::toArrayTests with data set #1
+.
+TYPO3\Flow\Tests\Unit\Utility\PositionalArraySorterTest::toArrayTests with data set #10
+.
+TYPO3\Flow\Tests\Unit\Utility\PositionalArraySorterTest::toArrayTests with data set #11
+.
+TYPO3\Flow\Tests\Unit\Utility\PositionalArraySorterTest::toArrayTests with data set #12
+.
+TYPO3\Flow\Tests\Unit\Utility\PositionalArraySorterTest::toArrayTests with data set #2
+.
+TYPO3\Flow\Tests\Unit\Utility\PositionalArraySorterTest::toArrayTests with data set #3
+.
+TYPO3\Flow\Tests\Unit\Utility\PositionalArraySorterTest::toArrayTests with data set #4
+.
+TYPO3\Flow\Tests\Unit\Utility\PositionalArraySorterTest::toArrayTests with data set #5
+.
+TYPO3\Flow\Tests\Unit\Utility\PositionalArraySorterTest::toArrayTests with data set #6
+.
+TYPO3\Flow\Tests\Unit\Utility\PositionalArraySorterTest::toArrayTests with data set #7
+.
+TYPO3\Flow\Tests\Unit\Utility\PositionalArraySorterTest::toArrayTests with data set #8
+.
+TYPO3\Flow\Tests\Unit\Utility\PositionalArraySorterTest::toArrayTests with data set #9
+.
+TYPO3\Flow\Tests\Unit\Utility\PositionalArraySorterTest::toArrayThrowsExceptionForInvalidPositions with data set #0
+.
+TYPO3\Flow\Tests\Unit\Utility\PositionalArraySorterTest::toArrayThrowsExceptionForInvalidPositions with data set #1
+.
+TYPO3\Flow\Tests\Unit\Utility\PositionalArraySorterTest::toArrayThrowsExceptionForInvalidPositions with data set #2
+.
+TYPO3\Flow\Tests\Unit\Utility\PositionalArraySorterTest::toArrayThrowsExceptionForInvalidPositions with data set #3
+.
+TYPO3\Flow\Tests\Unit\Utility\PositionalArraySorterTest::toArrayThrowsExceptionForInvalidPositions with data set #4
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaGeneratorTest::testSchemaGenerationForArrayOfTypes with data set #0
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaGeneratorTest::testSchemaGenerationForArrayOfTypes with data set #1
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaGeneratorTest::testSchemaGenerationForArrayOfTypes with data set #2
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaGeneratorTest::testSchemaGenerationForSimpleTypes with data set #0
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaGeneratorTest::testSchemaGenerationForSimpleTypes with data set #1
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaGeneratorTest::testSchemaGenerationForSimpleTypes with data set #2
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaGeneratorTest::testSchemaGenerationForSimpleTypes with data set #3
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaGeneratorTest::testSchemaGenerationForSimpleTypes with data set #4
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaGeneratorTest::testSchemaGenerationForSimpleTypes with data set #5
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateAnyTypeResultHasNoErrorsInAnyCase with data set #0
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateAnyTypeResultHasNoErrorsInAnyCase with data set #1
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateAnyTypeResultHasNoErrorsInAnyCase with data set #2
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateAnyTypeResultHasNoErrorsInAnyCase with data set #3
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateAnyTypeResultHasNoErrorsInAnyCase with data set #4
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateAnyTypeResultHasNoErrorsInAnyCase with data set #5
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesArrayTypeProperty with data set #0
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesArrayTypeProperty with data set #1
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesArrayTypeProperty with data set #2
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesArrayTypePropertyWithItemsArrayConstraint with data set #0
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesArrayTypePropertyWithItemsArrayConstraint with data set #1
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesArrayTypePropertyWithItemsConstraint with data set #0
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesArrayTypePropertyWithItemsConstraint with data set #1
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesArrayTypePropertyWithItemsSchemaConstraint with data set #0
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesArrayTypePropertyWithItemsSchemaConstraint with data set #1
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesArrayUniqueItemsConstraint with data set #0
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesArrayUniqueItemsConstraint with data set #1
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesArrayUniqueItemsConstraint with data set #2
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesArrayUniqueItemsConstraint with data set #3
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesBooleanType with data set #0
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesBooleanType with data set #1
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesBooleanType with data set #2
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesBooleanType with data set #3
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesBooleanType with data set #4
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesBooleanType with data set #5
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesDictionaryType with data set #0
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesDictionaryType with data set #1
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesDictionaryTypeWithAdditionalPropertyFalseConstraint with data set #0
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesDictionaryTypeWithAdditionalPropertyFalseConstraint with data set #1
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesDictionaryTypeWithAdditionalPropertyFalseConstraint with data set #2
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesDictionaryTypeWithAdditionalPropertySchemaConstraint with data set #0
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesDictionaryTypeWithAdditionalPropertySchemaConstraint with data set #1
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesDictionaryTypeWithAdditionalPropertySchemaConstraint with data set #2
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesDictionaryTypeWithAdditionalPropertyTrueSchemaConstraint
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesDictionaryTypeWithFormatPropertiesConstraint with data set #0
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesDictionaryTypeWithFormatPropertiesConstraint with data set #1
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesDictionaryTypeWithFormatPropertiesConstraint with data set #2
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesDictionaryTypeWithPatternPropertiesConstraint with data set #0
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesDictionaryTypeWithPatternPropertiesConstraint with data set #1
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesDictionaryTypeWithPatternPropertiesConstraint with data set #2
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesDictionaryTypeWithPatternPropertiesConstraint with data set #3
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesDictionaryTypeWithPropertiesConstraint with data set #0
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesDictionaryTypeWithPropertiesConstraint with data set #1
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesDictionaryTypeWithPropertiesConstraint with data set #2
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesDisallowProperty with data set #0
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesDisallowProperty with data set #1
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesEnumProperty with data set #0
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesEnumProperty with data set #1
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesEnumProperty with data set #2
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesEnumProperty with data set #3
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesIntegerTypeProperty with data set #0
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesIntegerTypeProperty with data set #1
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesIntegerTypeProperty with data set #2
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesIntegerTypeProperty with data set #3
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesIntegerTypeProperty with data set #4
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesMultipleTypes
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesNullType with data set #0
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesNullType with data set #1
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesNumberTypeProperty with data set #0
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesNumberTypeProperty with data set #1
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesNumberTypeProperty with data set #2
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesNumberTypeProperty with data set #3
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesNumberTypePropertyWithDivisibleByConstraint with data set #0
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesNumberTypePropertyWithDivisibleByConstraint with data set #1
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesNumberTypePropertyWithDivisibleByConstraint with data set #2
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesNumberTypePropertyWithDivisibleByConstraint with data set #3
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesNumberTypePropertyWithDivisibleByConstraint with data set #4
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesNumberTypePropertyWithExclusiveMinimumAndMaximumConstraint with data set #0
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesNumberTypePropertyWithExclusiveMinimumAndMaximumConstraint with data set #1
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesNumberTypePropertyWithExclusiveMinimumAndMaximumConstraint with data set #2
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesNumberTypePropertyWithExclusiveMinimumAndMaximumConstraint with data set #3
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesNumberTypePropertyWithExclusiveMinimumAndMaximumConstraint with data set #4
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesNumberTypePropertyWithExclusiveMinimumAndMaximumConstraint with data set #5
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesNumberTypePropertyWithMinimumAndMaximumConstraint with data set #0
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesNumberTypePropertyWithMinimumAndMaximumConstraint with data set #1
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesNumberTypePropertyWithMinimumAndMaximumConstraint with data set #2
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesNumberTypePropertyWithMinimumAndMaximumConstraint with data set #3
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesNumberTypePropertyWithMinimumAndMaximumConstraint with data set #4
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesNumberTypePropertyWithNonExclusiveMinimumAndMaximumConstraint with data set #0
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesNumberTypePropertyWithNonExclusiveMinimumAndMaximumConstraint with data set #1
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesNumberTypePropertyWithNonExclusiveMinimumAndMaximumConstraint with data set #2
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesNumberTypePropertyWithNonExclusiveMinimumAndMaximumConstraint with data set #3
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesNumberTypePropertyWithNonExclusiveMinimumAndMaximumConstraint with data set #4
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesRequiredProperty with data set #0
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesRequiredProperty with data set #1
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesRequiredProperty with data set #2
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesRequiredProperty with data set #3
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesRequiredProperty with data set #4
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesRequiredProperty with data set #5
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesRequiredProperty with data set #6
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesStringTypeProperty with data set #0
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesStringTypeProperty with data set #1
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesStringTypePropertyWithDateTimeConstraint with data set #0
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesStringTypePropertyWithDateTimeConstraint with data set #1
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesStringTypePropertyWithDateTimeConstraint with data set #2
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesStringTypePropertyWithDateTimeConstraint with data set #3
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesStringTypePropertyWithDateTimeConstraint with data set #4
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesStringTypePropertyWithFormatClassNameConstraint with data set #0
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesStringTypePropertyWithFormatClassNameConstraint with data set #1
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesStringTypePropertyWithFormatClassNameConstraint with data set #2
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesStringTypePropertyWithFormatClassNameConstraint with data set #3
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesStringTypePropertyWithFormatClassNameConstraint with data set #4
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesStringTypePropertyWithFormatClassNameConstraint with data set #5
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesStringTypePropertyWithFormatClassNameConstraint with data set #6
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesStringTypePropertyWithFormatDateConstraint with data set #0
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesStringTypePropertyWithFormatDateConstraint with data set #1
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesStringTypePropertyWithFormatDateConstraint with data set #2
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesStringTypePropertyWithFormatDateConstraint with data set #3
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesStringTypePropertyWithFormatDateConstraint with data set #4
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesStringTypePropertyWithFormatHostnameConstraint with data set #0
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesStringTypePropertyWithFormatHostnameConstraint with data set #1
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesStringTypePropertyWithFormatHostnameConstraint with data set #2
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesStringTypePropertyWithFormatHostnameConstraint with data set #3
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesStringTypePropertyWithFormatInterfaceNameConstraint with data set #0
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesStringTypePropertyWithFormatInterfaceNameConstraint with data set #1
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesStringTypePropertyWithFormatInterfaceNameConstraint with data set #2
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesStringTypePropertyWithFormatInterfaceNameConstraint with data set #3
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesStringTypePropertyWithFormatInterfaceNameConstraint with data set #4
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesStringTypePropertyWithFormatInterfaceNameConstraint with data set #5
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesStringTypePropertyWithFormatInterfaceNameConstraint with data set #6
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesStringTypePropertyWithFormatIpAddressConstraint with data set #0
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesStringTypePropertyWithFormatIpAddressConstraint with data set #1
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesStringTypePropertyWithFormatIpAddressConstraint with data set #2
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesStringTypePropertyWithFormatIpAddressConstraint with data set #3
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesStringTypePropertyWithFormatIpAddressConstraint with data set #4
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesStringTypePropertyWithFormatIpv4Constraint with data set #0
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesStringTypePropertyWithFormatIpv4Constraint with data set #1
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesStringTypePropertyWithFormatIpv4Constraint with data set #2
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesStringTypePropertyWithFormatIpv4Constraint with data set #3
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesStringTypePropertyWithFormatIpv6Constraint with data set #0
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesStringTypePropertyWithFormatIpv6Constraint with data set #1
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesStringTypePropertyWithFormatIpv6Constraint with data set #2
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesStringTypePropertyWithFormatIpv6Constraint with data set #3
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesStringTypePropertyWithFormatTimeConstraint with data set #0
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesStringTypePropertyWithFormatTimeConstraint with data set #1
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesStringTypePropertyWithFormatTimeConstraint with data set #2
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesStringTypePropertyWithFormatTimeConstraint with data set #3
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesStringTypePropertyWithFormatTimeConstraint with data set #4
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesStringTypePropertyWithFormatUriPConstraint with data set #0
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesStringTypePropertyWithFormatUriPConstraint with data set #1
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesStringTypePropertyWithFormatUriPConstraint with data set #2
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesStringTypePropertyWithFormatUriPConstraint with data set #3
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesStringTypePropertyWithMaxLengthConstraint with data set #0
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesStringTypePropertyWithMaxLengthConstraint with data set #1
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesStringTypePropertyWithMaxLengthConstraint with data set #2
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesStringTypePropertyWithMinLengthConstraint with data set #0
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesStringTypePropertyWithMinLengthConstraint with data set #1
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesStringTypePropertyWithMinLengthConstraint with data set #2
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesStringTypePropertyWithPatternConstraint with data set #0
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesStringTypePropertyWithPatternConstraint with data set #1
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesStringTypePropertyWithPatternConstraint with data set #2
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesUnknownType with data set #0
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateHandlesUnknownType with data set #1
+.
+TYPO3\Flow\Tests\Unit\Utility\SchemaValidatorTest::validateReturnsErrorPath
+.
+TYPO3\Flow\Tests\Unit\Utility\TypeHandlingTest::extractCollectionTypeReturnsOnlyTheMainType with data set #0
+.
+TYPO3\Flow\Tests\Unit\Utility\TypeHandlingTest::extractCollectionTypeReturnsOnlyTheMainType with data set #1
+.
+TYPO3\Flow\Tests\Unit\Utility\TypeHandlingTest::extractCollectionTypeReturnsOnlyTheMainType with data set #10
+.
+TYPO3\Flow\Tests\Unit\Utility\TypeHandlingTest::extractCollectionTypeReturnsOnlyTheMainType with data set #11
+.
+TYPO3\Flow\Tests\Unit\Utility\TypeHandlingTest::extractCollectionTypeReturnsOnlyTheMainType with data set #2
+.
+TYPO3\Flow\Tests\Unit\Utility\TypeHandlingTest::extractCollectionTypeReturnsOnlyTheMainType with data set #3
+.
+TYPO3\Flow\Tests\Unit\Utility\TypeHandlingTest::extractCollectionTypeReturnsOnlyTheMainType with data set #4
+.
+TYPO3\Flow\Tests\Unit\Utility\TypeHandlingTest::extractCollectionTypeReturnsOnlyTheMainType with data set #5
+.
+TYPO3\Flow\Tests\Unit\Utility\TypeHandlingTest::extractCollectionTypeReturnsOnlyTheMainType with data set #6
+.
+TYPO3\Flow\Tests\Unit\Utility\TypeHandlingTest::extractCollectionTypeReturnsOnlyTheMainType with data set #7
+.
+TYPO3\Flow\Tests\Unit\Utility\TypeHandlingTest::extractCollectionTypeReturnsOnlyTheMainType with data set #8
+.
+TYPO3\Flow\Tests\Unit\Utility\TypeHandlingTest::extractCollectionTypeReturnsOnlyTheMainType with data set #9
+.
+TYPO3\Flow\Tests\Unit\Utility\TypeHandlingTest::isCollectionTypeReturnsTrueForCollectionType with data set #0
+.
+TYPO3\Flow\Tests\Unit\Utility\TypeHandlingTest::isCollectionTypeReturnsTrueForCollectionType with data set #1
+.
+TYPO3\Flow\Tests\Unit\Utility\TypeHandlingTest::isCollectionTypeReturnsTrueForCollectionType with data set #10
+.
+TYPO3\Flow\Tests\Unit\Utility\TypeHandlingTest::isCollectionTypeReturnsTrueForCollectionType with data set #11
+.
+TYPO3\Flow\Tests\Unit\Utility\TypeHandlingTest::isCollectionTypeReturnsTrueForCollectionType with data set #12
+.
+TYPO3\Flow\Tests\Unit\Utility\TypeHandlingTest::isCollectionTypeReturnsTrueForCollectionType with data set #2
+.
+TYPO3\Flow\Tests\Unit\Utility\TypeHandlingTest::isCollectionTypeReturnsTrueForCollectionType with data set #3
+.
+TYPO3\Flow\Tests\Unit\Utility\TypeHandlingTest::isCollectionTypeReturnsTrueForCollectionType with data set #4
+.
+TYPO3\Flow\Tests\Unit\Utility\TypeHandlingTest::isCollectionTypeReturnsTrueForCollectionType with data set #5
+.
+TYPO3\Flow\Tests\Unit\Utility\TypeHandlingTest::isCollectionTypeReturnsTrueForCollectionType with data set #6
+.
+TYPO3\Flow\Tests\Unit\Utility\TypeHandlingTest::isCollectionTypeReturnsTrueForCollectionType with data set #7
+.
+TYPO3\Flow\Tests\Unit\Utility\TypeHandlingTest::isCollectionTypeReturnsTrueForCollectionType with data set #8
+.
+TYPO3\Flow\Tests\Unit\Utility\TypeHandlingTest::isCollectionTypeReturnsTrueForCollectionType with data set #9
+.
+TYPO3\Flow\Tests\Unit\Utility\TypeHandlingTest::isLiteralReturnsFalseForNonLiteralTypes with data set #0
+.
+TYPO3\Flow\Tests\Unit\Utility\TypeHandlingTest::isLiteralReturnsFalseForNonLiteralTypes with data set #1
+.
+TYPO3\Flow\Tests\Unit\Utility\TypeHandlingTest::isLiteralReturnsFalseForNonLiteralTypes with data set #2
+.
+TYPO3\Flow\Tests\Unit\Utility\TypeHandlingTest::isLiteralReturnsFalseForNonLiteralTypes with data set #3
+.
+TYPO3\Flow\Tests\Unit\Utility\TypeHandlingTest::isLiteralReturnsFalseForNonLiteralTypes with data set #4
+.
+TYPO3\Flow\Tests\Unit\Utility\TypeHandlingTest::isLiteralReturnsTrueForLiteralType with data set #0
+.
+TYPO3\Flow\Tests\Unit\Utility\TypeHandlingTest::isLiteralReturnsTrueForLiteralType with data set #1
+.
+TYPO3\Flow\Tests\Unit\Utility\TypeHandlingTest::isLiteralReturnsTrueForLiteralType with data set #2
+.
+TYPO3\Flow\Tests\Unit\Utility\TypeHandlingTest::isLiteralReturnsTrueForLiteralType with data set #3
+.
+TYPO3\Flow\Tests\Unit\Utility\TypeHandlingTest::isLiteralReturnsTrueForLiteralType with data set #4
+.
+TYPO3\Flow\Tests\Unit\Utility\TypeHandlingTest::isLiteralReturnsTrueForLiteralType with data set #5
+.
+TYPO3\Flow\Tests\Unit\Utility\TypeHandlingTest::isLiteralReturnsTrueForLiteralType with data set #6
+.
+TYPO3\Flow\Tests\Unit\Utility\TypeHandlingTest::normalizeTypesReturnsNormalizedType with data set #0
+.
+TYPO3\Flow\Tests\Unit\Utility\TypeHandlingTest::normalizeTypesReturnsNormalizedType with data set #1
+.
+TYPO3\Flow\Tests\Unit\Utility\TypeHandlingTest::normalizeTypesReturnsNormalizedType with data set #2
+.
+TYPO3\Flow\Tests\Unit\Utility\TypeHandlingTest::normalizeTypesReturnsNormalizedType with data set #3
+.
+TYPO3\Flow\Tests\Unit\Utility\TypeHandlingTest::parseTypeReturnsArrayWithInformation with data set #0
+.
+TYPO3\Flow\Tests\Unit\Utility\TypeHandlingTest::parseTypeReturnsArrayWithInformation with data set #1
+.
+TYPO3\Flow\Tests\Unit\Utility\TypeHandlingTest::parseTypeReturnsArrayWithInformation with data set #10
+.
+TYPO3\Flow\Tests\Unit\Utility\TypeHandlingTest::parseTypeReturnsArrayWithInformation with data set #2
+.
+TYPO3\Flow\Tests\Unit\Utility\TypeHandlingTest::parseTypeReturnsArrayWithInformation with data set #3
+.
+TYPO3\Flow\Tests\Unit\Utility\TypeHandlingTest::parseTypeReturnsArrayWithInformation with data set #4
+.
+TYPO3\Flow\Tests\Unit\Utility\TypeHandlingTest::parseTypeReturnsArrayWithInformation with data set #5
+.
+TYPO3\Flow\Tests\Unit\Utility\TypeHandlingTest::parseTypeReturnsArrayWithInformation with data set #6
+.
+TYPO3\Flow\Tests\Unit\Utility\TypeHandlingTest::parseTypeReturnsArrayWithInformation with data set #7
+.
+TYPO3\Flow\Tests\Unit\Utility\TypeHandlingTest::parseTypeReturnsArrayWithInformation with data set #8
+.
+TYPO3\Flow\Tests\Unit\Utility\TypeHandlingTest::parseTypeReturnsArrayWithInformation with data set #9
+.
+TYPO3\Flow\Tests\Unit\Utility\TypeHandlingTest::parseTypeThrowsExceptionOnInvalidElementTypeHint
+.
+TYPO3\Flow\Tests\Unit\Utility\TypeHandlingTest::parseTypeThrowsExceptionOnInvalidType
+.
+TYPO3\Flow\Tests\Unit\Utility\Unicode\FunctionsTest::lcfirstWorksWithCertainSpecialChars
+.
+TYPO3\Flow\Tests\Unit\Utility\Unicode\FunctionsTest::lcfirstWorksWithLatinCharacters
+.
+TYPO3\Flow\Tests\Unit\Utility\Unicode\FunctionsTest::parse_urlWorksWithUTF8Chars
+.
+TYPO3\Flow\Tests\Unit\Utility\Unicode\FunctionsTest::pathinfoWorksWithCertainSpecialChars
+.
+TYPO3\Flow\Tests\Unit\Utility\Unicode\FunctionsTest::strlenWorksWithCertainSpecialChars
+.
+TYPO3\Flow\Tests\Unit\Utility\Unicode\FunctionsTest::strlenWorksWithLatinCharacters
+.
+TYPO3\Flow\Tests\Unit\Utility\Unicode\FunctionsTest::strposWorksWithCertainSpecialChars
+.
+TYPO3\Flow\Tests\Unit\Utility\Unicode\FunctionsTest::strposWorksWithLatinCharacters
+.
+TYPO3\Flow\Tests\Unit\Utility\Unicode\FunctionsTest::strtolowerWorksWithCertainSpecialChars
+.
+TYPO3\Flow\Tests\Unit\Utility\Unicode\FunctionsTest::strtolowerWorksWithLatinCharacters
+.
+TYPO3\Flow\Tests\Unit\Utility\Unicode\FunctionsTest::strtotitleWorksWithLatinCharacters
+.
+TYPO3\Flow\Tests\Unit\Utility\Unicode\FunctionsTest::strtotitleWorksWithUnicodeStrings
+.
+TYPO3\Flow\Tests\Unit\Utility\Unicode\FunctionsTest::strtoupperWorksWithCertainSpecialChars
+.
+TYPO3\Flow\Tests\Unit\Utility\Unicode\FunctionsTest::strtoupperWorksWithLatinCharacters
+.
+TYPO3\Flow\Tests\Unit\Utility\Unicode\FunctionsTest::substrWorksWithLatinCharacters
+.
+TYPO3\Flow\Tests\Unit\Utility\Unicode\FunctionsTest::substrWorksWithUTF8Characters
+.
+TYPO3\Flow\Tests\Unit\Utility\Unicode\FunctionsTest::substrWorksWithUTF8CharactersSpecifyingNoLength
+.
+TYPO3\Flow\Tests\Unit\Utility\Unicode\FunctionsTest::ucfirstWorksWithCertainSpecialChars
+.
+TYPO3\Flow\Tests\Unit\Utility\Unicode\FunctionsTest::ucfirstWorksWithLatinCharacters
+.
+TYPO3\Flow\Tests\Unit\Utility\Unicode\TextIteratorTest::canCreateIteratorOfDefaultType
+.
+TYPO3\Flow\Tests\Unit\Utility\Unicode\TextIteratorTest::characterIterationBasicallyWorks
+.
+TYPO3\Flow\Tests\Unit\Utility\Unicode\TextIteratorTest::firstBasicallyWorks
+.
+TYPO3\Flow\Tests\Unit\Utility\Unicode\TextIteratorTest::followingBasicallyWorks
+.
+TYPO3\Flow\Tests\Unit\Utility\Unicode\TextIteratorTest::getAllBasicallyWorks
+.
+TYPO3\Flow\Tests\Unit\Utility\Unicode\TextIteratorTest::instantiatingCharacterIteratorWorks
+.
+TYPO3\Flow\Tests\Unit\Utility\Unicode\TextIteratorTest::instantiatingIteratorWithInvalidTypeThrowsError
+.
+TYPO3\Flow\Tests\Unit\Utility\Unicode\TextIteratorTest::instantiatingLineIteratorWorks
+.
+TYPO3\Flow\Tests\Unit\Utility\Unicode\TextIteratorTest::instantiatingSentenceIteratorWorks
+.
+TYPO3\Flow\Tests\Unit\Utility\Unicode\TextIteratorTest::instantiatingWordIteratorWorks
+.
+TYPO3\Flow\Tests\Unit\Utility\Unicode\TextIteratorTest::isBoundaryInCharacterIterationBasicallyWorks
+.
+TYPO3\Flow\Tests\Unit\Utility\Unicode\TextIteratorTest::isBoundaryInLineIterationBasicallyWorks
+.
+TYPO3\Flow\Tests\Unit\Utility\Unicode\TextIteratorTest::isBoundaryInSentenceIterationBasicallyWorks
+.
+TYPO3\Flow\Tests\Unit\Utility\Unicode\TextIteratorTest::isBoundaryInWordIterationBasicallyWorks
+.
+TYPO3\Flow\Tests\Unit\Utility\Unicode\TextIteratorTest::lastBasicallyWorks
+.
+TYPO3\Flow\Tests\Unit\Utility\Unicode\TextIteratorTest::lineIterationBasicallyWorks
+.
+TYPO3\Flow\Tests\Unit\Utility\Unicode\TextIteratorTest::offsetInCharacterIterationBasicallyWorks
+.
+TYPO3\Flow\Tests\Unit\Utility\Unicode\TextIteratorTest::offsetInSentenceIterationBasicallyWorks
+.
+TYPO3\Flow\Tests\Unit\Utility\Unicode\TextIteratorTest::offsetInWordIterationBasicallyWorks
+.
+TYPO3\Flow\Tests\Unit\Utility\Unicode\TextIteratorTest::precedingBasicallyWorks
+.
+TYPO3\Flow\Tests\Unit\Utility\Unicode\TextIteratorTest::sentenceIterationBasicallyWorks
+.
+TYPO3\Flow\Tests\Unit\Utility\Unicode\TextIteratorTest::wordIterationBasicallyWorks
+.
+TYPO3\Flow\Tests\Unit\Validation\ValidatorResolverTest::addCustomValidatorsAddsExpectedPolyTypeValidatorToTheConjunction
+.
+TYPO3\Flow\Tests\Unit\Validation\ValidatorResolverTest::buildBaseValidatorCachesTheResultOfTheBuildBaseValidatorConjunctionCalls
+.
+TYPO3\Flow\Tests\Unit\Validation\ValidatorResolverTest::buildBaseValidatorConjunctionAddsCustomValidatorToTheReturnedConjunction
+.
+TYPO3\Flow\Tests\Unit\Validation\ValidatorResolverTest::buildBaseValidatorConjunctionAddsValidatorsDefinedByAnnotationsInTheClassToTheReturnedConjunction
+.
+TYPO3\Flow\Tests\Unit\Validation\ValidatorResolverTest::buildBaseValidatorConjunctionAddsValidatorsOnlyForPropertiesHoldingPrototypes
+.
+TYPO3\Flow\Tests\Unit\Validation\ValidatorResolverTest::buildBaseValidatorConjunctionReturnsNullIfNoValidatorBuilt
+.
+TYPO3\Flow\Tests\Unit\Validation\ValidatorResolverTest::buildBaseValidatorConjunctionSkipsPropertiesAnnotatedWithIgnoreValidation
+.
+TYPO3\Flow\Tests\Unit\Validation\ValidatorResolverTest::buildMethodArgumentsValidatorConjunctionsBuildsAConjunctionFromValidateAnnotationsOfTheSpecifiedMethod
+.
+TYPO3\Flow\Tests\Unit\Validation\ValidatorResolverTest::buildMethodArgumentsValidatorConjunctionsReturnsEmptyArrayIfMethodHasNoArguments
+.
+TYPO3\Flow\Tests\Unit\Validation\ValidatorResolverTest::buildMethodArgumentsValidatorConjunctionsReturnsEmptyConjunctionIfNoValidatorIsFoundForMethodParameter
+.
+TYPO3\Flow\Tests\Unit\Validation\ValidatorResolverTest::buildMethodArgumentsValidatorConjunctionsThrowsExceptionIfValidationAnnotationForNonExistingArgumentExists
+.
+TYPO3\Flow\Tests\Unit\Validation\ValidatorResolverTest::createValidatorResolvesAndReturnsAValidatorAndPassesTheGivenOptions
+.
+TYPO3\Flow\Tests\Unit\Validation\ValidatorResolverTest::createValidatorReturnsNullIfAValidatorCouldNotBeResolved
+.
+TYPO3\Flow\Tests\Unit\Validation\ValidatorResolverTest::createValidatorThrowsExceptionForSingletonValidatorsWithOptions
+.
+TYPO3\Flow\Tests\Unit\Validation\ValidatorResolverTest::getValidatorTypeCorrectlyRenamesPhpDataTypes
+.
+TYPO3\Flow\Tests\Unit\Validation\ValidatorResolverTest::getValidatorTypeRenamesMixedToRaw
+.
+TYPO3\Flow\Tests\Unit\Validation\ValidatorResolverTest::resetEmptiesBaseValidatorConjunctions
+.
+TYPO3\Flow\Tests\Unit\Validation\ValidatorResolverTest::resolveValidatorObjectNameCallsGetValidatorType
+.
+TYPO3\Flow\Tests\Unit\Validation\ValidatorResolverTest::resolveValidatorObjectNameCanResolveShortNamesOfBuiltInValidators
+.
+TYPO3\Flow\Tests\Unit\Validation\ValidatorResolverTest::resolveValidatorObjectNameCanResolveShorthandValidatornames
+.
+TYPO3\Flow\Tests\Unit\Validation\ValidatorResolverTest::resolveValidatorObjectNameCanResolveShorthandValidatornamesForHierarchicalPackages
+.
+TYPO3\Flow\Tests\Unit\Validation\ValidatorResolverTest::resolveValidatorObjectNameRemovesALeadingBackslashFromThePassedType
+.
+TYPO3\Flow\Tests\Unit\Validation\ValidatorResolverTest::resolveValidatorObjectNameReturnsFalseIfAnObjectOfTheArgumentNameIsRegisteredButDoesNotImplementValidatorInterface
+.
+TYPO3\Flow\Tests\Unit\Validation\ValidatorResolverTest::resolveValidatorObjectNameReturnsFalseIfValidatorCantBeResolved
+.
+TYPO3\Flow\Tests\Unit\Validation\ValidatorResolverTest::resolveValidatorObjectNameReturnsTheGivenArgumentIfAnObjectOfThatNameIsRegisteredAndImplementsValidatorInterface
+.
+TYPO3\Flow\Tests\Unit\Validation\ValidatorResolverTest::resolveValidatorObjectNameReturnsValidatorObjectNameIfAnObjectOfTheArgumentNameIsRegisteredAndDoesNotImplementValidatorInterfaceAndAValidatorForTheObjectExists
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\AbstractValidatorTest::abstractValidatorConstructWithRequiredOptionShouldNotFail
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\AbstractValidatorTest::abstractValidatorConstructWithoutRequiredOptionShouldFail
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\AlphanumericValidatorTest::alphanumericValidatorCreatesTheCorrectErrorForAnInvalidSubject
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\AlphanumericValidatorTest::alphanumericValidatorReturnsErrorsForAStringWithSpecialCharacters
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\AlphanumericValidatorTest::alphanumericValidatorShouldReturnNoErrorsForAnAlphanumericString
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\AlphanumericValidatorTest::alphanumericValidatorShouldReturnNoErrorsForAnAlphanumericStringWithUmlauts
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\AlphanumericValidatorTest::alphanumericValidatorShouldReturnNoErrorsIfTheGivenStringIsEmpty
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\AlphanumericValidatorTest::alphanumericValidatorShouldReturnNoErrorsIfTheGivenValueIsNull
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\BooleanValueValidatorTest::validateReturnsErrorIfTheGivenValueIsAString
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\BooleanValueValidatorTest::validateReturnsErrorIfTheGivenValueIsAnInteger
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\BooleanValueValidatorTest::validateReturnsErrorIfTheGivenValueIsFalse
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\BooleanValueValidatorTest::validateReturnsNoErrorIfTheGivenValueIsAnEmptyString
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\BooleanValueValidatorTest::validateReturnsNoErrorIfTheGivenValueIsFalseAndExpectedValueIsFalse
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\BooleanValueValidatorTest::validateReturnsNoErrorIfTheGivenValueIsNull
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\BooleanValueValidatorTest::validateReturnsNoErrorIfTheGivenValueIsTrueAndNoOptionIsSet
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\CollectionValidatorTest::collectionValidatorFailsForAValueNotBeingACollection
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\CollectionValidatorTest::collectionValidatorIsValidEarlyReturnsOnUnitializedDoctrinePersistenceCollections
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\CollectionValidatorTest::collectionValidatorReturnsNoErrorsForANullValue
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\CollectionValidatorTest::collectionValidatorValidatesEveryElementOfACollectionWithTheGivenElementValidator
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\CollectionValidatorTest::collectionValidatorValidatesNestedObjectStructuresWithoutEndlessLooping
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\ConjunctionValidatorTest::addingValidatorsToAJunctionValidatorWorks
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\ConjunctionValidatorTest::allValidatorsInTheConjunctionAreCalledEvenIfOneReturnsError
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\ConjunctionValidatorTest::countReturnesTheNumberOfValidatorsContainedInTheConjunction
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\ConjunctionValidatorTest::removingANotExistingValidatorIndexThrowsException
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\ConjunctionValidatorTest::removingAValidatorOfTheValidatorConjunctionWorks
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\ConjunctionValidatorTest::validatorConjunctionReturnsErrorsIfOneValidatorReturnsErrors
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\ConjunctionValidatorTest::validatorConjunctionReturnsNoErrorsIfAllJunctionedValidatorsReturnNoErrors
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\CountValidatorTest::countValidatorReturnsErrorsForInvalidCountables with data set #0
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\CountValidatorTest::countValidatorReturnsErrorsForInvalidCountables with data set #1
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\CountValidatorTest::countValidatorReturnsErrorsForInvalidCountables with data set #2
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\CountValidatorTest::countValidatorReturnsErrorsForNonCountables with data set #0
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\CountValidatorTest::countValidatorReturnsErrorsForNonCountables with data set #1
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\CountValidatorTest::countValidatorReturnsErrorsForNonCountables with data set #2
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\CountValidatorTest::countValidatorReturnsNoErrorsForValidCountables with data set #0
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\CountValidatorTest::countValidatorReturnsNoErrorsForValidCountables with data set #1
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\CountValidatorTest::countValidatorReturnsNoErrorsForValidCountables with data set #2
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\CountValidatorTest::countValidatorReturnsNoErrorsIfTheGivenStringIsEmpty
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\CountValidatorTest::countValidatorReturnsNoErrorsIfTheGivenValueIsNull
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\DateTimeRangeValidatorTest::parseReferenceDateAddsTimeIntervalCorrectlyUsingOnlyHourAndMinute
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\DateTimeRangeValidatorTest::parseReferenceDateReturnsInstanceOfDateTime
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\DateTimeRangeValidatorTest::parseReferenceDateReturnsTimeWithoutCalculationCorrectly
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\DateTimeRangeValidatorTest::parseReferenceDateSubstractsTimeIntervalCorrectlyUsingMonthAndMinuteForcingYearSwap
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\DateTimeRangeValidatorTest::validateReturnsErrorForAGivenDateMustBeingAfterACalculatedDateRangeViaSubstracting
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\DateTimeRangeValidatorTest::validateReturnsErrorForAGivenDateMustBeingAfterAFixDate
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\DateTimeRangeValidatorTest::validateReturnsErrorForAGivenDateMustBeingBeforeACalculatedDateRangeViaSubstracting
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\DateTimeRangeValidatorTest::validateReturnsErrorForAGivenDateOutsideUpperAndLowerBoundaries
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\DateTimeRangeValidatorTest::validateReturnsNoErrorForAGivenDateInsideUpperAndLowerBoundaries
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\DateTimeRangeValidatorTest::validateReturnsNoErrorForAGivenDateMustBeingAfterACalculatedDateRangeViaAdding
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\DateTimeRangeValidatorTest::validateReturnsNoErrorForAGivenDateMustBeingAfterAFixDate
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\DateTimeRangeValidatorTest::validateReturnsNoErrorForAGivenDateMustBeingBeforeACalculatedDateRangeViaAdding
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\DateTimeRangeValidatorTest::validateReturnsNoErrorForAGivenDateThatIsEqualToTheMaximumDate
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\DateTimeRangeValidatorTest::validateReturnsNoErrorForAGivenDateThatIsEqualToTheMinimumDate
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\DateTimeRangeValidatorTest::validateReturnsNoErrorIfTheGivenValueIsAnEmptyString
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\DateTimeRangeValidatorTest::validateReturnsNoErrorIfTheGivenValueIsNull
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\DateTimeRangeValidatorTest::validateReturnsOneErrorIfGivenValueIsNoDate
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\DateTimeValidatorTest::returnsErrorsOnIncorrectValues
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\DateTimeValidatorTest::returnsTrueForCorrectValues
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\DateTimeValidatorTest::validateReturnsNoErrorIfTheGivenValueIsAnEmptyString
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\DateTimeValidatorTest::validateReturnsNoErrorIfTheGivenValueIsNull
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\DateTimeValidatorTest::validateReturnsNoErrorIfTheGivenValueIsOfTypeDateTime
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\DisjunctionValidatorTest::validateReturnsAllErrorsIfAllValidatorsReturnErrrors
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\DisjunctionValidatorTest::validateReturnsNoErrorsIfOneValidatorReturnsNoError
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\EmailAddressValidatorTest::emailAddressValidatorReturnsFalseForAnInvalidEmailAddress with data set #0
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\EmailAddressValidatorTest::emailAddressValidatorReturnsFalseForAnInvalidEmailAddress with data set #1
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\EmailAddressValidatorTest::emailAddressValidatorReturnsFalseForAnInvalidEmailAddress with data set #2
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\EmailAddressValidatorTest::emailAddressValidatorReturnsFalseForAnInvalidEmailAddress with data set #3
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\EmailAddressValidatorTest::emailAddressValidatorReturnsFalseForAnInvalidEmailAddress with data set #4
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\EmailAddressValidatorTest::emailAddressValidatorReturnsFalseForAnInvalidEmailAddress with data set #5
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\EmailAddressValidatorTest::emailAddressValidatorReturnsFalseForAnInvalidEmailAddress with data set #6
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\EmailAddressValidatorTest::emailAddressValidatorReturnsFalseForAnInvalidEmailAddress with data set #7
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\EmailAddressValidatorTest::emailAddressValidatorReturnsFalseForAnInvalidEmailAddress with data set #8
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\EmailAddressValidatorTest::emailAddressValidatorReturnsNoErrorsForAValidEmailAddress with data set #0
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\EmailAddressValidatorTest::emailAddressValidatorReturnsNoErrorsForAValidEmailAddress with data set #1
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\EmailAddressValidatorTest::emailAddressValidatorReturnsNoErrorsForAValidEmailAddress with data set #2
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\EmailAddressValidatorTest::emailAddressValidatorReturnsNoErrorsForAValidEmailAddress with data set #3
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\EmailAddressValidatorTest::emailAddressValidatorReturnsNoErrorsForAValidEmailAddress with data set #4
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\EmailAddressValidatorTest::emailValidatorCreatesTheCorrectErrorForAnInvalidEmailAddress
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\EmailAddressValidatorTest::validateReturnsNoErrorIfTheGivenValueIsAnEmptyString
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\EmailAddressValidatorTest::validateReturnsNoErrorIfTheGivenValueIsNull
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\FloatValidatorTest::floatValidatorReturnsErrorForAnInvalidFloat with data set #0
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\FloatValidatorTest::floatValidatorReturnsErrorForAnInvalidFloat with data set #1
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\FloatValidatorTest::floatValidatorReturnsErrorForAnInvalidFloat with data set #2
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\FloatValidatorTest::floatValidatorReturnsErrorForAnInvalidFloat with data set #3
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\FloatValidatorTest::floatValidatorReturnsNoErrorsForAValidFloat with data set #0
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\FloatValidatorTest::floatValidatorReturnsNoErrorsForAValidFloat with data set #1
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\FloatValidatorTest::floatValidatorReturnsNoErrorsForAValidFloat with data set #2
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\FloatValidatorTest::floatValidatorReturnsNoErrorsForAValidFloat with data set #3
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\FloatValidatorTest::floatValidatorReturnsNoErrorsForAValidFloat with data set #4
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\FloatValidatorTest::floatValidatorReturnsNoErrorsForAValidFloat with data set #5
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\FloatValidatorTest::validateReturnsNoErrorIfTheGivenValueIsAnEmptyString
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\FloatValidatorTest::validateReturnsNoErrorIfTheGivenValueIsNull
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\GenericObjectValidatorTest::objectsAreValidatedOnlyOnce
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\GenericObjectValidatorTest::validateCanHandleRecursiveTargetsWithoutEndlessLooping
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\GenericObjectValidatorTest::validateChecksAllPropertiesForWhichAPropertyValidatorExists with data set #0
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\GenericObjectValidatorTest::validateChecksAllPropertiesForWhichAPropertyValidatorExists with data set #1
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\GenericObjectValidatorTest::validateDetectsFailuresInRecursiveTargetsI
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\GenericObjectValidatorTest::validateDetectsFailuresInRecursiveTargetsII
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\GenericObjectValidatorTest::validateReturnsNoErrorIfTheGivenValueIsAnEmptyString
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\GenericObjectValidatorTest::validatorShouldReturnErrorsIfTheValueIsNoObjectAndNotNull
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\GenericObjectValidatorTest::validatorShouldReturnNoErrorsIfTheValueIsNull
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\IntegerValidatorTest::integerValidatorCreatesTheCorrectErrorForAnInvalidSubject
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\IntegerValidatorTest::integerValidatorReturnsErrorForAnInvalidInteger with data set #0
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\IntegerValidatorTest::integerValidatorReturnsErrorForAnInvalidInteger with data set #1
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\IntegerValidatorTest::integerValidatorReturnsErrorForAnInvalidInteger with data set #2
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\IntegerValidatorTest::integerValidatorReturnsNoErrorsForAValidInteger with data set #0
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\IntegerValidatorTest::integerValidatorReturnsNoErrorsForAValidInteger with data set #1
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\IntegerValidatorTest::integerValidatorReturnsNoErrorsForAValidInteger with data set #2
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\IntegerValidatorTest::integerValidatorReturnsNoErrorsForAValidInteger with data set #3
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\IntegerValidatorTest::validateReturnsNoErrorIfTheGivenValueIsAnEmptyString
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\IntegerValidatorTest::validateReturnsNoErrorIfTheGivenValueIsNull
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\LabelValidatorTest::labelValidatorReturnsErrorsForInvalidLabels with data set #0
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\LabelValidatorTest::labelValidatorReturnsErrorsForInvalidLabels with data set #1
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\LabelValidatorTest::labelValidatorReturnsErrorsForInvalidLabels with data set #2
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\LabelValidatorTest::labelValidatorReturnsErrorsForInvalidLabels with data set #3
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\LabelValidatorTest::labelValidatorReturnsNoErrorForValidLabels with data set #0
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\LabelValidatorTest::labelValidatorReturnsNoErrorForValidLabels with data set #1
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\LabelValidatorTest::labelValidatorReturnsNoErrorForValidLabels with data set #2
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\LabelValidatorTest::labelValidatorReturnsNoErrorForValidLabels with data set #3
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\LabelValidatorTest::labelValidatorReturnsNoErrorForValidLabels with data set #4
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\LabelValidatorTest::labelValidatorReturnsNoErrorForValidLabels with data set #5
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\LabelValidatorTest::labelValidatorReturnsNoErrorForValidLabels with data set #6
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\LabelValidatorTest::labelValidatorReturnsNoErrorForValidLabels with data set #7
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\LabelValidatorTest::labelValidatorReturnsNoErrorForValidLabels with data set #8
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\LabelValidatorTest::validateReturnsNoErrorIfTheGivenValueIsAnEmptyString
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\LabelValidatorTest::validateReturnsNoErrorIfTheGivenValueIsNull
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\LocaleIdentifierValidatorTest::localeIdentifierReturnsErrorIfLocaleIsInvalid
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\LocaleIdentifierValidatorTest::localeIdentifierReturnsNoErrorIfLocaleIsEmpty
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\LocaleIdentifierValidatorTest::localeIdentifierReturnsNoErrorIfLocaleIsValid
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\NotEmptyValidatorTest::notEmptyValidatorCreatesTheCorrectErrorForANullValue
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\NotEmptyValidatorTest::notEmptyValidatorCreatesTheCorrectErrorForAnEmptySubject
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\NotEmptyValidatorTest::notEmptyValidatorReturnsErrorForANullValue
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\NotEmptyValidatorTest::notEmptyValidatorReturnsErrorForAnEmptyArray
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\NotEmptyValidatorTest::notEmptyValidatorReturnsErrorForAnEmptyCountableObject
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\NotEmptyValidatorTest::notEmptyValidatorReturnsErrorForAnEmptyString
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\NotEmptyValidatorTest::notEmptyValidatorReturnsNoErrorForASimpleString
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\NumberRangeValidatorTest::numberRangeValidatorReturnsErrorForANumberOutOfRange
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\NumberRangeValidatorTest::numberRangeValidatorReturnsErrorForAString
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\NumberRangeValidatorTest::numberRangeValidatorReturnsNoErrorForANumberInReversedRange
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\NumberRangeValidatorTest::numberRangeValidatorReturnsNoErrorForASimpleIntegerInRange
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\NumberRangeValidatorTest::validateReturnsNoErrorIfTheGivenValueIsAnEmptyString
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\NumberRangeValidatorTest::validateReturnsNoErrorIfTheGivenValueIsNull
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\NumberValidatorTest::numberValidatorCreatesTheCorrectErrorForAnInvalidSubject
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\NumberValidatorTest::returnsFalseForIncorrectValues
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\NumberValidatorTest::validateReturnsNoErrorIfTheGivenValueIsAnEmptyString
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\NumberValidatorTest::validateReturnsNoErrorIfTheGivenValueIsNull
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\RawValidatorTest::theRawValidatorAlwaysReturnsNoErrors
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\RegularExpressionValidatorTest::regularExpressionValidatorCreatesTheCorrectErrorIfTheExpressionDidNotMatch
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\RegularExpressionValidatorTest::regularExpressionValidatorMatchesABasicExpressionCorrectly
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\RegularExpressionValidatorTest::validateReturnsNoErrorIfTheGivenValueIsAnEmptyString
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\RegularExpressionValidatorTest::validateReturnsNoErrorIfTheGivenValueIsNull
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\RegularExpressionValidatorTest::validateThrowsExceptionIfExpressionIsEmpty
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\StringLengthValidatorTest::stringLengthValidatorCanHandleAnObjectWithAToStringMethod
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\StringLengthValidatorTest::stringLengthValidatorInsertsAnErrorObjectIfValidationFails
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\StringLengthValidatorTest::stringLengthValidatorReturnsErrorForAStringShorterThanThanMinLength
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\StringLengthValidatorTest::stringLengthValidatorReturnsErrorsForAStringLongerThanThanMaxLength
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\StringLengthValidatorTest::stringLengthValidatorReturnsNoErrorForAStringLengthEqualToMinLengthAndMaxLengthNotSpecified
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\StringLengthValidatorTest::stringLengthValidatorReturnsNoErrorForAStringShorterThanMaxLengthAndLongerThanMinLength
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\StringLengthValidatorTest::stringLengthValidatorReturnsNoErrorIfMinLengthAndMaxLengthAreEqualAndTheGivenStringMatchesThisValue
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\StringLengthValidatorTest::stringLengthValidatorReturnsNoErrorIfTheStringLengthIsEqualToMinLength
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\StringLengthValidatorTest::stringLengthValidatorReturnsNoErrorsForAStringLengthEqualToMaxLengthAndMinLengthNotSpecified
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\StringLengthValidatorTest::stringLengthValidatorReturnsNoErrorsForAStringLongerThanThanMinLengthAndMaxLengthNotSpecified
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\StringLengthValidatorTest::stringLengthValidatorReturnsNoErrorsForAStringShorterThanThanMaxLengthAndMinLengthNotSpecified
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\StringLengthValidatorTest::stringLengthValidatorReturnsNoErrorsfTheStringLengthIsEqualToMaxLength
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\StringLengthValidatorTest::stringLengthValidatorThrowsAnExceptionIfMinLengthIsGreaterThanMaxLength
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\StringLengthValidatorTest::validateRegardsMultibyteStringsCorrectly
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\StringLengthValidatorTest::validateReturnsErrorsIfTheGivenObjectCanNotBeConvertedToAString
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\StringLengthValidatorTest::validateReturnsNoErrorIfTheGivenValueIsAnEmptyString
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\StringLengthValidatorTest::validateReturnsNoErrorIfTheGivenValueIsNull
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\StringValidatorTest::stringValidatorShouldReturnErrorIfNumberIsGiven
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\StringValidatorTest::stringValidatorShouldReturnErrorIfObjectWithToStringMethodStringIsGiven
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\StringValidatorTest::stringValidatorShouldValidateString
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\StringValidatorTest::validateReturnsNoErrorIfTheGivenValueIsAnEmptyString
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\StringValidatorTest::validateReturnsNoErrorIfTheGivenValueIsNull
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\TextValidatorTest::textValidatorAcceptsValidInput with data set #0
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\TextValidatorTest::textValidatorAcceptsValidInput with data set #1
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\TextValidatorTest::textValidatorAcceptsValidInput with data set #2
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\TextValidatorTest::textValidatorCreatesTheCorrectErrorIfTheSubjectContainsHtmlEntities
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\TextValidatorTest::textValidatorRejectsInvalidInput with data set #0
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\TextValidatorTest::textValidatorReturnsNoErrorForASimpleString
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\TextValidatorTest::validateReturnsNoErrorIfTheGivenValueIsNull
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\UniqueEntityValidatorTest::validatorThrowsExceptionIfSetupPropertiesAreNotPresentInActualClass
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\UniqueEntityValidatorTest::validatorThrowsExceptionIfThereIsNoIdentityProperty
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\UniqueEntityValidatorTest::validatorThrowsExceptionIfValueIsNotAFlowEntity
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\UniqueEntityValidatorTest::validatorThrowsExceptionIfValueIsNotAnObject
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\UniqueEntityValidatorTest::validatorThrowsExceptionIfValueIsNotReflectedAtAll
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\UniqueEntityValidatorTest::validatorThrowsExceptionOnMultipleOrmIdAnnotations
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\UuidValidatorTest::UUIDValidatorCreatesTheCorrectErrorIfTheSubjectIsInvalid
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\UuidValidatorTest::UUIDWithOtherThanHexValuesIsRejected
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\UuidValidatorTest::tooLongButValidUUIDIsRejected
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\UuidValidatorTest::tooShortUUIDIsRejected
+.
+TYPO3\Flow\Tests\Unit\Validation\Validator\UuidValidatorTest::validatorAcceptsCorrectUUIDs
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\Interceptor\EscapeTest::processDisablesEscapingInterceptorIfViewHelperDisablesIt
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\Interceptor\EscapeTest::processDoesNotDisableEscapingInterceptorByDefault
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\Interceptor\EscapeTest::processReenablesEscapingInterceptorOnClosingViewHelperTagIfItWasDisabledBefore
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\Interceptor\EscapeTest::processWrapsCurrentViewHelperInHtmlspecialcharsViewHelperOnObjectAccessor
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\Interceptor\ResourceTest::resourcesInCssUrlsAreReplacedCorrectly
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\Interceptor\ResourceTest::supportedUrlsAreDetected with data set #0
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\Interceptor\ResourceTest::supportedUrlsAreDetected with data set #1
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\Interceptor\ResourceTest::supportedUrlsAreDetected with data set #2
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\Interceptor\ResourceTest::supportedUrlsAreDetected with data set #3
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\Interceptor\ResourceTest::supportedUrlsAreDetected with data set #4
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\ParsingStateTest::pushAndGetFromStackWorks
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\ParsingStateTest::renderCallsTheRightMethodsOnTheRootNode
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\ParsingStateTest::setRootNodeCanBeReadOutAgain
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\SyntaxTree\AbstractNodeTest::childNodeCanBeReadOutAgain
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\SyntaxTree\AbstractNodeTest::evaluateChildNodesPassesRenderingContextToChildNodes
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\SyntaxTree\BooleanNodeTest::comparingEqualNumbersReturnsTrue
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\SyntaxTree\BooleanNodeTest::comparingUnequalNumbersReturnsFalse
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\SyntaxTree\BooleanNodeTest::convertToBooleanProperlyConvertsNumericValues
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\SyntaxTree\BooleanNodeTest::convertToBooleanProperlyConvertsObjects
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\SyntaxTree\BooleanNodeTest::convertToBooleanProperlyConvertsValuesOfTypeArray
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\SyntaxTree\BooleanNodeTest::convertToBooleanProperlyConvertsValuesOfTypeBoolean
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\SyntaxTree\BooleanNodeTest::convertToBooleanProperlyConvertsValuesOfTypeString
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\SyntaxTree\BooleanNodeTest::equalsReturnsFalseIfComparingNonMatchingStrings
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\SyntaxTree\BooleanNodeTest::equalsReturnsFalseIfComparingStringWithNonZero
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\SyntaxTree\BooleanNodeTest::equalsReturnsTrueIfComparingMatchingStrings
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\SyntaxTree\BooleanNodeTest::equalsReturnsTrueIfComparingMatchingStringsWithEscapedQuotes
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\SyntaxTree\BooleanNodeTest::equalsReturnsTrueIfComparingStringWithZero
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\SyntaxTree\BooleanNodeTest::evenNumberModulo2ReturnsFalse
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\SyntaxTree\BooleanNodeTest::greaterOrEqualsReturnFalseIfNumberIsSmaller
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\SyntaxTree\BooleanNodeTest::greaterOrEqualsReturnsTrueIfNumberIsEqual
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\SyntaxTree\BooleanNodeTest::greaterOrEqualsReturnsTrueIfNumberIsReallyGreater
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\SyntaxTree\BooleanNodeTest::greaterThanReturnsFalseIfNumberIsEqual
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\SyntaxTree\BooleanNodeTest::greaterThanReturnsTrueIfNumberIsReallyGreater
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\SyntaxTree\BooleanNodeTest::havingMoreThanThreeElementsInTheSyntaxTreeThrowsException
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\SyntaxTree\BooleanNodeTest::lessOrEqualsReturnFalseIfComparingWithANegativeNumber
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\SyntaxTree\BooleanNodeTest::lessOrEqualsReturnFalseIfNumberIsBigger
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\SyntaxTree\BooleanNodeTest::lessOrEqualsReturnsTrueIfNumberIsEqual
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\SyntaxTree\BooleanNodeTest::lessOrEqualsReturnsTrueIfNumberIsReallyLess
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\SyntaxTree\BooleanNodeTest::lessThanReturnsFalseIfNumberIsEqual
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\SyntaxTree\BooleanNodeTest::lessThanReturnsTrueIfNumberIsReallyless
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\SyntaxTree\BooleanNodeTest::notEqualReturnsFalseIfComparingMatchingStrings
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\SyntaxTree\BooleanNodeTest::notEqualReturnsFalseIfNumbersAreEqual
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\SyntaxTree\BooleanNodeTest::notEqualReturnsTrueIfComparingNonMatchingStrings
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\SyntaxTree\BooleanNodeTest::notEqualReturnsTrueIfNumbersAreNotEqual
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\SyntaxTree\BooleanNodeTest::objectsAreComparedStrictly
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\SyntaxTree\BooleanNodeTest::objectsAreComparedStrictlyInUnequalComparison
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\SyntaxTree\BooleanNodeTest::oddNumberModulo2ReturnsTrue
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\SyntaxTree\NumericNodeTest::addChildNodeThrowsException
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\SyntaxTree\NumericNodeTest::constructorThrowsExceptionIfNoNumericGiven
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\SyntaxTree\NumericNodeTest::renderReturnsProperFloatGivenInConstructor
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\SyntaxTree\NumericNodeTest::renderReturnsProperIntegerGivenInConstructor
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\SyntaxTree\ObjectAccessorNodeTest::evaluateCallsObjectAccessOnSubjectWithTemplateObjectAccessInterface
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\SyntaxTree\ObjectAccessorNodeTest::evaluateGetsPropertyPathFromVariableContainer
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\SyntaxTree\TextNodeTest::constructorThrowsExceptionIfNoStringGiven
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\SyntaxTree\TextNodeTest::renderReturnsSameStringAsGivenInConstructor
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\SyntaxTree\ViewHelperNodeTest::childNodeAccessFacetWorksAsExpected
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\SyntaxTree\ViewHelperNodeTest::constructorSetsViewHelperAndArguments
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\SyntaxTree\ViewHelperNodeTest::evaluateMethodPassesRenderingContextToViewHelper
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\SyntaxTree\ViewHelperNodeTest::initializeArgumentsAndRenderIsCalledByViewHelperNode
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\SyntaxTree\ViewHelperNodeTest::initializeArgumentsAndRenderIsCalledWithCorrectArguments
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\SyntaxTree\ViewHelperNodeTest::multipleEvaluateCallsShareTheSameViewHelperInstance
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\TemplateParserPatternTest::testSCAN_PATTERN_CDATA
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\TemplateParserPatternTest::testSCAN_PATTERN_CLOSINGDYNAMICTAG
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\TemplateParserPatternTest::testSCAN_PATTERN_DYNAMICTAG
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\TemplateParserPatternTest::testSCAN_PATTERN_NAMESPACEDECLARATION
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\TemplateParserPatternTest::testSCAN_PATTERN_SHORTHANDSYNTAX_ARRAYS
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\TemplateParserPatternTest::testSCAN_PATTERN_SHORTHANDSYNTAX_OBJECTACCESSORS
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\TemplateParserPatternTest::testSPLIT_PATTERN_DYNAMICTAGS
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\TemplateParserPatternTest::testSPLIT_PATTERN_SHORTHANDSYNTAX
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\TemplateParserPatternTest::testSPLIT_PATTERN_SHORTHANDSYNTAX_ARRAY_PARTS
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\TemplateParserPatternTest::testSPLIT_PATTERN_SHORTHANDSYNTAX_VIEWHELPER
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\TemplateParserPatternTest::testSPLIT_PATTERN_TAGARGUMENTS
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\TemplateParserTest::abortIfRequiredArgumentsAreMissingDoesNotThrowExceptionIfRequiredArgumentExists
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\TemplateParserTest::abortIfRequiredArgumentsAreMissingThrowsException
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\TemplateParserTest::abortIfUnregisteredArgumentsExistDoesNotThrowExceptionIfEverythingIsOk
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\TemplateParserTest::abortIfUnregisteredArgumentsExistThrowsExceptionOnUnregisteredArguments
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\TemplateParserTest::arrayHandlerAddsArrayNodeWithProperContentToStack
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\TemplateParserTest::buildArgumentObjectTreeBuildsObjectTreeForComlexString
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\TemplateParserTest::buildArgumentObjectTreeReturnsTextNodeForSimplyString
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\TemplateParserTest::buildObjectTreeCreatesRootNodeAndSetsUpParsingState
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\TemplateParserTest::buildObjectTreeDelegatesHandlingOfTemplateElements
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\TemplateParserTest::buildObjectTreeThrowsExceptionIfOpenTagsRemain
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\TemplateParserTest::closingViewHelperTagHandlerThrowsExceptionBecauseOfClosingTagWhichWasNeverOpened
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\TemplateParserTest::closingViewHelperTagHandlerThrowsExceptionBecauseOfWrongTagNesting
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\TemplateParserTest::extractNamespaceDefinitionsExtractsNamespacesCorrectly
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\TemplateParserTest::extractNamespaceDefinitionsExtractsXmlNamespacesCorrectly
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\TemplateParserTest::extractNamespaceDefinitionsResolveNamespacesWithDefaultPattern
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\TemplateParserTest::extractNamespaceDefinitionsSilentlySkipsXmlNamespaceDeclarationForTheDefaultFluidNamespace
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\TemplateParserTest::extractNamespaceDefinitionsSilentlySkipsXmlNamespaceDeclarationsThatCantBeResolved
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\TemplateParserTest::extractNamespaceDefinitionsThrowsExceptionIfFluidNamespaceIsRedeclaredAsXmlNamespace
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\TemplateParserTest::extractNamespaceDefinitionsThrowsExceptionIfNamespaceIsRedeclared
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\TemplateParserTest::extractNamespaceDefinitionsThrowsExceptionIfXmlNamespaceIsRedeclaredAsFluidNamespace
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\TemplateParserTest::initializeViewHelperAndAddItToStackChecksViewHelperArguments
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\TemplateParserTest::initializeViewHelperAndAddItToStackCreatesRequestedViewHelperAndViewHelperNode
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\TemplateParserTest::initializeViewHelperAndAddItToStackHandlesPostParseFacets
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\TemplateParserTest::initializeViewHelperAndAddItToStackThrowsExceptionIfViewHelperClassDoesNotExisit
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\TemplateParserTest::initializeViewHelperAndAddItToStackThrowsExceptionIfViewHelperClassNameIsWronglyCased
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\TemplateParserTest::objectAccessorHandlerCallsInitializeViewHelperAndAddItToStackIfViewHelperSyntaxIsPresent
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\TemplateParserTest::objectAccessorHandlerCreatesObjectAccessorNodeWithExpectedValueAndAddsItToStack
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\TemplateParserTest::openingViewHelperTagHandlerDelegatesViewHelperInitialization
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\TemplateParserTest::openingViewHelperTagHandlerPopsNodeFromStackForSelfClosingTags
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\TemplateParserTest::parseArgumentsWorksAsExpected with data set #0
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\TemplateParserTest::parseArgumentsWorksAsExpected with data set #1
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\TemplateParserTest::parseArgumentsWorksAsExpected with data set #2
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\TemplateParserTest::parseThrowsExceptionWhenStringArgumentMissing
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\TemplateParserTest::recursiveArrayHandlerReturnsExpectedArray with data set #0
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\TemplateParserTest::recursiveArrayHandlerReturnsExpectedArray with data set #1
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\TemplateParserTest::registerNamespaceDoesNotThrowAnExceptionIfTheAliasExistAlreadyAndPointsToTheSamePhpNamespace
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\TemplateParserTest::registerNamespaceThrowsExceptionIfOneAliasIsRegisteredWithDifferentPhpNamespaces
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\TemplateParserTest::splitTemplateAtDynamicTagsReturnsCorrectlySplitTemplate with data set #0
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\TemplateParserTest::splitTemplateAtDynamicTagsReturnsCorrectlySplitTemplate with data set #1
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\TemplateParserTest::splitTemplateAtDynamicTagsReturnsCorrectlySplitTemplate with data set #2
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\TemplateParserTest::textAndShorthandSyntaxHandlerDelegatesAppropriately
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\TemplateParserTest::textNodesAreNotRunThroughEscapingInterceptorsIfEscapingIsDisabled
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\TemplateParserTest::textNodesAreRunThroughEscapingInterceptorsByDefault
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\TemplateParserTest::textNodesAreRunThroughInterceptors
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\TemplateParserTest::unquoteStringReturnsUnquotedStrings with data set #0
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\TemplateParserTest::unquoteStringReturnsUnquotedStrings with data set #1
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\TemplateParserTest::unquoteStringReturnsUnquotedStrings with data set #2
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\TemplateParserTest::unquoteStringReturnsUnquotedStrings with data set #3
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\TemplateParserTest::unquoteStringReturnsUnquotedStrings with data set #4
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\TemplateParserTest::unquoteStringReturnsUnquotedStrings with data set #5
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\TemplateParserTest::valuesFromObjectAccessorsAreNotRunThroughEscapingInterceptorsIfEscapingIsDisabled
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\TemplateParserTest::valuesFromObjectAccessorsAreRunThroughEscapingInterceptorsByDefault
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\TemplateParserTest::valuesFromObjectAccessorsAreRunThroughInterceptors
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\TemplateParserTest::viewHelperNameWithMultipleLevelsCanBeResolvedByResolveViewHelperName
+.
+TYPO3\Fluid\Tests\Unit\Core\Parser\TemplateParserTest::viewHelperNameWithOneLevelCanBeResolvedByResolveViewHelperName
+.
+TYPO3\Fluid\Tests\Unit\Core\Rendering\RenderingContextTest::controllerContextCanBeReadCorrectly
+.
+TYPO3\Fluid\Tests\Unit\Core\Rendering\RenderingContextTest::templateVariableContainerCanBeReadCorrectly
+.
+TYPO3\Fluid\Tests\Unit\Core\Rendering\RenderingContextTest::viewHelperVariableContainerCanBeReadCorrectly
+.
+TYPO3\Fluid\Tests\Unit\Core\ViewHelper\AbstractConditionViewHelperTest::elseArgumentHasPriorityOverChildNodesIfConditionIsFalse
+.
+TYPO3\Fluid\Tests\Unit\Core\ViewHelper\AbstractConditionViewHelperTest::renderElseChildRendersElseViewHelperChildIfConditionIsFalseAndNoThenViewHelperChildExists
+.
+TYPO3\Fluid\Tests\Unit\Core\ViewHelper\AbstractConditionViewHelperTest::renderElseChildReturnsEmptyStringIfConditionIsFalseAndNoElseViewHelperChildExists
+.
+TYPO3\Fluid\Tests\Unit\Core\ViewHelper\AbstractConditionViewHelperTest::renderReturnsValueOfElseArgumentIfConditionIsFalse
+.
+TYPO3\Fluid\Tests\Unit\Core\ViewHelper\AbstractConditionViewHelperTest::renderThenChildReturnsAllChildrenIfNoThenViewHelperChildExists
+.
+TYPO3\Fluid\Tests\Unit\Core\ViewHelper\AbstractConditionViewHelperTest::renderThenChildReturnsEmptyStringIfChildNodesOnlyContainElseViewHelper
+.
+TYPO3\Fluid\Tests\Unit\Core\ViewHelper\AbstractConditionViewHelperTest::renderThenChildReturnsThenViewHelperChildIfConditionIsTrueAndThenViewHelperChildExists
+.
+TYPO3\Fluid\Tests\Unit\Core\ViewHelper\AbstractConditionViewHelperTest::renderThenChildReturnsValueOfThenArgumentIfItIsSpecified
+.
+TYPO3\Fluid\Tests\Unit\Core\ViewHelper\AbstractConditionViewHelperTest::thenArgumentHasPriorityOverChildNodesIfConditionIsTrue
+.
+TYPO3\Fluid\Tests\Unit\Core\ViewHelper\AbstractTagBasedViewHelperTest::additionalTagAttributesAreRenderedCorrectly
+.
+TYPO3\Fluid\Tests\Unit\Core\ViewHelper\AbstractTagBasedViewHelperTest::dataAttributesAreRenderedCorrectly
+.
+TYPO3\Fluid\Tests\Unit\Core\ViewHelper\AbstractTagBasedViewHelperTest::initializeResetsUnderlyingTagBuilder
+.
+TYPO3\Fluid\Tests\Unit\Core\ViewHelper\AbstractTagBasedViewHelperTest::oneTagAttributeIsRenderedCorrectly
+.
+TYPO3\Fluid\Tests\Unit\Core\ViewHelper\AbstractTagBasedViewHelperTest::standardTagAttributesAreRegistered
+.
+TYPO3\Fluid\Tests\Unit\Core\ViewHelper\AbstractViewHelperTest::argumentsCanBeRegistered
+.
+TYPO3\Fluid\Tests\Unit\Core\ViewHelper\AbstractViewHelperTest::initializeArgumentsAndRenderCallsTheCorrectSequenceOfMethods
+.
+TYPO3\Fluid\Tests\Unit\Core\ViewHelper\AbstractViewHelperTest::overrideArgumentOverwritesExistingArgumentDefinition
+.
+TYPO3\Fluid\Tests\Unit\Core\ViewHelper\AbstractViewHelperTest::overrideArgumentThrowsExceptionWhenTryingToOverwriteAnNonexistingArgument
+.
+TYPO3\Fluid\Tests\Unit\Core\ViewHelper\AbstractViewHelperTest::prepareArgumentsCallsInitializeArguments
+.
+TYPO3\Fluid\Tests\Unit\Core\ViewHelper\AbstractViewHelperTest::prepareArgumentsRegistersAnnotationBasedArgumentsWithDescriptionIfDebugModeIsEnabled
+.
+TYPO3\Fluid\Tests\Unit\Core\ViewHelper\AbstractViewHelperTest::prepareArgumentsRegistersAnnotationBasedArgumentsWithoutDescriptionIfDebugModeIsDisabled
+.
+TYPO3\Fluid\Tests\Unit\Core\ViewHelper\AbstractViewHelperTest::registeringTheSameArgumentNameAgainThrowsException
+.
+TYPO3\Fluid\Tests\Unit\Core\ViewHelper\AbstractViewHelperTest::setRenderingContextShouldSetInnerVariables
+.
+TYPO3\Fluid\Tests\Unit\Core\ViewHelper\AbstractViewHelperTest::validateArgumentsAcceptsAllObjectsImplemtingArrayAccessAsAnArray
+.
+TYPO3\Fluid\Tests\Unit\Core\ViewHelper\AbstractViewHelperTest::validateArgumentsCallsPrepareArguments
+.
+TYPO3\Fluid\Tests\Unit\Core\ViewHelper\AbstractViewHelperTest::validateArgumentsCallsTheRightValidators
+.
+TYPO3\Fluid\Tests\Unit\Core\ViewHelper\AbstractViewHelperTest::validateArgumentsCallsTheRightValidatorsAndThrowsExceptionIfValidationIsWrong
+.
+TYPO3\Fluid\Tests\Unit\Core\ViewHelper\ArgumentDefinitionTest::objectStoresDataCorrectly
+.
+TYPO3\Fluid\Tests\Unit\Core\ViewHelper\TagBuilderTest::attributeValuesAreEscapedByDefault
+.
+TYPO3\Fluid\Tests\Unit\Core\ViewHelper\TagBuilderTest::attributeValuesAreNotEscapedIfDisabled
+.
+TYPO3\Fluid\Tests\Unit\Core\ViewHelper\TagBuilderTest::attributesAreProperlyRendered
+.
+TYPO3\Fluid\Tests\Unit\Core\ViewHelper\TagBuilderTest::attributesCanBeAccessed
+.
+TYPO3\Fluid\Tests\Unit\Core\ViewHelper\TagBuilderTest::attributesCanBeRemoved
+.
+TYPO3\Fluid\Tests\Unit\Core\ViewHelper\TagBuilderTest::constructorSetsTagContent
+.
+TYPO3\Fluid\Tests\Unit\Core\ViewHelper\TagBuilderTest::constructorSetsTagName
+.
+TYPO3\Fluid\Tests\Unit\Core\ViewHelper\TagBuilderTest::contentCanBeRemoved
+.
+TYPO3\Fluid\Tests\Unit\Core\ViewHelper\TagBuilderTest::getAttributeWithMissingAttributeReturnsNull
+.
+TYPO3\Fluid\Tests\Unit\Core\ViewHelper\TagBuilderTest::hasContentReturnsFalseIfContentIsAnEmptyString
+.
+TYPO3\Fluid\Tests\Unit\Core\ViewHelper\TagBuilderTest::hasContentReturnsFalseIfContentIsNull
+.
+TYPO3\Fluid\Tests\Unit\Core\ViewHelper\TagBuilderTest::hasContentReturnsTrueIfTagContainsText
+.
+TYPO3\Fluid\Tests\Unit\Core\ViewHelper\TagBuilderTest::renderReturnsEmptyStringByDefault
+.
+TYPO3\Fluid\Tests\Unit\Core\ViewHelper\TagBuilderTest::renderReturnsOpeningAndClosingTagIfNoContentIsSpecifiedButForceClosingTagIsTrue
+.
+TYPO3\Fluid\Tests\Unit\Core\ViewHelper\TagBuilderTest::renderReturnsSelfClosingTagIfNoContentIsSpecified
+.
+TYPO3\Fluid\Tests\Unit\Core\ViewHelper\TagBuilderTest::resetResetsTagBuilder
+.
+TYPO3\Fluid\Tests\Unit\Core\ViewHelper\TagBuilderTest::setContentDoesNotEscapeValue
+.
+TYPO3\Fluid\Tests\Unit\Core\ViewHelper\TagBuilderTest::tagContentCanBeOverridden
+.
+TYPO3\Fluid\Tests\Unit\Core\ViewHelper\TagBuilderTest::tagIsNotRenderedIfTagNameIsEmpty
+.
+TYPO3\Fluid\Tests\Unit\Core\ViewHelper\TagBuilderTest::tagNameCanBeOverridden
+.
+TYPO3\Fluid\Tests\Unit\Core\ViewHelper\TemplateVariableContainerTest::addedObjectsCanBeRetrievedAgain
+.
+TYPO3\Fluid\Tests\Unit\Core\ViewHelper\TemplateVariableContainerTest::addedObjectsCanBeRetrievedAgainUsingArrayAccess
+.
+TYPO3\Fluid\Tests\Unit\Core\ViewHelper\TemplateVariableContainerTest::addedObjectsExistInAllIdentifiers
+.
+TYPO3\Fluid\Tests\Unit\Core\ViewHelper\TemplateVariableContainerTest::addedObjectsExistInArray
+.
+TYPO3\Fluid\Tests\Unit\Core\ViewHelper\TemplateVariableContainerTest::addingReservedIdentifiersThrowException
+.
+TYPO3\Fluid\Tests\Unit\Core\ViewHelper\TemplateVariableContainerTest::addingVariableWhichIsReservedThrowsException with data set #0
+.
+TYPO3\Fluid\Tests\Unit\Core\ViewHelper\TemplateVariableContainerTest::addingVariableWhichIsReservedThrowsException with data set #1
+.
+TYPO3\Fluid\Tests\Unit\Core\ViewHelper\TemplateVariableContainerTest::addingVariableWhichIsReservedThrowsException with data set #2
+.
+TYPO3\Fluid\Tests\Unit\Core\ViewHelper\TemplateVariableContainerTest::addingVariableWhichIsReservedThrowsException with data set #3
+.
+TYPO3\Fluid\Tests\Unit\Core\ViewHelper\TemplateVariableContainerTest::addingVariableWhichIsReservedThrowsException with data set #4
+.
+TYPO3\Fluid\Tests\Unit\Core\ViewHelper\TemplateVariableContainerTest::addingVariableWhichIsReservedThrowsException with data set #5
+.
+TYPO3\Fluid\Tests\Unit\Core\ViewHelper\TemplateVariableContainerTest::addingVariableWhichIsReservedThrowsException with data set #6
+.
+TYPO3\Fluid\Tests\Unit\Core\ViewHelper\TemplateVariableContainerTest::attemptToGetReservedVariableInUncoveredLetterCaseThrowsException with data set #0
+.
+TYPO3\Fluid\Tests\Unit\Core\ViewHelper\TemplateVariableContainerTest::attemptToGetReservedVariableInUncoveredLetterCaseThrowsException with data set #1
+.
+TYPO3\Fluid\Tests\Unit\Core\ViewHelper\TemplateVariableContainerTest::attemptToGetReservedVariableInUncoveredLetterCaseThrowsException with data set #2
+.
+TYPO3\Fluid\Tests\Unit\Core\ViewHelper\TemplateVariableContainerTest::attemptToGetReservedVariableInUncoveredLetterCaseThrowsException with data set #3
+.
+TYPO3\Fluid\Tests\Unit\Core\ViewHelper\TemplateVariableContainerTest::attemptToGetReservedVariableInUncoveredLetterCaseThrowsException with data set #4
+.
+TYPO3\Fluid\Tests\Unit\Core\ViewHelper\TemplateVariableContainerTest::attemptToGetReservedVariableInUncoveredLetterCaseThrowsException with data set #5
+.
+TYPO3\Fluid\Tests\Unit\Core\ViewHelper\TemplateVariableContainerTest::attemptToGetReservedVariableInUncoveredLetterCaseThrowsException with data set #6
+.
+TYPO3\Fluid\Tests\Unit\Core\ViewHelper\TemplateVariableContainerTest::attemptToSetReservedVariableInUncoveredLetterCaseThrowsException with data set #0
+.
+TYPO3\Fluid\Tests\Unit\Core\ViewHelper\TemplateVariableContainerTest::attemptToSetReservedVariableInUncoveredLetterCaseThrowsException with data set #1
+.
+TYPO3\Fluid\Tests\Unit\Core\ViewHelper\TemplateVariableContainerTest::attemptToSetReservedVariableInUncoveredLetterCaseThrowsException with data set #2
+.
+TYPO3\Fluid\Tests\Unit\Core\ViewHelper\TemplateVariableContainerTest::attemptToSetReservedVariableInUncoveredLetterCaseThrowsException with data set #3
+.
+TYPO3\Fluid\Tests\Unit\Core\ViewHelper\TemplateVariableContainerTest::attemptToSetReservedVariableInUncoveredLetterCaseThrowsException with data set #4
+.
+TYPO3\Fluid\Tests\Unit\Core\ViewHelper\TemplateVariableContainerTest::attemptToSetReservedVariableInUncoveredLetterCaseThrowsException with data set #5
+.
+TYPO3\Fluid\Tests\Unit\Core\ViewHelper\TemplateVariableContainerTest::attemptToSetReservedVariableInUncoveredLetterCaseThrowsException with data set #6
+.
+TYPO3\Fluid\Tests\Unit\Core\ViewHelper\TemplateVariableContainerTest::deletingNonexistentValueThrowsException
+.
+TYPO3\Fluid\Tests\Unit\Core\ViewHelper\TemplateVariableContainerTest::duplicateIdentifiersThrowException
+.
+TYPO3\Fluid\Tests\Unit\Core\ViewHelper\TemplateVariableContainerTest::getAllShouldReturnAllVariables
+.
+TYPO3\Fluid\Tests\Unit\Core\ViewHelper\TemplateVariableContainerTest::gettingAReservedVariableMatchesItsExpectation with data set #0
+.
+TYPO3\Fluid\Tests\Unit\Core\ViewHelper\TemplateVariableContainerTest::gettingAReservedVariableMatchesItsExpectation with data set #1
+.
+TYPO3\Fluid\Tests\Unit\Core\ViewHelper\TemplateVariableContainerTest::gettingAReservedVariableMatchesItsExpectation with data set #2
+.
+TYPO3\Fluid\Tests\Unit\Core\ViewHelper\TemplateVariableContainerTest::gettingAReservedVariableMatchesItsExpectation with data set #3
+.
+TYPO3\Fluid\Tests\Unit\Core\ViewHelper\TemplateVariableContainerTest::gettingAReservedVariableMatchesItsExpectation with data set #4
+.
+TYPO3\Fluid\Tests\Unit\Core\ViewHelper\TemplateVariableContainerTest::gettingAReservedVariableMatchesItsExpectation with data set #5
+.
+TYPO3\Fluid\Tests\Unit\Core\ViewHelper\TemplateVariableContainerTest::gettingAReservedVariableMatchesItsExpectation with data set #6
+.
+TYPO3\Fluid\Tests\Unit\Core\ViewHelper\TemplateVariableContainerTest::gettingNonexistentValueThrowsException
+.
+TYPO3\Fluid\Tests\Unit\Core\ViewHelper\TemplateVariableContainerTest::removeReallyRemovesVariables
+.
+TYPO3\Fluid\Tests\Unit\Core\ViewHelper\TemplateVariableContainerTest::reservedVariableNameIsAlwaysConsideredExisting with data set #0
+.
+TYPO3\Fluid\Tests\Unit\Core\ViewHelper\TemplateVariableContainerTest::reservedVariableNameIsAlwaysConsideredExisting with data set #1
+.
+TYPO3\Fluid\Tests\Unit\Core\ViewHelper\TemplateVariableContainerTest::reservedVariableNameIsAlwaysConsideredExisting with data set #2
+.
+TYPO3\Fluid\Tests\Unit\Core\ViewHelper\TemplateVariableContainerTest::reservedVariableNameIsAlwaysConsideredExisting with data set #3
+.
+TYPO3\Fluid\Tests\Unit\Core\ViewHelper\TemplateVariableContainerTest::reservedVariableNameIsAlwaysConsideredExisting with data set #4
+.
+TYPO3\Fluid\Tests\Unit\Core\ViewHelper\TemplateVariableContainerTest::reservedVariableNameIsAlwaysConsideredExisting with data set #5
+.
+TYPO3\Fluid\Tests\Unit\Core\ViewHelper\TemplateVariableContainerTest::reservedVariableNameIsAlwaysConsideredExisting with data set #6
+.
+TYPO3\Fluid\Tests\Unit\Core\ViewHelper\ViewHelperVariableContainerTest::aSetValueCanBeRemovedAgain
+.
+TYPO3\Fluid\Tests\Unit\Core\ViewHelper\ViewHelperVariableContainerTest::addOrUpdateOverridesAnExistingKey
+.
+TYPO3\Fluid\Tests\Unit\Core\ViewHelper\ViewHelperVariableContainerTest::addOrUpdateSetsAKeyIfItDoesNotExistYet
+.
+TYPO3\Fluid\Tests\Unit\Core\ViewHelper\ViewHelperVariableContainerTest::existsReturnsFalseIfTheSpecifiedKeyDoesNotExist
+.
+TYPO3\Fluid\Tests\Unit\Core\ViewHelper\ViewHelperVariableContainerTest::existsReturnsTrueIfTheSpecifiedKeyExists
+.
+TYPO3\Fluid\Tests\Unit\Core\ViewHelper\ViewHelperVariableContainerTest::existsReturnsTrueIfTheSpecifiedKeyExistsAndIsNull
+.
+TYPO3\Fluid\Tests\Unit\Core\ViewHelper\ViewHelperVariableContainerTest::gettingNonNonExistentValueThrowsException
+.
+TYPO3\Fluid\Tests\Unit\Core\ViewHelper\ViewHelperVariableContainerTest::removingNonExistentKeyThrowsException
+.
+TYPO3\Fluid\Tests\Unit\Core\ViewHelper\ViewHelperVariableContainerTest::settingKeyWhichIsAlreadyStoredThrowsException
+.
+TYPO3\Fluid\Tests\Unit\Core\ViewHelper\ViewHelperVariableContainerTest::storedDataCanBeReadOutAgain
+.
+TYPO3\Fluid\Tests\Unit\Core\ViewHelper\ViewHelperVariableContainerTest::viewCanBeReadOutAgain
+.
+TYPO3\Fluid\Tests\Unit\Core\Widget\AbstractWidgetControllerTest::processRequestShouldSetWidgetConfiguration
+.
+TYPO3\Fluid\Tests\Unit\Core\Widget\AbstractWidgetControllerTest::processRequestShouldThrowExceptionIfWidgetContextNotFound
+.
+TYPO3\Fluid\Tests\Unit\Core\Widget\AbstractWidgetViewHelperTest::initializeArgumentsAndRenderCallsTheRightSequenceOfMethods
+.
+TYPO3\Fluid\Tests\Unit\Core\Widget\AbstractWidgetViewHelperTest::initializeArgumentsAndRenderDoesNotStoreTheWidgetContextForStatelessWidgets
+.
+TYPO3\Fluid\Tests\Unit\Core\Widget\AbstractWidgetViewHelperTest::initializeArgumentsAndRenderStoresTheWidgetContextIfInAjaxMode
+.
+TYPO3\Fluid\Tests\Unit\Core\Widget\AbstractWidgetViewHelperTest::initiateSubRequestThrowsExceptionIfControllerIsNoWidgetController
+.
+TYPO3\Fluid\Tests\Unit\Core\Widget\AbstractWidgetViewHelperTest::setChildNodesAddsChildNodesToWidgetContext
+.
+TYPO3\Fluid\Tests\Unit\Core\Widget\AjaxWidgetComponentTest::extractWidgetContextDecodesSerializedWidgetContextIfPresent
+.
+TYPO3\Fluid\Tests\Unit\Core\Widget\AjaxWidgetComponentTest::handleCancelsComponentChainIfWidgetContextIsPresent
+.
+TYPO3\Fluid\Tests\Unit\Core\Widget\AjaxWidgetComponentTest::handleDispatchesActionRequestIfWidgetContextIsPresent
+.
+TYPO3\Fluid\Tests\Unit\Core\Widget\AjaxWidgetComponentTest::handleDoesNotCreateActionRequestIfHttpRequestContainsNoWidgetContext
+.
+TYPO3\Fluid\Tests\Unit\Core\Widget\AjaxWidgetComponentTest::handleInjectsActionRequestToSecurityContext
+.
+TYPO3\Fluid\Tests\Unit\Core\Widget\AjaxWidgetComponentTest::handleSetsWidgetContextAndControllerObjectNameIfWidgetIdIsPresent
+.
+TYPO3\Fluid\Tests\Unit\Core\Widget\AjaxWidgetContextHolderTest::getThrowsExceptionIfWidgetContextIsNotFound
+.
+TYPO3\Fluid\Tests\Unit\Core\Widget\AjaxWidgetContextHolderTest::storeSetsTheAjaxWidgetIdentifierInContextAndIncreasesIt
+.
+TYPO3\Fluid\Tests\Unit\Core\Widget\AjaxWidgetContextHolderTest::storedWidgetContextCanBeRetrievedAgain
+.
+TYPO3\Fluid\Tests\Unit\Core\Widget\WidgetContextTest::aWidgetConfigurationIsReturnedWhenContextIsSerialized
+.
+TYPO3\Fluid\Tests\Unit\Core\Widget\WidgetContextTest::ajaxWidgetIdentifierCanBeReadAgain
+.
+TYPO3\Fluid\Tests\Unit\Core\Widget\WidgetContextTest::controllerObjectNameCanBeReadAgain
+.
+TYPO3\Fluid\Tests\Unit\Core\Widget\WidgetContextTest::nonAjaxWidgetConfigurationIsReturnedWhenContextIsNotSerialized
+.
+TYPO3\Fluid\Tests\Unit\Core\Widget\WidgetContextTest::viewHelperChildNodesCanBeReadAgain
+.
+TYPO3\Fluid\Tests\Unit\Core\Widget\WidgetContextTest::widgetIdentifierCanBeReadAgain
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\AliasViewHelperTest::renderAddsMultipleValuesToTemplateVariableContainerAndRemovesThemAfterRendering
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\AliasViewHelperTest::renderAddsSingleValueToTemplateVariableContainerAndRemovesItAfterRendering
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\AliasViewHelperTest::renderDoesNotTouchTemplateVariableContainerAndReturnsChildNodesIfMapIsEmpty
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\BaseViewHelperTest::renderEscapesBaseUri
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\BaseViewHelperTest::renderTakesBaseUriFromControllerContext
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\CaseViewHelperTest::renderReturnsAnEmptyStringIfTheSpecifiedValueIsNotEqualToTheSwitchExpression
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\CaseViewHelperTest::renderReturnsChildNodesIfTheSpecifiedValueIsEqualToTheSwitchExpression
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\CaseViewHelperTest::renderSetsBreakStateInViewHelperVariableContainerIfTheSpecifiedValueIsEqualToTheSwitchExpression
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\CaseViewHelperTest::renderThrowsExceptionIfSwitchExpressionIsNotSetInViewHelperVariableContainer
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\CaseViewHelperTest::renderWeaklyComparesSpecifiedValueWithSwitchExpression
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\CountViewHelperTest::renderReturnsNumberOfElementsInAnArray
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\CountViewHelperTest::renderReturnsNumberOfElementsInAnArrayObject
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\CountViewHelperTest::renderReturnsZeroIfGivenArrayIsEmpty
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\CountViewHelperTest::renderReturnsZeroIfGivenSubjectIsNullAndRenderChildrenReturnsNull
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\CountViewHelperTest::renderThrowsExceptionIfGivenSubjectIsNotCountable
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\CountViewHelperTest::renderUsesChildrenAsSubjectIfGivenSubjectIsNull
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\CycleViewHelperTest::renderAddsCurrentValueToTemplateVariableContainerAndRemovesItAfterRendering
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\CycleViewHelperTest::renderAddsFirstValueToTemplateVariableContainerAfterLastValue
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\CycleViewHelperTest::renderIteratesThroughElementsOfTraversableObjects
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\CycleViewHelperTest::renderReturnsChildNodesIfValuesIsAnEmptyArray
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\CycleViewHelperTest::renderReturnsChildNodesIfValuesIsNull
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\CycleViewHelperTest::renderThrowsExceptionWhenPassingObjectsToValuesThatAreNotTraversable
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\CycleViewHelperTest::viewHelperSupportsAssociativeArrays
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\ElseViewHelperTest::renderRendersChildren
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\FlashMessagesViewHelperTest::renderReturnsEmptyStringIfNoFlashMessagesAreInQueue
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\FlashMessagesViewHelperTest::renderTests with data set #0
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\FlashMessagesViewHelperTest::renderTests with data set #1
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\FlashMessagesViewHelperTest::renderTests with data set #2
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\FlashMessagesViewHelperTest::renderTests with data set #3
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\FlashMessagesViewHelperTest::renderTests with data set #4
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\ForViewHelperTest::iterationDataIsAddedToTemplateVariableContainerIfIterationArgumentIsSet
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\ForViewHelperTest::keyContainsNumericalIndexIfTheGivenArrayDoesNotHaveAKey
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\ForViewHelperTest::keyContainsNumericalIndexInAscendingOrderEvenIfReverseIsTrueIfTheGivenArrayDoesNotHaveAKey
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\ForViewHelperTest::keyContainsTheNumericalIndexWhenIteratingThroughElementsOfObjectsOfTyeSplObjectStorage
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\ForViewHelperTest::renderExecutesTheLoopCorrectly
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\ForViewHelperTest::renderIteratesElementsInReverseOrderIfReverseIsTrue
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\ForViewHelperTest::renderIteratesThroughElementsOfTraversableObjects
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\ForViewHelperTest::renderPreservesKeyWhenIteratingThroughElementsOfObjectsThatImplementIteratorInterface
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\ForViewHelperTest::renderPreservesKeys
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\ForViewHelperTest::renderPreservesKeysIfReverseIsTrue
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\ForViewHelperTest::renderReturnsEmptyStringIfObjectIsEmptyArray
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\ForViewHelperTest::renderReturnsEmptyStringIfObjectIsNull
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\ForViewHelperTest::renderThrowsExceptionWhenPassingObjectsToEachThatAreNotTraversable
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\FormViewHelperTest::csrfTokenFieldIsNotRenderedIfFormMethodIsSafe
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\FormViewHelperTest::csrfTokenFieldIsNotRenderedIfNoAccountIsAuthenticated
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\FormViewHelperTest::csrfTokenFieldIsNotRenderedIfSecurityContextIsNotInitialized
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\FormViewHelperTest::csrfTokenFieldIsRenderedForUnsafeRequests
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\FormViewHelperTest::formObjectNameArgumentOverrulesNameArgument
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\FormViewHelperTest::renderAdditionalIdentityFieldsFetchesTheFieldsFromViewHelperVariableContainerAndBuildsHiddenFieldsForThem
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\FormViewHelperTest::renderAddsDefaultFieldNamePrefixToTemplateVariableContainerIfNoPrefixIsSpecifiedAndRequestIsASubRequest
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\FormViewHelperTest::renderAddsDefaultFieldNamePrefixToTemplateVariableContainerIfNoPrefixIsSpecifiedAndUseParentRequestArgumentIsSet
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\FormViewHelperTest::renderAddsNoFieldNamePrefixToTemplateVariableContainerIfNoPrefixIsSpecified
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\FormViewHelperTest::renderAddsObjectNameToTemplateVariableContainer
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\FormViewHelperTest::renderAddsObjectToViewHelperVariableContainer
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\FormViewHelperTest::renderAddsSpecifiedPrefixToTemplateVariableContainer
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\FormViewHelperTest::renderCallsRenderAdditionalIdentityFields
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\FormViewHelperTest::renderCallsRenderHiddenIdentityField
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\FormViewHelperTest::renderCallsRenderHiddenReferrerFields
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\FormViewHelperTest::renderEmptyHiddenFieldsRendersEmptyStringByDefault
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\FormViewHelperTest::renderEmptyHiddenFieldsRendersOneHiddenFieldPerEntry
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\FormViewHelperTest::renderHiddenReferrerFieldsAddCurrentControllerAndActionAsHiddenFields
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\FormViewHelperTest::renderHiddenReferrerFieldsAddCurrentControllerAndActionOfParentAndSubRequestAsHiddenFields
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\FormViewHelperTest::renderResetsFormActionUri
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\FormViewHelperTest::renderThrowsExceptionIfNeitherActionNorActionUriArgumentIsSpecified
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\FormViewHelperTest::renderThrowsExceptionIfUseParentRequestIsSetAndTheCurrentRequestHasNoParentRequest
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\FormViewHelperTest::renderUsesParentRequestIfUseParentRequestIsSet
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\FormViewHelperTest::renderWithMethodGetAddsActionUriQueryAsHiddenFields
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\FormViewHelperTest::renderWithMethodGetAddsActionUriQueryAsHiddenFieldsWithHtmlescape
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\FormViewHelperTest::renderWithMethodGetDoesNotBreakInRenderHiddenActionUriQueryParametersIfNoQueryStringExists
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\FormViewHelperTest::renderWrapsHiddenFieldsWithDivForXhtmlCompatibility
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Form\AbstractFormFieldViewHelperTest::addAdditionalIdentityPropertiesIfNeededCallsRenderIdentityFieldWithTheRightParameters
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Form\AbstractFormFieldViewHelperTest::addAdditionalIdentityPropertiesIfNeededCallsRenderIdentityFieldWithTheRightParametersWithMoreHierarchyLevels
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Form\AbstractFormFieldViewHelperTest::addAdditionalIdentityPropertiesIfNeededDoesNotCreateAnythingIfPropertyIsWithoutDot
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Form\AbstractFormFieldViewHelperTest::addAdditionalIdentityPropertiesIfNeededDoesNotTryToAccessObjectPropertiesIfFormObjectIsNotSet
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Form\AbstractFormFieldViewHelperTest::getMappingResultsForPropertyReturnsEmptyResultIfNoErrorOccurredInNonObjectAccessorMode
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Form\AbstractFormFieldViewHelperTest::getMappingResultsForPropertyReturnsEmptyResultIfNoErrorOccurredInObjectAccessorMode
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Form\AbstractFormFieldViewHelperTest::getMappingResultsForPropertyReturnsErrorsFromRequestIfFormObjectNameIsNotSet
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Form\AbstractFormFieldViewHelperTest::getMappingResultsForPropertyReturnsErrorsFromRequestIfPropertyIsSet
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Form\AbstractFormFieldViewHelperTest::getMappingResultsForPropertyReturnsValidationResultsIfErrorsHappenedInNonObjectAccessorMode
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Form\AbstractFormFieldViewHelperTest::getMappingResultsForPropertyReturnsValidationResultsIfErrorsHappenedInObjectAccessorMode
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Form\AbstractFormFieldViewHelperTest::getMappingResultsForSubPropertyReturnsValidationResultsIfErrorsHappenedInNonObjectAccessorMode
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Form\AbstractFormFieldViewHelperTest::getMappingResultsForSubPropertyReturnsValidationResultsIfErrorsHappenedInObjectAccessorMode
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Form\AbstractFormFieldViewHelperTest::getNameBuildsNameFromFieldNamePrefixAndFieldNameIfNotInObjectAccessorMode
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Form\AbstractFormFieldViewHelperTest::getNameBuildsNameFromFieldNamePrefixAndPropertyIfInObjectAccessorModeAndNoFormObjectNameIsSpecified
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Form\AbstractFormFieldViewHelperTest::getNameBuildsNameFromFieldNamePrefixFormObjectNameAndHierarchicalPropertyIfInObjectAccessorMode
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Form\AbstractFormFieldViewHelperTest::getNameBuildsNameFromFieldNamePrefixFormObjectNameAndPropertyIfInObjectAccessorMode
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Form\AbstractFormFieldViewHelperTest::getNameResolvesPropertyPathIfInObjectAccessorModeAndNoFormObjectNameIsSpecified
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Form\AbstractFormFieldViewHelperTest::getValueAttributeBuildsValueFromPropertyAndFormObjectIfInObjectAccessorMode with data set #0
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Form\AbstractFormFieldViewHelperTest::getValueAttributeBuildsValueFromPropertyAndFormObjectIfInObjectAccessorMode with data set #1
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Form\AbstractFormFieldViewHelperTest::getValueAttributeConvertsObjectsToIdentifiers
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Form\AbstractFormFieldViewHelperTest::getValueAttributeReturnsNullIfNotInObjectAccessorModeAndValueArgumentIsNoSet
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Form\AbstractFormFieldViewHelperTest::getValueAttributeReturnsValueArgumentIfSpecified
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Form\AbstractFormFieldViewHelperTest::ifAnAttributeValueIsAnObjectMaintainedByThePersistenceManagerItIsConvertedToAUUID
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Form\AbstractFormFieldViewHelperTest::isObjectAccessorModeReturnsTrueIfPropertyIsSetAndFormObjectIsGiven
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Form\AbstractFormFieldViewHelperTest::renderHiddenFieldForEmptyValueAddsHiddenFieldNameToVariableContainer
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Form\AbstractFormFieldViewHelperTest::renderHiddenFieldForEmptyValueDoesNotAddTheSameHiddenFieldNameMoreThanOnce
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Form\AbstractFormFieldViewHelperTest::renderHiddenFieldForEmptyValueDoesNotRemoveNonEmptySquareBracketsFromHiddenFieldName
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Form\AbstractFormFieldViewHelperTest::renderHiddenFieldForEmptyValueRemovesEmptySquareBracketsFromHiddenFieldName
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Form\AbstractFormFieldViewHelperTest::setErrorClassAttributeAppendsCustomErrorClassIfAnErrorOccurred
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Form\AbstractFormFieldViewHelperTest::setErrorClassAttributeAppendsErrorClassToExistingClassesIfAnErrorOccurred
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Form\AbstractFormFieldViewHelperTest::setErrorClassAttributeDoesNotSetClassAttributeIfNoErrorOccurred
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Form\AbstractFormFieldViewHelperTest::setErrorClassAttributeSetsCustomErrorClassIfAnErrorOccurred
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Form\AbstractFormFieldViewHelperTest::setErrorClassAttributeSetsErrorClassIfAnErrorOccurred
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Form\AbstractFormViewHelperTest::prefixFieldNamePrefixesGivenFieldNameWithFieldNamePrefix
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Form\AbstractFormViewHelperTest::prefixFieldNamePreservesSquareBracketsOfFieldName
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Form\AbstractFormViewHelperTest::prefixFieldNameReturnsEmptyStringIfGivenFieldNameIsEmpty
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Form\AbstractFormViewHelperTest::prefixFieldNameReturnsEmptyStringIfGivenFieldNameIsNULL
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Form\AbstractFormViewHelperTest::prefixFieldNameReturnsGivenFieldNameIfFieldNamePrefixIsEmpty
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Form\AbstractFormViewHelperTest::renderHiddenIdentityFieldReturnsACommentIfTheObjectIsWithoutIdentity
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Form\AbstractFormViewHelperTest::renderHiddenIdentityFieldReturnsAHiddenInputFieldContainingTheObjectsUUID
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Form\AbstractFormViewHelperTest::renderHiddenIdentityFieldReturnsAHiddenInputFieldIfObjectIsNewButAClone
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Form\ButtonViewHelperTest::renderCorrectlySetsTagNameAndDefaultAttributes
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Form\CheckboxViewHelperTest::renderAppendsSquareBracketsToNameAttributeIfBoundToAPropertyOfTypeArray
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Form\CheckboxViewHelperTest::renderCallsSetErrorClassAttribute
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Form\CheckboxViewHelperTest::renderCorrectlySetsCheckedAttributeIfCheckboxIsBoundToAPropertyOfTypeArray
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Form\CheckboxViewHelperTest::renderCorrectlySetsCheckedAttributeIfCheckboxIsBoundToAPropertyOfTypeArrayObject
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Form\CheckboxViewHelperTest::renderCorrectlySetsCheckedAttributeIfCheckboxIsBoundToAPropertyOfTypeBoolean
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Form\CheckboxViewHelperTest::renderCorrectlySetsTagNameAndDefaultAttributes
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Form\CheckboxViewHelperTest::renderIgnoresValueOfBoundPropertyIfCheckedIsSet
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Form\CheckboxViewHelperTest::renderSetsCheckedAttributeIfBoundPropertyIsNotNull
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Form\CheckboxViewHelperTest::renderSetsCheckedAttributeIfSpecified
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Form\HiddenViewHelperTest::renderCorrectlySetsTagNameAndDefaultAttributes
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Form\RadioViewHelperTest::renderCallsSetErrorClassAttribute
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Form\RadioViewHelperTest::renderCorrectlySetsCheckedAttributeIfCheckboxIsBoundToAPropertyOfTypeBoolean
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Form\RadioViewHelperTest::renderCorrectlySetsCheckedAttributeIfCheckboxIsBoundToAPropertyOfTypeString
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Form\RadioViewHelperTest::renderCorrectlySetsTagNameAndDefaultAttributes
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Form\RadioViewHelperTest::renderDoesNotAppendSquareBracketsToNameAttributeIfBoundToAPropertyOfTypeArray
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Form\RadioViewHelperTest::renderIgnoresBoundPropertyIfCheckedIsSet
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Form\RadioViewHelperTest::renderSetsCheckedAttributeIfSpecified
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Form\SelectViewHelperTest::allOptionsAreSelectedIfSelectAllIsTrue
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Form\SelectViewHelperTest::anEmptyOptionTagIsRenderedIfOptionsArrayIsEmptyToAssureXhtmlCompatibility
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Form\SelectViewHelperTest::multipleSelectCreatesExpectedOptions
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Form\SelectViewHelperTest::multipleSelectOnDomainObjectsCreatesExpectedOptions
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Form\SelectViewHelperTest::multipleSelectOnDomainObjectsCreatesExpectedOptionsWithoutOptionValueField
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Form\SelectViewHelperTest::optionsAreSortedByLabelIfSortByOptionLabelIsSet
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Form\SelectViewHelperTest::optionsContainPrependedItemWithCorrectValueIfPrependOptionLabelAndPrependOptionValueAreSet
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Form\SelectViewHelperTest::optionsContainPrependedItemWithEmptyValueIfPrependOptionLabelIsSet
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Form\SelectViewHelperTest::orderOfOptionsIsNotAlteredByDefault
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Form\SelectViewHelperTest::prependedOptionLabelIsTranslatedIfTranslateArgumentIsSet
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Form\SelectViewHelperTest::renderCallsSetErrorClassAttribute
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Form\SelectViewHelperTest::selectAllHasNoEffectIfValueIsSet
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Form\SelectViewHelperTest::selectCorrectlySetsTagName
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Form\SelectViewHelperTest::selectCreatesExpectedOptions
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Form\SelectViewHelperTest::selectOnDomainObjectsCreatesExpectedOptions
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Form\SelectViewHelperTest::selectOnDomainObjectsThrowsExceptionIfNoValueCanBeFound
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Form\SelectViewHelperTest::selectWithoutFurtherConfigurationOnDomainObjectsUsesToStringForLabelIfAvailable
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Form\SelectViewHelperTest::selectWithoutFurtherConfigurationOnDomainObjectsUsesUuidForValueAndLabel
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Form\SelectViewHelperTest::translateByIdAskForTranslationOfValueById
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Form\SelectViewHelperTest::translateByIdUsingLabelUsesLabel
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Form\SelectViewHelperTest::translateByLabelAskForTranslationOfLabelByLabel
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Form\SelectViewHelperTest::translateByLabelUsingValueUsesValue
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Form\SelectViewHelperTest::translateLabelIsCalledIfTranslateArgumentIsGiven
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Form\SelectViewHelperTest::translateOptionsAreObserved
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Form\SubmitViewHelperTest::renderCorrectlySetsTagNameAndDefaultAttributes
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Form\TextareaViewHelperTest::renderCallsSetErrorClassAttribute
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Form\TextareaViewHelperTest::renderCorrectlySetsNameAttributeAndContent
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Form\TextareaViewHelperTest::renderCorrectlySetsTagName
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Form\TextareaViewHelperTest::renderEscapesTextareaContent
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Form\TextfieldViewHelperTest::renderCallsSetErrorClassAttribute
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Form\TextfieldViewHelperTest::renderCorrectlySetsTagName
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Form\TextfieldViewHelperTest::renderCorrectlySetsTypeNameAndValueAttributes
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Form\UploadViewHelperTest::hiddenFieldsAreNotRenderedByDefault
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Form\UploadViewHelperTest::hiddenFieldsAreNotRenderedIfPropertyMappingErrorsOccurred
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Form\UploadViewHelperTest::hiddenFieldsContainDataOfAPreviouslyUploadedResource
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Form\UploadViewHelperTest::hiddenFieldsContainDataOfTheSpecifiedResource
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Form\UploadViewHelperTest::renderCallsSetErrorClassAttribute
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Form\UploadViewHelperTest::renderCorrectlySetsTagName
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Form\UploadViewHelperTest::renderCorrectlySetsTypeNameAndValueAttributes
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\BytesViewHelperTest::renderCorrectlyConvertsAValue with data set #0
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\BytesViewHelperTest::renderCorrectlyConvertsAValue with data set #1
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\BytesViewHelperTest::renderCorrectlyConvertsAValue with data set #2
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\BytesViewHelperTest::renderCorrectlyConvertsAValue with data set #3
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\BytesViewHelperTest::renderCorrectlyConvertsAValue with data set #4
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\BytesViewHelperTest::renderCorrectlyConvertsAValue with data set #5
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\BytesViewHelperTest::renderCorrectlyConvertsAValue with data set #6
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\BytesViewHelperTest::renderCorrectlyConvertsAValue with data set #7
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\BytesViewHelperTest::renderCorrectlyConvertsAValue with data set #8
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\BytesViewHelperTest::renderCorrectlyConvertsAValue with data set #9
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\BytesViewHelperTest::renderUsesChildNodesIfValueArgumentIsOmitted
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\CaseViewHelperTest::viewHelperConvertsCorrectly with data set #0
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\CaseViewHelperTest::viewHelperConvertsCorrectly with data set #1
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\CaseViewHelperTest::viewHelperConvertsCorrectly with data set #2
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\CaseViewHelperTest::viewHelperConvertsCorrectly with data set #3
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\CaseViewHelperTest::viewHelperConvertsCorrectly with data set #4
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\CaseViewHelperTest::viewHelperConvertsCorrectly with data set #5
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\CaseViewHelperTest::viewHelperConvertsCorrectly with data set #6
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\CaseViewHelperTest::viewHelperConvertsCorrectly with data set #7
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\CaseViewHelperTest::viewHelperConvertsCorrectly with data set #8
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\CaseViewHelperTest::viewHelperConvertsCorrectly with data set #9
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\CaseViewHelperTest::viewHelperConvertsUppercasePerDefault
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\CaseViewHelperTest::viewHelperDoesNotRenderChildrenIfGivenValueIsNotNull
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\CaseViewHelperTest::viewHelperRendersChildrenIfGivenValueIsNull
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\CaseViewHelperTest::viewHelperRestoresMbInternalEncodingAfterExceptionOccurred
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\CaseViewHelperTest::viewHelperRestoresMbInternalEncodingValueAfterInvocation
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\CaseViewHelperTest::viewHelperThrowsExceptionIfIncorrectModeIsGiven
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\CropViewHelperTest::viewHelperAppendsCustomSuffix
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\CropViewHelperTest::viewHelperAppendsEllipsisToTruncatedText
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\CropViewHelperTest::viewHelperAppendsSuffixEvenIfResultingTextIsLongerThanMaxCharacters
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\CropViewHelperTest::viewHelperDoesNotCropTextIfMaxCharactersIsLargerThanNumberOfCharacters
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\CropViewHelperTest::viewHelperDoesNotFallbackToRenderChildNodesIfEmptyValueArgumentIsProvided
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\CropViewHelperTest::viewHelperHandlesMultiByteValuesCorrectly
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\CropViewHelperTest::viewHelperUsesProvidedValueInsteadOfRenderingChildren
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\CurrencyViewHelperTest::viewHelperConvertsI18nExceptionsIntoViewHelperExceptions
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\CurrencyViewHelperTest::viewHelperFetchesCurrentLocaleViaI18nService
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\CurrencyViewHelperTest::viewHelperRendersCurrencySign
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\CurrencyViewHelperTest::viewHelperRendersNegativeAmounts
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\CurrencyViewHelperTest::viewHelperRendersNullValues
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\CurrencyViewHelperTest::viewHelperRespectsDecimalSeparator
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\CurrencyViewHelperTest::viewHelperRespectsThousandsSeparator
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\CurrencyViewHelperTest::viewHelperRoundsFloatCorrectly
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\CurrencyViewHelperTest::viewHelperThrowsExceptionIfLocaleIsUsedWithoutExplicitCurrencySign
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\CurrencyViewHelperTest::viewHelperUsesNumberFormatterOnGivenLocale
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\DateViewHelperTest::dateArgumentHasPriorityOverChildNodes
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\DateViewHelperTest::viewHelperCallsDateTimeFormatterWithCorrectlyBuiltConfigurationArguments
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\DateViewHelperTest::viewHelperCallsDateTimeFormatterWithCustomFormat
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\DateViewHelperTest::viewHelperConvertsI18nExceptionsIntoViewHelperExceptions
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\DateViewHelperTest::viewHelperFetchesCurrentLocaleViaI18nService
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\DateViewHelperTest::viewHelperFormatsDateCorrectly
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\DateViewHelperTest::viewHelperFormatsDateStringCorrectly
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\DateViewHelperTest::viewHelperRespectsCustomFormat
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\DateViewHelperTest::viewHelperReturnsEmptyStringIfNULLIsGiven
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\DateViewHelperTest::viewHelperThrowsExceptionIfDateStringCantBeParsed
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\DateViewHelperTest::viewHelperThrowsExceptionIfInvalidLocaleIdentifierIsGiven
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\DateViewHelperTest::viewHelperUsesChildNodesIfDateAttributeIsNotSpecified
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\HtmlentitiesDecodeViewHelperTest::renderDecodesObjectsToStrings
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\HtmlentitiesDecodeViewHelperTest::renderDecodesSimpleString
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\HtmlentitiesDecodeViewHelperTest::renderDoesNotModifySourceIfItIsAnObjectThatCantBeConvertedToAString
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\HtmlentitiesDecodeViewHelperTest::renderDoesNotModifyValueIfItDoesNotContainSpecialCharacters
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\HtmlentitiesDecodeViewHelperTest::renderRespectsEncodingArgument
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\HtmlentitiesDecodeViewHelperTest::renderRespectsKeepQuoteArgument
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\HtmlentitiesDecodeViewHelperTest::renderReturnsUnmodifiedSourceIfItIsANumber
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\HtmlentitiesDecodeViewHelperTest::renderUsesChildnodesAsSourceIfSpecified
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\HtmlentitiesDecodeViewHelperTest::renderUsesValueAsSourceIfSpecified
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\HtmlentitiesDecodeViewHelperTest::viewHelperDeactivatesEscapingInterceptor
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\HtmlentitiesViewHelperTest::renderConvertsAlreadyConvertedEntitiesByDefault
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\HtmlentitiesViewHelperTest::renderConvertsObjectsToStrings
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\HtmlentitiesViewHelperTest::renderDecodesSimpleString
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\HtmlentitiesViewHelperTest::renderDoesNotConvertAlreadyConvertedEntitiesIfDoubleQuoteIsFalse
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\HtmlentitiesViewHelperTest::renderDoesNotModifySourceIfItIsAnObjectThatCantBeConvertedToAString
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\HtmlentitiesViewHelperTest::renderDoesNotModifyValueIfItDoesNotContainSpecialCharacters
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\HtmlentitiesViewHelperTest::renderRespectsEncodingArgument
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\HtmlentitiesViewHelperTest::renderRespectsKeepQuoteArgument
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\HtmlentitiesViewHelperTest::renderReturnsUnmodifiedSourceIfItIsANumber
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\HtmlentitiesViewHelperTest::renderUsesChildnodesAsSourceIfSpecified
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\HtmlentitiesViewHelperTest::renderUsesValueAsSourceIfSpecified
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\HtmlentitiesViewHelperTest::viewHelperDeactivatesEscapingInterceptor
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\HtmlspecialcharsViewHelperTest::compileDoesNotModifySourceIfItIsAnObjectThatCantBeConvertedToAString
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\HtmlspecialcharsViewHelperTest::renderTestsWithRenderChildrenFallback with data set #0
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\HtmlspecialcharsViewHelperTest::renderTestsWithRenderChildrenFallback with data set #1
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\HtmlspecialcharsViewHelperTest::renderTestsWithRenderChildrenFallback with data set #2
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\HtmlspecialcharsViewHelperTest::renderTestsWithRenderChildrenFallback with data set #3
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\HtmlspecialcharsViewHelperTest::renderTestsWithRenderChildrenFallback with data set #4
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\HtmlspecialcharsViewHelperTest::renderTestsWithRenderChildrenFallback with data set #5
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\HtmlspecialcharsViewHelperTest::renderTestsWithRenderChildrenFallback with data set #6
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\HtmlspecialcharsViewHelperTest::renderTestsWithRenderChildrenFallback with data set #7
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\HtmlspecialcharsViewHelperTest::renderTestsWithRenderChildrenFallback with data set #8
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\HtmlspecialcharsViewHelperTest::renderUsesValueAsSourceIfSpecified
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\HtmlspecialcharsViewHelperTest::viewHelperDeactivatesEscapingInterceptor
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\IdentifierViewHelperTest::renderGetsIdentifierForObjectFromPersistenceManager
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\IdentifierViewHelperTest::renderReturnsNullIfGivenValueIsNull
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\IdentifierViewHelperTest::renderThrowsExceptionIfGivenValueIsNoObject
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\IdentifierViewHelperTest::renderWithoutValueInvokesRenderChildren
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\JsonViewHelperTest::viewHelperConvertsSimpleAssociativeArrayGivenAsChildren
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\JsonViewHelperTest::viewHelperConvertsSimpleAssociativeArrayGivenAsDataArgument
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\JsonViewHelperTest::viewHelperEscapesGreaterThanLowerThanCharacters
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\JsonViewHelperTest::viewHelperOutputsArrayOnIndexedArrayInputAndObjectIfSetSo
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\Nl2brViewHelperTest::viewHelperConvertsLineBreaksToBRTags
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\Nl2brViewHelperTest::viewHelperConvertsWindowsLineBreaksToBRTags
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\Nl2brViewHelperTest::viewHelperDoesNotModifyTextWithoutLineBreaks
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\NumberViewHelperTest::formatNumberDefaultsToEnglishNotationWithTwoDecimals
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\NumberViewHelperTest::formatNumberWithDecimalsDecimalPointAndSeparator
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\NumberViewHelperTest::viewHelperConvertsI18nExceptionsIntoViewHelperExceptions
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\NumberViewHelperTest::viewHelperFetchesCurrentLocaleViaI18nService
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\NumberViewHelperTest::viewHelperUsesNumberFormatterOnGivenLocale
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\PaddingViewHelperTest::integersArePaddedCorrectly
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\PaddingViewHelperTest::paddingStringCanBeSpecified
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\PaddingViewHelperTest::stringIsNotTruncatedIfPadLengthIsBelowStringLength
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\PaddingViewHelperTest::stringsArePaddedWithBlanksByDefault
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\PrintfViewHelperTest::viewHelperCanSwapMultipleArguments
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\PrintfViewHelperTest::viewHelperCanUseArrayAsArgument
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\RawViewHelperTest::renderReturnsUnmodifiedChildNodesIfNoValueIsSpecified
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\RawViewHelperTest::renderReturnsUnmodifiedValueIfSpecified
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\RawViewHelperTest::viewHelperDeactivatesEscapingInterceptor
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\StripTagsViewHelperTest::renderConvertsObjectsToStrings
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\StripTagsViewHelperTest::renderCorrectlyConvertsIntoPlaintext with data set #0
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\StripTagsViewHelperTest::renderCorrectlyConvertsIntoPlaintext with data set #1
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\StripTagsViewHelperTest::renderCorrectlyConvertsIntoPlaintext with data set #2
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\StripTagsViewHelperTest::renderDoesNotModifySourceIfItIsAnObjectThatCantBeConvertedToAString
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\StripTagsViewHelperTest::renderReturnsUnmodifiedSourceIfItIsANumber
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\StripTagsViewHelperTest::renderUsesChildnodesAsSourceIfSpecified
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\StripTagsViewHelperTest::renderUsesValueAsSourceIfSpecified
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\StripTagsViewHelperTest::viewHelperDeactivatesEscapingInterceptor
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\UrlencodeViewHelperTest::renderDoesNotModifyValueIfItDoesNotContainSpecialCharacters
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\UrlencodeViewHelperTest::renderEncodesString
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\UrlencodeViewHelperTest::renderRendersObjectWithToStringMethod
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\UrlencodeViewHelperTest::renderThrowsExceptionIfItIsNoStringAndHasNoToStringMethod
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\UrlencodeViewHelperTest::renderUsesChildnodesAsSourceIfSpecified
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\UrlencodeViewHelperTest::renderUsesValueAsSourceIfSpecified
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Format\UrlencodeViewHelperTest::viewHelperDeactivatesEscapingInterceptor
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\GroupedForViewHelperTest::groupingByAKeyThatDoesNotExistCreatesASingleGroup
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\GroupedForViewHelperTest::renderGroupsArrayOfObjectsAndPreservesKeys
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\GroupedForViewHelperTest::renderGroupsMultidimensionalArrayAndPreservesKeys
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\GroupedForViewHelperTest::renderGroupsMultidimensionalArrayByObjectKey
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\GroupedForViewHelperTest::renderGroupsMultidimensionalArrayByPropertyPath
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\GroupedForViewHelperTest::renderGroupsMultidimensionalArrayObjectAndPreservesKeys
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\GroupedForViewHelperTest::renderGroupsMultidimensionalObjectByDateTimeObject
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\GroupedForViewHelperTest::renderGroupsMultidimensionalObjectByObjectKey
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\GroupedForViewHelperTest::renderReturnsEmptyStringIfObjectIsEmptyArray
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\GroupedForViewHelperTest::renderReturnsEmptyStringIfObjectIsNull
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\GroupedForViewHelperTest::renderThrowsExceptionWhenPassingObjectsToEachThatAreNotTraversable
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\GroupedForViewHelperTest::renderThrowsExceptionWhenPassingOneDimensionalArraysToEach
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\IfViewHelperTest::viewHelperRendersElseChildIfConditionIsFalse
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\IfViewHelperTest::viewHelperRendersThenChildIfConditionIsTrue
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Link\ActionViewHelperTest::renderCorrectlyPassesAllArgumentsToUriBuilder
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Link\ActionViewHelperTest::renderCorrectlyPassesDefaultArgumentsToUriBuilder
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Link\ActionViewHelperTest::renderCorrectlySetsTagNameAndAttributesAndContent
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Link\ActionViewHelperTest::renderCreatesAbsoluteUrisByDefault
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Link\ActionViewHelperTest::renderCreatesRelativeUrisIfAbsoluteIsFalse
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Link\ActionViewHelperTest::renderThrowsExceptionIfUseParentRequestIsSetAndTheCurrentRequestHasNoParentRequest
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Link\ActionViewHelperTest::renderThrowsViewHelperExceptionIfUriBuilderThrowsFlowException
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Link\ActionViewHelperTest::renderUsesParentRequestIfUseParentRequestIsSet
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Link\EmailViewHelperTest::renderCorrectlySetsTagNameAndAttributesAndContent
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Link\EmailViewHelperTest::renderSetsTagContentToEmailIfRenderChildrenReturnNull
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Link\ExternalViewHelperTest::renderAddsHttpPrefixIfSpecifiedUriDoesNotContainScheme
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Link\ExternalViewHelperTest::renderAddsSpecifiedSchemeIfUriDoesNotContainScheme
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Link\ExternalViewHelperTest::renderCorrectlySetsTagNameAndAttributesAndContent
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Link\ExternalViewHelperTest::renderDoesNotAddEmptyScheme
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\RenderChildrenViewHelperTest::renderCallsEvaluateOnTheRootNodeAndRegistersTheArguments
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\RenderChildrenViewHelperTest::renderThrowsExceptionIfTheChildNodeRenderingContextIsNotThere
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\RenderChildrenViewHelperTest::renderThrowsExceptionIfTheRequestIsNotAWidgetRequest
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\RenderViewHelperTest::loadSettingsIntoArgumentsDoesNotOverrideGivenSettings
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\RenderViewHelperTest::loadSettingsIntoArgumentsDoesNotThrowExceptionIfSettingsAreNotInTemplateVariableContainer
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\RenderViewHelperTest::loadSettingsIntoArgumentsSetsSettingsIfNoSettingsAreSpecified
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\SectionViewHelperTest::sectionIsAddedToParseVariableContainer
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Security\CsrfTokenViewHelperTest::viewHelperRendersTheCsrfTokenReturnedFromTheSecurityContext
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Security\IfAccessViewHelperTest::viewHelperRendersElseIfHasAccessToPrivilegeTargetReturnsFalse
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Security\IfAccessViewHelperTest::viewHelperRendersThenIfHasAccessToPrivilegeTargetReturnsTrue
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Security\IfHasErrorsViewHelperTest::queriesResultForPropertyIfPropertyPathIsGiven
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Security\IfHasErrorsViewHelperTest::returnsAndRendersElseChildIfNoValidationResultsArePresentAtAll
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Security\IfHasErrorsViewHelperTest::returnsAndRendersThenChildIfResultsHaveErrors
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Security\IfHasRoleViewHelperTest::viewHelperHandlesPackageKeyAttributeCorrectly
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Security\IfHasRoleViewHelperTest::viewHelperRendersThenPartIfHasRoleReturnsTrue
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Security\IfHasRoleViewHelperTest::viewHelperUsesSpecifiedAccountForCheck
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\SwitchViewHelperTest::renderRemovesSwitchExpressionFromViewHelperVariableContainerAfterInvocation
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\SwitchViewHelperTest::renderSetsSwitchExpressionInViewHelperVariableContainer
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\ThenViewHelperTest::renderRendersChildren
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\TranslateViewHelperTest::renderThrowsExceptionIfGivenLocaleIdentifierIsInvalid
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\TranslateViewHelperTest::renderThrowsExceptionIfNoPackageCouldBeResolved
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\TranslateViewHelperTest::viewHelperReturnsIdWhenRenderChildrenReturnsEmptyResultIfIdIsNotFound
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\TranslateViewHelperTest::viewHelperTranslatesById
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\TranslateViewHelperTest::viewHelperTranslatesByOriginalLabel
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\TranslateViewHelperTest::viewHelperUsesRenderChildrenIfIdIsNotFound
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\TranslateViewHelperTest::viewHelperUsesValueIfIdIsNotFound
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Uri\ActionViewHelperTest::renderCorrectlyPassesAllArgumentsToUriBuilder
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Uri\ActionViewHelperTest::renderCorrectlyPassesDefaultArgumentsToUriBuilder
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Uri\ActionViewHelperTest::renderReturnsUriReturnedFromUriBuilder
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Uri\ActionViewHelperTest::renderThrowsExceptionIfUseParentRequestIsSetAndTheCurrentRequestHasNoParentRequest
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Uri\ActionViewHelperTest::renderThrowsViewHelperExceptionIfUriBuilderThrowsFlowException
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Uri\ActionViewHelperTest::renderUsesParentRequestIfUseParentRequestIsSet
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Uri\EmailViewHelperTest::renderPrependsEmailWithMailto
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Uri\ExternalViewHelperTest::renderAddsHttpPrefixIfSpecifiedUriDoesNotContainScheme
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Uri\ExternalViewHelperTest::renderAddsSpecifiedSchemeIfUriDoesNotContainScheme
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Uri\ExternalViewHelperTest::renderDoesNotAddEmptyScheme
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Uri\ExternalViewHelperTest::renderReturnsSpecifiedUri
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Uri\ResourceViewHelperTest::renderCreatesASpecialBrokenResourceUriIfTheResourceCouldNotBePublished
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Uri\ResourceViewHelperTest::renderLocalizesResource
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Uri\ResourceViewHelperTest::renderLocalizesResourceGivenAsResourceUri
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Uri\ResourceViewHelperTest::renderSkipsLocalizationForResourcesGivenAsResourceUriIfRequested
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Uri\ResourceViewHelperTest::renderSkipsLocalizationIfRequested
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Uri\ResourceViewHelperTest::renderThrowsExceptionIfNeitherResourceNorPathWereGiven
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Uri\ResourceViewHelperTest::renderThrowsExceptionIfResourceUriNotPointingToPublicWasGivenAsPath
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Uri\ResourceViewHelperTest::renderUsesCurrentControllerPackageKeyToBuildTheResourceUri
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Uri\ResourceViewHelperTest::renderUsesCustomPackageKeyIfSpecified
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Uri\ResourceViewHelperTest::renderUsesProvidedResourceObjectInsteadOfPackageAndPath
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Validation\ResultsViewHelperTest::renderAddsValidationResultsForOnePropertyIfForArgumentIsNotEmpty
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Validation\ResultsViewHelperTest::renderAddsValidationResultsToTemplateVariableContainer
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Validation\ResultsViewHelperTest::renderAddsValidationResultsToTemplateVariableContainerWithCustomVariableNameIfSpecified
+.
+TYPO3\Fluid\Tests\Unit\ViewHelpers\Validation\ResultsViewHelperTest::renderOutputsChildNodesByDefault
+.
+TYPO3\Fluid\Tests\Unit\View\AbstractTemplateViewTest::assignAddsValueToTemplateVariableContainer
+.
+TYPO3\Fluid\Tests\Unit\View\AbstractTemplateViewTest::assignCanOverridePreviouslyAssignedValues
+.
+TYPO3\Fluid\Tests\Unit\View\AbstractTemplateViewTest::assignMultipleAddsValuesToTemplateVariableContainer
+.
+TYPO3\Fluid\Tests\Unit\View\AbstractTemplateViewTest::assignMultipleCanOverridePreviouslyAssignedValues
+.
+TYPO3\Fluid\Tests\Unit\View\AbstractTemplateViewTest::viewIsPlacedInViewHelperVariableContainer
+.
+TYPO3\Fluid\Tests\Unit\View\StandaloneViewTest::getLayoutPathAndFilenameThrowsExceptionIfLayoutFileIsADirectory
+.
+TYPO3\Fluid\Tests\Unit\View\StandaloneViewTest::getLayoutPathAndFilenameThrowsExceptionIfSpecifiedLayoutRootPathIsNoDirectory
+.
+TYPO3\Fluid\Tests\Unit\View\StandaloneViewTest::getPartialPathAndFilenameThrowsExceptionIfPartialFileIsADirectory
+.
+TYPO3\Fluid\Tests\Unit\View\StandaloneViewTest::getPartialPathAndFilenameThrowsExceptionIfSpecifiedPartialRootPathIsNoDirectory
+.
+TYPO3\Fluid\Tests\Unit\View\StandaloneViewTest::getTemplateSourceThrowsExceptionIfSpecifiedTemplatePathAndFilenameDoesNotExist
+.
+TYPO3\Fluid\Tests\Unit\View\StandaloneViewTest::getTemplateSourceThrowsExceptionIfSpecifiedTemplatePathAndFilenamePointsToADirectory
+.
+TYPO3\Fluid\Tests\Unit\View\TemplateViewTest::expandGenericPathPatternTests with data set #0
+.
+TYPO3\Fluid\Tests\Unit\View\TemplateViewTest::expandGenericPathPatternTests with data set #1
+.
+TYPO3\Fluid\Tests\Unit\View\TemplateViewTest::expandGenericPathPatternTests with data set #10
+.
+TYPO3\Fluid\Tests\Unit\View\TemplateViewTest::expandGenericPathPatternTests with data set #11
+.
+TYPO3\Fluid\Tests\Unit\View\TemplateViewTest::expandGenericPathPatternTests with data set #12
+.
+TYPO3\Fluid\Tests\Unit\View\TemplateViewTest::expandGenericPathPatternTests with data set #13
+.
+TYPO3\Fluid\Tests\Unit\View\TemplateViewTest::expandGenericPathPatternTests with data set #14
+.
+TYPO3\Fluid\Tests\Unit\View\TemplateViewTest::expandGenericPathPatternTests with data set #15
+.
+TYPO3\Fluid\Tests\Unit\View\TemplateViewTest::expandGenericPathPatternTests with data set #2
+.
+TYPO3\Fluid\Tests\Unit\View\TemplateViewTest::expandGenericPathPatternTests with data set #3
+.
+TYPO3\Fluid\Tests\Unit\View\TemplateViewTest::expandGenericPathPatternTests with data set #4
+.
+TYPO3\Fluid\Tests\Unit\View\TemplateViewTest::expandGenericPathPatternTests with data set #5
+.
+TYPO3\Fluid\Tests\Unit\View\TemplateViewTest::expandGenericPathPatternTests with data set #6
+.
+TYPO3\Fluid\Tests\Unit\View\TemplateViewTest::expandGenericPathPatternTests with data set #7
+.
+TYPO3\Fluid\Tests\Unit\View\TemplateViewTest::expandGenericPathPatternTests with data set #8
+.
+TYPO3\Fluid\Tests\Unit\View\TemplateViewTest::expandGenericPathPatternTests with data set #9
+.
+TYPO3\Fluid\Tests\Unit\View\TemplateViewTest::expandGenericPathPatternWorksWithBubblingDisabledAndFormatNotOptional
+.
+TYPO3\Fluid\Tests\Unit\View\TemplateViewTest::expandGenericPathPatternWorksWithSubpackageAndBubblingDisabledAndFormatNotOptional
+.
+TYPO3\Fluid\Tests\Unit\View\TemplateViewTest::expandGenericPathPatternWorksWithSubpackageAndBubblingDisabledAndFormatOptional
+.
+TYPO3\Fluid\Tests\Unit\View\TemplateViewTest::expandGenericPathPatternWorksWithSubpackageAndBubblingEnabledAndFormatOptional
+.
+TYPO3\Fluid\Tests\Unit\View\TemplateViewTest::getLayoutPathAndFilenameThrowsExceptionIfNoPathCanBeResolved
+.
+TYPO3\Fluid\Tests\Unit\View\TemplateViewTest::getLayoutPathAndFilenameThrowsExceptionIfResolvedPathPointsToADirectory
+.
+TYPO3\Fluid\Tests\Unit\View\TemplateViewTest::getLayoutRootPathsReturnsUserSpecifiedPartialPaths
+.
+TYPO3\Fluid\Tests\Unit\View\TemplateViewTest::getPartialPathAndFilenameThrowsExceptionIfNoPathCanBeResolved
+.
+TYPO3\Fluid\Tests\Unit\View\TemplateViewTest::getPartialPathAndFilenameThrowsExceptionIfResolvedPathPointsToADirectory
+.
+TYPO3\Fluid\Tests\Unit\View\TemplateViewTest::getPartialRootPathsReturnsUserSpecifiedPartialPath
+.
+TYPO3\Fluid\Tests\Unit\View\TemplateViewTest::getTemplatePathAndFilenameThrowsExceptionIfNoPathCanBeResolved
+.
+TYPO3\Fluid\Tests\Unit\View\TemplateViewTest::getTemplatePathAndFilenameThrowsExceptionIfResolvedPathPointsToADirectory
+.
+TYPO3\Fluid\Tests\Unit\View\TemplateViewTest::getTemplateRootPathsReturnsUserSpecifiedTemplatePaths
+.
+TYPO3\Fluid\Tests\Unit\View\TemplateViewTest::getTemplateSourceChecksDifferentPathPatternsAndReturnsTheFirstPathWhichExists
+.
+TYPO3\Fluid\Tests\Unit\View\TemplateViewTest::pathToPartialIsResolvedCorrectly
+.
+TYPO3\Fluid\Tests\Unit\View\TemplateViewTest::resolveTemplatePathAndFilenameReturnsTheExplicitlyConfiguredTemplatePathAndFilename
+.
+TYPO3\Fluid\ViewHelpers\Form\PasswordViewHelperTest::renderCallsSetErrorClassAttribute
+.
+TYPO3\Fluid\ViewHelpers\Form\PasswordViewHelperTest::renderCorrectlySetsTagName
+.
+TYPO3\Fluid\ViewHelpers\Form\PasswordViewHelperTest::renderCorrectlySetsTypeNameAndValueAttributes
+.
+TYPO3\Kickstart\Tests\Unit\Service\GeneratorServiceTest::normalizeFieldDefinitionsConvertsBoolTypeToBoolean
+.
+TYPO3\Kickstart\Tests\Unit\Service\GeneratorServiceTest::normalizeFieldDefinitionsPrefixesGlobalClassesWithBackslash
+.
+TYPO3\Kickstart\Tests\Unit\Service\GeneratorServiceTest::normalizeFieldDefinitionsPrefixesLocalTypesWithNamespaceIfNeeded
+.
+TYPO3\Kickstart\Tests\Unit\Utility\InflectorTest::humanizeCamelCaseConvertsCamelCaseToSpacesAndUppercasesFirstWord
+.
+TYPO3\Kickstart\Tests\Unit\Utility\InflectorTest::pluralizePluralizesWords
+.


### PR DESCRIPTION
Add class override for Flow framework
Use phpUnit shipped with the framework (v 4.5)
Use branch 3.0 of Flow, which contains HHVM fixes already

Resolves: https://github.com/facebook/hhvm/issues/3007