### PR TITLE
Array pointer modification functions (next, current, each etc) can be used on ArrayObject

### DIFF
--- a/hphp/system/php/spl/miscellaneous/ArrayObject.php
+++ b/hphp/system/php/spl/miscellaneous/ArrayObject.php
@@ -499,6 +499,7 @@ class ArrayObject implements IteratorAggregate, ArrayAccess,
     } else {
       $this->storage = $input;
     }
+    reset($this->storage);
   }
 
   public function __debugInfo() {
@@ -508,5 +509,75 @@ class ArrayObject implements IteratorAggregate, ArrayAccess,
         "\0ArrayObject\0storage" => $this->storage,
       ),
     );
+  }
+
+  /*
+   * Magic function called when invoking reset($arrayObject)
+   */
+  private function __reset() {
+    if($this->flags & self::STD_PROP_LIST) {
+      return false;
+    }
+    reset($this->storage);
+  }
+
+  /*
+   * Magic function called when invoking current($arrayObject)
+   */
+  private function __current() {
+    if($this->flags & self::STD_PROP_LIST) {
+      return false;
+    }
+    return current($this->storage);
+  }
+
+  /*
+   * Magic function called when invoking key($arrayObject)
+   */
+  private function __key() {
+    if($this->flags & self::STD_PROP_LIST) {
+      return null;
+    }
+    return key($this->storage);
+  }
+
+  /*
+   * Magic function called when invoking next($arrayObject)
+   */
+  private function __next() {
+    if($this->flags & self::STD_PROP_LIST) {
+      return false;
+    }
+    return next($this->storage);
+  }
+
+  /*
+   * Magic function called when invoking prev($arrayObject)
+   */
+  private function __prev() {
+    if($this->flags & self::STD_PROP_LIST) {
+      return false;
+    }
+    return prev($this->storage);
+  }
+
+  /*
+   * Magic function called when invoking each($arrayObject)
+   */
+  private function __each() {
+    if($this->flags & self::STD_PROP_LIST) {
+      return false;
+    }
+    return each($this->storage);
+  }
+
+  /*
+   * Magic function called when invoking end($arrayObject)
+   */
+  private function __end() {
+    if($this->flags & self::STD_PROP_LIST) {
+      return false;
+    }
+    return end($this->storage);
   }
 }

--- a/hphp/system/php/spl/miscellaneous/ArrayObject.php
+++ b/hphp/system/php/spl/miscellaneous/ArrayObject.php
@@ -499,7 +499,6 @@ class ArrayObject implements IteratorAggregate, ArrayAccess,
     } else {
       $this->storage = $input;
     }
-    reset($this->storage);
   }
 
   public function __debugInfo() {

--- a/hphp/test/slow/array_object/pointer_modifications.php
+++ b/hphp/test/slow/array_object/pointer_modifications.php
@@ -2,6 +2,7 @@
 
 function testPointerModifications() {
   $array = array(1, 2, 3);
+  next($array);
   $arrayObject = new ArrayObject($array);
 
   reset($arrayObject);
@@ -27,6 +28,27 @@ function testPointerModifications() {
 
   end($arrayObject);
   echo "Last value of " . get_class($arrayObject) . " is: ";
+  echo current($arrayObject), "\n";
+
+  reset($arrayObject);
+  next($arrayObject);
+  foreach($arrayObject as $key => $value) {
+    echo "next/reset etc have no impact on using arrayObject as iterator, ";
+    echo "proof: ", $value, "\n";
+    break;
+  }
+
+  $arrayObject->setFlags(ArrayObject::STD_PROP_LIST);
+  echo "current value after setting STD_PROP_LIST: ";
+  echo var_export(current($arrayObject), true), "\n";
+
+  foreach(array('each', 'current', 'key', 'prev', 'next', 'reset') as $op) {
+    echo "$op with STD_PROP_LIST enabled: ";
+    echo var_export($op($arrayObject), true), "\n";
+  }
+
+  $arrayObject->setFlags(ArrayObject::ARRAY_AS_PROPS);
+  echo "Disabling STD_PROP_LIST and checking current value: ";
   echo current($arrayObject), "\n";
 }
 testPointerModifications();

--- a/hphp/test/slow/array_object/pointer_modifications.php
+++ b/hphp/test/slow/array_object/pointer_modifications.php
@@ -1,0 +1,33 @@
+<?php
+
+function testPointerModifications() {
+  $array = array(1, 2, 3);
+  $arrayObject = new ArrayObject($array);
+
+  reset($arrayObject);
+  echo "After reset current of " . get_class($arrayObject) . " value is: ";
+  echo current($arrayObject), "\n";
+
+  next($arrayObject);
+  echo "Next value of " . get_class($arrayObject) . " is: ";
+  echo current($arrayObject), "\n";
+
+  echo "Looking back to real array, current value is: ";
+  echo current($array), "\n";
+
+  echo "Key of current value of " . get_class($arrayObject) . " is: ";
+  echo key($arrayObject), "\n";
+
+  echo "Previous value of " . get_class($arrayObject) . " is: ";
+  echo prev($arrayObject), "\n";
+
+  $keyValuePair = each($arrayObject);
+  echo "Current key-value pair of " . get_class($arrayObject) . " is: ";
+  echo "(", $keyValuePair[0], ', ', $keyValuePair[1], ")\n";
+
+  end($arrayObject);
+  echo "Last value of " . get_class($arrayObject) . " is: ";
+  echo current($arrayObject), "\n";
+}
+testPointerModifications();
+

--- a/hphp/test/slow/array_object/pointer_modifications.php
+++ b/hphp/test/slow/array_object/pointer_modifications.php
@@ -52,4 +52,3 @@ function testPointerModifications() {
   echo current($arrayObject), "\n";
 }
 testPointerModifications();
-

--- a/hphp/test/slow/array_object/pointer_modifications.php.expect
+++ b/hphp/test/slow/array_object/pointer_modifications.php.expect
@@ -1,0 +1,8 @@
+After reset current of ArrayObject value is: 1
+Next value of ArrayObject is: 2
+Looking back to real array, current value is: 1
+Key of current value of ArrayObject is: 1
+Previous value of ArrayObject is: 1
+Current key-value pair of ArrayObject is: (0, 1)
+Last value of ArrayObject is: 3
+

--- a/hphp/test/slow/array_object/pointer_modifications.php.expect
+++ b/hphp/test/slow/array_object/pointer_modifications.php.expect
@@ -1,8 +1,16 @@
 After reset current of ArrayObject value is: 1
 Next value of ArrayObject is: 2
-Looking back to real array, current value is: 1
+Looking back to real array, current value is: 2
 Key of current value of ArrayObject is: 1
 Previous value of ArrayObject is: 1
 Current key-value pair of ArrayObject is: (0, 1)
 Last value of ArrayObject is: 3
-
+next/reset etc have no impact on using arrayObject as iterator, proof: 1
+current value after setting STD_PROP_LIST: false
+each with STD_PROP_LIST enabled: false
+current with STD_PROP_LIST enabled: false
+key with STD_PROP_LIST enabled: NULL
+prev with STD_PROP_LIST enabled: false
+next with STD_PROP_LIST enabled: false
+reset with STD_PROP_LIST enabled: false
+Disabling STD_PROP_LIST and checking current value: 2


### PR DESCRIPTION
The C implementation of PHP allows reset(), key(), prev(), current(), each() to be called on arrays and ArrayObjects. Hhvm only allows these functions to be called on arrays. This commit fixes this