### PR TITLE
Remove the NOUSER define when compiling with MSVC, Cygwin, or MinGW

### DIFF
--- a/CMake/HPHPSetup.cmake
+++ b/CMake/HPHPSetup.cmake
@@ -161,7 +161,7 @@ if(CYGWIN)
 endif()
 
 if(MSVC OR CYGWIN OR MINGW)
-  add_definitions(-DNOUSER=1 -DGLOG_NO_ABBREVIATED_SEVERITIES)
+  add_definitions(-DGLOG_NO_ABBREVIATED_SEVERITIES)
   add_definitions(-DWIN32_LEAN_AND_MEAN)
 endif()
 

--- a/hphp/runtime/base/program-functions.cpp
+++ b/hphp/runtime/base/program-functions.cpp
@@ -102,7 +102,6 @@
 
 
 #if (defined(__CYGWIN__) || defined(__MINGW__) || defined(_MSC_VER))
-#undef NOUSER
 #include <windows.h>
 #include <winuser.h>
 #endif

--- a/hphp/util/embedded-data.cpp
+++ b/hphp/util/embedded-data.cpp
@@ -17,7 +17,6 @@
 #include "hphp/util/embedded-data.h"
 
 #if (defined(__CYGWIN__) || defined(__MINGW__) || defined(_MSC_VER))
-#undef NOUSER
 #include <windows.h>
 #include <winuser.h>
 #endif


### PR DESCRIPTION
This define causes nothing but problems and isn't actually needed. It causes the windows header to exclude a specific header, and, in order to use that header, we have to make sure to `#undef NOUSER` before we include `windows.h`, but that may be included by other headers with no knowledge of our needs, causing all sorts of messes. If you don't know the define is there, it's also a massive pain to figure out why your code isn't compiling (see: 4 hours digging through the internals of the windows headers to no avail).
Overall, it's better to just remove the define and save the headache.