### PR TITLE
Fix fread on an SSL socket potentially waiting for data from socket when OpenSSL already has data

### DIFF
--- a/hphp/runtime/base/ssl-socket.cpp
+++ b/hphp/runtime/base/ssl-socket.cpp
@@ -349,7 +349,7 @@ SmartPtr<SSLSocket> SSLSocket::Create(
 }
 
 bool SSLSocket::waitForData() {
-  if (m_ssl_active && SSL_pending(m_handle)) {
+  if (m_data->m_ssl_active && SSL_pending(m_data->m_handle)) {
     return true;
   }
 

--- a/hphp/runtime/base/ssl-socket.cpp
+++ b/hphp/runtime/base/ssl-socket.cpp
@@ -348,13 +348,21 @@ SmartPtr<SSLSocket> SSLSocket::Create(
   return sock;
 }
 
+bool SSLSocket::waitForData() {
+  if (m_ssl_active && SSL_pending(m_handle)) {
+    return true;
+  }
+
+  return Socket::waitForData();
+}
+
 int64_t SSLSocket::readImpl(char *buffer, int64_t length) {
   int64_t nr_bytes = 0;
   if (m_data->m_ssl_active) {
     bool retry = true;
     do {
       if (m_data->m_is_blocked) {
-        Socket::waitForData();
+        waitForData();
         if (timedOut()) {
           break;
         }

--- a/hphp/runtime/base/ssl-socket.h
+++ b/hphp/runtime/base/ssl-socket.h
@@ -63,6 +63,7 @@ struct SSLSocket : Socket {
   // overriding ResourceData
   const String& o_getClassNameHook() const override { return classnameof(); }
 
+  bool waitForData();
   virtual int64_t readImpl(char *buffer, int64_t length) override;
   virtual int64_t writeImpl(const char *buffer, int64_t length) override;
   virtual bool checkLiveness() override;


### PR DESCRIPTION
Resolves #4315. OpenSSL may have data ready without the socket necessarily having data ready to read.