### PR TITLE
Leak in socket_select() when returning while having buffered data available

### DIFF
--- a/hphp/runtime/ext/sockets/ext_sockets.cpp
+++ b/hphp/runtime/ext/sockets/ext_sockets.cpp
@@ -899,6 +899,7 @@ Variant HHVM_FUNCTION(socket_select,
         except = empty_array();
       }
       read = hasData;
+      free(fds);
       return hasData.size();
     }
   }


### PR DESCRIPTION
This example leaks memory.

```
$fp = pfsockopen('www.example.com', 80);
fwrite($fp, "GET / HTTP/1.0\r\nHost: www.example.com\r\n\r\n");
echo fgets($fp);
while (1) {
	socket_select(array($fp), NULL, NULL, 0);
}
```