### PR TITLE
Fixes issue #5503 Certain places construct Mutex<T> incorrectly

### DIFF
--- a/hphp/util/mutex.h
+++ b/hphp/util/mutex.h
@@ -189,6 +189,8 @@ class Mutex : public BaseMutex<false> {
 public:
   explicit Mutex(bool recursive = true, Rank rank = RankUnranked) :
     BaseMutex<false>(recursive, rank) {}
+  explicit Mutex(Rank rank, bool recursive = true) :
+    BaseMutex<false>(recursive, rank) {}
   pthread_mutex_t &getRaw() { return m_mutex; }
 };
 


### PR DESCRIPTION
Fixes issue #5503 Certain places construct Mutex<T> incorrectly.

This takes the approach of adding an additional constructor to `Mutex<T>` that accepts `Rank` first, rather than hard-coding the default value of `recursive`.