### PR TITLE
Cache time zone validity.

### DIFF
--- a/hphp/runtime/base/program-functions.cpp
+++ b/hphp/runtime/base/program-functions.cpp
@@ -1764,6 +1764,10 @@ void hphp_process_init() {
   pthread_attr_destroy(&attr);
 
   Process::InitProcessStatics();
+
+  // initialize the tzinfo cache.
+  timezone_init();
+
   init_thread_locals();
 
   struct sigaction action = {};
@@ -1783,9 +1787,6 @@ void hphp_process_init() {
 
   // reinitialize pcre table
   pcre_reinit();
-
-  // initialize the tzinfo cache.
-  timezone_init();
 
   // the liboniguruma docs say this isnt needed,
   // but the implementation of init is not

--- a/hphp/runtime/base/timezone.cpp
+++ b/hphp/runtime/base/timezone.cpp
@@ -92,10 +92,17 @@ using TimeZoneCacheEntry = std::pair<const char*, timelib_tzinfo*>;
 
 TimeZoneCache* s_tzCache;
 
+using TimeZoneValidityCache =
+  folly::AtomicHashArray<const char*, bool, cstr_hash, ahm_eqstr>;
+using TimeZoneValidityCacheEntry = std::pair<const char*, bool>;
+
+TimeZoneValidityCache* s_tzvCache;
+
 void timezone_init() {
   // Allocate enough space to cache all possible timezones, if needed.
   constexpr size_t kMaxTimeZoneCache = 1000;
   s_tzCache = TimeZoneCache::create(kMaxTimeZoneCache).release();
+  s_tzvCache = TimeZoneValidityCache::create(kMaxTimeZoneCache).release();
 }
 
 const timelib_tzdb *TimeZone::GetDatabase() {
@@ -170,7 +177,24 @@ SmartPtr<TimeZone> TimeZone::Current() {
 }
 
 bool TimeZone::SetCurrent(const String& zone) {
-  if (!IsValid(zone)) {
+  bool valid;
+  const char* name = zone.data();
+  auto const it = s_tzvCache->find(name);
+  if (it != s_tzvCache->end()) {
+    valid = it->second;
+  } else {
+    valid = IsValid(zone);
+
+    auto key = strdup(name);
+    auto result = s_tzvCache->insert(TimeZoneValidityCacheEntry(key, valid));
+    if (!result.second) {
+      // The cache is full or a collision occurred, and we don't need our
+      // strdup'ed key.
+      free(key);
+    }
+  }
+
+  if (!valid) {
     raise_notice("Timezone ID '%s' is invalid", zone.data());
     return false;
   }


### PR DESCRIPTION
date_default_timezone_set() is called once for every WordPress request in
stock WordPress 4.1.1. Cache the time zone validity for better performance.

Related to #5173