### PR TITLE
fix right log tips while php file not exists

### DIFF
--- a/hphp/runtime/base/builtin-functions.cpp
+++ b/hphp/runtime/base/builtin-functions.cpp
@@ -728,11 +728,15 @@ Variant include_impl_invoke(const String& file, bool once,
       } catch(PhpFileDoesNotExistException &e) {}
     }
 
-    String rel_path(FileUtil::relativePath(RuntimeOption::SourceRoot,
+    try {
+      String rel_path(FileUtil::relativePath(RuntimeOption::SourceRoot,
                                            string(file.data())));
 
-    // Don't try/catch - We want the exception to be passed along
-    return invoke_file(rel_path, once, currentDir);
+      // Don't try/catch - We want the exception to be passed along
+      return invoke_file(rel_path, once, currentDir);
+    } catch(PhpFileDoesNotExistException &e) {
+      throw PhpFileDoesNotExistException(file.c_str());
+    }
   } else {
     // Don't try/catch - We want the exception to be passed along
     return invoke_file(file, once, currentDir);

--- a/hphp/test/quick/hhvm_client_mode.php
+++ b/hphp/test/quick/hhvm_client_mode.php
@@ -1,0 +1,7 @@
+<?php
+
+$hhvm = PHP_BINARY;
+$file = '/home/sherlockhua/a/b/test.php';
+$cmd = "$hhvm $file";
+$out = exec($cmd);
+echo $out;

--- a/hphp/test/quick/hhvm_client_mode.php
+++ b/hphp/test/quick/hhvm_client_mode.php
@@ -1,7 +1,7 @@
 <?php
 
 $hhvm = PHP_BINARY;
-$file = '/home/sherlockhua/a/b/test.php';
+$file = '/../../a/b/test.php';
 $cmd = "$hhvm $file";
 $out = exec($cmd);
 echo $out;

--- a/hphp/test/quick/hhvm_client_mode.php.expect
+++ b/hphp/test/quick/hhvm_client_mode.php.expect
@@ -1,1 +1,1 @@
-Notice: File could not be loaded: /home/sherlockhua/a/b/test.php
+Notice: File could not be loaded: /../../a/b/test.php

--- a/hphp/test/quick/hhvm_client_mode.php.expect
+++ b/hphp/test/quick/hhvm_client_mode.php.expect
@@ -1,0 +1,1 @@
+Notice: File could not be loaded: /home/sherlockhua/a/b/test.php


### PR DESCRIPTION
when I execute hhvm in client mode, for example:
$ hhvm /home/sherlockhua/a/b/test.php
if file /home/sherlockhua/a/b/test.php not exists, it's output:
Notice: File could not be loaded: ../../a/b/test.php
In fact,  the right output is:
Notice: File could not be loaded: /home/sherlockhua/a/b/a/b/test.php

This patch fix this problem!