### PR TITLE
SoapClient's compression is set with bitwise flags (not a boolean)

### DIFF
--- a/hphp/runtime/ext/soap/ext_soap.cpp
+++ b/hphp/runtime/ext/soap/ext_soap.cpp
@@ -2410,7 +2410,7 @@ SoapClient::SoapClient() :
     m_connection_timeout(0),
     m_max_redirect(HttpClient::defaultMaxRedirect),
     m_use11(true),
-    m_compression(false),
+    m_compression(0),
     m_exceptions(true),
     m_trace(false) {
 }
@@ -2475,7 +2475,7 @@ void HHVM_METHOD(SoapClient, __construct,
       data->m_exceptions = options[s_exceptions].toBoolean();
     }
     if (options.exists(s_compression)) {
-      data->m_compression = options[s_compression].toBoolean();
+      data->m_compression = options[s_compression].toInt32();
     }
 
     String encoding = options[s_encoding].toString();

--- a/hphp/runtime/ext/soap/ext_soap.h
+++ b/hphp/runtime/ext/soap/ext_soap.h
@@ -81,7 +81,7 @@ public:
   int                         m_max_redirect;
   bool                        m_use11;
   String                      m_user_agent;
-  bool                        m_compression;
+  int                         m_compression;
   Variant                     m_default_headers;
   Array                       m_cookies;
   bool                        m_exceptions;


### PR DESCRIPTION
The m_compression variable should be an integer to hold the bitwise flags. If the type is changed the flags works as expected in the rest of the existing code.

```
$client = new SoapClient('file.wsdl',
			[
			'location' => 'http://url',
			'compression' => SOAP_COMPRESSION_ACCEPT | (SOAP_COMPRESSION_GZIP | 6)
			]);
```