### PR TITLE
Remove traces of unimplemented features from admin server

### DIFF
--- a/hphp/doc/command.admin_server
+++ b/hphp/doc/command.admin_server
@@ -32,7 +32,6 @@ This is a list of available URLs:
 /stats-mem:       turn on/off memory statistics
 /stats-apc:       turn on/off APC statistics
 /stats-apc-key:   turn on/off APC key statistics
-/stats-mcc:       turn on/off memcache statistics
 /stats-sql:       turn on/off SQL statistics
 /stats-mutex:     turn on/off mutex statistics
     sampling      optional, default 1000

--- a/hphp/runtime/base/runtime-option.cpp
+++ b/hphp/runtime/base/runtime-option.cpp
@@ -316,8 +316,6 @@ bool RuntimeOption::EnableStats = false;
 bool RuntimeOption::EnableAPCStats = false;
 bool RuntimeOption::EnableWebStats = false;
 bool RuntimeOption::EnableMemoryStats = false;
-bool RuntimeOption::EnableMemcacheStats = false;
-bool RuntimeOption::EnableMemcacheKeyStats = false;
 bool RuntimeOption::EnableSQLStats = false;
 bool RuntimeOption::EnableSQLTableStats = false;
 bool RuntimeOption::EnableNetworkIOStatus = false;
@@ -1501,8 +1499,6 @@ void RuntimeOption::Load(IniSetting::Map& ini, Hdf& config,
     Config::Bind(EnableAPCStats, ini, config, "Stats.APC", false);
     Config::Bind(EnableWebStats, ini, config, "Stats.Web");
     Config::Bind(EnableMemoryStats, ini, config, "Stats.Memory");
-    Config::Bind(EnableMemcacheStats, ini, config, "Stats.Memcache");
-    Config::Bind(EnableMemcacheKeyStats, ini, config, "Stats.MemcacheKey");
     Config::Bind(EnableSQLStats, ini, config, "Stats.SQL");
     Config::Bind(EnableSQLTableStats, ini, config, "Stats.SQLTable");
     Config::Bind(EnableNetworkIOStatus, ini, config, "Stats.NetworkIO");

--- a/hphp/runtime/base/runtime-option.h
+++ b/hphp/runtime/base/runtime-option.h
@@ -301,8 +301,6 @@ public:
   static bool EnableAPCStats;
   static bool EnableWebStats;
   static bool EnableMemoryStats;
-  static bool EnableMemcacheStats;
-  static bool EnableMemcacheKeyStats;
   static bool EnableSQLStats;
   static bool EnableSQLTableStats;
   static bool EnableNetworkIOStatus;

--- a/hphp/runtime/server/admin-request-handler.cpp
+++ b/hphp/runtime/server/admin-request-handler.cpp
@@ -187,7 +187,6 @@ void AdminRequestHandler::handleRequest(Transport *transport) {
 
         "/stats-web:       turn on/off server page stats (CPU and gen time)\n"
         "/stats-mem:       turn on/off memory statistics\n"
-        "/stats-mcc:       turn on/off memcache statistics\n"
         "/stats-sql:       turn on/off SQL statistics\n"
         "/stats-mutex:     turn on/off mutex statistics\n"
         "    sampling      optional, default 1000\n"
@@ -216,8 +215,6 @@ void AdminRequestHandler::handleRequest(Transport *transport) {
         "/dump-apc-meta:   dump meta information for all objects in APC to\n"
         "                  /tmp/apc_dump_meta\n"
         "/advise-out-apc:  forcibly madvise out APC prime data\n"
-        "/dump-const:      dump all constant value in constant map to\n"
-        "                  /tmp/const_map_dump\n"
         "/random-apc:      dump the key and size of a random APC entry\n"
         "    count         number of entries to return\n"
 
@@ -855,9 +852,6 @@ bool AdminRequestHandler::handleStatsRequest(const std::string &cmd,
   if (cmd == "stats-mem") {
     toggle_switch(transport, RuntimeOption::EnableMemoryStats);
     return true;
-  }
-  if (cmd == "stats-mcc") {
-    return toggle_switch(transport, RuntimeOption::EnableMemcacheStats);
   }
   if (cmd == "stats-sql") {
     return toggle_switch(transport, RuntimeOption::EnableSQLStats);


### PR DESCRIPTION
* The /dump-const endpoint does not exist, so don't advertise it.
* The /stats-mcc endpoint does exist, but the setting it toggles
  (EnableMemcacheStats) does nothing. So remove both the endpoint
  and the setting, as well as a sister-setting which likewise does
  nothing (EnableMemcacheKeyStats).