### PR TITLE
Enable relocation and use ETCH_NAME in translator-asm-helpers on Mac.

### DIFF
--- a/hphp/runtime/vm/jit/translator-asm-helpers.S
+++ b/hphp/runtime/vm/jit/translator-asm-helpers.S
@@ -44,7 +44,11 @@ ETCH_NAME(enterTCHelper):
    */
   test %r9, %r9
   jz ETCH_LABEL(enterTCHelper$callTC)
+#ifdef __APPLE__
+  push $_enterTCExit@GOTPCREL
+#else
   push $enterTCExit
+#endif
   push 0x8(%r9)
   mov %r9, %rbp
   jmp *%rdx
@@ -104,7 +108,7 @@ ETCH_NAME(handleSRHelper):
   CFI2(adjust_cfa_offset, 0x30)
 
   // call mcg->handleServiceRequest(%rsp)
-  mov mcg(%rip), %rdi
+  mov ETCH_NAME(mcg)(%rip), %rdi
   mov %rsp, %rsi
   call MCGenerator_handleServiceRequest
 

--- a/hphp/runtime/vm/jit/translator-asm-helpers.S
+++ b/hphp/runtime/vm/jit/translator-asm-helpers.S
@@ -44,11 +44,7 @@ ETCH_NAME(enterTCHelper):
    */
   test %r9, %r9
   jz ETCH_LABEL(enterTCHelper$callTC)
-#ifdef __APPLE__
-  push $_enterTCExit@GOTPCREL
-#else
-  push $enterTCExit
-#endif
+  push ETCH_NAME_REL(enterTCExit)
   push 0x8(%r9)
   mov %r9, %rbp
   jmp *%rdx

--- a/hphp/util/etch-helpers.h
+++ b/hphp/util/etch-helpers.h
@@ -13,6 +13,7 @@
 #define ETCH_NAME(x)    x
 #define ETCH_LABEL(x)   .L##x
 #define ETCH_TYPE(x, y) /* Not used on Windows */
+#define ETCH_NAME_REL(x) $##x
 #elif defined(__APPLE__)
 #define CFI(x)          .cfi_##x
 #define CFI2(x, y)      .cfi_##x y
@@ -25,6 +26,7 @@
 #define ETCH_NAME(x)    _##x
 #define ETCH_LABEL(x)   .L##_##x
 #define ETCH_TYPE(x, y) /* not used on OSX */
+#define ETCH_NAME_REL(x) _##x@GOTPCREL(%rip)
 #else
 #define CFI(x)          .cfi_##x
 #define CFI2(x, y)      .cfi_##x y
@@ -37,6 +39,7 @@
 #define ETCH_NAME(x)    x
 #define ETCH_LABEL(x)   .L##x
 #define ETCH_TYPE(x, y) .type x, y
+#define ETCH_NAME_REL(x) $##x
 #endif
 
 #endif // incl_ETCH_HELPERS_H


### PR DESCRIPTION
This fixes clang error "32-bit absolute addressing is not supported in 64-bit
mode". The names on Mac are prefixed by an underscore, so use ETCH_NAME for
mcg.

Part of #4444.