### PR TITLE
Add ContextLines(ctx) setting to debugger

### DIFF
--- a/hphp/runtime/debugger/cmd/cmd_config.cpp
+++ b/hphp/runtime/debugger/cmd/cmd_config.cpp
@@ -35,6 +35,7 @@ void CmdConfig::help(DebuggerClient &client) {
       "on makes the debugger take small steps (not entire lines)",
     "set sa on/off","on makes where command display argument values",
     "set mcl limit","display at most limit source lines at breakpoints",
+    "set ctx num","display num lines of code before and after breakpoint (default=1)",
     nullptr);
   client.helpBody(
     "Use this command to change default settings. "
@@ -156,6 +157,16 @@ void CmdConfig::onClient(DebuggerClient &client) {
     }
     return;
   }
+  if (var == "ContextLines" || var == "ctx") {
+    int ctx = strtol(value.c_str(), nullptr, 10);
+    if (ctx < -1) {
+      client.error("%d is invalid for ContextLines(ctx)", ctx);
+    } else {
+      client.setDebuggerClientContextLines(ctx);
+      client.print("ContextLines(ctx) is set to %d", ctx);
+    }
+    return;
+  }
 
   listVars(client);
 }
@@ -175,6 +186,8 @@ void CmdConfig::listVars(DebuggerClient &client) {
                 client.getDebuggerClientStackArgs() ? "on" : "off");
   client.print("MaxCodeLines(mcl) %d",
                 client.getDebuggerClientMaxCodeLines());
+  client.print("ContextLines(ctx) %d",
+                client.getDebuggerClientContextLines());
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/hphp/runtime/debugger/cmd/cmd_config.cpp
+++ b/hphp/runtime/debugger/cmd/cmd_config.cpp
@@ -159,7 +159,7 @@ void CmdConfig::onClient(DebuggerClient &client) {
   }
   if (var == "ContextLines" || var == "ctx") {
     int ctx = strtol(value.c_str(), nullptr, 10);
-    if (ctx < -1) {
+    if (ctx < 0) {
       client.error("%d is invalid for ContextLines(ctx)", ctx);
     } else {
       client.setDebuggerClientContextLines(ctx);

--- a/hphp/runtime/debugger/debugger_client.cpp
+++ b/hphp/runtime/debugger/debugger_client.cpp
@@ -1248,9 +1248,10 @@ void DebuggerClient::shortCode(BreakPointInfoPtr bp) {
       int beginHighlightColumn = bp->m_char1;
       int endHighlightLine = bp->m_line2;
       int endHighlightColumn = bp->m_char2;
+      int contextLines = std::max(0, getDebuggerClientContextLines());
       // Lines where source listing should start and end
-      int firstLine = std::max(beginHighlightLine - 1, 1);
-      int lastLine = endHighlightLine + 1;
+      int firstLine = std::max(beginHighlightLine - contextLines, 1);
+      int lastLine = endHighlightLine + contextLines;
       int maxLines = getDebuggerClientMaxCodeLines();
 
       // If MaxCodeLines == 0: don't spew any code after a [s]tep or [n]ext
@@ -2370,6 +2371,15 @@ void DebuggerClient::loadConfig() {
        [this]() { return getDebuggerClientMaxCodeLines(); }
   ));
 
+  setDebuggerClientContextLines(Config::GetInt16(ini, config["ContextLines"], 1));
+  BIND(context_lines, IniSetting::SetAndGet<short>(
+       [this](const short& v) {
+         setDebuggerClientContextLines(v);
+         return true;
+       },
+       [this]() { return getDebuggerClientContextLines(); }
+  ));
+
   setDebuggerClientBypassCheck(Config::GetBool(ini, config["BypassAccessCheck"]));
   BIND(bypass_access_check, IniSetting::SetAndGet<bool>(
        [this](const bool& v) { setDebuggerClientBypassCheck(v); return true; },
@@ -2511,6 +2521,8 @@ void DebuggerClient::saveConfig() {
   stream << "hhvm.stack_args = " << getDebuggerClientStackArgs()
          << std::endl;
   stream << "hhvm.max_code_lines = " << getDebuggerClientMaxCodeLines()
+         << std::endl;
+  stream << "hhvm.context_lines = " << getDebuggerClientContextLines()
          << std::endl;
   stream << "hhvm.small_step = " << getDebuggerClientSmallStep()
          << std::endl;

--- a/hphp/runtime/debugger/debugger_client_settings.h
+++ b/hphp/runtime/debugger/debugger_client_settings.h
@@ -22,6 +22,7 @@
   HPHPD_CLIENT_SETTING(PrintLevel,          int,   5)             \
   HPHPD_CLIENT_SETTING(StackArgs,           bool,  true)          \
   HPHPD_CLIENT_SETTING(MaxCodeLines,        int,   -1)            \
+  HPHPD_CLIENT_SETTING(ContextLines,        int,   1)             \
   HPHPD_CLIENT_SETTING(SmallStep,           bool,  false)         \
   HPHPD_CLIENT_SETTING(ShortPrintCharCount, int,   200)           \
 

--- a/hphp/test/quick/debugger/hphpd.ini
+++ b/hphp/test/quick/debugger/hphpd.ini
@@ -1,5 +1,6 @@
 hhvm.color = 0
 hhvm.max_code_lines = -1
+hhvm.context_lines = 1
 hhvm.never_save_config = 1
 hhvm.print_level = 3
 hhvm.tutorial = -1 

--- a/hphp/test/server/debugger/config/hphpd.ini
+++ b/hphp/test/server/debugger/config/hphpd.ini
@@ -1,5 +1,6 @@
 hhvm.color = 0
 hhvm.max_code_lines = -1
+hhvm.context_lines = 1
 hhvm.script_mode = true
 hhvm.tutorial = -1 
 hhvm.utf8 = 1

--- a/hphp/test/slow/debugger/hphpd.ini
+++ b/hphp/test/slow/debugger/hphpd.ini
@@ -1,5 +1,6 @@
 hhvm.color = 0
 hhvm.max_code_lines = -1
+hhvm.context_lines = 1
 hhvm.never_save_config = 1;
 hhvm.print_level = 3;
 hhvm.tutorial = -1 


### PR DESCRIPTION
Demo of ContextLines(ctx) setting:

    localhost> b s
    b s
    Breakpoint 1 set start of request
    localhost> set
    set
    LogFile(lf) off
    BypassAccessCheck(bac) off
    PrintLevel(pl) 5
    ShortPrintCharCount(cc) 200
    SmallStep(ss) off
    StackArgs(sa) on
    MaxCodeLines(mcl) -1
    ContextLines(ctx) 1
    localhost> c
    c
    Web request /test.php started.
    localhost> n
    n
    Break on line 7 of /var/www/htdocs/test.php
       6 
       7*a(1);
       8 a(2);
    
    localhost> set ctx 5
    set ctx 5
    ContextLines(ctx) is set to 5
    localhost> n
    n
    Break on line 8 of /var/www/htdocs/test.php
       3 function a($i) {
       4   echo "$i\n";
       5 }
       6 
       7 a(1);
       8*a(2);
       9 a(3);
      10 a(4);
      11 a(5);
      12 a(6);
      13 a(7);
    
    localhost> 
