### PR TITLE
Allow hh_server to find files with a .xhp extension

### DIFF
--- a/hphp/hack/src/server/findUtils.ml
+++ b/hphp/hack/src/server/findUtils.ml
@@ -17,6 +17,7 @@ let extensions = [
   ".hh"   ; (* Hack extension some open source code is starting to use *)
   ".phpt" ; (* our php template files *)
   ".hhi"  ; (* interface files only visible to the type checker *)
+  ".xhp"  ; (* XHP extensions *)
 ]
 
 let is_directory path = try Sys.is_directory path with Sys_error _ -> false


### PR DESCRIPTION
Adds `.xhp` as an allowable extension for type checking. It's a nice way to distinguish XHP code from non-XHP code, and the extension is not used by any other application (as far as I can find).