### PR TITLE
Record correct path and line on fatal error

### DIFF
--- a/hphp/runtime/vm/bytecode.cpp
+++ b/hphp/runtime/vm/bytecode.cpp
@@ -2556,6 +2556,10 @@ void ExecutionContext::recordLastError(const Exception &e, int errnum) {
   m_lastErrorNum = errnum;
   m_lastErrorPath = String::attach(getContainingFileName());
   m_lastErrorLine = getLine();
+  if (auto const ee = dynamic_cast<const ExtendedException *>(&e)) {
+    m_lastErrorPath = ee->getFileAndLine().first;
+    m_lastErrorLine = ee->getFileAndLine().second;
+  }
 }
 
 void ExecutionContext::clearLastError() {

--- a/hphp/test/slow/error_handler/error_get_last_error.php
+++ b/hphp/test/slow/error_handler/error_get_last_error.php
@@ -10,7 +10,7 @@ function handleError($errno, $errstr, $errfile, $errline) {
 }
 
 function shutdownFunc() {
-  var_dump(error_get_last() != NULL);
+  var_dump(error_get_last()['line']);
 }
 
 set_error_handler('handleError');

--- a/hphp/test/slow/error_handler/error_get_last_error.php.expectf
+++ b/hphp/test/slow/error_handler/error_get_last_error.php.expectf
@@ -5,4 +5,4 @@ no x
 NULL
 
 Fatal error: Call to undefined function nosuchfunc() in %s on line %d
-bool(true)
+int(28)

--- a/hphp/test/slow/error_handler/error_get_last_error.php.expectf
+++ b/hphp/test/slow/error_handler/error_get_last_error.php.expectf
@@ -4,5 +4,5 @@ NULL
 no x
 NULL
 
-Fatal error: Call to undefined function nosuchfunc() in %s on line %d
+Fatal error: Call to undefined function nosuchfunc() in %s on line 28
 int(28)


### PR DESCRIPTION
This PR makes error_get_last() return correct file and line instead of ("", -1) for fatal errors.