### PR TITLE
Fix using common_type<void, void> in Either::match to build with libc++.

### DIFF
--- a/hphp/util/either.h
+++ b/hphp/util/either.h
@@ -21,6 +21,19 @@
 #include <cstddef>
 #include <type_traits>
 
+// Workaround a bug that using std::common_type<void, void> causes error with
+// libc++. See https://llvm.org/bugs/show_bug.cgi?id=22135
+#ifdef _LIBCPP_VERSION
+namespace std {
+
+template<>
+struct common_type<void, void> {
+  typedef void type;
+};
+
+}
+#endif
+
 namespace HPHP {
 
 //////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
clang++ fails to compile with libc++ when std::common_type<void, void> is used.
This patch adds a specialization of this case. The upstream link of this bug is
at https://llvm.org/bugs/show_bug.cgi?id=22135.

Part of #4444. Related to #5194.