### PR TITLE
Fix fastcgi behavior with FixPathInfo=true and apache 2.4+mod_proxy_fastcgi

### DIFF
--- a/hphp/runtime/server/fastcgi/fastcgi-transport.cpp
+++ b/hphp/runtime/server/fastcgi/fastcgi-transport.cpp
@@ -267,11 +267,13 @@ void FastCGITransport::onHeadersComplete() {
 
   // RequestURI needs script_filename and path_translated to not include
   // the document root
-  if (m_scriptName.find(m_docRoot) == 0) {
-    m_scriptName.erase(0, m_docRoot.length());
-  } else {
-    // if the document root isn't in the url set document root to /
-    m_docRoot = "/";
+  if (!m_scriptName.empty()) {
+    if (m_scriptName.find(m_docRoot) == 0) {
+      m_scriptName.erase(0, m_docRoot.length());
+    } else {
+      // if the document root isn't in the url set document root to /
+      m_docRoot = "/";
+    }
   }
 
   // XXX: This was originally done before remapping scriptName but that seemed


### PR DESCRIPTION
If SCRIPT_FILENAME is empty don't make any assumptions about what the document root should be set to based off of it. This patch adds a check to see if scriptName is empty, a check that was present prior to the FastCGI refactor. 

cc @paulbiss 