### PR TITLE
Fix some test failures

### DIFF
--- a/hphp/runtime/ext/icu/ext_icu_uchar.cpp
+++ b/hphp/runtime/ext/icu/ext_icu_uchar.cpp
@@ -104,9 +104,9 @@ static UBool enumCharType_callback(CallCtx* ctx,
 
 void HHVM_STATIC_METHOD(IntlChar, enumCharTypes, const Variant& callback) {
   CallCtx ctx;
+  CallerFrame cf;
   ctx.func = nullptr;
   if (!callback.isNull()) {
-    CallerFrame cf;
     vm_decode_function(callback, cf(), false, ctx);
   }
   if (!ctx.func) {
@@ -175,9 +175,9 @@ void HHVM_STATIC_METHOD(IntlChar, enumCharNames,
   GETCP_VOID(vStart, start);
   GETCP_VOID(vLimit, limit);
   CallCtx ctx;
+  CallerFrame cf;
   ctx.func = nullptr;
   if (!callback.isNull()) {
-    CallerFrame cf;
     vm_decode_function(callback, cf(), false, ctx);
   }
   if (!ctx.func) {

--- a/hphp/test/slow/ext_date/1776.php.ini
+++ b/hphp/test/slow/ext_date/1776.php.ini
@@ -1,0 +1,1 @@
+date.timezone=UTC

--- a/hphp/test/slow/ini/collection_ini_options.php.expectf
+++ b/hphp/test/slow/ini/collection_ini_options.php.expectf
@@ -2,7 +2,7 @@ array(3) {
   [0]=>
   string(4) "/tmp"
   [1]=>
-  string(%d) "/var/releases/continuous_www_scripts%s"
+  string(13) "/var/releases"
   [2]=>
   string(8) "/var/www"
 }

--- a/hphp/test/slow/ini/collection_ini_options.php.ini
+++ b/hphp/test/slow/ini/collection_ini_options.php.ini
@@ -1,5 +1,6 @@
 hhvm.server.allowed_directories[] = "/tmp"
 hhvm.server.allowed_directories[] = "/var/www"
+hhvm.server.allowed_directories[] = "/var/releases"
 hhvm.static_file.extensions[] = ".txt"
 hhvm.static_file.extensions[] = ".doc"
 hhvm.server.forbidden_file_extensions[] = ".exe"


### PR DESCRIPTION
* slow/ext_date/1776.php: Timezone dependent, added
  date.timezone=UTC ini setting

* slow/ini/collection_ini_options.php: Had
  /var/releases/continuous_www_scripts%s as part of the
  allowed_directories output - presumably this is something FB
  specific? Added /var/releases to the ini settings, so a predicable
  path is there for everyone.

* zend/good/ext/intl/uchar/tests/basic-functionality.php:
  Was segfaulting during fixup. Fixed by moving CallerFrame declaration
  outside of if statement, to prevent the dtor running early.