### PR TITLE
simplexml_load_file: check for null return from File::Open()

### DIFF
--- a/hphp/runtime/ext/ext_simplexml.cpp
+++ b/hphp/runtime/ext/ext_simplexml.cpp
@@ -1124,7 +1124,7 @@ Variant f_simplexml_load_file(const String& filename,
   }
 
   auto stream = File::Open(filename, "rb");
-  if (stream->isInvalid()) return false;
+  if (!stream || stream->isInvalid()) return false;
 
   xmlDocPtr doc = nullptr;
 

--- a/hphp/test/slow/simple_xml/failed-load.php
+++ b/hphp/test/slow/simple_xml/failed-load.php
@@ -1,0 +1,1 @@
+<?php simplexml_load_file('xhttp://example.com/');

--- a/hphp/test/slow/simple_xml/failed-load.php.expectf
+++ b/hphp/test/slow/simple_xml/failed-load.php.expectf
@@ -1,0 +1,1 @@
+Warning: Unknown URI scheme "xhttp" in %s on line 1


### PR DESCRIPTION
Fixes  #5416.