### PR TITLE
Fix double free in stack trace handler.

### DIFF
--- a/hphp/util/stack-trace.cpp
+++ b/hphp/util/stack-trace.cpp
@@ -482,7 +482,7 @@ static bool fill_bfd_cache(const char *filename, bfd_cache *p) {
 #ifdef BFD_DECOMPRESS
   abfd->flags |= BFD_DECOMPRESS;
 #endif
-  p->abfd = abfd;
+  p->abfd = nullptr;
   p->syms = nullptr;
   char **match;
   if (bfd_check_format(abfd, bfd_archive) ||
@@ -491,6 +491,7 @@ static bool fill_bfd_cache(const char *filename, bfd_cache *p) {
     bfd_close(abfd);
     return true;
   }
+  p->abfd = abfd;
   return false;
 }
 


### PR DESCRIPTION
bfd_close and bfd_close_all_done may be called for the same bfd handler, causing
a double free crash. On Mac, hhvm hangs when exiting the stack trace handler.

Part of #4444.