### PR TITLE
Link with boost_context library.

### DIFF
--- a/CMake/HPHPFindLibs.cmake
+++ b/CMake/HPHPFindLibs.cmake
@@ -28,7 +28,7 @@ if (LIBDL_INCLUDE_DIRS)
 endif()
 
 # boost checks
-find_package(Boost 1.51.0 COMPONENTS system program_options filesystem REQUIRED)
+find_package(Boost 1.51.0 COMPONENTS system program_options filesystem context REQUIRED)
 include_directories(${Boost_INCLUDE_DIRS})
 link_directories(${Boost_LIBRARY_DIRS})
 add_definitions("-DHAVE_BOOST1_49")


### PR DESCRIPTION
Otherwise ld will report undefined references in folly.