### PR TITLE
Do not set KEEP_SECTION for vtraceRingbuffer() on Mac.

### DIFF
--- a/hphp/util/ringbuffer.cpp
+++ b/hphp/util/ringbuffer.cpp
@@ -45,7 +45,9 @@ const char* ringbufferName(RingBufferType t) {
   not_reached();
 }
 
+#ifndef __APPLE__
 KEEP_SECTION
+#endif
 void vtraceRingbuffer(const char* fmt, va_list ap) {
   char buf[4096];
   char* bufP = &buf[0];


### PR DESCRIPTION
hhvm crashes at once when enters this function on Mac. Maybe the memory is not executable when
KEEP_SECTION is set. This fixes several debugger tests.

Part of #4444.