### PR TITLE
Call zend_startup_strtod so ezc extensions can use zend_strtod.

### DIFF
--- a/hphp/runtime/base/program-functions.cpp
+++ b/hphp/runtime/base/program-functions.cpp
@@ -1200,6 +1200,32 @@ std::string get_right_option_name(const basic_parsed_options<char>& opts,
 }
 #endif
 
+//
+// Note that confusingly there are two different implementations
+// of zend_strtod.
+//
+// The one from
+//   hphp/runtime/ext_zend_compat/php-src/Zend/zend_strtod.h
+// does not wrap with HPHP namespace, and implements
+// functionality required by the zend extension compatability layer.
+// Empirically, this zend_strtod.h file can't be included because
+// it includes <zend.h> which isn't on any search path when compiling this.
+//
+// The zend_startup_strtod from
+//   hphp/runtime/base/zend-strtod.h
+// uses the HPHP namespace, is used for other purposes,
+// and predates the EZC extensions.
+//
+// Before we can call zend_strtod from zend compatability extensions,
+// we need to initialize it.  Since it doesn't seem
+// to work to include the .h file, just sleaze declare it here.
+//
+// See the related issue https://github.com/facebook/hhvm/issues/5244
+//
+extern "C" {
+  void zend_startup_strtod(void);
+}
+
 static int execute_program_impl(int argc, char** argv) {
   string usage = "Usage:\n\n   ";
   usage += argv[0];
@@ -1424,6 +1450,13 @@ static int execute_program_impl(int argc, char** argv) {
 
   // we need to initialize pcre cache table very early
   pcre_init();
+
+  //
+  // Initialize in the zend extension compatability layer, as needed
+  // before any calls from legacy zend extensions to zend_strtod. See
+  // the extern "C" declaration of this function, above.
+  //
+  zend_startup_strtod();
 
   MemoryManager::TlsWrapper::getCheck();
   if (RuntimeOption::ServerExecutionMode()) {

--- a/hphp/runtime/ext_zend_compat/ezc_test/ext_ezc_test.php
+++ b/hphp/runtime/ext_zend_compat/ezc_test/ext_ezc_test.php
@@ -102,3 +102,9 @@ function ezc_get_error_reporting(): mixed;
 <<__Native("ZendCompat")>>
 function ezc_set_error_reporting(int $error_reporting): mixed;
 
+/* Convert a string to a double, then back to a string again.
+ * Only purpose is to test basic code paths
+ * in the ezc string to double and double to string routines.
+ */
+<<__Native("ZendCompat")>>
+function ezc_atof_toa(string $source): mixed;

--- a/hphp/runtime/ext_zend_compat/ezc_test/ezc_test.cpp
+++ b/hphp/runtime/ext_zend_compat/ezc_test/ezc_test.cpp
@@ -651,6 +651,36 @@ PHP_FUNCTION(ezc_create_cloneable_in_array)
 }
 /* }}} */
 
+/* {{{ proto mixed ezc_atof_toa()
+ * Convert a string to a double and back to a string again */
+PHP_FUNCTION(ezc_atof_toa)
+{
+  char *value;
+  int valuelen;
+  double d;
+  const char *end_value;
+  const int ndigits = 10;
+  int decpt = -1;
+  int sign = -1;
+  char *result;
+  char *resulte;
+  char *composed_result;
+
+  if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s",
+        &value, &valuelen) == FAILURE) {
+    RETURN_FALSE;
+  }
+
+  d = zend_strtod(value, &end_value);
+  (void)end_value;
+
+  result = zend_dtoa(d, 0, ndigits, &decpt, &sign, &resulte);
+  asprintf(&composed_result, "%d %d %s", decpt, sign, result);
+  zend_freedtoa(result);
+  RETVAL_STRING(composed_result, 1);
+}
+/* }}} */
+
 /* {{{ arginfo */
 ZEND_BEGIN_ARG_INFO(arginfo_ezc_fetch_global, 0)
 ZEND_END_ARG_INFO()
@@ -731,6 +761,11 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_INFO(arginfo_ezc_set_error_reporting, 0)
   ZEND_ARG_INFO(0, value)
 ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO(arginfo_ezc_atof_toa, 0)
+  ZEND_ARG_INFO(0, value)
+ZEND_END_ARG_INFO()
+
 /* }}} */
 
 /* {{{ ezc_test_functions[]
@@ -754,6 +789,7 @@ const zend_function_entry ezc_test_functions[] = {
   PHP_FE(ezc_array_set, arginfo_ezc_array_set)
   PHP_FE(ezc_get_error_reporting, arginfo_ezc_get_error_reporting)
   PHP_FE(ezc_set_error_reporting, arginfo_ezc_set_error_reporting)
+  PHP_FE(ezc_atof_toa, arginfo_ezc_atof_toa)
   PHP_FE_END
 };
 /* }}} */

--- a/hphp/test/slow/ext_ezc_test/ezc-atof_toa.php
+++ b/hphp/test/slow/ext_ezc_test/ezc-atof_toa.php
@@ -1,0 +1,17 @@
+<?php
+var_dump(ezc_atof_toa("1.25"));
+var_dump(ezc_atof_toa("64.25"));
+var_dump(ezc_atof_toa("4.09625e+03"));
+var_dump(ezc_atof_toa("1234567890123456789.00"));
+//
+// Unfortunately, zend_strtod doesn't handle Nan's and Infs
+//
+// var_dump(ezc_atof_toa("NaN"));
+// var_dump(ezc_atof_toa("Inf"));
+// var_dump(ezc_atof_toa("-Inf"));
+var_dump(ezc_atof_toa("-0.0"));
+var_dump(ezc_atof_toa("0.0"));
+var_dump(ezc_atof_toa(" 1.0"));
+
+echo "Done\n";
+?>

--- a/hphp/test/slow/ext_ezc_test/ezc-atof_toa.php.expectf
+++ b/hphp/test/slow/ext_ezc_test/ezc-atof_toa.php.expectf
@@ -1,0 +1,8 @@
+string(7) "1 0 125"
+string(8) "2 0 6425"
+string(10) "4 0 409625"
+string(22) "19 0 12345678901234568"
+string(5) "1 1 0"
+string(5) "1 0 0"
+string(5) "1 0 1"
+Done


### PR DESCRIPTION
Part of the trick is to get the right zend_startup_strtod.

Without calling zend_startup_strtod, some paths through zend_strtod
and zend_dtoa will encounter and uninitialized mutex that guards
a "do once" computation.

Add unit tests that convert a string to a double, then back to
string pieces again.  This test doesn't work for Inf or Nan, but that's
zend_strtod's fault.

This closes https://github.com/facebook/hhvm/issues/5245