### PR TITLE
Add in a facility to pool curl handles between requests.

### DIFF
--- a/hphp/runtime/ext/curl/ext_curl.cpp
+++ b/hphp/runtime/ext/curl/ext_curl.cpp
@@ -147,7 +147,7 @@ public:
   static std::map<std::string, CurlHandlePool*> namedPools;
 
   explicit CurlHandlePool(int poolSize, int waitTimeout, int numConnReuses)
-  : m_poolSize(poolSize), m_waitTimeout(waitTimeout) {
+  : m_waitTimeout(waitTimeout) {
     for (int i = 0; i < poolSize; i++) {
       m_handleStack.push(new PooledCurlHandle(numConnReuses));
     }
@@ -196,7 +196,6 @@ private:
   std::stack<PooledCurlHandle*> m_handleStack;
   Mutex m_mutex;
   pthread_cond_t m_cond;
-  int m_poolSize;
   int m_waitTimeout;
 };
 

--- a/hphp/runtime/ext/curl/ext_curl.cpp
+++ b/hphp/runtime/ext/curl/ext_curl.cpp
@@ -3231,7 +3231,6 @@ class CurlExtension final : public Extension {
 
     IniSetting::Bind(ext, IniSetting::PHP_INI_SYSTEM, "curl.namedPools",
       "", &s_namedPools);
-    IniSetting::Get("curl.namedPools");
     if (s_namedPools.length() > 0) {
 
       // split on commas, search and bind ini settings for each pool
@@ -3254,10 +3253,6 @@ class CurlExtension final : public Extension {
             "100", &s_reuseLimit);
         IniSetting::Bind(ext, IniSetting::PHP_INI_SYSTEM, getTimeoutIni,
             "5000", &s_getTimeout);
-
-        IniSetting::Get(poolSizeIni);
-        IniSetting::Get(reuseLimitIni);
-        IniSetting::Get(getTimeoutIni);
 
         CurlHandlePool *hp =
           new CurlHandlePool(s_poolSize, s_getTimeout, s_reuseLimit);

--- a/hphp/runtime/ext/curl/ext_curl.h
+++ b/hphp/runtime/ext/curl/ext_curl.h
@@ -269,7 +269,7 @@ extern const int64_t k_CURL_VERSION_LIBZ;
 extern const int64_t k_CURL_VERSION_SSL;
 
 Variant HHVM_FUNCTION(curl_init, const Variant& url = null_string);
-Variant HHVM_FUNCTION(curl_init_pooled, const Variant& url = null_string);
+Variant HHVM_FUNCTION(curl_init_pooled, const String& poolName, const Variant& url = null_string);
 Variant HHVM_FUNCTION(curl_copy_handle, const Resource& ch);
 Variant HHVM_FUNCTION(curl_version, int uversion = k_CURLVERSION_NOW);
 bool HHVM_FUNCTION(curl_setopt, const Resource& ch, int option, const Variant& value);

--- a/hphp/runtime/ext/curl/ext_curl.h
+++ b/hphp/runtime/ext/curl/ext_curl.h
@@ -269,7 +269,8 @@ extern const int64_t k_CURL_VERSION_LIBZ;
 extern const int64_t k_CURL_VERSION_SSL;
 
 Variant HHVM_FUNCTION(curl_init, const Variant& url = null_string);
-Variant HHVM_FUNCTION(curl_init_pooled, const String& poolName, const Variant& url = null_string);
+Variant HHVM_FUNCTION(curl_init_pooled, const String& poolName,
+                              const Variant& url = null_string);
 Variant HHVM_FUNCTION(curl_copy_handle, const Resource& ch);
 Variant HHVM_FUNCTION(curl_version, int uversion = k_CURLVERSION_NOW);
 bool HHVM_FUNCTION(curl_setopt, const Resource& ch, int option, const Variant& value);

--- a/hphp/runtime/ext/curl/ext_curl.h
+++ b/hphp/runtime/ext/curl/ext_curl.h
@@ -269,6 +269,7 @@ extern const int64_t k_CURL_VERSION_LIBZ;
 extern const int64_t k_CURL_VERSION_SSL;
 
 Variant HHVM_FUNCTION(curl_init, const Variant& url = null_string);
+Variant HHVM_FUNCTION(curl_init_pooled, const Variant& url = null_string);
 Variant HHVM_FUNCTION(curl_copy_handle, const Resource& ch);
 Variant HHVM_FUNCTION(curl_version, int uversion = k_CURLVERSION_NOW);
 bool HHVM_FUNCTION(curl_setopt, const Resource& ch, int option, const Variant& value);

--- a/hphp/runtime/ext/curl/ext_curl.php
+++ b/hphp/runtime/ext/curl/ext_curl.php
@@ -128,6 +128,22 @@ function curl_getinfo(resource $ch,
 <<__Native>>
 function curl_init(?string $url = null): mixed;
 
+
+/**
+ * Initialize a cURL session using a pooled curl handle. When this resource
+ * is garbage collected, the curl handle will be saved for reuse later.
+ * Pooled curl handles persist between requests.
+ *
+ * @param string $url - If provided, the CURLOPT_URL option will be set
+ *   to its value. You can manually set this using the curl_setopt()
+ *   function.    The file protocol is disabled by cURL if open_basedir is
+ *   set.
+ *
+ * @return resource - Returns a cURL handle on success, FALSE on errors.
+ */
+<<__Native, __HipHopSpecific>>
+function curl_init_pooled(?string $url = null): mixed;
+
 /**
  * Add a normal cURL handle to a cURL multi handle
  *

--- a/hphp/runtime/ext/curl/ext_curl.php
+++ b/hphp/runtime/ext/curl/ext_curl.php
@@ -134,6 +134,9 @@ function curl_init(?string $url = null): mixed;
  * is garbage collected, the curl handle will be saved for reuse later.
  * Pooled curl handles persist between requests.
  *
+ * @param string $poolName - The name of the connection pool to use.
+ *  Named connection pools are initialized via the 'curl.namedPools' ini
+ *  setting, which is a comma separated list of named pools to create.
  * @param string $url - If provided, the CURLOPT_URL option will be set
  *   to its value. You can manually set this using the curl_setopt()
  *   function.    The file protocol is disabled by cURL if open_basedir is
@@ -142,7 +145,7 @@ function curl_init(?string $url = null): mixed;
  * @return resource - Returns a cURL handle on success, FALSE on errors.
  */
 <<__Native, __HipHopSpecific>>
-function curl_init_pooled(?string $url = null): mixed;
+function curl_init_pooled(string $poolName, ?string $url = null): mixed;
 
 /**
  * Add a normal cURL handle to a cURL multi handle

--- a/hphp/test/slow/ext_curl/curl_handles_are_reset_with_pooling.php
+++ b/hphp/test/slow/ext_curl/curl_handles_are_reset_with_pooling.php
@@ -1,5 +1,5 @@
 <?php
-$ch = curl_init_pooled('foo.bar.com');
+$ch = curl_init_pooled('pool', 'foo.bar.com');
 curl_close($ch);
-$ch = curl_init_pooled('therighturl.com');
+$ch = curl_init_pooled('pool', 'therighturl.com');
 var_dump(curl_getinfo($ch)['url']);

--- a/hphp/test/slow/ext_curl/curl_handles_are_reset_with_pooling.php
+++ b/hphp/test/slow/ext_curl/curl_handles_are_reset_with_pooling.php
@@ -1,0 +1,5 @@
+<?php
+$ch = curl_init_pooled('foo.bar.com');
+curl_close($ch);
+$ch = curl_init_pooled('therighturl.com');
+var_dump(curl_getinfo($ch)['url']);

--- a/hphp/test/slow/ext_curl/curl_handles_are_reset_with_pooling.php.expect
+++ b/hphp/test/slow/ext_curl/curl_handles_are_reset_with_pooling.php.expect
@@ -1,0 +1,1 @@
+string(15) "therighturl.com"

--- a/hphp/test/slow/ext_curl/curl_handles_are_reset_with_pooling.php.ini
+++ b/hphp/test/slow/ext_curl/curl_handles_are_reset_with_pooling.php.ini
@@ -1,0 +1,1 @@
+curl.connectionPoolSize=1

--- a/hphp/test/slow/ext_curl/curl_handles_are_reset_with_pooling.php.ini
+++ b/hphp/test/slow/ext_curl/curl_handles_are_reset_with_pooling.php.ini
@@ -1,1 +1,2 @@
-curl.connectionPoolSize=1
+curl.namedPools=pool
+curl.namedPools.pool.size=1

--- a/hphp/test/slow/ext_curl/curl_handles_in_different_pools_dont_interfere.php
+++ b/hphp/test/slow/ext_curl/curl_handles_in_different_pools_dont_interfere.php
@@ -1,0 +1,9 @@
+<?php
+$ch1 = curl_init_pooled('test', 'foo.com');
+$ch2 = curl_init_pooled('test2', 'bar.com');
+var_dump(curl_getinfo($ch1)['url']);
+var_dump(curl_getinfo($ch2)['url']);
+curl_close($ch1);
+curl_close($ch2);
+$ch3 = curl_init_pooled('test', 'foo.com');
+$ch4 = curl_init_pooled('test', 'foo.com');

--- a/hphp/test/slow/ext_curl/curl_handles_in_different_pools_dont_interfere.php.expectf
+++ b/hphp/test/slow/ext_curl/curl_handles_in_different_pools_dont_interfere.php.expectf
@@ -1,0 +1,4 @@
+string(7) "foo.com"
+string(7) "bar.com"
+
+Fatal error: Timeout reached waiting for an available pooled curl connection! %s

--- a/hphp/test/slow/ext_curl/curl_handles_in_different_pools_dont_interfere.php.ini
+++ b/hphp/test/slow/ext_curl/curl_handles_in_different_pools_dont_interfere.php.ini
@@ -1,0 +1,4 @@
+curl.namedPools=test,test2,tester
+curl.namedPools.test.size=1
+curl.namedPools.test.connGetTimeout=1
+curl.namedPools.test2.size=1

--- a/hphp/test/slow/ext_curl/get_pooled_curl_timeout_works.php
+++ b/hphp/test/slow/ext_curl/get_pooled_curl_timeout_works.php
@@ -1,4 +1,4 @@
 <?php
 // the curl pool is 1, so the second request will fatal
-$ch = curl_init_pooled('foo.bar.com');
-$ch2 = curl_init_pooled('www.baz.com');
+$ch = curl_init_pooled('test', 'foo.bar.com');
+$ch2 = curl_init_pooled('test', 'www.baz.com');

--- a/hphp/test/slow/ext_curl/get_pooled_curl_timeout_works.php
+++ b/hphp/test/slow/ext_curl/get_pooled_curl_timeout_works.php
@@ -1,0 +1,4 @@
+<?php
+// the curl pool is 1, so the second request will fatal
+$ch = curl_init_pooled('foo.bar.com');
+$ch2 = curl_init_pooled('www.baz.com');

--- a/hphp/test/slow/ext_curl/get_pooled_curl_timeout_works.php.expectf
+++ b/hphp/test/slow/ext_curl/get_pooled_curl_timeout_works.php.expectf
@@ -1,1 +1,1 @@
-Fatal error: Timeout reached for waiting for a pooled curl connection! %s
+Fatal error: Timeout reached waiting for an available pooled curl connection! %s

--- a/hphp/test/slow/ext_curl/get_pooled_curl_timeout_works.php.expectf
+++ b/hphp/test/slow/ext_curl/get_pooled_curl_timeout_works.php.expectf
@@ -1,0 +1,1 @@
+Fatal error: Timeout reached for waiting for a pooled curl connection! %s

--- a/hphp/test/slow/ext_curl/get_pooled_curl_timeout_works.php.ini
+++ b/hphp/test/slow/ext_curl/get_pooled_curl_timeout_works.php.ini
@@ -1,0 +1,2 @@
+curl.connectionPoolSize=1
+curl.pooledConnGetTimeout=1

--- a/hphp/test/slow/ext_curl/get_pooled_curl_timeout_works.php.ini
+++ b/hphp/test/slow/ext_curl/get_pooled_curl_timeout_works.php.ini
@@ -1,2 +1,3 @@
-curl.connectionPoolSize=1
-curl.pooledConnGetTimeout=1
+curl.namedPools=,test,
+curl.namedPools.test.size=1
+curl.namedPools.test.connGetTimeout=10

--- a/hphp/test/slow/ext_curl/multiple_curl_handles_can_coexist_with_pooling.php
+++ b/hphp/test/slow/ext_curl/multiple_curl_handles_can_coexist_with_pooling.php
@@ -1,6 +1,6 @@
 <?php
-$ch = curl_init_pooled('foo.bar.com');
-$ch2 = curl_init_pooled('www.baz.com');
+$ch = curl_init_pooled('test', 'foo.bar.com');
+$ch2 = curl_init_pooled('test', 'www.baz.com');
 var_dump(curl_getinfo($ch)['url']);
 var_dump(curl_getinfo($ch2)['url']);
 curl_close($ch);

--- a/hphp/test/slow/ext_curl/multiple_curl_handles_can_coexist_with_pooling.php
+++ b/hphp/test/slow/ext_curl/multiple_curl_handles_can_coexist_with_pooling.php
@@ -1,0 +1,7 @@
+<?php
+$ch = curl_init_pooled('foo.bar.com');
+$ch2 = curl_init_pooled('www.baz.com');
+var_dump(curl_getinfo($ch)['url']);
+var_dump(curl_getinfo($ch2)['url']);
+curl_close($ch);
+curl_close($ch2);

--- a/hphp/test/slow/ext_curl/multiple_curl_handles_can_coexist_with_pooling.php.expect
+++ b/hphp/test/slow/ext_curl/multiple_curl_handles_can_coexist_with_pooling.php.expect
@@ -1,0 +1,2 @@
+string(11) "foo.bar.com"
+string(11) "www.baz.com"

--- a/hphp/test/slow/ext_curl/multiple_curl_handles_can_coexist_with_pooling.php.ini
+++ b/hphp/test/slow/ext_curl/multiple_curl_handles_can_coexist_with_pooling.php.ini
@@ -1,0 +1,1 @@
+curl.connectionPoolSize=10

--- a/hphp/test/slow/ext_curl/multiple_curl_handles_can_coexist_with_pooling.php.ini
+++ b/hphp/test/slow/ext_curl/multiple_curl_handles_can_coexist_with_pooling.php.ini
@@ -1,1 +1,1 @@
-curl.connectionPoolSize=10
+curl.namedPools=test

--- a/hphp/test/slow/ext_curl/pools_can_be_configured_independently.php
+++ b/hphp/test/slow/ext_curl/pools_can_be_configured_independently.php
@@ -1,0 +1,6 @@
+<?php
+$ch1 = curl_init_pooled('pool1', "foo.bar");
+$ch2 = curl_init_pooled('pool1', "foo.bar");
+$ch3 = curl_init_pooled('pool2', "foo.bar");
+echo "here\n";
+$ch4 = curl_init_pooled('pool2', "foo.bar");

--- a/hphp/test/slow/ext_curl/pools_can_be_configured_independently.php.expectf
+++ b/hphp/test/slow/ext_curl/pools_can_be_configured_independently.php.expectf
@@ -1,0 +1,3 @@
+here
+
+Fatal error: Timeout reached waiting for an available pooled curl connection!%s

--- a/hphp/test/slow/ext_curl/pools_can_be_configured_independently.php.ini
+++ b/hphp/test/slow/ext_curl/pools_can_be_configured_independently.php.ini
@@ -1,0 +1,4 @@
+curl.namedPools=pool1,pool2
+curl.namedPools.pool1.size=2
+curl.namedPools.pool2.size=1
+curl.namedPools.pool2.connGetTimeout=1

--- a/hphp/test/slow/ext_curl/using_uninit_pool_generates_warning.php
+++ b/hphp/test/slow/ext_curl/using_uninit_pool_generates_warning.php
@@ -1,0 +1,4 @@
+<?php
+$ch = curl_init_pooled('nonextantpool', 'foo.com');
+var_dump(curl_getinfo($ch)['url']);
+curl_close($ch);

--- a/hphp/test/slow/ext_curl/using_uninit_pool_generates_warning.php.expectf
+++ b/hphp/test/slow/ext_curl/using_uninit_pool_generates_warning.php.expectf
@@ -1,0 +1,2 @@
+Warning: Attempting to use connection pooling without specifying an existant connection pool! %s
+string(7) "foo.com"

--- a/hphp/test/slow/ext_curl/using_uninit_pool_generates_warning.php.expectf
+++ b/hphp/test/slow/ext_curl/using_uninit_pool_generates_warning.php.expectf
@@ -1,2 +1,2 @@
-Warning: Attempting to use connection pooling without specifying an existant connection pool! %s
+Warning: Attempting to use connection pooling without specifying an existent connection pool! %s
 string(7) "foo.com"


### PR DESCRIPTION
This diff introduces a new function, 'curl_init_pooled', which
pulls a curl handle from a persistent process-wide pool of curl
handles instead of making a new one (as 'curl_init' does). The
size of the process-wide pool and the maximum number of times a
curl handle will be reused in PHP are configurable via ini values.
By default, the connection pool will be turned off and a warning
will be issued if a user tries to use the facility without turning
it on.

This facility also introduces a new failure mode that one should
be aware of. When attempting to get a pooled curl handle but none
are available, the request will wait for an ini-value-configurable
number of seconds before timing out and fatal-ing. This serves as
a guard against resource starvation and will allow users to better
manager the curl handle pool.