### PR TITLE
Automatic identification charset

### DIFF
--- a/hphp/runtime/base/runtime-option.cpp
+++ b/hphp/runtime/base/runtime-option.cpp
@@ -203,7 +203,7 @@ std::string RuntimeOption::Rfc1867Name = "video_ptoken";
 bool RuntimeOption::LibEventSyncSend = true;
 bool RuntimeOption::ExpiresActive = true;
 int RuntimeOption::ExpiresDefault = 2592000;
-std::string RuntimeOption::DefaultCharsetName = "utf-8";
+std::string RuntimeOption::DefaultCharsetName = "";
 bool RuntimeOption::ForceServerNameToHeader = false;
 bool RuntimeOption::EnableCufAsync = false;
 bool RuntimeOption::PathDebug = false;
@@ -1153,7 +1153,7 @@ void RuntimeOption::Load(IniSetting::Map& ini, Hdf& config,
     Config::Bind(ExpiresDefault, ini, server["ExpiresDefault"], 2592000);
     if (ExpiresDefault < 0) ExpiresDefault = 2592000;
     Config::Bind(DefaultCharsetName, ini, server["DefaultCharsetName"],
-                 "utf-8");
+                 "");
 
     Config::Bind(RequestBodyReadLimit, ini, server["RequestBodyReadLimit"], -1);
 

--- a/hphp/runtime/server/transport.cpp
+++ b/hphp/runtime/server/transport.cpp
@@ -724,8 +724,10 @@ void Transport::prepareHeaders(bool compressed, bool chunked,
 
   if (m_responseHeaders.find("Content-Type") == m_responseHeaders.end() &&
       m_responseCode != 304) {
-    std::string contentType = "text/html; charset="
-                              + IniSetting::Get("default_charset");
+    std::string contentType = "text/html";
+    if (IniSetting::Get("default_charset") != "") {
+      contentType += "; charset=" + IniSetting::Get("default_charset");
+    }
     addHeaderImpl("Content-Type", contentType.c_str());
   }
 


### PR DESCRIPTION
The default is utf-8 charsetName now,but php exists multiple character sets  Unable to automatically identify in HHVM,so default charset name is empty,let HHVM follow up PHP file charset automatic identification charset