### PR TITLE
Fix ZendSorting performance.

### DIFF
--- a/hphp/runtime/base/sort-flags.h
+++ b/hphp/runtime/base/sort-flags.h
@@ -17,6 +17,9 @@
 #ifndef incl_HPHP_SORT_FLAGS_H_
 #define incl_HPHP_SORT_FLAGS_H_
 
+#include <stdint.h>
+#include "hphp/util/assertions.h"
+
 namespace HPHP {
 
 enum SortFlavor { IntegerSort, StringSort, GenericSort };

--- a/hphp/runtime/base/zend-sort.cpp
+++ b/hphp/runtime/base/zend-sort.cpp
@@ -1,0 +1,221 @@
+/*
+   +----------------------------------------------------------------------+
+   | HipHop for PHP                                                       |
+   +----------------------------------------------------------------------+
+   | Copyright (c) 2010-2014 Facebook, Inc. (http://www.facebook.com)     |
+   | Copyright (c) 2014-2015 Etsy, Inc. (http://www.etsy.com)             |
+   +----------------------------------------------------------------------+
+   | This source file is subject to version 2.00 of the Zend license,     |
+   | that is bundled with this package in the file LICENSE, and is        |
+   | available through the world-wide-web at the following url:           |
+   | http://www.zend.com/license/2_00.txt.                                |
+   | If you did not receive a copy of the Zend license and are unable to  |
+   | obtain it through the world-wide-web, please send a note to          |
+   | license@zend.com so we can mail you a copy immediately.              |
+   +----------------------------------------------------------------------+
+*/
+#include "hphp/runtime/base/sort-flags.h"
+#include "hphp/runtime/base/bstring.h"
+#include "hphp/runtime/base/zend-string.h"
+#include "hphp/runtime/base/comparisons.h"
+#include "hphp/runtime/base/type-array.h"
+#include <string.h>
+
+namespace HPHP {
+
+#define COMPARE_AND_RETURN(o1, o2) do { \
+  if (equal(o1, o2)) return 0; \
+  else if (less(o1, o2)) return -1; \
+  else return 1; \
+} while (0)
+
+static inline int zend_numeric_compare(const Variant& v1,
+                                       const Variant& v2,
+                                       UNUSED const void* unused) {
+  auto v1_d = v1.toDouble();
+  auto v2_d = v2.toDouble();
+  COMPARE_AND_RETURN(v1_d, v2_d);
+}
+
+enum StringType {
+  REGULAR_STRING,
+  NATURAL_STRING,
+  LOCALE_STRING
+};
+
+static inline int zend_string_compare_function(StringType type,
+                                               const Variant& v1,
+                                               const Variant& v2,
+                                               bool case_insensitive) {
+  int ret = 0;
+  const auto &v1_str = v1.toString();
+  const auto &v2_str = v2.toString();
+
+  switch (type) {
+  case REGULAR_STRING:
+    if (case_insensitive) {
+      ret = bstrcasecmp(v1_str.data(), v1_str.size(),
+                        v2_str.data(), v2_str.size());
+    } else {
+      ret = string_strcmp(v1_str.data(), v1_str.size(),
+                          v2_str.data(), v2_str.size());
+    }
+    break;
+
+  case NATURAL_STRING:
+    ret = string_natural_cmp(v1_str.data(), v1_str.size(),
+                             v2_str.data(), v2_str.size(),
+                             (int) case_insensitive);
+    break;
+
+  case LOCALE_STRING:
+    ret = strcoll(v1_str.data(), v2_str.data());
+    break;
+  }
+
+  return ret;
+}
+
+static inline int zend_locale_string_compare(const Variant& v1,
+                                             const Variant& v2,
+                                             UNUSED const void* unused) {
+  bool case_insensitive = false;
+  return zend_string_compare_function(LOCALE_STRING, v1, v2,
+                                      case_insensitive);
+}
+
+static inline int zend_string_compare(const Variant& v1,
+                                      const Variant& v2,
+                                      UNUSED const void* unused) {
+  bool case_insensitive = false;
+  return zend_string_compare_function(REGULAR_STRING, v1, v2,
+                                      case_insensitive);
+}
+
+static inline int zend_string_case_compare(const Variant& v1,
+                                           const Variant& v2,
+                                           UNUSED const void* unused) {
+  bool case_insensitive = true;
+  return zend_string_compare_function(REGULAR_STRING, v1, v2,
+                                      case_insensitive);
+}
+
+static inline int zend_natural_string_compare(const Variant& v1,
+                                              const Variant& v2,
+                                              UNUSED const void* unused) {
+  bool case_insensitive = false;
+  return zend_string_compare_function(NATURAL_STRING, v1, v2,
+                                      case_insensitive);
+}
+
+static inline int zend_natural_string_case_compare(const Variant& v1,
+                                                   const Variant& v2,
+                                                   UNUSED const void* unused) {
+  bool case_insensitive = true;
+  return zend_string_compare_function(NATURAL_STRING, v1, v2,
+                                      case_insensitive);
+}
+
+static inline Variant convert_object_for_comparison(const Variant& obj) {
+  if (obj.isObject()) return obj.toString();
+  else return obj;
+}
+
+static inline int zend_regular_compare(const Variant& v1,
+                                       const Variant& v2,
+                                       UNUSED const void* unused) {
+  if ((v1.isNull() || v1.isInteger() || v1.isDouble() || v1.isBoolean()) &&
+      (v2.isNull() || v2.isInteger() || v2.isDouble() || v2.isBoolean())) {
+    return zend_numeric_compare(v1, v2, NULL);
+  } else if (v1.isString() && v2.isString()) {
+    return zend_string_compare(v1, v2, NULL);
+  } else if (v1.isNull() && v2.isString()) {
+    return v2.toString().size() ? 0 : -1;
+  } else if (v1.isString() && v2.isNull()) {
+    return v1.toString().size() ? 0 : 1;
+  } else if (v1.isNull() && v2.isObject()) {
+    return -1;
+  } else if (v1.isObject() && v2.isNull()) {
+    return 1;
+  } else if (v1.isArray() && v2.isArray()) {
+    const auto &v1_arr = v1.toArray();
+    const auto &v2_arr = v2.toArray();
+    COMPARE_AND_RETURN(v1_arr, v2_arr);
+  } else if (v1.isObject() && v2.isObject()) {
+    const auto &v1_obj = v1.toObject();
+    const auto &v2_obj = v2.toObject();
+    COMPARE_AND_RETURN(v1_obj, v2_obj);
+  } else {
+    /* Out of options. Do what the zend-collator code does */
+    const auto &v1_mod = convert_object_for_comparison(v1);
+    const auto &v2_mod = convert_object_for_comparison(v2);
+    COMPARE_AND_RETURN(v1_mod, v2_mod);
+  }
+}
+
+#undef COMPARE_AND_RETURN
+
+typedef struct {
+  Array::PFUNC_CMP cmp_func;
+  bool ascending;
+} SortData;
+
+static inline int zend_sort_wrapper(const Variant& v1,
+                                    const Variant& v2,
+                                    const void *data) {
+  SortData *sort_data = (SortData *) data;
+  int ret = sort_data->cmp_func(v1, v2, NULL);
+  return sort_data->ascending ? ret : (-ret);
+}
+
+static bool zend_sort_handler(bool renumber, Variant& array,
+                              int sort_flags, bool ascending, bool byKey) {
+  Array temp = array.toArray();
+  SortData sort_data;
+
+  sort_data.ascending = ascending;
+
+  switch (sort_flags) {
+  case SORT_NUMERIC:
+    sort_data.cmp_func = zend_numeric_compare;
+    break;
+  case SORT_STRING_CASE:
+    sort_data.cmp_func = zend_string_case_compare;
+    break;
+  case SORT_STRING:
+    sort_data.cmp_func = zend_string_compare;
+    break;
+  case SORT_LOCALE_STRING:
+    sort_data.cmp_func = zend_locale_string_compare;
+    break;
+  case SORT_NATURAL_CASE:
+    sort_data.cmp_func = zend_natural_string_case_compare;
+    break;
+  case SORT_NATURAL:
+    sort_data.cmp_func = zend_natural_string_compare;
+    break;
+  case SORT_REGULAR:
+  default:
+    sort_data.cmp_func = zend_regular_compare;
+    break;
+  }
+
+  /* Sort specified array. */
+  temp.sort(zend_sort_wrapper, byKey, renumber, &sort_data);
+
+  array = temp;
+  return true;
+}
+
+#define CREATE_ZEND_SORT_FUNCTION(NAME, RENUMBER, BYKEY) \
+  bool zend_ ## NAME (Variant &array, int sort_flags, bool ascending) { \
+    return zend_sort_handler(RENUMBER, array, sort_flags, ascending, BYKEY); \
+  }
+
+CREATE_ZEND_SORT_FUNCTION(sort, true, false);
+CREATE_ZEND_SORT_FUNCTION(asort, false, false);
+CREATE_ZEND_SORT_FUNCTION(ksort, false, true);
+
+#undef CREATE_ZEND_SORT_FUNCTION
+
+}

--- a/hphp/runtime/base/zend-sort.h
+++ b/hphp/runtime/base/zend-sort.h
@@ -1,0 +1,33 @@
+/*
+   +----------------------------------------------------------------------+
+   | HipHop for PHP                                                       |
+   +----------------------------------------------------------------------+
+   | Copyright (c) 2010-2014 Facebook, Inc. (http://www.facebook.com)     |
+   | Copyright (c) 2014-2015 Etsy, Inc. (http://www.etsy.com)             |
+   +----------------------------------------------------------------------+
+   | This source file is subject to version 2.00 of the Zend license,     |
+   | that is bundled with this package in the file LICENSE, and is        |
+   | available through the world-wide-web at the following url:           |
+   | http://www.zend.com/license/2_00.txt.                                |
+   | If you did not receive a copy of the Zend license and are unable to  |
+   | obtain it through the world-wide-web, please send a note to          |
+   | license@zend.com so we can mail you a copy immediately.              |
+   +----------------------------------------------------------------------+
+*/
+
+#ifndef incl_HPHP_ZEND_SORT_H_
+#define incl_HPHP_ZEND_SORT_H_
+
+namespace HPHP {
+///////////////////////////////////////////////////////////////////////////////
+
+struct Variant;
+
+bool zend_sort(Variant& array, int sort_flags, bool ascending);
+bool zend_asort(Variant& array, int sort_flags, bool ascending);
+bool zend_ksort(Variant &array, int sort_flags, bool ascending);
+
+///////////////////////////////////////////////////////////////////////////////
+}
+
+#endif // incl_HPHP_ZEND_SORT_H_

--- a/hphp/runtime/ext/array/ext_array.cpp
+++ b/hphp/runtime/ext/array/ext_array.cpp
@@ -29,6 +29,7 @@
 #include "hphp/runtime/base/request-local.h"
 #include "hphp/runtime/base/sort-flags.h"
 #include "hphp/runtime/base/zend-collator.h"
+#include "hphp/runtime/base/zend-sort.h"
 #include "hphp/runtime/ext/ext_generator.h"
 #include "hphp/runtime/ext/ext_collections.h"
 #include "hphp/runtime/ext/std/ext_std_function.h"
@@ -2349,16 +2350,11 @@ class ArraySortTmp {
 
 static bool
 php_sort(VRefParam container, int sort_flags,
-         bool ascending, bool use_collator) {
+         bool ascending, bool use_zend_sort) {
   if (container.isArray()) {
     Array& arr_array = container.wrapped().toArrRef();
-    if (use_collator && sort_flags != SORT_LOCALE_STRING) {
-      UCollator *coll = s_collator->getCollator();
-      if (coll) {
-        Intl::IntlError &errcode = s_collator->getErrorRef();
-        return collator_sort(container, sort_flags, ascending,
-                             coll, &errcode);
-      }
+    if (use_zend_sort) {
+      return zend_sort(container, sort_flags, ascending);
     }
     SortFunction sf = getSortFunction(SORTFUNC_SORT, ascending);
     ArraySortTmp ast(arr_array, sf);
@@ -2383,16 +2379,11 @@ php_sort(VRefParam container, int sort_flags,
 
 static bool
 php_asort(VRefParam container, int sort_flags,
-          bool ascending, bool use_collator) {
+          bool ascending, bool use_zend_sort) {
   if (container.isArray()) {
     Array& arr_array = container.wrapped().toArrRef();
-    if (use_collator && sort_flags != SORT_LOCALE_STRING) {
-      UCollator *coll = s_collator->getCollator();
-      if (coll) {
-        Intl::IntlError &errcode = s_collator->getErrorRef();
-        return collator_asort(container, sort_flags, ascending,
-                              coll, &errcode);
-      }
+    if (use_zend_sort) {
+      return zend_asort(container, sort_flags, ascending);
     }
     SortFunction sf = getSortFunction(SORTFUNC_ASORT, ascending);
     ArraySortTmp ast(arr_array, sf);
@@ -2416,16 +2407,11 @@ php_asort(VRefParam container, int sort_flags,
 
 static bool
 php_ksort(VRefParam container, int sort_flags, bool ascending,
-          bool use_collator) {
+          bool use_zend_sort) {
   if (container.isArray()) {
     Array& arr_array = container.wrapped().toArrRef();
-    if (use_collator && sort_flags != SORT_LOCALE_STRING) {
-      UCollator *coll = s_collator->getCollator();
-      if (coll) {
-        Intl::IntlError &errcode = s_collator->getErrorRef();
-        return collator_ksort(container, sort_flags, ascending,
-                              coll, &errcode);
-      }
+    if (use_zend_sort) {
+      return zend_ksort(container, sort_flags, ascending);
     }
     SortFunction sf = getSortFunction(SORTFUNC_KRSORT, ascending);
     ArraySortTmp ast(arr_array, sf);
@@ -2450,43 +2436,43 @@ php_ksort(VRefParam container, int sort_flags, bool ascending,
 bool HHVM_FUNCTION(sort,
                   VRefParam array,
                   int sort_flags /* = 0 */) {
-  bool use_collator = RuntimeOption::EnableZendSorting;
-  return php_sort(array, sort_flags, true, use_collator);
+  bool use_zend_sort = RuntimeOption::EnableZendSorting;
+  return php_sort(array, sort_flags, true, use_zend_sort);
 }
 
 bool HHVM_FUNCTION(rsort,
                    VRefParam array,
                    int sort_flags /* = 0 */) {
-  bool use_collator = RuntimeOption::EnableZendSorting;
-  return php_sort(array, sort_flags, false, use_collator);
+  bool use_zend_sort = RuntimeOption::EnableZendSorting;
+  return php_sort(array, sort_flags, false, use_zend_sort);
 }
 
 bool HHVM_FUNCTION(asort,
                    VRefParam array,
                    int sort_flags /* = 0 */) {
-  bool use_collator = RuntimeOption::EnableZendSorting;
-  return php_asort(array, sort_flags, true, use_collator);
+  bool use_zend_sort = RuntimeOption::EnableZendSorting;
+  return php_asort(array, sort_flags, true, use_zend_sort);
 }
 
 bool HHVM_FUNCTION(arsort,
                    VRefParam array,
                    int sort_flags /* = 0 */) {
-  bool use_collator = RuntimeOption::EnableZendSorting;
-  return php_asort(array, sort_flags, false, use_collator);
+  bool use_zend_sort = RuntimeOption::EnableZendSorting;
+  return php_asort(array, sort_flags, false, use_zend_sort);
 }
 
 bool HHVM_FUNCTION(ksort,
                    VRefParam array,
                    int sort_flags /* = 0 */) {
-  bool use_collator = RuntimeOption::EnableZendSorting;
-  return php_ksort(array, sort_flags, true, use_collator);
+  bool use_zend_sort = RuntimeOption::EnableZendSorting;
+  return php_ksort(array, sort_flags, true, use_zend_sort);
 }
 
 bool HHVM_FUNCTION(krsort,
                    VRefParam array,
                    int sort_flags /* = 0 */) {
-  bool use_collator = RuntimeOption::EnableZendSorting;
-  return php_ksort(array, sort_flags, false, use_collator);
+  bool use_zend_sort = RuntimeOption::EnableZendSorting;
+  return php_ksort(array, sort_flags, false, use_zend_sort);
 }
 
 // NOTE: PHP's implementation of natsort and natcasesort accepts ArrayAccess

--- a/hphp/test/slow/array/zend_sort_locale.php
+++ b/hphp/test/slow/array/zend_sort_locale.php
@@ -1,0 +1,17 @@
+<?php
+setlocale(LC_ALL, 'fr_FR.ISO8859-1', 'fr_FR');
+$table = array("AB" => "Alberta",
+"BC" => "Colombie-Britannique",
+"MB" => "Manitoba",
+"NB" => "Nouveau-Brunswick",
+"NL" => "Terre-Neuve-et-Labrador",
+"NS" => "Nouvelle-�cosse",
+"ON" => "Ontario",
+"PE" => "�le-du-Prince-�douard",
+"QC" => "Qu�bec",
+"SK" => "Saskatchewan",
+"NT" => "Territoires du Nord-Ouest",
+"NU" => "Nunavut",
+"YT" => "Territoire du Yukon");
+asort($table, SORT_LOCALE_STRING);
+var_dump($table);

--- a/hphp/test/slow/array/zend_sort_locale.php.expect
+++ b/hphp/test/slow/array/zend_sort_locale.php.expect
@@ -1,0 +1,28 @@
+array(13) {
+  ["AB"]=>
+  string(7) "Alberta"
+  ["BC"]=>
+  string(20) "Colombie-Britannique"
+  ["PE"]=>
+  string(25) "�le-du-Prince-�douard"
+  ["MB"]=>
+  string(8) "Manitoba"
+  ["NB"]=>
+  string(17) "Nouveau-Brunswick"
+  ["NS"]=>
+  string(17) "Nouvelle-�cosse"
+  ["NU"]=>
+  string(7) "Nunavut"
+  ["ON"]=>
+  string(7) "Ontario"
+  ["QC"]=>
+  string(8) "Qu�bec"
+  ["SK"]=>
+  string(12) "Saskatchewan"
+  ["NL"]=>
+  string(23) "Terre-Neuve-et-Labrador"
+  ["YT"]=>
+  string(19) "Territoire du Yukon"
+  ["NT"]=>
+  string(25) "Territoires du Nord-Ouest"
+}

--- a/hphp/test/slow/array/zend_sort_locale.php.opts
+++ b/hphp/test/slow/array/zend_sort_locale.php.opts
@@ -1,0 +1,1 @@
+-vEval.EnableZendSorting=1

--- a/hphp/test/slow/ext_array/asort.php
+++ b/hphp/test/slow/ext_array/asort.php
@@ -11,25 +11,14 @@ asort($fruits);
 var_dump($fruits);
 
 $arr = array("at", "\xe0s", "as");
-i18n_loc_set_default("en_US");
 asort($arr, 0);
 $arr = array("num2ber", "num1ber", "num10ber");
-i18n_loc_set_default("en_US");
-i18n_loc_set_attribute(UCOL_NUMERIC_COLLATION, UCOL_ON);
-i18n_loc_set_strength(UCOL_PRIMARY);
 asort($arr, SORT_REGULAR);
-i18n_loc_set_attribute(UCOL_NUMERIC_COLLATION, UCOL_DEFAULT);
-i18n_loc_set_strength(UCOL_DEFAULT);
 var_dump($arr);
 
 $arr = array("G\xediron",        // &iacute; (Latin-1)
                      "G\xc3\xb3nzales",  // &oacute; (UTF-8)
                      "G\xc3\xa9 ara",    // &eacute; (UTF-8)
                      "G\xe1rcia");       // &aacute; (Latin-1)
-i18n_loc_set_default("en_US");
-i18n_loc_set_attribute(UCOL_NUMERIC_COLLATION, UCOL_ON);
-i18n_loc_set_strength(UCOL_PRIMARY);
 asort($arr, SORT_REGULAR);
-i18n_loc_set_attribute(UCOL_NUMERIC_COLLATION, UCOL_DEFAULT);
-i18n_loc_set_strength(UCOL_DEFAULT);
 var_dump($arr);

--- a/hphp/test/slow/ext_array/asort.php.expect
+++ b/hphp/test/slow/ext_array/asort.php.expect
@@ -9,20 +9,20 @@ array(4) {
   string(6) "orange"
 }
 array(3) {
+  [2]=>
+  string(8) "num10ber"
   [1]=>
   string(7) "num1ber"
   [0]=>
   string(7) "num2ber"
-  [2]=>
-  string(8) "num10ber"
 }
 array(4) {
-  [0]=>
-  string(6) "Gíiron"
-  [1]=>
-  string(9) "GÃ³nzales"
   [2]=>
   string(7) "GÃ© ara"
+  [1]=>
+  string(9) "GÃ³nzales"
   [3]=>
   string(6) "Gárcia"
+  [0]=>
+  string(6) "Gíiron"
 }


### PR DESCRIPTION
Details: The old implementation use zend-collator which does a lot of useless
conversions to UTF-16 back to UTF-8 and comparisons using ICU, all of which
gets really expensive.
The new implementation ports the existing Zend functionality to HHVM and
relies on regular string/numeric comparison functions where possible. The
performance is an order of magnitude faster.