### PR TITLE
Fixes issue #5487 /hphp/hhbbc/main.cpp is included in all CMake builds

### DIFF
--- a/hphp/hhbbc/CMakeLists.txt
+++ b/hphp/hhbbc/CMakeLists.txt
@@ -8,7 +8,7 @@ HHVM_PUBLIC_HEADERS(hhbc ${files})
 
 # remove anything in a test folder
 foreach (file ${CXX_SOURCES})
-  if (${file} MATCHES "/test/")
+  if (${file} MATCHES "/test/" OR MATCHES "main.cpp$")
     list(REMOVE_ITEM CXX_SOURCES ${file})
   endif()
 endforeach(file ${CXX_SOURCES})


### PR DESCRIPTION
Fixes issue #5487 /hphp/hhbbc/main.cpp is included in all CMake builds

This will conflict with PR #5581. Whichever one is merged second will need to be updated to reflect the other.