### PR TITLE
Travis modernize build-in

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,19 @@
 language: cpp
 
-# This doesn't work - travis defaults to plain gcc if unknown
-# http://github.com/travis-ci/travis-ci/issues/979
-# http://llvm.org/apt/
+os:
+  - linux
+#  - osx
+#osx_image: xcode61
+
 compiler:
+#  - clang
   - gcc
-#  - gcc-4.8
-#  - clang-3.4
-#  - clang-3.5
 
 cache:
   - apt
+  - ccache
+  - directories
+    - $HOME/.ccache
 
 services:
   - memcached
@@ -19,21 +22,25 @@ services:
 # Commands before installing prerequisites
 before_script:
 # we can't compile with this system version
+  - mkdir $HOME/.ccache
   - time sudo apt-get remove libsqlite3-dev
-  - time TRAVIS=1 ./configure_generic.sh -DENABLE_COTIRE=ON
+  - time sudo apt-get install -yqq ccache; ccache -M 4G
+  - export CCACHE_DIR="$HOME/.ccache" CCACHE_PATH="/usr/bin"; ccache -s
+  - time CC="ccache gcc" CXX="ccache g++" TRAVIS=1 ./configure_generic.sh
 # for some tests
-  - time sudo locale-gen de_DE && sudo locale-gen zh_CN.utf8 && sudo locale-gen fr_FR
+  - time sudo locale-gen de_DE zh_CN.utf8 fr_FR
   - time make -j 6
 # mysql configuration for unit-tests
   - mysql -e 'CREATE DATABASE IF NOT EXISTS hhvm;'
   - export PDO_MYSQL_TEST_DSN="mysql:host=127.0.0.1;dbname=hhvm"
-  - export PDO_MYSQL_TEST_USER="travis"
-  - export PDO_MYSQL_TEST_PASS=""
+  - export PDO_MYSQL_TEST_USER="travis" PDO_MYSQL_TEST_PASS=""
 # For PHP5 mysqli tests
-  - export MYSQL_TEST_USER="travis"
-  - export MYSQL_TEST_DB="hhvm"
+  - export MYSQL_TEST_USER="travis" MYSQL_TEST_DB="hhvm"
 # For redis tests
   - export REDIS_TEST_HOST="localhost"
+
+after_script:
+  - ccache -s
 
 # Sadly, travis only gives up 50 minutes to compile and run our tests. The
 # compilation machines usually have a bunch of CPUs but very little RAM so gcc
@@ -44,8 +51,8 @@ before_script:
 # test run. Please check out the attached phabricator to your PR for full unit
 # test coverage.
 env:
-  - TEST_RUN_MODE="-m jit       quick"
-  - TEST_RUN_MODE="-m interp    quick"
+  - TEST_RUN_MODE="-m jit     quick"
+  - TEST_RUN_MODE="-m interp  quick"
 
 # Main test script
 script: time hphp/hhvm/hhvm hphp/test/run $TEST_RUN_MODE
@@ -57,4 +64,12 @@ notifications:
   email: false
 
 matrix:
-  fast_finish: true
+#  exclude:
+#    - os: osx
+#      compiler: clang
+#    - os: linux
+#      compiler: clang
+  allow_failures:
+#    - os: osx
+    - os: linux
+      compiler: clang

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,10 +20,10 @@ services:
 before_script:
 # we can't compile with this system version
   - time sudo apt-get remove libsqlite3-dev
-  - time TRAVIS=1 ./configure_generic.sh
+  - time TRAVIS=1 ./configure_generic.sh -DCMAKE_BUILD_TYPE=MinSizeRel
 # for some tests
   - time sudo locale-gen de_DE zh_CN.utf8 fr_FR
-  - time make -j 6
+  - time make -j1
 # mysql configuration for unit-tests
   - mysql -e 'CREATE DATABASE IF NOT EXISTS hhvm;'
   - export PDO_MYSQL_TEST_DSN="mysql:host=127.0.0.1;dbname=hhvm"

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,6 @@ compiler:
 
 cache:
   - apt
-  - ccache
-  - directories
-    - $HOME/.ccache
 
 services:
   - memcached
@@ -22,11 +19,8 @@ services:
 # Commands before installing prerequisites
 before_script:
 # we can't compile with this system version
-  - mkdir $HOME/.ccache
   - time sudo apt-get remove libsqlite3-dev
-  - time sudo apt-get install -yqq ccache; ccache -M 4G
-  - export CCACHE_DIR="$HOME/.ccache" CCACHE_PATH="/usr/bin"; ccache -s
-  - time CC="ccache gcc" CXX="ccache g++" TRAVIS=1 ./configure_generic.sh
+  - time TRAVIS=1 ./configure_generic.sh
 # for some tests
   - time sudo locale-gen de_DE zh_CN.utf8 fr_FR
   - time make -j 6

--- a/configure
+++ b/configure
@@ -6,12 +6,12 @@ if [ "$1" = '--help' ] || [ "$1" = '-h' ]; then
   echo "usage: $0 -Dvariable=argument ...\n"
   echo 'Variables: '
   options=`cat $DIR/CMake/Options.cmake | grep option | sed -e 's/^[ \t]*//' |
-           sed 's/\s*option(/  -D/; s/ "/=ON|OFF : /;  
+           sed 's/\s*option(/  -D/; s/ "/=ON|OFF : /;
                 s/" / : Default: /; s/)$//' | sort`
   options="  -DCMAKE_BUILD_TYPE=Debug|Release|RelWithDebInfo|MinSizeRel : Sets build type \
 : Default: Release
 $options"
-  if which column > /dev/null; then 
+  if which column > /dev/null; then
     options=`echo "$options" | column -t -s : `
   fi
   echo "$options"

--- a/configure_generic.sh
+++ b/configure_generic.sh
@@ -1,19 +1,19 @@
-#########################################
-#                                       #
-# Generic Dependency Installer Script   #
-#                                       #
-#########################################
+#!/usr/bin/env bash
 
-# Current Script details
-SCRIPT="$(readlink -f $0)"
-SCRIPT_DIR="$(dirname $SCRIPT)"
-PWD=$(readlink -f `pwd`)
+#######################################
+# Generic Dependency Installer Script #
+#######################################
 
 # Make sure the script is run from its proper path.
 # OR Since we know the path, why don't we do it ourselves ?
+SCRIPT="$(basename $0)"
+pushd "$(dirname $0)" >/dev/null
+SCRIPT_DIR="$(pwd -P)"
+popd >/dev/null
+PWD="$(pwd -P)"
 if [ $PWD != $SCRIPT_DIR ]
 then
-    echo "Run the script from the hiphop-php directory like:"
+    echo "Run the script from the HHVM directory like:"
     echo "cd $SCRIPT_DIR && ./$SCRIPT"
     exit 1
 fi
@@ -22,6 +22,7 @@ fi
 OS_TYPE=$(uname)
 if [ "x$OS_TYPE" = "xLinux" ];then
     DISTRO_NAME=$(head -1 /etc/issue)
+    CPUS=$(egrep '(^CPU|processor.*:.*)' /proc/cpuinfo|wc -l)
     if grep -i fedora /etc/issue >/dev/null 2>&1; then
         DISTRO=fedora
     elif grep -i ubuntu /etc/issue >/dev/null 2>&1;then
@@ -43,20 +44,18 @@ fi
 echo "Date/Time      : $(date)"
 echo "Current Distro : $DISTRO_NAME"
 
-# Determine the CPUs irrespective of Travis Mode
-CPUS=`cat /proc/cpuinfo | grep -E '^processor' | tail -1 | cut -d : -f 2`
-CPUS=`expr ${CPUS} + 1`
-
 # For travis
 if [ "x${TRAVIS}" != "x" ]; then
   # Collect some stats for use in tuning build later on
-  free
-  echo "Travis Mode    : YES"
-  echo "# CPUs         : ${CPUS}"
+  more /proc/meminfo
+  vmstat
+  free -t -m
+  echo "Travis Mode : YES"
+  echo "# CPUs      : ${CPUS}"
   echo ""
 else
-  echo "Travis Mode    : NO"
-  echo "# CPUs         : ${CPUS}"
+  echo "Travis Mode : NO"
+  echo "# CPUs      : ${CPUS}"
   echo ""
 fi
 
@@ -66,8 +65,8 @@ export CMAKE_PREFIX_PATH=`/bin/pwd`/..
 case $DISTRO in
     fedora)
         # install the actual dependencies
-        sudo yum groupinstall "Fedora Packager" -y
-        sudo yum install -y git wget make autoconf binutils-devel \
+        sudo yum groupinstall "Fedora Packager" -yq
+        sudo yum install -yq git wget make autoconf binutils-devel \
             boost-devel bzip2-devel chrpath cmake cyrus-sasl elfutils-libelf-devel  \
             expat-devel fontconfig-devel freetype-devel gcc-c++ gd-devel glibc-devel  \
             glog-devel jemalloc-devel keyutils-libs krb5-devel libaio-devel libcap-devel  \
@@ -81,23 +80,36 @@ case $DISTRO in
             ImageMagick-devel libxslt-devel &
 
         # For patched stuff.
-        git clone git://github.com/libevent/libevent.git --quiet &
-        git clone git://github.com/bagder/curl.git --quiet &
+        git clone --depth=1 --branch=release-2.0.22-stable git://github.com/libevent/libevent.git --quiet &
+        git clone --depth=1 --branch=curl-7_41_0 git://github.com/bagder/curl.git --quiet &
         ;;
     ubuntu)
         # install python-software-properties before trying to add a PPA
-        sudo apt-get -y update
-        sudo apt-get install -y python-software-properties
-
-        # install apt-fast to speed up later dependency installation
-        sudo add-apt-repository -y ppa:apt-fast/stable
+        sudo apt-get install -yqq python-software-properties
+        sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
         sudo add-apt-repository -y ppa:boost-latest/ppa
-        sudo apt-get -y update
-        sudo apt-get -y install apt-fast
+        sudo apt-get -yqq update
+
+        # Leave this install till after the main parallel package install above
+        # since it adds a non-12.04 package repo and we don't want to
+        # pull EVERYTHING in, just the newer gcc compiler (and toolchain)
+        GCC_VER=4.9
+        if [ "$CXX" = "g++" ]; then
+            sudo apt-get -yqq install --force-yes gcc-${GCC_VER} g++-${GCC_VER} libstdc++-${GCC_VER}-dev
+            sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${GCC_VER} 60 \
+                                     --slave   /usr/bin/g++ g++ /usr/bin/g++-${GCC_VER}
+            sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.6 40 \
+                                     --slave   /usr/bin/g++ g++ /usr/bin/g++-4.6
+            sudo update-alternatives --set gcc /usr/bin/gcc-${GCC_VER}
+        fi
+
+        # LLVM testing
+        if [ "$CXX" = "clang++" ]; then
+            sudo apt-get install -yqq clang-3.4 libstdc++-4.8-dev
+        fi
 
         # install the actual dependencies
-        sudo apt-fast -y update
-        sudo apt-fast -y install git-core cmake g++ boost1.55 libmysqlclient-dev \
+        sudo apt-get -yqq install git-core cmake boost1.55 libmysqlclient-dev \
             libxml2-dev libmcrypt-dev libicu-dev openssl build-essential binutils-dev \
             libcap-dev libgd2-xpm-dev zlib1g-dev libtbb-dev libonig-dev libpcre3-dev \
             wget memcached libreadline-dev libncurses-dev libmemcached-dev libbz2-dev \
@@ -106,10 +118,10 @@ case $DISTRO in
             autoconf libtool libcurl4-openssl-dev \
             libmagickwand-dev libxslt1-dev &
 
-        git clone git://github.com/libevent/libevent.git --quiet &
-        git clone git://github.com/bagder/curl.git --quiet &
+        git clone --depth=1 --branch=release-2.0.22-stable git://github.com/libevent/libevent.git --quiet &
+        git clone --depth=1 --branch=curl-7_41_0 git://github.com/bagder/curl.git --quiet &
         svn checkout http://google-glog.googlecode.com/svn/trunk/ google-glog --quiet &
-        wget -nc http://www.canonware.com/download/jemalloc/jemalloc-3.6.0.tar.bz2 --quiet &
+        git clone --depth=1 --branch=3.6.0 git://github.com/jemalloc/jemalloc.git --quiet &
         ;;
     *)
         echo "Unknown distribution. Please update packages in this section."
@@ -129,35 +141,17 @@ do
     wait $job || let "FAIL+=1"
 done
 
-if [ "$FAIL" == "0" ];
-then
+if [ "$FAIL" == "0" ]; then
     echo "all downloads finished"
 else
     echo "$FAIL errors while downloading!"
     exit 100
 fi
 
-if [[ "x$DISTRO" == "xubuntu" ]];then
-    # Leave this install till after the main parallel package install above
-    # since it adds a non-12.04 package repo and we don't want to
-    # pull EVERYTHING in, just the newer gcc compiler (and toolchain)
-    GCC_VER=4.8
-    sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
-    sudo apt-get -y update
-    sudo apt-get -y install gcc-${GCC_VER} g++-${GCC_VER}
-    sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${GCC_VER} 60 \
-                                --slave /usr/bin/g++ g++ /usr/bin/g++-${GCC_VER}
-    sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.6 40 \
-                                --slave /usr/bin/g++ g++ /usr/bin/g++-4.6
-    sudo update-alternatives --set gcc /usr/bin/gcc-${GCC_VER}
-fi
-
 # libevent
 cd libevent
-git checkout release-1.4.14b-stable
-cat ../third-party/libevent-1.4.14.fb-changes.diff | patch -p1
 ./autogen.sh
-./configure --prefix=$CMAKE_PREFIX_PATH
+./configure --prefix=$CMAKE_PREFIX_PATH --disable-dependency-tracking --disable-debug-mode
 make -j $CPUS
 make install
 cd ..
@@ -165,29 +159,27 @@ cd ..
 # curl
 cd curl
 ./buildconf
-./configure --prefix=$CMAKE_PREFIX_PATH
+./configure --prefix=$CMAKE_PREFIX_PATH --disable-dependency-tracking --disable-debug --disable-silent-rules
 make -j $CPUS
 make install
 cd ..
 
-if [[ "x$DISTRO" == "xubuntu" ]];then
-    # glog
-    cd google-glog
-    ./configure --prefix=$CMAKE_PREFIX_PATH
-    make -j $CPUS
-    make install
-    cd ..
+if [[ "x$DISTRO" == "xubuntu" ]]; then
+  # glog
+  cd google-glog
+  ./configure --prefix=$CMAKE_PREFIX_PATH --disable-dependency-tracking
+  make -j $CPUS
+  make install
+  cd ..
 
-    # jemaloc
-    tar xjvf jemalloc-3.6.0.tar.bz2
-    cd jemalloc-3.6.0
-    ./configure --prefix=$CMAKE_PREFIX_PATH
-    make -j $CPUS
-    make install
-    cd ..
+  # jemaloc
+  cd jemalloc
+  ./autogen.sh --prefix=$CMAKE_PREFIX_PATH --disable-debug
+  make -j $CPUS install_bin install_include install_lib
+  cd ..
 
-    # cleanup
-    rm -rf google-glog jemalloc-3.6.0.tar.bz2 jemalloc-3.6.0
+  # cleanup
+  rm -rf google-glog jemalloc
 fi
 
 # cleanup


### PR DESCRIPTION
* Try to use gcc-4.9 soon gcc-5
* `SCRIPT_DIR` correct work for Darwin
* `CPUS` more correct definition cores
* Stable version `libevent-2.0.22-stable`, `curl-7.41.0` and `jemalloc-3.6.0`
* clang added but not enabled, the problem is in the patches clang compiler
* silent `apt-get` removed unnecessary items from the logfile
* check `more /proc/meminfo` and `vmstat`
* enable `ccache`, disable `cotire`

> **Travis CI Support**
apt-fast: We are speeding up apt-get with a proxy we run on the VM hosts.
