### PR TITLE
Check for empty docroot before looking for trailing slash.

### DIFF
--- a/hphp/runtime/server/http-protocol.cpp
+++ b/hphp/runtime/server/http-protocol.cpp
@@ -686,7 +686,8 @@ static void CopyPathInfo(Array& server,
     // fix it so it is settable, so I'll leave this for now
     documentRoot = vhost->getDocumentRoot();
   }
-  if (documentRoot != s_forwardslash &&
+  if (!documentRoot.empty() &&
+      documentRoot != s_forwardslash &&
       documentRoot[documentRoot.length() - 1] == '/') {
     documentRoot = documentRoot.substr(0, documentRoot.length() - 1);
   }


### PR DESCRIPTION
We ran into this case during warmup requests on a debug build. I didn't look into what the docroot is supposed to be for warmup requests, or why we only ran into this now, but this prevents a segfault in one case on our end.