### PR TITLE
When using fromTimeStamp with utc=true, make sure to initialise the timezone to UTC

### DIFF
--- a/hphp/runtime/base/datetime.cpp
+++ b/hphp/runtime/base/datetime.cpp
@@ -284,6 +284,8 @@ void DateTime::fromTimeStamp(int64_t timestamp, bool utc /* = false */) {
 
   timelib_time *t = timelib_time_ctor();
   if (utc) {
+    t->zone_type = TIMELIB_ZONETYPE_OFFSET;
+    t->z = 0;
     timelib_unixtime2gmt(t, (timelib_sll)m_timestamp);
   } else {
     if (!m_tz.get()) {


### PR DESCRIPTION
Without this change, the following code:

    c_dt = HPHP::Unit::lookupClass(HPHP::s_DateTime.get());
    assert(c_dt);
    HPHP::ObjectData* obj = HPHP::ObjectData::newInstance(c_dt);

    DateTimeData* data = Native::data<DateTimeData>(obj);
    data->m_dt = makeSmartPtr<DateTime>(0, false);
    data->m_dt->fromTimeStamp(milliseconds / 1000, true);

Would cause issues when var_dumping the returned object. var_dump would call
debugInfo on the object, which in turns tries to use zone_type_to_string, which
has an assertion if it can't find the type. With the above example, the zone
type would be false, and we'd get this assertion:

    Program received signal SIGABRT, Aborted.
    0x00007fffeeae5107 in __GI_raise (sig=sig@entry=6) at ../nptl/sysdeps/unix/sysv/linux/raise.c:56
    56	../nptl/sysdeps/unix/sysv/linux/raise.c: No such file or directory.
    (gdb) bt
    #0  0x00007fffeeae5107 in __GI_raise (sig=sig@entry=6) at ../nptl/sysdeps/unix/sysv/linux/raise.c:56
    #1  0x00007fffeeae64e8 in __GI_abort () at abort.c:89
    #2  0x00000000027ef459 in HPHP::assert_fail (e=e@entry=0x2eefd44 "!\"Bad zone type\"", 
        file=file@entry=0x2f7b278 "/home/derick/dev/facebook-hhvm/hphp/runtime/ext/datetime/ext_datetime.cpp", line=line@entry=59, 
        func=func@entry=0x4081380 <HPHP::zone_type_to_string(int, HPHP::SmartPtr<HPHP::DateTime>)::__PRETTY_FUNCTION__> "HPHP::String HPHP::zone_type_to_string(int, HPHP::SmartPtr<HPHP::DateTime>)", msg="") at /home/derick/dev/facebook-hhvm/hphp/util/assertions.cpp:80
    #3  0x00000000023c18cb in HPHP::zone_type_to_string (zoneType=<optimized out>, dt=...) at /home/derick/dev/facebook-hhvm/hphp/runtime/ext/datetime/ext_datetime.cpp:59
    #4  0x00000000023c6222 in HPHP::DateTimeData::getDebugInfo (this=0x7fffe5c1d438) at /home/derick/dev/facebook-hhvm/hphp/runtime/ext/datetime/ext_datetime.cpp:307
    #5  0x00000000015250d7 in HPHP::ObjectData::toArray (this=0x7fffe5c1d440, pubOnly=pubOnly@entry=false) at /home/derick/dev/facebook-hhvm/hphp/runtime/base/object-data.cpp:442
    #6  0x00000000014861e2 in HPHP::Object::toArray (this=this@entry=0x7fffffffca40) at /home/derick/dev/facebook-hhvm/hphp/runtime/base/type-object.cpp:49
