### PR TITLE
Define NO_HARDWARE_COUNTERS in hphp/util for non-Linux systems.

### DIFF
--- a/hphp/util/CMakeLists.txt
+++ b/hphp/util/CMakeLists.txt
@@ -45,6 +45,10 @@ if (ENABLE_COTIRE)
   cotire(hphp_util)
 endif()
 
+if (NOT LINUX)
+  add_definitions(-DNO_HARDWARE_COUNTERS)
+endif()
+
 #if (LIBNUMA_LIBRARIES)
 #  target_link_libraries(hphp_util ${LIBNUMA_LIBRARIES})
 #endif()


### PR DESCRIPTION
This is copied from runtime/CMakeLists.txt to build hardware-counter.cpp.

Part of #4444.