### PR TITLE
Add some configurability to hh_format

### DIFF
--- a/hphp/hack/src/format/formatConfig.ml
+++ b/hphp/hack/src/format/formatConfig.ml
@@ -1,0 +1,61 @@
+(**
+ * Copyright (c) 2014, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the "hack" directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ *)
+
+open Utils
+
+type t = {
+  indent_offset        : int  ;
+  line_width           : int  ;
+  indent_case          : bool ;
+  align_cascaded_calls : bool ;
+}
+
+let default_config = {
+  indent_offset        = 2     ;
+  line_width           = 80    ;
+  indent_case          = true  ;
+  align_cascaded_calls = false ;
+}
+
+let load_int map key default = match SMap.get key map with
+  | None -> default
+  | Some s -> int_of_string s
+
+let load_bool map key default = match SMap.get key map with
+  | None -> default
+  | Some s -> bool_of_string s
+
+let load config_filename =
+  let config_path = (Relative_path.to_absolute config_filename) in
+  if Path.file_exists (Path.mk_path config_path) then
+    let config = Config_file.parse config_path in
+
+    let indent_offset        =
+      load_int config "format.indent_offset" default_config.indent_offset in
+    let line_width           =
+      load_int config "format.line_width" default_config.line_width in
+    let indent_case          =
+      load_bool config "format.indent_case" default_config.indent_case in
+    let align_cascaded_calls =
+      load_bool config "format.align_cascaded_calls"
+                default_config.align_cascaded_calls in
+
+    {
+      indent_offset        = indent_offset;
+      line_width           = line_width;
+      indent_case          = indent_case;
+      align_cascaded_calls = align_cascaded_calls;
+    }
+  else default_config
+
+let indent_offset config = config.indent_offset
+let line_width config = config.line_width
+let indent_case config = config.indent_case
+let align_cascaded_calls config = config.align_cascaded_calls

--- a/hphp/hack/src/format/formatConfig.mli
+++ b/hphp/hack/src/format/formatConfig.mli
@@ -1,0 +1,25 @@
+(**
+ * Copyright (c) 2014, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the "hack" directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ *)
+
+type t = {
+  indent_offset        : int  ;
+  line_width           : int  ;
+  indent_case          : bool ;
+  align_cascaded_calls : bool ;
+}
+
+val load : Relative_path.t -> t
+
+val default_config : t
+
+val indent_offset : t -> int
+val line_width : t -> int
+val indent_case : t -> bool
+val align_cascaded_calls : t -> bool

--- a/hphp/hack/src/format/format_diff.ml
+++ b/hphp/hack/src/format/format_diff.ml
@@ -357,17 +357,17 @@ let apply_blocks outc blocks lines =
 let parse_diff diff_text =
   ParseDiff.go diff_text
 
-let rec apply modes in_place ~diff:file_and_lines_modified =
+let rec apply modes config in_place ~diff:file_and_lines_modified =
   List.iter begin fun (filepath, modified_lines) ->
     let filename = Relative_path.to_absolute filepath in
     let file_content = Utils.cat filename in
-    apply_file modes in_place filepath file_content modified_lines
+    apply_file modes config in_place filepath file_content modified_lines
   end file_and_lines_modified
 
-and apply_file modes in_place filepath file_content modified_lines =
+and apply_file modes config in_place filepath file_content modified_lines =
   let filename = Relative_path.to_absolute filepath in
   let result =
-    Format_hack.program_with_source_metadata modes filepath file_content in
+    Format_hack.program_with_source_metadata modes config filepath file_content in
   match result with
   | Format_hack.Success formatted_content ->
       apply_formatted in_place filename formatted_content file_content

--- a/hphp/hack/src/format/format_diff.mli
+++ b/hphp/hack/src/format/format_diff.mli
@@ -20,4 +20,4 @@ type interval = int * int
 type file_diff = filename * interval list
 
 val parse_diff: string -> file_diff list
-val apply: FileInfo.mode option list -> bool -> diff:(file_diff list) -> unit
+val apply: FileInfo.mode option list -> FormatConfig.t -> bool -> diff:(file_diff list) -> unit

--- a/hphp/hack/src/format/format_hack.mli
+++ b/hphp/hack/src/format/format_hack.mli
@@ -31,6 +31,7 @@ type source_pos = char_pos * source_tag
 
 val region:
   FileInfo.mode option list ->
+  FormatConfig.t ->
   Relative_path.t ->
   start:int ->
   end_:int ->
@@ -40,11 +41,13 @@ val region:
 val program:
   ?no_trailing_commas:bool ->
   FileInfo.mode option list ->
+  FormatConfig.t ->
   Relative_path.t -> string ->
   string return
 
 val program_with_source_metadata:
   FileInfo.mode option list ->
+  FormatConfig.t ->
   Relative_path.t ->
   string ->
   (string * source_pos list) return

--- a/hphp/hack/src/h2tp/unparser/unparser.ml
+++ b/hphp/hack/src/h2tp/unparser/unparser.ml
@@ -968,7 +968,7 @@ let unparse :
   fun s ->
     dn s;
     let modes = [Some FileInfo.Mstrict; Some FileInfo.Mpartial] in
-    let formatted = Format_hack.program modes file ~no_trailing_commas:true s in
+    let formatted = Format_hack.program modes FormatConfig.default_config file ~no_trailing_commas:true s in
     let s' = match formatted with
     | Format_hack.Disabled_mode -> raise Impossible
     | Format_hack.Internal_error -> raise (FormatterError "")


### PR DESCRIPTION
Adds the ability to set the values of a few important settings in the
formatter. These are currently pulled from the `.hhconfig` file. Each
option is prefixed with "format." to avoid potential conflicts with
other configuration variables.

The options all default to the values/behaviour that were already
present.

There are currently 4 options:

* Indent offset ("indent_offset") - Set the number of spaces used for
  indentation. Default 2.
* Line width ("line_width") - The maximum number of characters in a
  line. Default 80.
* Indent case ("indent_case") - Indent cases in switch statements.
  Default off.
* Align cascaded calls ("align_cascaded_calls") - Align cascaded method
  calls on the '->' or '?->' like this:

  ```php
  $foo->bar()
      ->baz()
      ->done();
  ```

  Defaults to off.