### PR TITLE
The Extension API check does not work

### DIFF
--- a/hphp/runtime/ext/extension.cpp
+++ b/hphp/runtime/ext/extension.cpp
@@ -108,10 +108,7 @@ static const char* dlerror() {
 
 ///////////////////////////////////////////////////////////////////////////////
 
-Extension::Extension(litstr name, const char *version /* = "" */)
-    : m_hhvmAPIVersion(HHVM_API_VERSION)
-    , m_name(name)
-    , m_version(version ? version : "") {
+void Extension::registerExtension(litstr name) {
   if (s_registered_extensions == NULL) {
     s_registered_extensions = new ExtensionMap();
   }
@@ -228,6 +225,15 @@ void Extension::LoadModules(const IniSetting::Map& ini, Hdf hdf) {
     if (!ptr) {
       throw Exception("Could not open extension %s: %s",
                       extFile.c_str(), dlerror());
+    }
+    auto getModuleBuildInfo =
+      (ExtensionBuildInfo *(*)())dlsym(ptr, "getModuleBuildInfo");
+    if (!getModuleBuildInfo) {
+      throw Exception("Could not load extension %s: %s %s (%s)",
+                      extFile.c_str(),
+                      "getModuleBuildInfo() symbol not defined.",
+                      "The HHVM binary version does not match the extension",
+                      dlerror());
     }
     auto getModule = (Extension *(*)())dlsym(ptr, "getModule");
     if (!getModule) {

--- a/hphp/runtime/ext/extension.h
+++ b/hphp/runtime/ext/extension.h
@@ -57,6 +57,8 @@ namespace HPHP {
 
 ///////////////////////////////////////////////////////////////////////////////
 
+#define HHVM_API_VERSION 20150324L
+
 class Extension : public IDebuggable {
 public:
   static bool IsLoaded(const String& name);
@@ -84,9 +86,15 @@ public:
   static void CompileSystemlib(const std::string &slib,
                                const std::string &name);
 public:
-  explicit Extension(litstr name, const char *version = "");
+  explicit Extension(litstr name, const char *version = "")
+    : m_hhvmAPIVersion(HHVM_API_VERSION)
+    , m_name(name)
+    , m_version(version ? version : "") {
+      registerExtension(name);
+  }
   virtual ~Extension() {}
 
+  void registerExtension(litstr name);
   const char *getVersion() const { return m_version.c_str();}
 
   // override these functions to implement module specific init/shutdown
@@ -130,12 +138,18 @@ private:
   std::string m_dsoName;
 };
 
-#define HHVM_API_VERSION 20150212L
+struct ExtensionBuildInfo {
+  uint64_t dso_version;
+  uint64_t branch_id;
+};
 
 #ifdef HHVM_BUILD_DSO
 #define HHVM_GET_MODULE(name) \
 extern "C" Extension *getModule() { \
   return &s_##name##_extension; \
+} \
+extern "C" ExtensionBuildInfo* getModuleBuildInfo() { \
+  return NULL; \
 }
 #else
 #define HHVM_GET_MODULE(name)


### PR DESCRIPTION
The Extension class constructor implementation is provided in the cpp file. So when the extension's static object s_##name_extension is constructed,
the constructor called is in the HHVM binary and hence the m_hhvmAPIVersion
private member variable is initialized to HHVM_API_VERSION defined in the
binary itself, not what it was when the extension was compiled.
The patch moves the Extension constructor to the header file to fix the issue.

The proper fix is coming in commit 1b2addb77d21b43447098c7b0cf1cfed31feebb9,
this is a placeholder until then. I've added a dummy getModuleBuildInfo()
method to aid in the transition

This reopens PR #5074 properly rebased to HHVM-3.6