### PR TITLE
Add /usr/local to libdouble-conversion detection

### DIFF
--- a/CMake/FindDoubleConversion.cmake
+++ b/CMake/FindDoubleConversion.cmake
@@ -6,8 +6,11 @@
 #
 
 find_path(DOUBLE_CONVERSION_INCLUDE_DIR
-    NAMES double-conversion.h
-    PATHS /usr/include/double-conversion)
+    NAMES
+      double-conversion.h
+    PATHS
+      /usr/include/double-conversion
+      /usr/local/include/double-conversion)
 find_library(DOUBLE_CONVERSION_LIBRARY NAMES double-conversion)
 
 include(FindPackageHandleStandardArgs)


### PR DESCRIPTION
Most of the CMake scripts correctly detect libraries when they're under /usr/local.  This adds the same detection to the libdouble-conversion script.
This also fixes libdouble-conversion detection on FreeBSD.