### PR TITLE
Fix lexing of heredoc end after interpolated var

### DIFF
--- a/hphp/parser/hphp.ll
+++ b/hphp/parser/hphp.ll
@@ -1231,8 +1231,9 @@ BACKQUOTE_CHARS     ("{"*([^$`\\{]|("\\"{ANY_CHAR}))|{BACKQUOTE_LITERAL_DOLLAR})
 
   YYCURSOR--;
 
-  // The rules that lead to this state all consume an end-of-line.
-  bool lookingForEndLabel = true;
+  // T_START_HEREDOC has a trailing newline, so we can start looking
+  // for the ending label right away
+  bool lookingForEndLabel = _scanner->lastToken() == T_START_HEREDOC;
 
   while (refillResult == EOB_ACT_CONTINUE_SCAN) {
     while (YYCURSOR < YYLIMIT) {

--- a/hphp/test/slow/string/heredoc_end_after_variable.php
+++ b/hphp/test/slow/string/heredoc_end_after_variable.php
@@ -1,0 +1,6 @@
+<?php
+$var = 'HERE';
+$str = <<<DOC
+{$var}DOC
+DOC;
+echo $str;

--- a/hphp/test/slow/string/heredoc_end_after_variable.php.expect
+++ b/hphp/test/slow/string/heredoc_end_after_variable.php.expect
@@ -1,0 +1,1 @@
+HEREDOC


### PR DESCRIPTION
Previously something like {$var}LABEL was detected as an end of the heredoc string, even though it misses the required newline.

And once again, this does not include the generated lexer...