### PR TITLE
Start on Windows support for hh_client and family

### DIFF
--- a/hphp/hack/src/fsevents_win/fsevents.ml
+++ b/hphp/hack/src/fsevents_win/fsevents.ml
@@ -1,0 +1,21 @@
+(**
+ * Copyright (c) 2014, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the "hack" directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ *)
+
+type env
+type event = string * string
+external init : unit -> env = "stub_fsevents_init"
+external add_watch : env -> string -> string = "stub_fsevents_add_watch"
+external get_event_fd : env -> Unix.file_descr = "stub_fsevents_get_event_fd"
+external read_events : env -> event list = "stub_fsevents_read_events"
+
+(* glevi is lazy and didn't implement removing watches since hh_server never
+ * actually does that at the moment (he's not the only one who didn't bother to implement removing)
+external rm_watch : env -> string -> string = "stub_fsevents_rm_watch"
+*)

--- a/hphp/hack/src/fsevents_win/fsevents.mli
+++ b/hphp/hack/src/fsevents_win/fsevents.mli
@@ -1,0 +1,20 @@
+(**
+ * Copyright (c) 2014, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the "hack" directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ *)
+
+type env
+type event = string * string
+val init : unit -> env
+val add_watch : env -> string -> string
+val get_event_fd : env -> Unix.file_descr
+val read_events : env -> event list
+
+(* Currently unimplemented
+val rm_watch : env -> string -> string
+*)

--- a/hphp/hack/src/utils/nproc.c
+++ b/hphp/hack/src/utils/nproc.c
@@ -8,12 +8,30 @@
  *
  */
 #include <caml/memory.h>
+#ifdef _MSC_VER
+#include <Windows.h>
+#else
 #include <unistd.h>
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 value nproc(void) {
   CAMLparam0();
   CAMLlocal1(result);
 
+#ifdef _MSC_VER
+  SYSTEM_INFO inf;
+  GetSystemInfo(&inf);
+  result = Val_long(inf.dwNumberOfProcessors);
+#else
   result = Val_long(sysconf(_SC_NPROCESSORS_ONLN));
+#endif
   CAMLreturn(result);
 }
+
+#ifdef __cplusplus
+}
+#endif

--- a/hphp/hack/src/utils/realpath.c
+++ b/hphp/hack/src/utils/realpath.c
@@ -15,6 +15,10 @@
 
 #define Val_none Val_int(0)
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 static value
 Val_some( value v )
 {
@@ -28,16 +32,25 @@ Val_some( value v )
 CAMLprim value
 hh_realpath(value v) {
   char *input;
-  char output[PATH_MAX];
   char *result;
 
   CAMLparam1(v);
 
   input = String_val(v);
+#ifdef _MSC_VER
+  char output[_MAX_PATH];
+  result = _fullpath(output, input, _MAX_PATH);
+#else
+  char output[PATH_MAX];
   result = realpath(input, output);
+#endif
   if (result == NULL) {
     CAMLreturn(Val_none);
   } else {
     CAMLreturn(Val_some(caml_copy_string(output)));
   }
 }
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
This also adds support for compiling the .c files as C++, due to MSVC's C mode being terrible.
This also implements the filesystem watcher, which is mostly adapted from the OSX implementation.
These ports are targetted towards MSVC 2013.

This doesn't touch the makefile, and I've left out the support for the shared heap, due to my implementation of it known to be broken.
This does not make it possible to build on windows, as I haven't touched the build system in this commit. OCamlbuild on Windows does not play well with the C files (it's possible, but not practical).


As the changes for Windows support will end up being massive, a lot of smaller PRs will be much easier to review than a single massive PR would be. 