### PR TITLE
Do not free the result of gethostbyname() to fix crash on Mac.

### DIFF
--- a/hphp/util/network.cpp
+++ b/hphp/util/network.cpp
@@ -60,9 +60,6 @@ bool safe_gethostbyname(const char *address, HostEnt &result) {
   }
 
   result.hostbuf = *hp;
-#ifdef __APPLE__
-  freehostent(hp);
-#endif
   return true;
 #else
   struct hostent *hp;


### PR DESCRIPTION
According to the man pages, freehostent is not able to free the result of
gethostbyname. gethostbyname uses a thread local storage for result.

Part of #4444.

Minimal repro (Assertion failed: (rc >= 0), function si_item_release):

```
#include <assert.h>
#include <netdb.h>
#include <stdio.h>

int main() {
  struct hostent *hp = gethostbyname("wordpress.org");
  assert(hp);
  freehostent(hp);

  hp = gethostbyname("planet.wordpress.org");
  assert(hp);
  freehostent(hp);
  return 0;
}
```