### PR TITLE
Convert T_HASHBANG to T_INLINE_HTML for token_get_all

### DIFF
--- a/hphp/runtime/ext/std/ext_std_misc.cpp
+++ b/hphp/runtime/ext/std/ext_std_misc.cpp
@@ -627,10 +627,8 @@ const int UserTokenId_T_ONUMBER = 431;
 const int UserTokenId_T_POW = 432;
 const int UserTokenId_T_POW_EQUAL = 433;
 const int UserTokenId_T_NULLSAFE_OBJECT_OPERATOR = 434;
-// Map T_HASHBANG to T_INLINE_HTML for Zend compatibility
-const int UserTokenId_T_HASHBANG = UserTokenId_T_INLINE_HTML;
-// Marker, not a real user token ID
-const int MaxUserTokenId = 436;
+const int UserTokenId_T_HASHBANG = 435;
+const int MaxUserTokenId = 436; // Marker, not a real user token ID
 
 #undef YYTOKENTYPE
 #undef YYTOKEN_MAP
@@ -666,43 +664,54 @@ loop_start: // For after seeing a T_INLINE_HTML, see below
       res.append(String::FromChar((char)tokid));
     } else {
       String value;
-      const int tokVal = get_user_token_id(tokid);
-      if (tokVal == UserTokenId_T_XHP_LABEL) {
-        value = String(":" + tok.text());
-      } else if (tokVal == UserTokenId_T_XHP_CATEGORY_LABEL) {
-        value = String("%" + tok.text());
-      } else if (tokVal == UserTokenId_T_INLINE_HTML) {
-        // Consecutive T_INLINE_HTML tokens should be merged together to
-        // match Zend behaviour.
-        value = String(tok.text());
-        int line = loc.line0;
-        tokid = scanner.getNextToken(tok, loc);
-        while (tokid == T_INLINE_HTML) {
+      int tokVal = get_user_token_id(tokid);
+      switch (tokVal) {
+        case UserTokenId_T_XHP_LABEL:
+          value = String(":" + tok.text());
+          break;
+        case UserTokenId_T_XHP_CATEGORY_LABEL:
+          value = String("%" + tok.text());
+          break;
+        case UserTokenId_T_HASHBANG:
+          // Convert T_HASHBANG to T_INLINE_HTML for Zend compatibility
+          tokVal = UserTokenId_T_INLINE_HTML;
+          // Fall through to merge it with following T_INLINE_HTML tokens
+        case UserTokenId_T_INLINE_HTML:
+        {
+          // Consecutive T_INLINE_HTML tokens should be merged together to
+          // match Zend behaviour.
+          value = String(tok.text());
+          int line = loc.line0;
+          tokid = scanner.getNextToken(tok, loc);
+          while (tokid == T_INLINE_HTML) {
             value += String(tok.text());
             tokid = scanner.getNextToken(tok, loc);
-        }
-        Array p = make_packed_array(
-          tokVal,
-          value,
-          line
-        );
-        res.append(p);
+          }
+          Array p = make_packed_array(
+            tokVal,
+            value,
+            line
+          );
+          res.append(p);
 
-        if (tokid) {
+          if (tokid) {
             // We have a new token to deal with, jump to the beginning
             // of the loop, but don't fetch the next token, hence the
             // goto.
             goto loop_start;
-        } else {
+          } else {
             // Break out otherwise we end up appending an empty token to
             // the end of the array
-            break;
+            return res;
+          }
+          break;
         }
-      } else {
-        value = String(tok.text());
+        default:
+          value = String(tok.text());
+          break;
       }
+
       Array p = make_packed_array(
-        // Convert the internal token ID to a user token ID
         tokVal,
         value,
         loc.line0

--- a/hphp/runtime/ext/std/ext_std_misc.cpp
+++ b/hphp/runtime/ext/std/ext_std_misc.cpp
@@ -627,8 +627,10 @@ const int UserTokenId_T_ONUMBER = 431;
 const int UserTokenId_T_POW = 432;
 const int UserTokenId_T_POW_EQUAL = 433;
 const int UserTokenId_T_NULLSAFE_OBJECT_OPERATOR = 434;
-const int UserTokenId_T_HASHBANG = 435;
-const int MaxUserTokenId = 436; // Marker, not a real user token ID
+// Map T_HASHBANG to T_INLINE_HTML for Zend compatibility
+const int UserTokenId_T_HASHBANG = UserTokenId_T_INLINE_HTML;
+// Marker, not a real user token ID
+const int MaxUserTokenId = 436;
 
 #undef YYTOKENTYPE
 #undef YYTOKEN_MAP

--- a/hphp/test/slow/ext_misc/token_get_all_hashbang.php
+++ b/hphp/test/slow/ext_misc/token_get_all_hashbang.php
@@ -1,0 +1,8 @@
+<?php
+
+$code = <<<'EOC'
+#!/usr/bin/env php
+another line
+<?php $x ?>
+EOC;
+var_dump(token_get_all($code));

--- a/hphp/test/slow/ext_misc/token_get_all_hashbang.php.expect
+++ b/hphp/test/slow/ext_misc/token_get_all_hashbang.php.expect
@@ -1,0 +1,49 @@
+array(5) {
+  [0]=>
+  array(3) {
+    [0]=>
+    int(311)
+    [1]=>
+    string(32) "#!/usr/bin/env php
+another line
+"
+    [2]=>
+    int(1)
+  }
+  [1]=>
+  array(3) {
+    [0]=>
+    int(368)
+    [1]=>
+    string(6) "<?php "
+    [2]=>
+    int(3)
+  }
+  [2]=>
+  array(3) {
+    [0]=>
+    int(309)
+    [1]=>
+    string(2) "$x"
+    [2]=>
+    int(3)
+  }
+  [3]=>
+  array(3) {
+    [0]=>
+    int(371)
+    [1]=>
+    string(1) " "
+    [2]=>
+    int(3)
+  }
+  [4]=>
+  array(3) {
+    [0]=>
+    int(370)
+    [1]=>
+    string(2) "?>"
+    [2]=>
+    int(3)
+  }
+}


### PR DESCRIPTION
Fixes #4810 and #4936 by converting `T_HASHBANG` to `T_INLINE_HTML` in `token_get_all()` output.