### PR TITLE
Only restore processor affinity in ~Profiler if it was saved.

### DIFF
--- a/hphp/runtime/ext/ext_hotprofiler.cpp
+++ b/hphp/runtime/ext/ext_hotprofiler.cpp
@@ -351,13 +351,14 @@ const StaticString
  */
 Profiler::Profiler(bool needCPUAffinity) : m_successful(true),
                                            m_stack(nullptr),
-                                           m_frame_free_list(nullptr) {
+                                           m_frame_free_list(nullptr),
+                                           m_has_affinity(needCPUAffinity) {
     if (!s_rand_initialized) {
       s_rand_initialized = true;
       srand(math_generate_seed());
     }
 
-    if (needCPUAffinity) {
+    if (m_has_affinity) {
       //
       // Bind to a random cpu so that we can use rdtsc instruction.
       //
@@ -376,7 +377,9 @@ Profiler::Profiler(bool needCPUAffinity) : m_successful(true),
 }
 
 Profiler::~Profiler() {
-    SET_AFFINITY(0, sizeof(cpu_set_t), &m_prev_mask);
+    if (m_has_affinity) {
+      SET_AFFINITY(0, sizeof(cpu_set_t), &m_prev_mask);
+    }
 
     endAllFrames();
     for (Frame *p = m_frame_free_list; p;) {

--- a/hphp/runtime/ext/ext_hotprofiler.h
+++ b/hphp/runtime/ext/ext_hotprofiler.h
@@ -190,7 +190,10 @@ public:
   cpu_set_t m_prev_mask;               // saved cpu affinity
   Frame    *m_frame_free_list;         // freelist of Frame
   uint8_t     m_func_hash_counters[256]; // counter table by hash code;
+private:
+  bool m_has_affinity;
 
+public:
   /*
    * A hash function to calculate a 8-bit hash code for a function name.
    * This is based on a small modification to 'zend_inline_hash_func' by summing


### PR DESCRIPTION
Formerly, this used unused memory.  The problem was caught with valgrind.