### PR TITLE
Update configure

### DIFF
--- a/configure
+++ b/configure
@@ -3,7 +3,8 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 if [ "$1" = '--help' ] || [ "$1" = '-h' ]; then
-  echo "usage: $0 -Dvariable=argument ...\n"
+  echo "usage: $0 -Dvariable=argument ..."
+  echo ''
   echo 'Variables: '
   options=`cat $DIR/CMake/Options.cmake | grep option | sed -e 's/^[ \t]*//' |
            sed 's/\s*option(/  -D/; s/ "/=ON|OFF : /;  


### PR DESCRIPTION
use echo in portable way

`\n` is not expanded here, alternative is to use `printf "%s\n" "$0"`, but this is simplier