### PR TITLE
Cache time zone validity and add lock for calling timelib on Mac.

### DIFF
--- a/hphp/runtime/base/program-functions.cpp
+++ b/hphp/runtime/base/program-functions.cpp
@@ -1762,6 +1762,10 @@ void hphp_process_init() {
   pthread_attr_destroy(&attr);
 
   Process::InitProcessStatics();
+
+  // initialize the tzinfo cache.
+  timezone_init();
+
   init_thread_locals();
 
   struct sigaction action = {};
@@ -1781,9 +1785,6 @@ void hphp_process_init() {
 
   // reinitialize pcre table
   pcre_reinit();
-
-  // initialize the tzinfo cache.
-  timezone_init();
 
   // the liboniguruma docs say this isnt needed,
   // but the implementation of init is not

--- a/hphp/runtime/base/timezone.cpp
+++ b/hphp/runtime/base/timezone.cpp
@@ -199,11 +199,10 @@ bool TimeZone::SetCurrent(const String& zone) {
     valid = IsValid(zone);
 
     auto key = strdup(name);
-    auto result = s_tzvCache->insert(TimeZoneValidityCacheEntry(name, valid));
+    auto result = s_tzvCache->insert(TimeZoneValidityCacheEntry(key, valid));
     if (!result.second) {
-      // The cache should never fill up since zones are finite.
-      always_assert(result.first != s_tzvCache->end());
-      // A collision occurred, so we don't need our strdup'ed key.
+      // The cache is full or a collision occurred, and we don't need our
+      // strdup'ed key.
       free(key);
     }
   }


### PR DESCRIPTION
date_default_timezone_set() is called once for every WordPress request in
stock WordPress 4.1.1. Cache the time zone validity for better performance.

A lock is needed when calling timelib_timezone_id_is_valid() because
setlocale() on Mac is not thread safe. When the first argument to setlocale
is LC_CTYPE, loadlocale() will call __setrunelocale() to modify the global
locale object and double free can happen and crash.

http://www.opensource.apple.com/source/Libc/Libc-997.90.3/locale/FreeBSD/setrunelocale.c

Part of #4444.