### PR TITLE
Switch the fatal error when compiling with MSVC to a warning.

### DIFF
--- a/CMake/HPHPCompiler.cmake
+++ b/CMake/HPHPCompiler.cmake
@@ -114,7 +114,21 @@ elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -no-ipo -fp-model precise -wd584 -wd1418 -wd1918 -wd383 -wd869 -wd981 -wd424 -wd1419 -wd444 -wd271 -wd2259 -wd1572 -wd1599 -wd82 -wd177 -wd593 -fno-omit-frame-pointer -Wall -Woverloaded-virtual -Wno-deprecated -w1 -Wno-strict-aliasing -Wno-write-strings -Wno-invalid-offsetof -fno-operator-names")
 # using Visual Studio C++
 elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
-  message(FATAL_ERROR "${PROJECT_NAME} is not yet compatible with Visual Studio")
+  message(WARNING "MSVC support is VERY experimental. It will likely not compile, and is intended for the utterly insane.")
+  # Accounting for each of the warnings disabled:
+  # 4068: Unknown pragma.
+  # 4099: Mixed use of struct and class on same type names. This is absolutely everywhere.
+  # 4101: Unused variables
+  # 4146: Unary minus applied to unsigned type, result still unsigned.
+  # 4267: Implicit truncation of data. This really shouldn't be disabled. (and isn't at the moment)
+  # 4800: Values being forced to bool, this happens many places, and is a "performance warning".
+  #
+  # And the extra defines:
+  # NOMINMAX: This is needed because, for some absurd reason, one of the windows headers tries to define "min" and "max" as macros, which messes up most uses of std::numeric_limits.
+  # _CRT_SECURE_NO_WARNINGS: Don't deprecate the non _s versions of various standard library functions, because safety is for chumps.
+  #
+  set(CMAKE_C_FLAGS   "${CMAKE_C_FLAGS} /fp:precise /wd4068 /wd4099 /wd4101 /wd4146 /wd4800 /D NOMINMAX /D _CRT_SECURE_NO_WARNINGS")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /fp:precise /wd4068 /wd4099 /wd4101 /wd4146 /wd4800 /D NOMINMAX /D _CRT_SECURE_NO_WARNINGS")
 else()
   message("Warning: unknown/unsupported compiler, things may go wrong")
 endif()


### PR DESCRIPTION
This allows attempting to compile HHVM with MSVC, which doesn't compile correctly, but makes it possible to work towards windows support.