### PR TITLE
Expose per directory ini settings in each request.

### DIFF
--- a/hphp/runtime/base/request-injection-data.cpp
+++ b/hphp/runtime/base/request-injection-data.cpp
@@ -378,8 +378,12 @@ void RequestInjectionData::threadInit() {
                    "zlib.output_compression", &m_gzipCompression);
   IniSetting::Bind(IniSetting::CORE, IniSetting::PHP_INI_ALL,
                    "zlib.output_compression_level", &m_gzipCompressionLevel);
-}
 
+  //
+  // Per directory
+  //
+  RuntimeOption::LoadPerDir();
+}
 
 std::string RequestInjectionData::getDefaultIncludePath() {
   auto include_paths = Array::Create();

--- a/hphp/runtime/base/runtime-option.h
+++ b/hphp/runtime/base/runtime-option.h
@@ -55,6 +55,8 @@ public:
     const std::vector<std::string>& iniClis = std::vector<std::string>(),
     const std::vector<std::string>& hdfClis = std::vector<std::string>());
 
+  static void LoadPerDir(void);
+
   static bool ServerExecutionMode() {
     return strcmp(ExecutionMode, "srv") == 0;
   }

--- a/hphp/test/server/fastcgi/server_root/test_ini_get_perdir.php
+++ b/hphp/test/server/fastcgi/server_root/test_ini_get_perdir.php
@@ -1,0 +1,57 @@
+<?php
+
+//
+// This test is ostensibly the same as
+//   ../../../slow/program_functions/ini_get_perdir.php
+// It's inconvenient to require_once that file,
+// since we need a wrapper to invoke the test in fcgi mode.
+// The test is small enough that we'll just repeat the guts of it here.
+//
+
+function print_some_ini_get_all(callable $filter_fn) {
+  $settings = ini_get_all();
+  $trimmed_arr = array_filter($settings, $filter_fn);
+  var_dump($trimmed_arr);
+}
+
+function print_some_ini_get_all_by_name($keys) {
+  $settings = ini_get_all();
+  $trimmed_arr = [];
+  foreach ($keys as $key) {
+    $trimmed_arr[$key] = $settings[$key];
+  }
+  var_dump($trimmed_arr);
+}
+
+function dumpInterestingIniSettings() {
+  print_some_ini_get_all(function($v)  {
+    //
+    // Alas, PHP_INI_PERDIR isn't exposed as a PHP constant,
+    // even though bitsets built from the various PHP_INI_FOO
+    // values are exposed through the "access" slot.
+    //
+    // See ./hphp/runtime/base/ini-setting.h
+    // But note HHVM's weird encoding of PHP_INI_ALL==(1<<4)
+    // and how it diverges from Zend's encoding PHP_INI_ALL==7
+    //
+    $PHP_INI_PERDIR = (1 << 1);
+    return $v["access"] === $PHP_INI_PERDIR;
+  });
+
+  print_some_ini_get_all_by_name([
+    //
+    // To test the efficacy of loading settings files,
+    // these values should match what's in
+    //   test/server/fastcgi/config/server.ini
+    // 
+    //
+    'hhvm.log.always_log_unhandled_exceptions',
+    'hhvm.server.type',
+    'hhvm.repo.local.mode',
+    // 'hhvm.repo.eval.mode',  // Called out in server.ini, but no longer used?
+    'hhvm.repo.commit',
+
+  ]);
+}
+
+dumpInterestingIniSettings();

--- a/hphp/test/server/fastcgi/tests/ini_get_perdir.php
+++ b/hphp/test/server/fastcgi/tests/ini_get_perdir.php
@@ -1,0 +1,16 @@
+<?php
+
+require_once(__DIR__ . '/test_base.inc');
+
+function perdirTestController($port) {
+  $host = php_uname('n');
+  //
+  // The server executes from its root dir,
+  // namely from ../server_root/
+  // and will execute ../server_root/test_ini_get_perdir.php
+  //
+  echo request($host, $port, 'test_ini_get_perdir.php');
+  echo "\n";
+}
+
+runTest("perdirTestController");

--- a/hphp/test/server/fastcgi/tests/ini_get_perdir.php.expectf
+++ b/hphp/test/server/fastcgi/tests/ini_get_perdir.php.expectf
@@ -1,0 +1,85 @@
+array(5) {
+  ["always_populate_raw_post_data"]=>
+  array(3) {
+    ["global_value"]=>
+    string(0) ""
+    ["local_value"]=>
+    string(0) ""
+    ["access"]=>
+    int(2)
+  }
+  ["auto_append_file"]=>
+  array(3) {
+    ["global_value"]=>
+    string(0) ""
+    ["local_value"]=>
+    string(0) ""
+    ["access"]=>
+    int(2)
+  }
+  ["auto_prepend_file"]=>
+  array(3) {
+    ["global_value"]=>
+    string(0) ""
+    ["local_value"]=>
+    string(0) ""
+    ["access"]=>
+    int(2)
+  }
+  ["post_max_size"]=>
+  array(3) {
+    ["global_value"]=>
+    string(9) "104857600"
+    ["local_value"]=>
+    string(9) "104857600"
+    ["access"]=>
+    int(2)
+  }
+  ["upload_max_filesize"]=>
+  array(3) {
+    ["global_value"]=>
+    string(4) "100M"
+    ["local_value"]=>
+    string(4) "100M"
+    ["access"]=>
+    int(2)
+  }
+}
+array(4) {
+  ["hhvm.log.always_log_unhandled_exceptions"]=>
+  array(3) {
+    ["global_value"]=>
+    string(0) ""
+    ["local_value"]=>
+    string(0) ""
+    ["access"]=>
+    int(4)
+  }
+  ["hhvm.server.type"]=>
+  array(3) {
+    ["global_value"]=>
+    string(7) "fastcgi"
+    ["local_value"]=>
+    string(7) "fastcgi"
+    ["access"]=>
+    int(4)
+  }
+  ["hhvm.repo.local.mode"]=>
+  array(3) {
+    ["global_value"]=>
+    string(2) "r-"
+    ["local_value"]=>
+    string(2) "r-"
+    ["access"]=>
+    int(4)
+  }
+  ["hhvm.repo.commit"]=>
+  array(3) {
+    ["global_value"]=>
+    string(1) "1"
+    ["local_value"]=>
+    string(1) "1"
+    ["access"]=>
+    int(4)
+  }
+}

--- a/hphp/test/server/util/server_tests.inc
+++ b/hphp/test/server/util/server_tests.inc
@@ -114,15 +114,28 @@ function startServer(&$serverPort, &$adminPort, &$debugPort, $home, $root,
         " -vRepo.Authoritative=true";
     }
 
-    $cmd = "exec env MALLOC_CONF=junk:true TESTID={$test_run_id} " . $hhvm .
-      ' --mode=server' . $serverConfig . $logFileConfig .
-      ' -vEval.JitProfileInterpRequests=0 -vServer.ExitOnBindFail=true' .
+    $cmd = 'exec' .
+      ' env ' .
+      ' MALLOC_CONF=junk:true' .
+      " TESTID={$test_run_id}" .
+      ' ' . $hhvm .
+      ' --mode=server' .
+      $serverConfig .
+
+      $logFileConfig .
+      ' -vEval.JitProfileInterpRequests=0' .
+      ' -vServer.ExitOnBindFail=true' .
       ' --instance-id=' . $test_run_id .
-      $portConfig . $srcRootConfig .
-      $includePathConfig . $sandboxHomeConfig . $adminPortConfig .
-      $debugPortConfig . $repoConfig . $jitConfig .
+      $portConfig .
+      $srcRootConfig .
+      $includePathConfig .
+      $sandboxHomeConfig .
+      $adminPortConfig .
+      $debugPortConfig .
+      $repoConfig .
+      $jitConfig .
       ' ' . $customArgs .
-      " > ${LOG_ROOT}_test_server_stdout$test_run_id.log" .
+      "  > ${LOG_ROOT}_test_server_stdout$test_run_id.log" .
       " 2> ${LOG_ROOT}_test_server_stderr$test_run_id.log";
 
     tlog('Starting server with command: '.$cmd);
@@ -177,7 +190,6 @@ function stopServer($adminPort, $serverProc) {
     dumpLogFilesToStdoutAndDie();
   }
   proc_close($serverProc);
-
   @unlink("${LOG_ROOT}_test$test_run_id.log");
   @unlink("${LOG_ROOT}_test_server$test_run_id.log");
   @unlink("${LOG_ROOT}_test_server_stderr$test_run_id.log");

--- a/hphp/test/slow/program_functions/ini_get_filtered_impl.inc
+++ b/hphp/test/slow/program_functions/ini_get_filtered_impl.inc
@@ -1,0 +1,6 @@
+<?php
+function run_tests(callable $filter_fn) {
+  $settings = ini_get_all();
+  $trimmed_arr = array_filter($settings, $filter_fn);
+  var_dump($trimmed_arr);
+}

--- a/hphp/test/slow/program_functions/ini_get_perdir.php
+++ b/hphp/test/slow/program_functions/ini_get_perdir.php
@@ -1,0 +1,17 @@
+<?php
+require_once __DIR__ . '/ini_get_filtered_impl.inc';
+
+run_tests(function($v)  {
+  //
+  // alas, PHP_INI_PERDIR isn't exposed as a PHP constant,
+  // even though bitsets built from the various PHP_INI_FOO
+  // values are exposed through the "access" slot.
+  //
+  // See ./hphp/runtime/base/ini-setting.h
+  // But note the wonky encoding of PHP_INI_ALL==(1<<4) and how it
+  // diverges from Zend's encoding PHP_INI_ALL==7
+  //
+  $PHP_INI_PERDIR = (1 << 1);
+  return $v["access"] === $PHP_INI_PERDIR;
+});
+

--- a/hphp/test/slow/program_functions/ini_get_perdir.php.expectf
+++ b/hphp/test/slow/program_functions/ini_get_perdir.php.expectf
@@ -1,0 +1,47 @@
+array(5) {
+  ["always_populate_raw_post_data"]=>
+  array(3) {
+    ["global_value"]=>
+    string(0) ""
+    ["local_value"]=>
+    string(0) ""
+    ["access"]=>
+    int(2)
+  }
+  ["auto_append_file"]=>
+  array(3) {
+    ["global_value"]=>
+    string(0) ""
+    ["local_value"]=>
+    string(0) ""
+    ["access"]=>
+    int(2)
+  }
+  ["auto_prepend_file"]=>
+  array(3) {
+    ["global_value"]=>
+    string(0) ""
+    ["local_value"]=>
+    string(0) ""
+    ["access"]=>
+    int(2)
+  }
+  ["post_max_size"]=>
+  array(3) {
+    ["global_value"]=>
+    string(9) "104857600"
+    ["local_value"]=>
+    string(9) "104857600"
+    ["access"]=>
+    int(2)
+  }
+  ["upload_max_filesize"]=>
+  array(3) {
+    ["global_value"]=>
+    string(4) "100M"
+    ["local_value"]=>
+    string(4) "100M"
+    ["access"]=>
+    int(2)
+  }
+}

--- a/hphp/test/slow/program_functions/ini_get_perdir.php.skipif
+++ b/hphp/test/slow/program_functions/ini_get_perdir.php.skipif
@@ -1,0 +1,2 @@
+<?php
+require_once __DIR__ . '/ini_get_perdir_skipif.inc';

--- a/hphp/test/slow/program_functions/ini_get_perdir_skipif.inc
+++ b/hphp/test/slow/program_functions/ini_get_perdir_skipif.inc
@@ -1,0 +1,8 @@
+<?php
+//
+// All perdir settings are interesting.  They don't change much.
+// Hopefully nobody will mutiny if/when these values change.
+//
+if (false) {
+  print "skip";
+}


### PR DESCRIPTION
This slight refactor makes the 5 PHP_INI_PERDIR ini settings visible to
each request. This commit appears to fix the bug reported in
  https://github.com/facebook/hhvm/issues/4993
and first introduced in:
  https://github.com/facebook/hhvm/commit/4bfeda9418331e6fea0de66a106b9ba5d04728a9

There are now tests that run in CLI mode and in FCGI mode that expose
the values of the 5 PHP_INI_PERDIR settings. These new tests failed
without this commit, and now pass with the commit.

These per directory settings tests assume that the values won't experience
much churn as development proceeds apace.  Alas, the tests that dump all
ini settings have been emasculated since November 2014; the expectf have
drifted greatly, and the tests probably don't work in OSS land anyway.