### PR TITLE
Correctly clear the vector to fix crash in cmd_break.

### DIFF
--- a/hphp/runtime/debugger/cmd/cmd_break.cpp
+++ b/hphp/runtime/debugger/cmd/cmd_break.cpp
@@ -319,7 +319,9 @@ void CmdBreak::processStatusChange(DebuggerClient& client) {
 
   if (client.arg(2, "all")) {
     if (hasClearArg(client)) {
-      m_breakpoints->clear();
+      while (m_breakpoints->size() > 0) {
+        m_breakpoints->erase(m_breakpoints->end() - 1);
+      }
       updateServer(client);
       client.info("All breakpoints are cleared.");
       return;

--- a/hphp/runtime/debugger/cmd/cmd_break.cpp
+++ b/hphp/runtime/debugger/cmd/cmd_break.cpp
@@ -319,9 +319,7 @@ void CmdBreak::processStatusChange(DebuggerClient& client) {
 
   if (client.arg(2, "all")) {
     if (hasClearArg(client)) {
-      while (m_breakpoints->size() > 0) {
-        m_breakpoints->erase(m_breakpoints->end());
-      }
+      m_breakpoints->clear();
       updateServer(client);
       client.info("All breakpoints are cleared.");
       return;


### PR DESCRIPTION
According to the reference, vector::end() does not point to any element. So
erasing this iterator crashes on Mac. Use end() - 1 instead.