### PR TITLE
Allow custom paths for pthread library when building Folly

### DIFF
--- a/CMake/FollySetup.cmake
+++ b/CMake/FollySetup.cmake
@@ -13,9 +13,9 @@ if (FOLLY_IFUNC)
 endif()
 
 if (LINUX OR FREEBSD)
-  set(CMAKE_REQUIRED_LIBRARIES rt pthread)
+  set(CMAKE_REQUIRED_LIBRARIES rt ${LIBPTHREAD_LIBRARIES})
 else()
-  set(CMAKE_REQUIRED_LIBRARIES pthread)
+  set(CMAKE_REQUIRED_LIBRARIES ${LIBPTHREAD_LIBRARIES})
 endif()
 
 include(CheckFunctionExists)


### PR DESCRIPTION
The current folly CMake file requires that pthread be in the library path to work. This changes it to use the path that is located by HPHPFindLibs, which may have been custom.