### PR TITLE
Fix lchgrp gid check and add warning as with chown

### DIFF
--- a/hphp/runtime/ext/std/ext_std_file.cpp
+++ b/hphp/runtime/ext/std/ext_std_file.cpp
@@ -1431,7 +1431,11 @@ bool HHVM_FUNCTION(chgrp,
   }
 
   int gid = get_gid(group);
-  if (gid == -1) return false;
+  if (gid == -1) {
+    raise_warning("chgrp(): Unable to find gid for %s",
+                  group.toString().c_str());
+    return false;
+  }
   CHECK_SYSTEM(chown(File::TranslatePath(filename).data(), (uid_t)-1, gid));
   return true;
 }
@@ -1456,7 +1460,11 @@ bool HHVM_FUNCTION(lchgrp,
   }
 
   int gid = get_gid(group);
-  if (gid == 0) return false;
+  if (gid == -1) {
+    raise_warning("lchgrp(): Unable to find gid for %s",
+                  group.toString().c_str());
+    return false;
+  }
   CHECK_SYSTEM(lchown(File::TranslatePath(filename).data(), (uid_t)-1, gid));
   return true;
 }

--- a/hphp/test/slow/ext_std/lchown_wronguser.php
+++ b/hphp/test/slow/ext_std/lchown_wronguser.php
@@ -7,3 +7,5 @@ touch($file);
 
 var_dump(lchown($link, 'ihopenomachinehasthisuserthatwouldbebad'));
 var_dump(chown($file, 'ihopenomachinehasthisuserthatwouldbebad'));
+var_dump(lchgrp($link, 'ihopenomachinehasthisgroupthatwouldbebad'));
+var_dump(chgrp($file, 'ihopenomachinehasthisgroupthatwouldbebad'));

--- a/hphp/test/slow/ext_std/lchown_wronguser.php.expectf
+++ b/hphp/test/slow/ext_std/lchown_wronguser.php.expectf
@@ -4,3 +4,9 @@ bool(false)
 
 Warning: chown(): Unable to find uid for ihopenomachinehasthisuserthatwouldbebad in %s/lchown_wronguser.php on line 9
 bool(false)
+
+Warning: lchgrp(): Unable to find gid for ihopenomachinehasthisgroupthatwouldbebad in %s/lchown_wronguser.php on line 10
+bool(false)
+
+Warning: chgrp(): Unable to find gid for ihopenomachinehasthisgroupthatwouldbebad in %s/lchown_wronguser.php on line 11
+bool(false)


### PR DESCRIPTION
This fixes lchgrp to return false when the group doesn't exist. I also added the same kind of warnings as with chown and lchown.