### PR TITLE
[HHVM 3.6] Raise a cmake error if MySQL socket path can't be identified

### DIFF
--- a/CMake/HPHPFindLibs.cmake
+++ b/CMake/HPHPFindLibs.cmake
@@ -82,7 +82,9 @@ endif()
 MYSQL_SOCKET_SEARCH()
 if (MYSQL_UNIX_SOCK_ADDR)
   add_definitions(-DPHP_MYSQL_UNIX_SOCK_ADDR="${MYSQL_UNIX_SOCK_ADDR}")
-endif()
+else ()
+  message(FATAL_ERROR "Could not find MySQL socket path - if you install a MySQL server, this should be automatically detected. Alternatively, specify -DMYSQL_UNIX_SOCK_ADDR=/path/to/mysql.socket ; if you don't care about unix socket support for MySQL, specify -DMYSQL_UNIX_SOCK_ADDR=/dev/null")
+endif ()
 
 # libmemcached checks
 find_package(Libmemcached REQUIRED)


### PR DESCRIPTION
Cherry pick version of #5005

Tested by:
 1. deleted CMakeCache.txt, re-ran cmake with mysql-server installed, worked
 2. deleted CMakeCache.txt, removed mysql-server. Re-ran cmake, failed
 3. deleted CMakeCache.txt, specified -DMYSQL_UNIX_SOCK_ADDR=/var/run/mysqld/mysqld.sock, worked

Tested at runtime too for 1 and 3:

```
hphpd> mysql_connect('localhost')
mysql_connect('localhost')

Warning: mysql_connect(): Can't connect to local MySQL server through socket '/var/run/mysqld/mysqld.sock' (2)
```

refs facebook/hhvm#5002