### PR TITLE
Fix building gd extension with libvpx 1.4.0

### DIFF
--- a/hphp/runtime/ext/gd/libgd/webpimg.cpp
+++ b/hphp/runtime/ext/gd/libgd/webpimg.cpp
@@ -705,14 +705,14 @@ static WebPResult VPXEncode(const uint8* Y,
     codec_ctl(&enc, VP8E_SET_STATIC_THRESHOLD, 0);
     codec_ctl(&enc, VP8E_SET_TOKEN_PARTITIONS, 2);
 
-    vpx_img_wrap(&img, IMG_FMT_I420,
+    vpx_img_wrap(&img, VPX_IMG_FMT_I420,
                  y_width, y_height, 16, (uint8*)(Y));
-    img.planes[PLANE_Y] = (uint8*)(Y);
-    img.planes[PLANE_U] = (uint8*)(U);
-    img.planes[PLANE_V] = (uint8*)(V);
-    img.stride[PLANE_Y] = y_stride;
-    img.stride[PLANE_U] = uv_stride;
-    img.stride[PLANE_V] = uv_stride;
+    img.planes[VPX_PLANE_Y] = (uint8*)(Y);
+    img.planes[VPX_PLANE_U] = (uint8*)(U);
+    img.planes[VPX_PLANE_V] = (uint8*)(V);
+    img.stride[VPX_PLANE_Y] = y_stride;
+    img.stride[VPX_PLANE_U] = uv_stride;
+    img.stride[VPX_PLANE_V] = uv_stride;
 
     res = vpx_codec_encode(&enc, &img, 0, 1, 0, VPX_DL_BEST_QUALITY);
 


### PR DESCRIPTION
In libvpx 1.4.0 the compatibility layer for some of the older constants have been removed [1].
The use of this constants was deprecated since 2010 in favor of the newer VPX_ prefixed names.
The same issue as been reported in the php bugtracker [2].

Thanks!

[1] https://gerrit.chromium.org/gerrit/#/c/70164/3/vpx/vpx_image.h,unified
[2] https://bugs.php.net/patch-display.php?bug_id=69479&patch=php-gd-newvpx.diff&revision=latest