### PR TITLE
Fix ReflectionClass::getMethods filter with abstract methods and interfaces

### DIFF
--- a/hphp/test/slow/reflection/class_methods_filtered.php
+++ b/hphp/test/slow/reflection/class_methods_filtered.php
@@ -1,0 +1,23 @@
+<?php
+abstract class A {
+  private function f() {}
+  abstract protected function g();
+  abstract public function h();
+}
+
+interface I {
+    public function i();
+    public function j();
+    static function s();
+}
+
+abstract class B extends A implements I {
+  protected function g(){}
+  public function h(){}
+  public function j() {}
+}
+
+$ref = new ReflectionClass("B");
+var_dump($ref->getMethods(ReflectionMethod::IS_ABSTRACT));
+var_dump($ref->getMethods(ReflectionMethod::IS_STATIC));
+

--- a/hphp/test/slow/reflection/class_methods_filtered.php.expectf
+++ b/hphp/test/slow/reflection/class_methods_filtered.php.expectf
@@ -1,0 +1,25 @@
+array(2) {
+  [0]=>
+  object(ReflectionMethod)#%d (2) {
+    ["name"]=>
+    string(1) "i"
+    ["class"]=>
+    string(1) "I"
+  }
+  [1]=>
+  object(ReflectionMethod)#%d (2) {
+    ["name"]=>
+    string(1) "s"
+    ["class"]=>
+    string(1) "I"
+  }
+}
+array(1) {
+  [0]=>
+  object(ReflectionMethod)#%d (2) {
+    ["name"]=>
+    string(1) "s"
+    ["class"]=>
+    string(1) "I"
+  }
+}


### PR DESCRIPTION
This is a fix for #5170.
I've introduced a second Set because we don't want to return abstract methods in parent classes which are implemented in the child class.