### PR TITLE
Fix typos of `__MSC_VER` to be the correct value, `_MSC_VER`

### DIFF
--- a/hphp/util/abi-cxx.cpp
+++ b/hphp/util/abi-cxx.cpp
@@ -25,7 +25,7 @@
 #include <unordered_map>
 
 #include <cxxabi.h>
-#if (defined(__CYGWIN__) || defined(__MINGW__) || defined(__MSC_VER))
+#if (defined(__CYGWIN__) || defined(__MINGW__) || defined(_MSC_VER))
 # include <windows.h>
 # include <dbghelp.h>
 #else
@@ -59,7 +59,7 @@ std::string getNativeFunctionName(void* codeAddr) {
   }
   std::string functionName;
 
-#if defined(__CYGWIN__) || defined(__MINGW__) || defined(__MSC_VER)
+#if defined(__CYGWIN__) || defined(__MINGW__) || defined(_MSC_VER)
   HANDLE process = GetCurrentProcess();
   SYMBOL_INFO *symbol;
   DWORD64 addr_disp = 0;

--- a/hphp/util/stack-trace.cpp
+++ b/hphp/util/stack-trace.cpp
@@ -15,7 +15,7 @@
 */
 #include "hphp/util/stack-trace.h"
 
-#if (!defined(__CYGWIN__) && !defined(__MINGW__) && !defined(__MSC_VER))
+#if (!defined(__CYGWIN__) && !defined(__MINGW__) && !defined(_MSC_VER))
 #include <execinfo.h>
 #endif
 

--- a/hphp/util/stacktrace-profiler.cpp
+++ b/hphp/util/stacktrace-profiler.cpp
@@ -16,7 +16,7 @@
 
 #include "hphp/util/stacktrace-profiler.h"
 #include "hphp/util/stack-trace.h"
-#if (!defined(__CYGWIN__) && !defined(__MINGW__) && !defined(__MSC_VER))
+#if (!defined(__CYGWIN__) && !defined(__MINGW__) && !defined(_MSC_VER))
 #include <execinfo.h>
 #endif
 #include <algorithm>


### PR DESCRIPTION
When these were originally added, they weren't actually tested on MSVC, otherwise this would have been noticed.