### PR TITLE
Update Redis.php

### DIFF
--- a/hphp/system/php/redis/Redis.php
+++ b/hphp/system/php/redis/Redis.php
@@ -855,7 +855,7 @@ class Redis {
     'sinterstore' => [ 'vararg' => self::VAR_KEY_ALL, 'return' => 'Long' ],
     'sismember' => [ 'format' => 'kv', 'return' => '1' ],
     'scontains' => [ 'alias' => 'sismember' ],
-    'smembers' => [ 'format' => 'k', 'return' => 'Vector' ],
+    'smembers' => [ 'format' => 'kv', 'return' => 'Vector' ],
     'sgetmembers' => [ 'alias' => 'smembers' ],
     'smove' => [ 'format' => 'kkv', 'return' => '1' ],
     'spop' => [ 'format' => 'k', 'return' => 'Serialized' ],


### PR DESCRIPTION
`smembers` returns an array of strings that need to be unserialized so it needs "v" in its format spec.