### PR TITLE
Remove typehint from Serializable::unserialize

### DIFF
--- a/hphp/hack/hhi/interfaces.hhi
+++ b/hphp/hack/hhi/interfaces.hhi
@@ -114,7 +114,7 @@ interface KeyedIterable<Tk, +Tv> extends KeyedTraversable<Tk, Tv>, Iterable<Tv> 
 
 interface Serializable {
   public function serialize(): string;
-  public function unserialize(string $serialized): void;
+  public function unserialize($serialized): void;
 }
 
 interface Countable {


### PR DESCRIPTION
Runtime demands it to be ?string and Hack demands it to be string. So we had to remove the type hint as a workaround, which also took away our strict mode.

Ref: https://github.com/facebook/hhvm/issues/4566