### PR TITLE
Fix DynamicContentCache and static content under FastCGI

### DIFF
--- a/hphp/runtime/server/http-request-handler.cpp
+++ b/hphp/runtime/server/http-request-handler.cpp
@@ -181,6 +181,7 @@ void HttpRequestHandler::sendStaticContent(Transport *transport,
   transport->disableCompression();
 
   transport->sendRaw((void*)data, len, 200, compressed);
+  transport->onSendEnd();
 }
 
 void HttpRequestHandler::logToAccessLog(Transport* transport) {
@@ -354,7 +355,7 @@ void HttpRequestHandler::handleRequest(Transport *transport) {
     if (cacheableDynamicContent) {
       // check against dynamic content cache
       assert(transport->getUrl());
-      string key = path + transport->getUrl();
+      string key = absPath + transport->getUrl();
       if (DynamicContentCache::TheCache.find(key, data, len, compressed)) {
         sendStaticContent(transport, data, len, 0, compressed, path, ext);
         ServerStats::LogPage(path, 200);


### PR DESCRIPTION
When sending static content via sendStaticContent(), for example on a
DynamicContentCache hit, Transport::onSendEnd() was not called, and so
the webserver would hang forever waiting for an FCGI_END_REQUEST record.

Also, the key used for DynamicContentCache was different when storing
and retrieving, so it always missed. It used reqURI.path() when
retrieving, and reqURI.absolutePath() when storing, which may have
possibly been the same under certain test circumstances but is not the
same under FastCGI.