### PR TITLE
Enhance checking for -latomic

### DIFF
--- a/hphp/hhvm/CMakeLists.txt
+++ b/hphp/hhvm/CMakeLists.txt
@@ -46,10 +46,11 @@ set(OLD_CMAKE_REQUIRED_FLAGS ${CMAKE_REQUIRED_FLAGS})
 set(CMAKE_REQUIRED_FLAGS "-std=c++11")
 CHECK_CXX_SOURCE_COMPILES("
 #include <atomic>
+#include <iostream>
 int main() {
     struct Test { int val; };
     std::atomic<Test> s;
-    s.is_lock_free();
+    std::cout << s.is_lock_free();
 }
 " NOT_REQUIRE_ATOMIC_LINKER_FLAG)
 


### PR DESCRIPTION
This is an enhancement of #5218. With GCC 5-20150519 and CXXFLAGS="-O2", the original line ```s.is_lock_free()``` is optimized out, so the checking result is incorrect. I managed to fix it by printing out the value.