### PR TITLE
When XDebug is enabled, always print PHP stacktraces on errors

### DIFF
--- a/hphp/runtime/base/backtrace.cpp
+++ b/hphp/runtime/base/backtrace.cpp
@@ -18,6 +18,7 @@
 #include "hphp/runtime/base/array-init.h"
 #include "hphp/runtime/base/class-info.h"
 #include "hphp/runtime/base/execution-context.h"
+#include "hphp/runtime/base/rds-header.h"
 #include "hphp/runtime/vm/bytecode.h"
 #include "hphp/runtime/vm/func.h"
 #include "hphp/runtime/vm/runtime.h"
@@ -85,7 +86,7 @@ Array createBacktrace(const BacktraceArgs& btArgs) {
 
   VMRegAnchor _;
   // If there are no VM frames, we're done.
-  if (!vmfp()) return bt;
+  if (!rds::header() || !vmfp()) return bt;
 
   int depth = 0;
   ActRec* fp = nullptr;

--- a/hphp/runtime/base/runtime-option.cpp
+++ b/hphp/runtime/base/runtime-option.cpp
@@ -774,6 +774,10 @@ void RuntimeOption::Load(IniSetting::Map& ini, Hdf& config,
     ));
 
     Config::Bind(Logger::LogHeader, ini, logger["Header"]);
+    if (Config::GetBool(ini, logger["AlwaysPrintStackTraces"])) {
+      Logger::SetTheLogger(new ExtendedLogger());
+      ExtendedLogger::EnabledByDefault = true;
+    }
     Config::Bind(Logger::LogNativeStackTrace, ini, logger["NativeStackTrace"],
                  true);
     Config::Bind(Logger::MaxMessagesPerRequest, ini,

--- a/hphp/runtime/ext/xdebug/ext_xdebug.cpp
+++ b/hphp/runtime/ext/xdebug/ext_xdebug.cpp
@@ -21,6 +21,7 @@
 #include "hphp/runtime/base/backtrace.h"
 #include "hphp/runtime/base/code-coverage.h"
 #include "hphp/runtime/base/execution-context.h"
+#include "hphp/runtime/base/extended-logger.h"
 #include "hphp/runtime/base/externals.h"
 #include "hphp/runtime/base/string-util.h"
 #include "hphp/runtime/base/thread-info.h"
@@ -30,6 +31,7 @@
 #include "hphp/runtime/ext/xdebug/xdebug_server.h"
 #include "hphp/runtime/vm/unwind.h"
 #include "hphp/runtime/vm/vm-regs.h"
+#include "hphp/util/logger.h"
 #include "hphp/util/timer.h"
 
 // TODO(#3704) Remove when xdebug fully implemented
@@ -771,6 +773,11 @@ void XDebugExtension::moduleInit() {
   if (!Enable) {
     return;
   }
+
+  // Stacktraces are always on when XDebug is enabled
+  Logger::SetTheLogger(new ExtendedLogger());
+  ExtendedLogger::EnabledByDefault = true;
+
   Native::registerConstant<KindOfInt64>(
     s_XDEBUG_CC_UNUSED.get(), k_XDEBUG_CC_UNUSED
   );

--- a/hphp/test/slow/ext_xdebug/code_coverage_dead.php.expectf
+++ b/hphp/test/slow/ext_xdebug/code_coverage_dead.php.expectf
@@ -1,1 +1,2 @@
 Fatal error: XDEBUG_CC_UNUSED and XDEBUG_CC_DEAD_CODE constants are not currently supported. in %s/test/slow/ext_xdebug/code_coverage_dead.php on line 2
+%w#0 xdebug_start_code_coverage(), called at [%s/hphp/test/slow/ext_xdebug/code_coverage_dead.php:2]

--- a/hphp/test/slow/ext_xdebug/code_coverage_unused.php.expectf
+++ b/hphp/test/slow/ext_xdebug/code_coverage_unused.php.expectf
@@ -1,1 +1,2 @@
 Fatal error: XDEBUG_CC_UNUSED and XDEBUG_CC_DEAD_CODE constants are not currently supported. in %s/test/slow/ext_xdebug/code_coverage_unused.php on line 2
+%w#0 xdebug_start_code_coverage(), called at [%shhvm/hphp/test/slow/ext_xdebug/code_coverage_unused.php:2]

--- a/hphp/test/slow/ext_xdebug/code_coverage_unused.php.expectf
+++ b/hphp/test/slow/ext_xdebug/code_coverage_unused.php.expectf
@@ -1,2 +1,2 @@
 Fatal error: XDEBUG_CC_UNUSED and XDEBUG_CC_DEAD_CODE constants are not currently supported. in %s/test/slow/ext_xdebug/code_coverage_unused.php on line 2
-%w#0 xdebug_start_code_coverage(), called at [%shhvm/hphp/test/slow/ext_xdebug/code_coverage_unused.php:2]
+%w#0 xdebug_start_code_coverage(), called at [%shphp/test/slow/ext_xdebug/code_coverage_unused.php:2]

--- a/hphp/test/slow/ext_xdebug/force_error_reporting.php.expectf
+++ b/hphp/test/slow/ext_xdebug/force_error_reporting.php.expectf
@@ -1,1 +1,2 @@
 Notice: This should show up in %s/test/slow/ext_xdebug/force_error_reporting.php on line 5
+%w#0 at [%s/hphp/test/slow/ext_xdebug/force_error_reporting.php:5]

--- a/hphp/test/slow/ext_xdebug/halt_level.php.expectf
+++ b/hphp/test/slow/ext_xdebug/halt_level.php.expectf
@@ -1,7 +1,11 @@
 Notice: Test notice in %s/test/slow/ext_xdebug/halt_level.php on line 3
+%w#0 at [%s/hphp/test/slow/ext_xdebug/halt_level.php:3]
 
 Deprecated: Test deprecated in %s/test/slow/ext_xdebug/halt_level.php on line 4
+%w#0 at [%s/hphp/test/slow/ext_xdebug/halt_level.php:4]
 
 Deprecated: Test deprecated in %s/test/slow/ext_xdebug/halt_level.php on line 6
+%w#0 at [%s/hphp/test/slow/ext_xdebug/halt_level.php:6]
 
 Fatal error: Test notice in %s/test/slow/ext_xdebug/halt_level.php on line 7
+%w#0 at [%s/hphp/test/slow/ext_xdebug/halt_level.php:7]

--- a/hphp/test/slow/ext_xdebug/max_nesting_level_0.php.expectf
+++ b/hphp/test/slow/ext_xdebug/max_nesting_level_0.php.expectf
@@ -3,3 +3,4 @@
 3
 
 Fatal error: Maximum function nesting level of '4' reached, aborting! in %s/test/slow/ext_xdebug/max_nesting_level_0.php on line 4
+%w#0 at [%s/hphp/test/slow/ext_xdebug/max_nesting_level_0.php:4]\n%w#1 foo(), called at [%s/hphp/test/slow/ext_xdebug/max_nesting_level_0.php:5]\n%w#2 foo(), called at [%s/hphp/test/slow/ext_xdebug/max_nesting_level_0.php:5]\n%w#3 foo(), called at [%s/hphp/test/slow/ext_xdebug/max_nesting_level_0.php:11]

--- a/hphp/test/slow/ext_xdebug/scream.php.expectf
+++ b/hphp/test/slow/ext_xdebug/scream.php.expectf
@@ -1,1 +1,3 @@
 Warning: Test warning in %s/test/slow/ext_xdebug/scream.php on line 6
+%w#0 foo(), called at [%s/hphp/test/slow/ext_xdebug/scream.php:9]
+%w#0 at [%s/hphp/test/slow/ext_xdebug/scream.php:6]\n%w#1 foo(), called at [%s/hphp/test/slow/ext_xdebug/scream.php:9]


### PR DESCRIPTION
This commit addresses #4186 by always enabling PHP stacktraces
on errors when the XDebug extension is enabled, as in Zend PHP.
This diff also adds in a hdf option Log { AlwaysPrintStackTraces }
which also enables stack traces for errors, for those who don't
want to use XDebug but still want stacktraces.