### PR TITLE
Set pagezero size and .text.keep section executable on Mac.

### DIFF
--- a/CMake/HPHPSetup.cmake
+++ b/CMake/HPHPSetup.cmake
@@ -34,7 +34,9 @@ if (APPLE)
   set(ENABLE_FASTCGI 1)
   set(HHVM_ANCHOR_SYMS
     -Wl,-u,_register_fastcgi_server
-    -Wl,-segaddr,__text,0
+    -Wl,-pagezero_size,0x00001000
+    # Set the .text.keep section to be executable.
+    -Wl,-segprot,.text,rx,rx
     -Wl,-all_load ${HHVM_WHOLE_ARCHIVE_LIBRARIES})
 elseif (IS_AARCH64)
   set(HHVM_ANCHOR_SYMS


### PR DESCRIPTION
The pagezero section is required to be the first section on Mac 10.10. Set the
size smaller than default, so the code blocks will get 32-bit addresses.

The .text.keep section needs to be executable because the functions in this
section will be called.

Part of #4444. Related to #5193.