### PR TITLE
fix_duplicate_fastcgi_header

### DIFF
--- a/hphp/runtime/server/fastcgi/fastcgi-transport.cpp
+++ b/hphp/runtime/server/fastcgi/fastcgi-transport.cpp
@@ -215,7 +215,7 @@ void FastCGITransport::onHeader(std::unique_ptr<folly::IOBuf> key_chain,
   Cursor valCur(value_chain.get());
   auto value = valCur.readFixedString(value_chain->computeChainDataLength());
 
-  m_requestParams.emplace(key, value);
+  m_requestParams[key] = value;
 }
 
 void FastCGITransport::onHeadersComplete() {


### PR DESCRIPTION
hhvm can‘t get the right fastcgi header value while web server set same header duplicate。for example：
1.  nginx fastcgi_params:

    fastcgi_param QUERY_STRING $query_string;
    fastcgi_param REQUEST_METHOD $request_method;
    fastcgi_param CONTENT_TYPE $content_type;
    fastcgi_param CONTENT_LENGTH $content_length;

    fastcgi_param SCRIPT_NAME $fastcgi_script_name;
    fastcgi_param REQUEST_URI $request_uri; //set request_uri here!
    fastcgi_param DOCUMENT_URI $document_uri;
    fastcgi_param DOCUMENT_ROOT $document_root;
    fastcgi_param SERVER_PROTOCOL $server_protocol;
    fastcgi_param HTTPS $https if_not_empty;

    fastcgi_param GATEWAY_INTERFACE CGI/1.1;
    fastcgi_param SERVER_SOFTWARE nginx/$nginx_version;

    fastcgi_param REMOTE_ADDR $remote_addr;
    fastcgi_param REMOTE_PORT $remote_port;
    fastcgi_param SERVER_ADDR $server_addr;
    fastcgi_param SERVER_PORT $server_port;
    fastcgi_param SERVER_NAME $server_name;
    fastcgi_param REDIRECT_STATUS 200;

2. I overwrite the fastcgi REQUEST_URI params via vhost conf:


        location ~ .php$ {
             root $webroot;
             fastcgi_pass 127.0.0.1:9000;
             fastcgi_index index.php;
             include fcgi.conf;
             include fastcgi_params; //include the fastcgi params
             fastcgi_param REQUEST_URI /$app_uri?$query_string; //override the REQUEST_URI
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
        }

3. In php， I will get the override value ( /$app_uri?$query_string)；but in hhvm, I can't get the override value.

4. I found function onHeader in file fastcgi-transport.cpp, it use m_requestParams.emplace(key, value).I think, it use m_requestParams[key]=value, more better.