### PR TITLE
Add libunwind support for JIT.

### DIFF
--- a/hphp/util/etch-helpers.h
+++ b/hphp/util/etch-helpers.h
@@ -14,9 +14,9 @@
 #define ETCH_LABEL(x)   .L##x
 #define ETCH_TYPE(x, y) /* Not used on Windows */
 #elif defined(__APPLE__)
-#define CFI(x)          /* not used on OSX */
-#define CFI2(x, y)      /* not used on OSX */
-#define CFI3C(x, y, z)  /* not used on OSX */
+#define CFI(x)          .cfi_##x
+#define CFI2(x, y)      .cfi_##x y
+#define CFI3C(x, y, z)  .cfi_##x y##, z
 #define ETCH_ALIGN16    .align 4 // on OSX this is 2^value
 #define ETCH_ALIGN8     .align 3
 #define ETCH_ALIGN4     .align 2


### PR DESCRIPTION
'z' field is required in the augmentation string to indicate length. Several
other required fields in libunwind are added. __register_frame needs the FDE
address, instead of the CIE address. _Unwind_GetIP is needed to get rip instead
of _Unwind_GetGR with Debug::RIP, because the rip number is -1 in libunwind
instead of 16. This change is compatible with both gcc and clang.

The cfi directives are enabled on Mac because they compiles with clang. All
quick tests pass in JIT mode after this change, expect 2 unrelated failures.
Part of #4444.