### PR TITLE
redis responseDouble returns false on error, not null

### DIFF
--- a/hphp/system/php/redis/Redis.php
+++ b/hphp/system/php/redis/Redis.php
@@ -1263,7 +1263,7 @@ class Redis {
           ($type === self::TYPE_BULK && is_numeric($resp))) {
         return (float)$resp;
       }
-      return null;
+      return false;
     }
     $this->multiHandler[] = [ 'cb' => [$this,'processDoubleResponse'] ];
     if (($this->mode === self::MULTI) && !$this->processQueuedResponse()) {

--- a/hphp/test/slow/ext_redis/zScoreReturn.php
+++ b/hphp/test/slow/ext_redis/zScoreReturn.php
@@ -1,0 +1,12 @@
+<?php
+
+include (__DIR__ . '/redis.inc');
+
+$redis = NewRedisTestInstance();
+$connect = $redis->connect('127.0.0.1',6379);
+var_dump($connect);
+$redis->zAdd('myzset', 1, 'one');
+$result = $redis->zScore('myzset',"one");
+var_dump($result);
+$result = $redis->zScore('myzset',"one3");
+var_dump ($result);

--- a/hphp/test/slow/ext_redis/zScoreReturn.php.expect
+++ b/hphp/test/slow/ext_redis/zScoreReturn.php.expect
@@ -1,0 +1,3 @@
+bool(true)
+float(1)
+bool(false)

--- a/hphp/test/slow/ext_redis/zScoreReturn.php.skipif
+++ b/hphp/test/slow/ext_redis/zScoreReturn.php.skipif
@@ -1,0 +1,12 @@
+<?php
+
+if (!getenv('REDIS_TEST_HOST')) {
+  echo 'skip';
+} else {
+  // Some people might have this variable set, but don't have the server running
+  $output = array();
+  exec("redis-cli ping", $output);
+  if ($output[0] !== "PONG") {
+    echo 'skip';
+  }
+}


### PR DESCRIPTION
I am thinking about why there is null in the first place. I thought that this is for a reason.
My guess is that the one who implemented this looked at php's implementation
and saw the `return;` call. But that isn't called actually.

So while not being 100% sure that this is correct for all cases, and having
not the best test coverage on redis (because we don't import the php-src
tests) I think this is most likely correct.

Fixes #5112

Test Plan:
new test && slow/ext_redis/
Note that these tests probably get skipped on sandcastle