### PR TITLE
Fix writing of null-characters in SessionHandler

### DIFF
--- a/hphp/runtime/ext/session/ext_session.cpp
+++ b/hphp/runtime/ext/session/ext_session.cpp
@@ -1828,7 +1828,7 @@ static Variant HHVM_METHOD(SessionHandler, hhread, const String& session_id) {
 static bool HHVM_METHOD(SessionHandler, hhwrite,
                         const String& session_id, const String& session_data) {
   return s_session->default_mod &&
-    s_session->default_mod->write(session_id.data(), session_data.data());
+    s_session->default_mod->write(session_id.data(), session_data);
 }
 
 static bool HHVM_METHOD(SessionHandler, hhdestroy, const String& session_id) {

--- a/hphp/test/slow/ext_session/private_properties.php
+++ b/hphp/test/slow/ext_session/private_properties.php
@@ -1,0 +1,22 @@
+<?php
+
+class MyClass {
+    private $id;
+    public function __construct($id) {
+        $this->id = $id;
+    }
+    public function getId() {
+        return $this->id;
+    }
+}
+
+$handler = new SessionHandler();
+session_set_save_handler($handler);
+session_start();
+$_SESSION['a'] = new MyClass(12);
+
+session_write_close();
+unset($_SESSION);
+
+session_start();
+var_dump($_SESSION['a']);

--- a/hphp/test/slow/ext_session/private_properties.php.expectf
+++ b/hphp/test/slow/ext_session/private_properties.php.expectf
@@ -1,0 +1,4 @@
+object(MyClass)#%d (1) {
+  ["id":"MyClass":private]=>
+  int(12)
+}


### PR DESCRIPTION
Private properties serialization contains null-characters. With the SessionHandler, the serialized string is not correctly written since it stops at the first null-character and this leads to session loss.
