### PR TITLE
Fix the format of hash-crc.S to build on Mac and Cygwin.

### DIFF
--- a/hphp/util/etch-helpers.h
+++ b/hphp/util/etch-helpers.h
@@ -12,6 +12,7 @@
 #define ETCH_SIZE(x)    /* Not used with PE/COFF on windows */
 #define ETCH_NAME(x)    x
 #define ETCH_LABEL(x)   .L##x
+#define ETCH_TYPE(x, y) /* Not used on Windows */
 #elif defined(__APPLE__)
 #define CFI(x)          /* not used on OSX */
 #define CFI2(x, y)      /* not used on OSX */
@@ -23,6 +24,7 @@
 #define ETCH_SIZE(x)    /* not used on OSX */
 #define ETCH_NAME(x)    _##x
 #define ETCH_LABEL(x)   .L##_##x
+#define ETCH_TYPE(x, y) /* not used on OSX */
 #else
 #define CFI(x)          .cfi_##x
 #define CFI2(x, y)      .cfi_##x y
@@ -34,6 +36,7 @@
 #define ETCH_SIZE(x)    .size x, .-x
 #define ETCH_NAME(x)    x
 #define ETCH_LABEL(x)   .L##x
+#define ETCH_TYPE(x, y) .type x, y
 #endif
 
 #endif // incl_ETCH_HELPERS_H

--- a/hphp/util/hash-crc.S
+++ b/hphp/util/hash-crc.S
@@ -5,6 +5,7 @@
 
 ETCH_SECTION(hash_string_i_crc)
 .globl	ETCH_NAME(hash_string_i_crc)
+ETCH_TYPE(ETCH_NAME(hash_string_i_crc), @function)
 ETCH_ALIGN16
 ETCH_NAME(hash_string_i_crc):
 ETCH_LABEL(FB800):
@@ -41,6 +42,7 @@ ETCH_LABEL(FE800):
 
 ETCH_SECTION(hash_string_i_unaligned_crc)
 .globl	ETCH_NAME(hash_string_i_unaligned_crc)
+ETCH_TYPE(ETCH_NAME(hash_string_i_unaligned_crc), @function)
 ETCH_ALIGN16
 ETCH_NAME(hash_string_i_unaligned_crc):
 ETCH_LABEL(FB801):
@@ -83,6 +85,7 @@ ETCH_LABEL(FE801):
 
 ETCH_SECTION(hash_string_cs_crc)
 .globl	ETCH_NAME(hash_string_cs_crc)
+ETCH_TYPE(ETCH_NAME(hash_string_cs_crc), @function)
 ETCH_ALIGN16
 ETCH_NAME(hash_string_cs_crc):
 ETCH_LABEL(FB802):
@@ -117,6 +120,7 @@ ETCH_LABEL(FE802):
 
 ETCH_SECTION(hash_string_cs_unaligned_crc)
 .globl	ETCH_NAME(hash_string_cs_unaligned_crc)
+ETCH_TYPE(ETCH_NAME(hash_string_cs_unaligned_crc), @function)
 ETCH_ALIGN16
 ETCH_NAME(hash_string_cs_unaligned_crc):
 ETCH_LABEL(FB803):
@@ -157,6 +161,7 @@ ETCH_LABEL(FE803):
 /* The following is the asm version of HPHP::StringData::hashHelper */
 ETCH_SECTION(g_hashHelper_crc)
 .globl	ETCH_NAME(g_hashHelper_crc)
+ETCH_TYPE(ETCH_NAME(g_hashHelper_crc), @function)
 ETCH_ALIGN16
 ETCH_NAME(g_hashHelper_crc):
 ETCH_LABEL(FB804):

--- a/hphp/util/hash-crc.S
+++ b/hphp/util/hash-crc.S
@@ -4,8 +4,7 @@
 .file	"hash-crc.S"
 
 ETCH_SECTION(hash_string_i_crc)
-.global	ETCH_NAME(hash_string_i_crc)
-.type	ETCH_NAME(hash_string_i_crc), @function
+.globl	ETCH_NAME(hash_string_i_crc)
 ETCH_ALIGN16
 ETCH_NAME(hash_string_i_crc):
 ETCH_LABEL(FB800):
@@ -41,8 +40,7 @@ ETCH_LABEL(FE800):
 
 
 ETCH_SECTION(hash_string_i_unaligned_crc)
-.global	ETCH_NAME(hash_string_i_unaligned_crc)
-.type	ETCH_NAME(hash_string_i_unaligned_crc), @function
+.globl	ETCH_NAME(hash_string_i_unaligned_crc)
 ETCH_ALIGN16
 ETCH_NAME(hash_string_i_unaligned_crc):
 ETCH_LABEL(FB801):
@@ -84,8 +82,7 @@ ETCH_LABEL(FE801):
 
 
 ETCH_SECTION(hash_string_cs_crc)
-.global	ETCH_NAME(hash_string_cs_crc)
-.type	ETCH_NAME(hash_string_cs_crc), @function
+.globl	ETCH_NAME(hash_string_cs_crc)
 ETCH_ALIGN16
 ETCH_NAME(hash_string_cs_crc):
 ETCH_LABEL(FB802):
@@ -119,8 +116,7 @@ ETCH_LABEL(FE802):
 
 
 ETCH_SECTION(hash_string_cs_unaligned_crc)
-.global	ETCH_NAME(hash_string_cs_unaligned_crc)
-.type	ETCH_NAME(hash_string_cs_unaligned_crc), @function
+.globl	ETCH_NAME(hash_string_cs_unaligned_crc)
 ETCH_ALIGN16
 ETCH_NAME(hash_string_cs_unaligned_crc):
 ETCH_LABEL(FB803):
@@ -160,8 +156,7 @@ ETCH_LABEL(FE803):
 
 /* The following is the asm version of HPHP::StringData::hashHelper */
 ETCH_SECTION(g_hashHelper_crc)
-.global	ETCH_NAME(g_hashHelper_crc)
-.type	ETCH_NAME(g_hashHelper_crc), @function
+.globl	ETCH_NAME(g_hashHelper_crc)
 ETCH_ALIGN16
 ETCH_NAME(g_hashHelper_crc):
 ETCH_LABEL(FB804):


### PR DESCRIPTION
Part of #4444 and #5068.