### PR TITLE
Add space in --from emacs caller

### DIFF
--- a/hphp/hack/editor-plugins/emacs/hack-mode.el
+++ b/hphp/hack/editor-plugins/emacs/hack-mode.el
@@ -324,7 +324,7 @@
   (setq font-lock-maximum-decoration t)
   (setq case-fold-search t)
   
-  (setq-local compile-command (concat hack-client-binary "--from emacs"))
+  (setq-local compile-command (concat hack-client-binary " --from emacs"))
   
   (add-hook 'completion-at-point-functions 'hack-completion nil t) 
 


### PR DESCRIPTION
Without this space, Emacs try to run `hh_client--from emacs`. It is so sad :'(