### PR TITLE
Fix protected output buffer flushing

### DIFF
--- a/hphp/runtime/base/execution-context.cpp
+++ b/hphp/runtime/base/execution-context.cpp
@@ -200,6 +200,7 @@ static void safe_stdout(const  void  *ptr,  size_t  size) {
 }
 
 void ExecutionContext::writeStdout(const char *s, int len) {
+  fflush(stdout);
   if (m_stdout == nullptr) {
     if (s_stdout_color) {
       safe_stdout(s_stdout_color, strlen(s_stdout_color));
@@ -211,6 +212,14 @@ void ExecutionContext::writeStdout(const char *s, int len) {
     m_stdoutBytesWritten += len;
   } else {
     m_stdout(s, len, m_stdoutData);
+  }
+}
+
+void ExecutionContext::writeTransport(const char *s, int len) {
+  if (m_transport) {
+    m_transport->sendRaw((void*)s, len, 200, false, true);
+  } else {
+    writeStdout(s, len);
   }
 }
 
@@ -226,10 +235,10 @@ void ExecutionContext::write(const char *s, int len) {
         obFlush();
       }
     }
+    if (m_implicitFlush) flush();
   } else {
-    writeStdout(s, len);
+    writeTransport(s, len);
   }
-  if (m_implicitFlush) flush();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -240,12 +249,13 @@ void ExecutionContext::obProtect(bool on) {
 }
 
 void ExecutionContext::obStart(const Variant& handler /* = null */,
-                               int chunk_size /* = 0 */) {
+                               int chunk_size /* = 0 */,
+                               int flags /* = k_PHP_OUTPUT_HANDLER_STDFLAGS */) {
   if (m_insideOBHandler) {
     raise_error("ob_start(): Cannot use output buffering "
                 "in output buffering display handlers");
   }
-  m_buffers.emplace_back(Variant(handler), chunk_size);
+  m_buffers.emplace_back(Variant(handler), chunk_size, flags);
   resetCurrentBuffer();
 }
 
@@ -292,12 +302,15 @@ void ExecutionContext::obClean(int handler_flag) {
 bool ExecutionContext::obFlush() {
   assert(m_protectedLevel >= 0);
 
-  if ((int)m_buffers.size() <= m_protectedLevel) {
+  if (m_buffers.empty()) {
     return false;
   }
 
   auto iter = m_buffers.end();
   OutputBuffer& last = *(--iter);
+  if (!(last.flags & k_PHP_OUTPUT_HANDLER_FLUSHABLE)) {
+    return false;
+  }
 
   const int flag = k_PHP_OUTPUT_HANDLER_START | k_PHP_OUTPUT_HANDLER_END;
 
@@ -338,17 +351,19 @@ bool ExecutionContext::obFlush() {
       }
       str = tout.toString();
     } catch (...) {
-      writeStdout(str.data(), str.size());
+      writeTransport(str.data(), str.size());
       throw;
     }
   }
 
-  writeStdout(str.data(), str.size());
+  writeTransport(str.data(), str.size());
   return true;
 }
 
 void ExecutionContext::obFlushAll() {
-  while (obFlush()) { obEnd();}
+  do {
+    obFlush();
+  } while (obEnd());
 }
 
 bool ExecutionContext::obEnd() {
@@ -375,6 +390,7 @@ int ExecutionContext::obGetLevel() {
 const StaticString
   s_level("level"),
   s_type("type"),
+  s_flags("flags"),
   s_name("name"),
   s_args("args"),
   s_chunk_size("chunk_size"),
@@ -393,6 +409,7 @@ Array ExecutionContext::obGetStatus(bool full) {
       status.set(s_name, buffer.handler);
       status.set(s_type, 1);
     }
+    status.set(s_flags, buffer.flags);
     status.set(s_level, level);
     status.set(s_chunk_size, buffer.chunk_size);
     status.set(s_buffer_used, static_cast<uint64_t>(buffer.oss.size()));
@@ -405,6 +422,22 @@ Array ExecutionContext::obGetStatus(bool full) {
     level++;
   }
   return ret;
+}
+
+String ExecutionContext::obGetBufferName() {
+  if (m_buffers.empty()) {
+    return String();
+  } else if (m_buffers.size() <= m_protectedLevel) {
+    return s_default_output_handler;
+  } else {
+    auto iter = m_buffers.end();
+    OutputBuffer& buffer = *(--iter);
+    if (buffer.handler.isNull()) {
+      return s_default_output_handler;
+    } else {
+      return buffer.handler.toString();
+    }
+  }
 }
 
 void ExecutionContext::obSetImplicitFlush(bool on) {
@@ -421,20 +454,12 @@ Array ExecutionContext::obGetHandlers() {
 }
 
 void ExecutionContext::flush() {
-  if (m_buffers.empty()) {
-    fflush(stdout);
-  } else if (RuntimeOption::EnableEarlyFlush && m_protectedLevel &&
-             (m_transport == nullptr ||
-              (m_transport->getHTTPVersion() == "1.1" &&
-               m_transport->getMethod() != Transport::Method::HEAD))) {
+  if (!m_buffers.empty() &&
+      RuntimeOption::EnableEarlyFlush && m_protectedLevel &&
+      (m_buffers.front().flags & k_PHP_OUTPUT_HANDLER_FLUSHABLE)) {
     StringBuffer &oss = m_buffers.front().oss;
     if (!oss.empty()) {
-      if (m_transport) {
-        m_transport->sendRaw((void*)oss.data(), oss.size(), 200, false, true);
-      } else {
-        writeStdout(oss.data(), oss.size());
-        fflush(stdout);
-      }
+      writeTransport(oss.data(), oss.size());
       oss.clear();
     }
   }

--- a/hphp/runtime/base/execution-context.cpp
+++ b/hphp/runtime/base/execution-context.cpp
@@ -250,7 +250,7 @@ void ExecutionContext::obProtect(bool on) {
 
 void ExecutionContext::obStart(const Variant& handler /* = null */,
                                int chunk_size /* = 0 */,
-                               int flags /* = k_PHP_OUTPUT_HANDLER_STDFLAGS */) {
+                               OBFlags flags /* = OBFlags::Default */) {
   if (m_insideOBHandler) {
     raise_error("ob_start(): Cannot use output buffering "
                 "in output buffering display handlers");
@@ -299,7 +299,7 @@ void ExecutionContext::obClean(int handler_flag) {
   }
 }
 
-bool ExecutionContext::obFlush() {
+bool ExecutionContext::obFlush(bool force /*= false*/) {
   assert(m_protectedLevel >= 0);
 
   if (m_buffers.empty()) {
@@ -308,7 +308,10 @@ bool ExecutionContext::obFlush() {
 
   auto iter = m_buffers.end();
   OutputBuffer& last = *(--iter);
-  if (!(last.flags & k_PHP_OUTPUT_HANDLER_FLUSHABLE)) {
+  if (!force && !(last.flags & OBFlags::Flushable)) {
+    return false;
+  }
+  if (last.flags & OBFlags::OutputDisabled) {
     return false;
   }
 
@@ -362,7 +365,7 @@ bool ExecutionContext::obFlush() {
 
 void ExecutionContext::obFlushAll() {
   do {
-    obFlush();
+    obFlush(true);
   } while (obEnd());
 }
 
@@ -409,7 +412,19 @@ Array ExecutionContext::obGetStatus(bool full) {
       status.set(s_name, buffer.handler);
       status.set(s_type, 1);
     }
-    status.set(s_flags, buffer.flags);
+
+    int flags = 0;
+    if (buffer.flags & OBFlags::Cleanable) {
+      flags |= k_PHP_OUTPUT_HANDLER_CLEANABLE;
+    }
+    if (buffer.flags & OBFlags::Flushable) {
+      flags |= k_PHP_OUTPUT_HANDLER_FLUSHABLE;
+    } 
+    if (buffer.flags & OBFlags::Removable) {
+      flags |= k_PHP_OUTPUT_HANDLER_REMOVABLE;
+    }
+    status.set(s_flags, flags);
+
     status.set(s_level, level);
     status.set(s_chunk_size, buffer.chunk_size);
     status.set(s_buffer_used, static_cast<uint64_t>(buffer.oss.size()));
@@ -456,7 +471,7 @@ Array ExecutionContext::obGetHandlers() {
 void ExecutionContext::flush() {
   if (!m_buffers.empty() &&
       RuntimeOption::EnableEarlyFlush && m_protectedLevel &&
-      (m_buffers.front().flags & k_PHP_OUTPUT_HANDLER_FLUSHABLE)) {
+      !(m_buffers.front().flags & OBFlags::OutputDisabled)) {
     StringBuffer &oss = m_buffers.front().oss;
     if (!oss.empty()) {
       writeTransport(oss.data(), oss.size());

--- a/hphp/runtime/base/execution-context.h
+++ b/hphp/runtime/base/execution-context.h
@@ -32,6 +32,7 @@
 #include "hphp/runtime/base/ini-setting.h"
 #include "hphp/runtime/base/mixed-array.h"
 #include "hphp/runtime/base/string-buffer.h"
+#include "hphp/runtime/ext/std/ext_std_output.h"
 #include "hphp/runtime/ext/stream/ext_stream.h"
 #include "hphp/runtime/server/transport.h"
 #include "hphp/runtime/server/virtual-host.h"
@@ -169,13 +170,20 @@ public:
   void writeStdout(const char* s, int len);
   size_t getStdoutBytesWritten() const;
 
+  /**
+   * Write to the transport, or to stdout if there is no transport.
+   */
+  void writeTransport(const char* s, int len);
+
   using PFUNC_STDOUT = void (*)(const char* s, int len, void* data);
   void setStdout(PFUNC_STDOUT func, void* data);
 
   /**
    * Output buffering.
    */
-  void obStart(const Variant& handler = uninit_null(), int chunk_size = 0);
+  void obStart(const Variant& handler = uninit_null(),
+               int chunk_size = 0,
+               int flags = k_PHP_OUTPUT_HANDLER_STDFLAGS);
   String obCopyContents();
   String obDetachContents();
   int obGetContentLength();
@@ -185,6 +193,7 @@ public:
   bool obEnd();
   void obEndAll();
   int obGetLevel();
+  String obGetBufferName();
   Array obGetStatus(bool full);
   void obSetImplicitFlush(bool on);
   Array obGetHandlers();
@@ -271,16 +280,18 @@ public:
 
 private:
   struct OutputBuffer {
-    explicit OutputBuffer(Variant&& h, int chunk_sz)
-      : oss(8192), handler(std::move(h)), chunk_size(chunk_sz)
+    explicit OutputBuffer(Variant&& h, int chunk_sz, int flgs)
+      : oss(8192), handler(std::move(h)), chunk_size(chunk_sz), flags(flgs)
     {}
     StringBuffer oss;
     Variant handler;
     int chunk_size;
+    int flags;
     template<class F> void scan(F& mark) {
       mark(oss);
       mark(handler);
       mark(chunk_size);
+      mark(flags);
     }
   };
 

--- a/hphp/runtime/base/program-functions.cpp
+++ b/hphp/runtime/base/program-functions.cpp
@@ -1982,10 +1982,7 @@ void hphp_session_init() {
 }
 
 ExecutionContext *hphp_context_init() {
-  ExecutionContext *context = g_context.getNoCheck();
-  context->obStart();
-  context->obProtect(true);
-  return context;
+  return g_context.getNoCheck();
 }
 
 bool hphp_invoke_simple(const std::string& filename, bool warmupOnly) {

--- a/hphp/runtime/ext/std/ext_std_output.cpp
+++ b/hphp/runtime/ext/std/ext_std_output.cpp
@@ -58,7 +58,11 @@ bool HHVM_FUNCTION(ob_start, const Variant& callback /* = null */,
       return false;
     }
   }
-  g_context->obStart(callback, chunk_size, flags);
+  OBFlags f = OBFlags::None;
+  if (flags & k_PHP_OUTPUT_HANDLER_CLEANABLE) f |= OBFlags::Cleanable;
+  if (flags & k_PHP_OUTPUT_HANDLER_FLUSHABLE) f |= OBFlags::Flushable;
+  if (flags & k_PHP_OUTPUT_HANDLER_REMOVABLE) f |= OBFlags::Removable;
+  g_context->obStart(callback, chunk_size, f);
   return true;
 }
 void HHVM_FUNCTION(ob_clean) {
@@ -85,7 +89,7 @@ bool HHVM_FUNCTION(ob_end_clean) {
   return g_context->obEnd();
 }
 bool HHVM_FUNCTION(ob_end_flush) {
-  bool ret = g_context->obFlush();
+  bool ret = g_context->obFlush(true);
   g_context->obEnd();
   return ret;
 }

--- a/hphp/runtime/ext/std/ext_std_output.h
+++ b/hphp/runtime/ext/std/ext_std_output.h
@@ -39,7 +39,7 @@ bool HHVM_FUNCTION(ob_start, const Variant& output_callback = uninit_null(),
                              int chunk_size = 0,
                              int flags = k_PHP_OUTPUT_HANDLER_STDFLAGS);
 void HHVM_FUNCTION(ob_clean);
-void HHVM_FUNCTION(ob_flush);
+bool HHVM_FUNCTION(ob_flush);
 bool HHVM_FUNCTION(ob_end_clean);
 bool HHVM_FUNCTION(ob_end_flush);
 void HHVM_FUNCTION(flush);

--- a/hphp/runtime/ext/std/ext_std_output.php
+++ b/hphp/runtime/ext/std/ext_std_output.php
@@ -68,7 +68,7 @@ function ob_clean(): void;
  * buffer like ob_end_flush() does.
  */
 <<__Native>>
-function ob_flush(): void;
+function ob_flush(): bool;
 
 /* This function discards the contents of the topmost output buffer and turns
  * off this output buffering. If you want to further process the buffer's

--- a/hphp/runtime/ext/std/ext_std_string.h
+++ b/hphp/runtime/ext/std/ext_std_string.h
@@ -15,8 +15,8 @@
    +----------------------------------------------------------------------+
 */
 
-#ifndef incl_HPHP_EXT_OUTPUT_H_
-#define incl_HPHP_EXT_OUTPUT_H_
+#ifndef incl_HPHP_EXT_STD_STRING_H_
+#define incl_HPHP_EXT_STD_STRING_H_
 
 #include "hphp/runtime/ext/std/ext_std.h"
 

--- a/hphp/runtime/server/http-request-handler.cpp
+++ b/hphp/runtime/server/http-request-handler.cpp
@@ -428,6 +428,13 @@ bool HttpRequestHandler::executePHPRequest(Transport *transport,
                                            SourceRootInfo &sourceRootInfo,
                                            bool cacheableDynamicContent) {
   ExecutionContext *context = hphp_context_init();
+  int obFlags = k_PHP_OUTPUT_HANDLER_STDFLAGS;
+  if (cacheableDynamicContent ||
+      transport->getHTTPVersion() != "1.1") {
+    obFlags &= ~k_PHP_OUTPUT_HANDLER_FLUSHABLE;
+  }
+  context->obStart(uninit_null(), 0, obFlags);
+  context->obProtect(true);
   if (RuntimeOption::ImplicitFlush) {
     context->obSetImplicitFlush(true);
   }

--- a/hphp/runtime/server/http-request-handler.cpp
+++ b/hphp/runtime/server/http-request-handler.cpp
@@ -428,10 +428,10 @@ bool HttpRequestHandler::executePHPRequest(Transport *transport,
                                            SourceRootInfo &sourceRootInfo,
                                            bool cacheableDynamicContent) {
   ExecutionContext *context = hphp_context_init();
-  int obFlags = k_PHP_OUTPUT_HANDLER_STDFLAGS;
+  OBFlags obFlags = OBFlags::Default;
   if (cacheableDynamicContent ||
       transport->getHTTPVersion() != "1.1") {
-    obFlags &= ~k_PHP_OUTPUT_HANDLER_FLUSHABLE;
+    obFlags |= OBFlags::OutputDisabled;
   }
   context->obStart(uninit_null(), 0, obFlags);
   context->obProtect(true);

--- a/hphp/runtime/server/proxygen/proxygen-transport.cpp
+++ b/hphp/runtime/server/proxygen/proxygen-transport.cpp
@@ -549,7 +549,7 @@ void ProxygenTransport::sendImpl(const void *data, int size, int code,
         m_response.getHeaders().add(HTTP_HEADER_CONTENT_LENGTH,
                                     folly::to<std::string>(size));
       }
-    } else {
+    } else if (!suppressBody) {
       // Explicitly add Transfer-Encoding: chunked here.  libproxygen will only
       // add it for keep-alive connections
       m_response.getHeaders().set(HTTP_HEADER_TRANSFER_ENCODING, "chunked");
@@ -560,10 +560,6 @@ void ProxygenTransport::sendImpl(const void *data, int size, int code,
       HTTPMessage::getDefaultReason(code) : reasonStr.c_str();
     m_response.setStatusMessage(reason);
     m_response.setHTTPVersion(1, 1);
-
-    // If it is a HEAD request, lie to Proxygen about the chunked status, since
-    // Proxygen is broken and will send a response body consisting of an empty
-    // chunk if the chunked flag is set.
     m_response.setIsChunked(chunked && !suppressBody);
 
     m_response.dumpMessage(4);

--- a/hphp/runtime/server/proxygen/proxygen-transport.cpp
+++ b/hphp/runtime/server/proxygen/proxygen-transport.cpp
@@ -538,17 +538,18 @@ void ProxygenTransport::sendImpl(const void *data, int size, int code,
     // somewhere.
     return;
   }
+  bool suppressBody = m_method == Method::HEAD;
 
   VLOG(4) << "sendImpl called with data size=" << size << ", code=" << code
           << ", chunked=" << chunked << ", eom=" << eom;
-  eom |= !chunked;
+  eom |= suppressBody || !chunked;
   if (!m_sendStarted) {
     if (!chunked) {
       if (!m_response.getHeaders().exists(HTTP_HEADER_CONTENT_LENGTH)) {
         m_response.getHeaders().add(HTTP_HEADER_CONTENT_LENGTH,
                                     folly::to<std::string>(size));
       }
-    } else {
+    } else if (!suppressBody) {
       // Explicitly add Transfer-Encoding: chunked here.  libproxygen will only
       // add it for keep-alive connections
       m_response.getHeaders().set(HTTP_HEADER_TRANSFER_ENCODING, "chunked");
@@ -559,26 +560,31 @@ void ProxygenTransport::sendImpl(const void *data, int size, int code,
       HTTPMessage::getDefaultReason(code) : reasonStr.c_str();
     m_response.setStatusMessage(reason);
     m_response.setHTTPVersion(1, 1);
-    m_response.setIsChunked(chunked);
+    m_response.setIsChunked(chunked && !suppressBody);
     m_response.dumpMessage(4);
     m_server->putResponseMessage(
       std::move(ResponseMessage(shared_from_this(),
                                 ResponseMessage::Type::HEADERS, 0,
-                                chunked, data, size, eom)));
+                                chunked && !suppressBody,
+                                data,
+                                suppressBody ? 0 : size,
+                                eom)));
     m_sendStarted = true;
   } else {
     m_server->putResponseMessage(
       std::move(ResponseMessage(shared_from_this(),
                                 ResponseMessage::Type::BODY, 0,
-                                chunked, data, size, eom)));
+                                chunked && !suppressBody,
+                                data,
+                                suppressBody ? 0 : size,
+                                eom)));
   }
 
   if (eom) {
     m_sendEnded = true;
   }
 
-  if (chunked) {
-    assert(m_method != Method::HEAD);
+  if (chunked && !suppressBody) {
     /*
      * Chunked replies are sent async, so there is no way to know the
      * time it took to flush the response, but tracking the bytes sent is

--- a/hphp/runtime/server/proxygen/proxygen-transport.cpp
+++ b/hphp/runtime/server/proxygen/proxygen-transport.cpp
@@ -549,7 +549,7 @@ void ProxygenTransport::sendImpl(const void *data, int size, int code,
         m_response.getHeaders().add(HTTP_HEADER_CONTENT_LENGTH,
                                     folly::to<std::string>(size));
       }
-    } else if (!suppressBody) {
+    } else {
       // Explicitly add Transfer-Encoding: chunked here.  libproxygen will only
       // add it for keep-alive connections
       m_response.getHeaders().set(HTTP_HEADER_TRANSFER_ENCODING, "chunked");

--- a/hphp/runtime/server/proxygen/proxygen-transport.cpp
+++ b/hphp/runtime/server/proxygen/proxygen-transport.cpp
@@ -560,7 +560,12 @@ void ProxygenTransport::sendImpl(const void *data, int size, int code,
       HTTPMessage::getDefaultReason(code) : reasonStr.c_str();
     m_response.setStatusMessage(reason);
     m_response.setHTTPVersion(1, 1);
+
+    // If it is a HEAD request, lie to Proxygen about the chunked status, since
+    // Proxygen is broken and will send a response body consisting of an empty
+    // chunk if the chunked flag is set.
     m_response.setIsChunked(chunked && !suppressBody);
+
     m_response.dumpMessage(4);
     m_server->putResponseMessage(
       std::move(ResponseMessage(shared_from_this(),

--- a/hphp/runtime/server/rpc-request-handler.cpp
+++ b/hphp/runtime/server/rpc-request-handler.cpp
@@ -68,8 +68,7 @@ void RPCRequestHandler::initState() {
   if (isServer) {
     m_context->obStart(uninit_null(),
                        0,
-                       k_PHP_OUTPUT_HANDLER_STDFLAGS &
-                       ~k_PHP_OUTPUT_HANDLER_FLUSHABLE);
+                       OBFlags::Default | OBFlags::OutputDisabled);
     m_context->obProtect(true);
   } else {
     // In command line mode, we want the xbox workers to

--- a/hphp/runtime/server/rpc-request-handler.cpp
+++ b/hphp/runtime/server/rpc-request-handler.cpp
@@ -64,8 +64,13 @@ RPCRequestHandler::~RPCRequestHandler() {
 void RPCRequestHandler::initState() {
   hphp_session_init();
   bool isServer = RuntimeOption::ServerExecutionMode();
+  m_context = hphp_context_init();
   if (isServer) {
-    m_context = hphp_context_init();
+    m_context->obStart(uninit_null(),
+                       0,
+                       k_PHP_OUTPUT_HANDLER_STDFLAGS &
+                       ~k_PHP_OUTPUT_HANDLER_FLUSHABLE);
+    m_context->obProtect(true);
   } else {
     // In command line mode, we want the xbox workers to
     // output to STDOUT

--- a/hphp/runtime/server/transport.cpp
+++ b/hphp/runtime/server/transport.cpp
@@ -944,6 +944,11 @@ void Transport::sendRawInternal(const void *data, int size,
 }
 
 void Transport::onSendEnd() {
+  if (m_sendEnded) {
+    // This can happen if the request was terminated early due to it being a
+    // HEAD request
+    return;
+  }
   bool eomSent = false;
   if (m_compressor && m_chunkedEncoding) {
     assert(m_headerSent);


### PR DESCRIPTION
* Implement OutputDisabled and Flushable output buffer flags and fix RPC early f
lush
* Fix HEAD handling, don't require buffering
* Migrate HTTP/1.0 handling to new OutputDisabled flag
* Allow obFlush() of top-level output buffer