### PR TITLE
Speedup up build by only building hack binaries if any source file is modified

### DIFF
--- a/hphp/hack/src/Makefile
+++ b/hphp/hack/src/Makefile
@@ -79,7 +79,7 @@ NATIVE_LIBRARIES=\
   $(ELF)\
   pthread
 
-TARGETS=_build/hh_client.native _build/hh_single_type_check.native \
+TARGETS=_build/hh_server.native _build/hh_client.native _build/hh_single_type_check.native \
 		_build/hh_format.native _build/h2tp.native _build/test_unparser.native
 
 # Find all source files (all files not in _build dir)
@@ -100,7 +100,7 @@ FRAMEWORK_OPTS=$(foreach framework, $(FRAMEWORKS),-cclib -framework -cclib $(fra
 
 LINKER_FLAGS=$(NATIVE_OBJECT_FILES) $(NATIVE_LIB_OPTS) $(EXTRA_LIB_OPTS) \
 	     $(EXTRA_NATIVE_LIB_OPTS) $(FRAMEWORK_OPTS) $(SECTCREATE)
-# Function the recursively find files, eg: $(call rwildcard,dir/to/look/in/,*.c)
+# Function to recursively find files, eg: $(call rwildcard,dir/to/look/in/,*.c)
 rwildcard=$(wildcard $1$2) $(foreach d,$(wildcard $1*),$(call rwildcard,$d/,$2))
 
 all: build-hhi-archive build-hack copy-hack-files
@@ -116,15 +116,14 @@ build-hack: $(TARGETS) build-hhi-archive
 .NOTPARALLEL: $(TARGETS)
 # As there is no efficient way to calculate the dependencies of
 # the targets, we make them dependent on all files. In doing this
-# we ensure that no rebuild is necessary of nothing has changed
+# we ensure that no rebuild is necessary if nothing has changed
 $(TARGETS): $(ALL_SRC_FILES)
 	# build-hack-native-deps is a dependency of $(TARGETS) but as it is phony
 	# we place it here to avoid unnecessary rebuilds
-	$(MAKE) build-hack-native-deps
+	$(MAKE) build-hack-native-deps build-hhi-archive
 	ocamlbuild -no-links $(INCLUDE_OPTS) $(LIB_OPTS) \
 		-lflags "$(LINKER_FLAGS)" \
-		hh_server.native hh_client.native hh_single_type_check.native \
-		hh_format.native h2tp.native test_unparser.native
+		$(patsubst _build/%,%,$(TARGETS))
 	# Touching the targets is necessary because the ocaml build
 	# doens't change the modification dates of the targets if
 	# the new binaries are exactly the same as the old ones

--- a/hphp/hack/src/Makefile
+++ b/hphp/hack/src/Makefile
@@ -79,6 +79,12 @@ NATIVE_LIBRARIES=\
   $(ELF)\
   pthread
 
+TARGETS=_build/hh_client.native _build/hh_single_type_check.native \
+		_build/hh_format.native _build/h2tp.native _build/test_unparser.native
+
+# Find all source files (all files not in _build dir)
+ALL_SRC_FILES=$(call rwildcard,$(patsubst _build,,$(wildcard *)),*.*)
+
 ################################################################################
 #                                    Rules                                     #
 ################################################################################
@@ -94,12 +100,8 @@ FRAMEWORK_OPTS=$(foreach framework, $(FRAMEWORKS),-cclib -framework -cclib $(fra
 
 LINKER_FLAGS=$(NATIVE_OBJECT_FILES) $(NATIVE_LIB_OPTS) $(EXTRA_LIB_OPTS) \
 	     $(EXTRA_NATIVE_LIB_OPTS) $(FRAMEWORK_OPTS) $(SECTCREATE)
-TARGETS=_build/hh_client.native _build/hh_single_type_check.native \
-		_build/hh_format.native _build/h2tp.native _build/test_unparser.native
 # Function the recursively find files, eg: $(call rwildcard,dir/to/look/in/,*.c)
 rwildcard=$(wildcard $1$2) $(foreach d,$(wildcard $1*),$(call rwildcard,$d/,$2))
-# Find all source files (all files not in _build dir)
-ALL_SRC_FILES=$(call rwildcard,$(patsubst _build,,$(wildcard *)),*.*)
 
 all: build-hhi-archive build-hack copy-hack-files
 
@@ -108,19 +110,24 @@ clean:
 	find ../bin -mindepth 1 -not -path ../bin/README -delete
 	rm -f utils/get_build_id.gen.c
 
-build-hack: build-hack-native-deps build-hhi-archive $(TARGETS)
+build-hack: $(TARGETS) build-hhi-archive
 
+# All targets are built in one time, so no parallelization is necessary
+.NOTPARALLEL: $(TARGETS)
 # As there is no efficient way to calculate the dependencies of
 # the targets, we make them dependent on all files. In doing this
 # we ensure that no rebuild is necessary of nothing has changed
 $(TARGETS): $(ALL_SRC_FILES)
+	# build-hack-native-deps is a dependency of $(TARGETS) but as it is phony
+	# we place it here to avoid unnecessary rebuilds
+	$(MAKE) build-hack-native-deps
 	ocamlbuild -no-links $(INCLUDE_OPTS) $(LIB_OPTS) \
 		-lflags "$(LINKER_FLAGS)" \
 		hh_server.native hh_client.native hh_single_type_check.native \
 		hh_format.native h2tp.native test_unparser.native
-	# touching the targets is necessary because the ocaml build
+	# Touching the targets is necessary because the ocaml build
 	# doens't change the modification dates of the targets if
-	# new binaries are exactly the same as the old ones
+	# the new binaries are exactly the same as the old ones
 	touch $(TARGETS)
 
 build-hack-native-deps: build-hack-stubs

--- a/hphp/hack/src/Makefile
+++ b/hphp/hack/src/Makefile
@@ -94,6 +94,11 @@ FRAMEWORK_OPTS=$(foreach framework, $(FRAMEWORKS),-cclib -framework -cclib $(fra
 
 LINKER_FLAGS=$(NATIVE_OBJECT_FILES) $(NATIVE_LIB_OPTS) $(EXTRA_LIB_OPTS) \
 	     $(EXTRA_NATIVE_LIB_OPTS) $(FRAMEWORK_OPTS) $(SECTCREATE)
+TARGETS=_build/hh_client.native _build/hh_single_type_check.native \
+		_build/hh_format.native _build/h2tp.native _build/test_unparser.native
+rwildcard=$(wildcard $1$2) $(foreach d,$(wildcard $1*),$(call rwildcard,$d/,$2))
+# Find all src files (all files not in _build dir)
+ALL_SRC_FILES=$(call rwildcard,$(patsubst _build,,$(wildcard *)),*.*)
 
 all: build-hhi-archive build-hack copy-hack-files
 
@@ -102,11 +107,14 @@ clean:
 	find ../bin -mindepth 1 -not -path ../bin/README -delete
 	rm -f utils/get_build_id.gen.c
 
-build-hack: build-hack-native-deps build-hhi-archive
+build-hack: build-hack-native-deps build-hhi-archive $(TARGETS)
+
+$(TARGETS): $(ALL_SRC_FILES)
 	ocamlbuild -no-links $(INCLUDE_OPTS) $(LIB_OPTS) \
 		-lflags "$(LINKER_FLAGS)" \
 		hh_server.native hh_client.native hh_single_type_check.native \
 		hh_format.native h2tp.native test_unparser.native
+	touch $(TARGETS)
 
 build-hack-native-deps: build-hack-stubs
 	# ocamlbuild before 4.00 does not pass thru cflags when building native C
@@ -114,7 +122,8 @@ build-hack-native-deps: build-hack-stubs
 	ocamlbuild -ocamlc "ocamlopt $(EXTRA_INCLUDE_OPTS) $(EXTRA_CC_OPTS)" $(NATIVE_OBJECT_FILES)
 
 build-hack-stubs:
-	echo "const char* const BuildInfo_kRevision = \"$$(git rev-parse HEAD)\";" > utils/get_build_id.gen.c
+	if [ "const char* const BuildInfo_kRevision = \"$$(git rev-parse HEAD)\";" != "$$(cat utils/get_build_id.gen.c)" ]; then \
+	echo "const char* const BuildInfo_kRevision = \"$$(git rev-parse HEAD)\";" > utils/get_build_id.gen.c; fi
 
 build-hhi-archive:
 	mkdir -p ../bin

--- a/hphp/hack/src/Makefile
+++ b/hphp/hack/src/Makefile
@@ -96,8 +96,9 @@ LINKER_FLAGS=$(NATIVE_OBJECT_FILES) $(NATIVE_LIB_OPTS) $(EXTRA_LIB_OPTS) \
 	     $(EXTRA_NATIVE_LIB_OPTS) $(FRAMEWORK_OPTS) $(SECTCREATE)
 TARGETS=_build/hh_client.native _build/hh_single_type_check.native \
 		_build/hh_format.native _build/h2tp.native _build/test_unparser.native
+# Function the recursively find files, eg: $(call rwildcard,dir/to/look/in/,*.c)
 rwildcard=$(wildcard $1$2) $(foreach d,$(wildcard $1*),$(call rwildcard,$d/,$2))
-# Find all src files (all files not in _build dir)
+# Find all source files (all files not in _build dir)
 ALL_SRC_FILES=$(call rwildcard,$(patsubst _build,,$(wildcard *)),*.*)
 
 all: build-hhi-archive build-hack copy-hack-files
@@ -109,11 +110,17 @@ clean:
 
 build-hack: build-hack-native-deps build-hhi-archive $(TARGETS)
 
+# As there is no efficient way to calculate the dependencies of
+# the targets, we make them dependent on all files. In doing this
+# we ensure that no rebuild is necessary of nothing has changed
 $(TARGETS): $(ALL_SRC_FILES)
 	ocamlbuild -no-links $(INCLUDE_OPTS) $(LIB_OPTS) \
 		-lflags "$(LINKER_FLAGS)" \
 		hh_server.native hh_client.native hh_single_type_check.native \
 		hh_format.native h2tp.native test_unparser.native
+	# touching the targets is necessary because the ocaml build
+	# doens't change the modification dates of the targets if
+	# new binaries are exactly the same as the old ones
 	touch $(TARGETS)
 
 build-hack-native-deps: build-hack-stubs
@@ -122,8 +129,8 @@ build-hack-native-deps: build-hack-stubs
 	ocamlbuild -ocamlc "ocamlopt $(EXTRA_INCLUDE_OPTS) $(EXTRA_CC_OPTS)" $(NATIVE_OBJECT_FILES)
 
 build-hack-stubs:
-	if [ "const char* const BuildInfo_kRevision = \"$$(git rev-parse HEAD)\";" != "$$(cat utils/get_build_id.gen.c)" ]; then \
-	echo "const char* const BuildInfo_kRevision = \"$$(git rev-parse HEAD)\";" > utils/get_build_id.gen.c; fi
+	REV="const char* const BuildInfo_kRevision = \"$$(git rev-parse HEAD)\";"; \
+	if [ "$$REV" != "$$(cat utils/get_build_id.gen.c)" ]; then echo "$$REV" > utils/get_build_id.gen.c; fi
 
 build-hhi-archive:
 	mkdir -p ../bin


### PR DESCRIPTION
Building hack takes about 7s on my machine ("time make -C hphp/hack") even if no files are changed. This can be dramatically reduced by not invoking a useless recompilation of hack if no files are changed. This patch reduced the build of hack, if unchanged, from 7s to 0.4s. On my machine it also reduces the build time of the complete hhvm tree by 20%