### PR TITLE
Exceptions: Change trace handling

### DIFF
--- a/hphp/system/php/lang/Exception.php
+++ b/hphp/system/php/lang/Exception.php
@@ -241,9 +241,24 @@ class Exception {
       if (isset($top['class']) && isset($top['function']) &&
           strcasecmp($top['class'], 'exception') === 0 &&
           strcasecmp($top['function'], '__init__') === 0) {
-        if (isset($top['file'])) $this->file = $top['file'];
-        if (isset($top['line'])) $this->line = $top['line'];
-        return;
+          if (isset($top['file'])) $this->file = $top['file'];
+          if (isset($top['line'])) $this->line = $top['line'];
+        break;
+      }
+    }
+    // Remove systemlib stack frames until we hit the user code.
+    // Assume user code will contain the elements for file and line.
+    if (($this->file === null) && ($this->line === null)) {
+      while (!empty($this->trace)
+        && !isset($this->trace[0]['file']) && !isset($this->trace[0]['line'])
+      ) {
+        array_shift($this->trace);
+      }
+      if (isset($this->trace[0]['file'])) {
+        $this->file = $this->trace[0]['file'];
+      }
+      if (isset($this->trace[0]['line'])) {
+        $this->line = $this->trace[0]['line'];
       }
     }
   }

--- a/hphp/system/php/lang/Exception.php
+++ b/hphp/system/php/lang/Exception.php
@@ -241,8 +241,8 @@ class Exception {
       if (isset($top['class']) && isset($top['function']) &&
           strcasecmp($top['class'], 'exception') === 0 &&
           strcasecmp($top['function'], '__init__') === 0) {
-          if (isset($top['file'])) $this->file = $top['file'];
-          if (isset($top['line'])) $this->line = $top['line'];
+        if (isset($top['file'])) $this->file = $top['file'];
+        if (isset($top['line'])) $this->line = $top['line'];
         break;
       }
     }

--- a/hphp/test/quick/Setprofile_async.php.expectf
+++ b/hphp/test/quick/Setprofile_async.php.expectf
@@ -56,6 +56,8 @@ In gen2
 ** exit strcasecmp
 ** enter strcasecmp
 ** exit strcasecmp
+** enter array_shift
+** exit array_shift
 ** exit Exception::initTrace
 ** exit Exception::__init__
 ** enter Exception::__construct

--- a/hphp/test/quick/fc_enum_7.php.expectf
+++ b/hphp/test/quick/fc_enum_7.php.expectf
@@ -64,7 +64,7 @@ string(2) "10"
 string(3) "foo"
 a broken assert()
 
-Fatal error: Uncaught exception 'UnexpectedValueException' with message 'welp is not a valid value for Bar' in :
+Fatal error: Uncaught exception 'UnexpectedValueException' with message 'welp is not a valid value for Bar' in %s:70
 Stack trace:
 #0 %s(70): HH\BuiltinEnum::assert()
 #1 {main}

--- a/hphp/test/quick/fc_enum_8.php.expectf
+++ b/hphp/test/quick/fc_enum_8.php.expectf
@@ -1,5 +1,4 @@
-Fatal error: Uncaught exception 'HH\InvariantException' with message 'Enum has overlapping values' in :
+Fatal error: Uncaught exception 'HH\InvariantException' with message 'Enum has overlapping values' in %s:10
 Stack trace:
-#0 (): HH\invariant_violation()
-#1 %s(10): HH\BuiltinEnum::getNames()
-#2 {main}
+#0 %s(10): HH\BuiltinEnum::getNames()
+#1 {main}

--- a/hphp/test/quick/fc_enum_9.php.expectf
+++ b/hphp/test/quick/fc_enum_9.php.expectf
@@ -15,8 +15,7 @@ array(3) {
   int(3)
 }
 
-Fatal error: Uncaught exception 'UnexpectedValueException' with message '300 is not a valid value for Foo' in :
+Fatal error: Uncaught exception 'UnexpectedValueException' with message '300 is not a valid value for Foo' in %s:12
 Stack trace:
-#0 (): HH\BuiltinEnum::assert()
-#1 %s(12): HH\BuiltinEnum::assertAll()
-#2 {main}
+#0 %s(12): HH\BuiltinEnum::assertAll()
+#1 {main}

--- a/hphp/test/slow/collection_classes/frozen_vector/const_index_access.php.expectf
+++ b/hphp/test/slow/collection_classes/frozen_vector/const_index_access.php.expectf
@@ -10,4 +10,5 @@ NULL
 int(1)
 int(3)
 
-Fatal error: Uncaught exception 'OutOfBoundsException' with message 'Integer key 3 is out of bounds' in :%a
+Fatal error: Uncaught exception 'OutOfBoundsException' with message 'Integer key 3 is out of bounds' in %s:%d
+%a

--- a/hphp/test/slow/debug_backtrace/metadata_call_user_func.php.expectf
+++ b/hphp/test/slow/debug_backtrace/metadata_call_user_func.php.expectf
@@ -1,4 +1,4 @@
-Fatal error: Uncaught exception 'InvalidArgumentException' with message 'Unsupported dynamic call of set_frame_metadata()' in :
+Fatal error: Uncaught exception 'InvalidArgumentException' with message 'Unsupported dynamic call of set_frame_metadata()' in %smetadata_call_user_func.php:8
 Stack trace:
 #0 %smetadata_call_user_func.php(8): HH\set_frame_metadata()
 #1 %smetadata_call_user_func.php(12): foo()

--- a/hphp/test/slow/ext_phar/corrupt.php.expectf
+++ b/hphp/test/slow/ext_phar/corrupt.php.expectf
@@ -1,9 +1,7 @@
 #!/usr/bin/env php
 
-Fatal error: Uncaught exception 'PharException' with message 'phar has a broken signature' in :
+Fatal error: Uncaught exception 'PharException' with message 'phar has a broken signature' in %s/composer-corrupt%s:13
 Stack trace:
-#0 (): Phar->parsePhar()
-#1 (): Phar->__construct()
-#2 %s/composer-corrupt%s(13): Phar::mapPhar()
-#3 %s/test/slow/ext_phar/corrupt.php(16): include()
-#4 {main}
+#0 %s/composer-corrupt%s(13): Phar::mapPhar()
+#1 %s/test/slow/ext_phar/corrupt.php(16): include()
+#2 {main}

--- a/hphp/test/slow/ext_spl_datastructures/queue_iteration.php.expectf
+++ b/hphp/test/slow/ext_spl_datastructures/queue_iteration.php.expectf
@@ -11,7 +11,7 @@ int(2)
 int(3)
 int(0)
 
-Fatal error: Uncaught exception 'RuntimeException' with message 'Iterators' LIFO/FIFO modes for SplStack/SplQueue objects are frozen' in :
+Fatal error: Uncaught exception 'RuntimeException' with message 'Iterators' LIFO/FIFO modes for SplStack/SplQueue objects are frozen' in %s/test/slow/ext_spl_datastructures/queue_iteration.php:5
 Stack trace:
 #0 %s/test/slow/ext_spl_datastructures/queue_iteration.php(5): SplQueue->setIteratorMode()
 #1 %s/test/slow/ext_spl_datastructures/queue_iteration.php(21): iterate_queue_with_mode()

--- a/hphp/test/slow/ext_spl_file/SplFileObject_construct_no_such_file.php.expectf
+++ b/hphp/test/slow/ext_spl_file/SplFileObject_construct_no_such_file.php.expectf
@@ -1,4 +1,4 @@
-Fatal error: Uncaught exception 'RuntimeException' with message 'SplFileObject::__construct(missing): failed to open stream: No such file or directory' in :
+Fatal error: Uncaught exception 'RuntimeException' with message 'SplFileObject::__construct(missing): failed to open stream: No such file or directory' in %s/test/slow/ext_spl_file/SplFileObject_construct_no_such_file.php:2
 Stack trace:
 #0 %s: SplFileObject->__construct()
 #1 {main}

--- a/hphp/test/slow/lang/invariant.php.expectf
+++ b/hphp/test/slow/lang/invariant.php.expectf
@@ -1,4 +1,4 @@
-Fatal error: Uncaught exception 'HH\InvariantException' with message 'nope' in :
+Fatal error: Uncaught exception 'HH\InvariantException' with message 'nope' in %s/test/slow/lang/invariant.php:8
 Stack trace:
 #0 %s/test/slow/lang/invariant.php(8): HH\invariant_violation()
 #1 {main}

--- a/hphp/test/slow/lang/invariant_cb.php.expectf
+++ b/hphp/test/slow/lang/invariant_cb.php.expectf
@@ -5,7 +5,7 @@ array(2) {
   string(1) "b"
 }
 
-Fatal error: Uncaught exception 'HH\InvariantException' with message 'a' in :
+Fatal error: Uncaught exception 'HH\InvariantException' with message 'a' in %s/test/slow/lang/invariant_cb.php:6
 Stack trace:
 #0 %s/test/slow/lang/invariant_cb.php(6): HH\invariant_violation()
 #1 {main}

--- a/hphp/test/slow/lang/invariant_cb_two.php.expectf
+++ b/hphp/test/slow/lang/invariant_cb_two.php.expectf
@@ -1,5 +1,4 @@
-Fatal error: Uncaught exception 'HH\InvariantException' with message 'Callback already registered: a' in :
+Fatal error: Uncaught exception 'HH\InvariantException' with message 'Callback already registered: a' in %s/test/slow/lang/invariant_cb_two.php:5
 Stack trace:
-#0 (): HH\invariant_violation()
-#1 %s/test/slow/lang/invariant_cb_two.php(5): HH\invariant_callback_register()
-#2 {main}
+#0 %s/test/slow/lang/invariant_cb_two.php(5): HH\invariant_callback_register()
+#1 {main}

--- a/hphp/test/slow/lang/invariant_vsprintf.php.expectf
+++ b/hphp/test/slow/lang/invariant_vsprintf.php.expectf
@@ -1,4 +1,4 @@
-Fatal error: Uncaught exception 'HH\InvariantException' with message 'nope - 42' in :
+Fatal error: Uncaught exception 'HH\InvariantException' with message 'nope - 42' in %s/test/slow/lang/invariant_vsprintf.php:3
 Stack trace:
 #0 %s/test/slow/lang/invariant_vsprintf.php(3): HH\invariant_violation()
 #1 {main}

--- a/hphp/test/slow/lang/meth_caller_bad.php.expectf
+++ b/hphp/test/slow/lang/meth_caller_bad.php.expectf
@@ -1,5 +1,4 @@
-Fatal error: Uncaught exception 'HH\InvariantException' with message 'object must be an instance of (B), instead it is (A)' in :
+Fatal error: Uncaught exception 'HH\InvariantException' with message 'object must be an instance of (B), instead it is (A)' in %s/test/slow/lang/meth_caller_bad.php:5
 Stack trace:
-#0 (): HH\invariant_violation()
-#1 %s/test/slow/lang/meth_caller_bad.php(5): __SystemLib\MethCallerHelper->__invoke()
-#2 {main}
+#0 %s/test/slow/lang/meth_caller_bad.php(5): __SystemLib\MethCallerHelper->__invoke()
+#1 {main}

--- a/hphp/test/slow/lang/meth_caller_bad2.php.expectf
+++ b/hphp/test/slow/lang/meth_caller_bad2.php.expectf
@@ -1,6 +1,5 @@
-Fatal error: Uncaught exception 'HH\InvariantException' with message 'object must be an instance of (B), instead it is (NULL)' in :
+Fatal error: Uncaught exception 'HH\InvariantException' with message 'object must be an instance of (B), instead it is (NULL)' in %s/test/slow/lang/meth_caller_bad2.php:6
 Stack trace:
-#0 (): HH\invariant_violation()
-#1 %s/test/slow/lang/meth_caller_bad2.php(6): __SystemLib\MethCallerHelper->__invoke()
-#2 %s/test/slow/lang/meth_caller_bad2.php(9): A->foo()
-#3 {main}
+#0 %s/test/slow/lang/meth_caller_bad2.php(6): __SystemLib\MethCallerHelper->__invoke()
+#1 %s/test/slow/lang/meth_caller_bad2.php(9): A->foo()
+#2 {main}

--- a/hphp/test/slow/libxml/dom-element-lifetime.php.expectf
+++ b/hphp/test/slow/libxml/dom-element-lifetime.php.expectf
@@ -1,6 +1,6 @@
 string(13) "<root></root>"
 
-Fatal error: Uncaught exception 'DOMException' with message 'No Modification Allowed Error' in :
+Fatal error: Uncaught exception 'DOMException' with message 'No Modification Allowed Error' in %s/dom-element-lifetime.php:20
 Stack trace:
 #0 %s/dom-element-lifetime.php(20): DOMNode->appendChild()
 #1 %s/dom-element-lifetime.php(26): two()

--- a/hphp/test/slow/reflection/scalar_param_types/php-noforcehh.php.expectf
+++ b/hphp/test/slow/reflection/scalar_param_types/php-noforcehh.php.expectf
@@ -1,8 +1,7 @@
-string(%d) "exception 'ReflectionException' with message 'Class int does not exist' in :
+string(%d) "exception 'ReflectionException' with message 'Class int does not exist' in %s/test/slow/reflection/scalar_param_types/php-noforcehh.php:8
 Stack trace:
-#0 (): ReflectionClass->__construct()
-#1 %s/test/slow/reflection/scalar_param_types/php-noforcehh.php(8): ReflectionParameter->getClass()
-#2 {main}"
+#0 %s/test/slow/reflection/scalar_param_types/php-noforcehh.php(8): ReflectionParameter->getClass()
+#1 {main}"
 string(3) "int"
 NULL
 string(5) "array"


### PR DESCRIPTION
In some cases the setup of traces in Exception::initTrace() leads to unexpected behaviour. The properties for file and line won't be populated and sometimes the stack contains stack frames from systemlib.

An example can be seen here: http://3v4l.org/OTQQa (based on the test in slow/reflection/scalar_param_types/php-noforcehh.php)

However the code assumes that systemlib stack frames never provide file and/or line which might not be true all the time.

In a discussion in IRC about this issue @paulbiss suggested other approaches to solve that more reliable.

> [...] It might make sense to skip over native frames for consistency (though maybe native functions implemented in PHP should still be present in the trace...)
>
> maybe adding a flag for debug_backtrace to ignore native frames and setting that in Exception::$traceOpts would make sense
>
> [...] we'd probably want to do something with either debug_backtrace or by exposing some information about if a frame is builtin in the backtrace itself

I guess it breaks a couple of internal tests (sorry for that ;)).
I spilt the change in multiple commits so in case another solution will be used at least the fixed tests can be recycled.