### PR TITLE
Port neo to MSVC

### DIFF
--- a/hphp/neo/cs_config.h
+++ b/hphp/neo/cs_config.h
@@ -43,12 +43,18 @@
 #define HAVE_PTHREADS 1
 
 /* Define to 1 if you have the `drand48' function. */
+#ifndef _MSC_VER
 #define HAVE_DRAND48 1
+#endif
 
 /* Define to 1 if you have the `gettimeofday' function. */
+#ifndef _MSC_VER
 #define HAVE_GETTIMEOFDAY 1
+#endif
 
 /* Define to 1 if you have the `random' function. */
+#ifndef _MSC_VER
 #define HAVE_RANDOM 1
+#endif
 
 #endif /* incl_HPHP_CS_CONFIG_H_ */

--- a/hphp/neo/neo_bool.h
+++ b/hphp/neo/neo_bool.h
@@ -8,6 +8,10 @@
 #define FALSE 0
 #endif
 
+#ifdef _MSC_VER
+typedef int BOOL;
+#else
 typedef char BOOL;
+#endif
 
 #endif /* incl_HPHP_NEO_BOOL_H_ */

--- a/hphp/neo/neo_err.c
+++ b/hphp/neo/neo_err.c
@@ -222,7 +222,7 @@ void nerr_log_error (NEOERR *err)
       }
       else
       {
-	r = uListGet (Errors, err->error - 1, (void *)&err_name);
+	r = uListGet (Errors, err->error - 1, (void **)&err_name);
 	if (r != STATUS_OK)
 	{
 	  err_name = buf;
@@ -275,7 +275,7 @@ void nerr_error_string (NEOERR *err, NEOSTRING *str)
       }
       else
       {
-	r = uListGet (Errors, err->error - 1, (void *)&err_name);
+	r = uListGet (Errors, err->error - 1, (void **)&err_name);
 	if (r != STATUS_OK)
 	{
 	  err_name = buf;
@@ -321,7 +321,7 @@ void nerr_error_traceback (NEOERR *err, NEOSTRING *str)
       }
       else
       {
-	r = uListGet (Errors, err->error - 1, (void *)&err_name);
+	r = uListGet (Errors, err->error - 1, (void **)&err_name);
 	if (r != STATUS_OK)
 	{
 	  err_name = buf;

--- a/hphp/neo/neo_err.h
+++ b/hphp/neo/neo_err.h
@@ -15,7 +15,7 @@
 #include "hphp/neo/neo_misc.h"
 
 /* For compilers (well, cpp actually) which don't define __PRETTY_FUNCTION__ */
-#ifndef __GNUC__
+#if !defined(__GNUC__) && !defined(__PRETTY_FUNCTION__)
 #define __PRETTY_FUNCTION__ "unknown_function"
 #endif
 
@@ -63,7 +63,7 @@ typedef struct _neo_err
 
 /* Technically, we could do this in configure and detect what their compiler
  * can handle, but for now... */
-#if defined (__STDC_VERSION__) && __STDC_VERSION__ >= 199901L
+#if (defined (__STDC_VERSION__) && __STDC_VERSION__ >= 199901L) || defined(_MSC_VER)
 #define USE_C99_VARARG_MACROS 1
 #elif __GNUC__ > 2 || (__GNUC__ == 2 && __GNUC_MINOR__ >= 4) || defined (S_SPLINT_S)
 #define USE_GNUC_VARARG_MACROS 1

--- a/hphp/neo/neo_files.h
+++ b/hphp/neo/neo_files.h
@@ -18,6 +18,9 @@ __BEGIN_DECLS
 #include <sys/types.h>
 #include "hphp/neo/ulist.h"
 
+#ifdef _MSC_VER
+typedef unsigned short mode_t;
+#endif
 
 
 typedef int (* MATCH_FUNC)(void *rock, const char *filename);

--- a/hphp/neo/neo_hdf.c
+++ b/hphp/neo/neo_hdf.c
@@ -12,7 +12,6 @@
 #include "cs_config.h"
 
 #include <stdlib.h>
-#include <unistd.h>
 #include <string.h>
 #include <stdio.h>
 #include <ctype.h>
@@ -20,6 +19,16 @@
 #include <limits.h>
 #include <stdarg.h>
 #include <sys/stat.h>
+
+#ifdef _MSC_VER
+#include <windows.h>
+#include <direct.h>
+#include <io.h>
+#define PATH_MAX MAX_PATH
+#else
+#include <unistd.h>
+#endif
+
 #include "neo_misc.h"
 #include "neo_err.h"
 #include "neo_rand.h"
@@ -1776,7 +1785,11 @@ static NEOERR* _hdf_read_string (HDF *hdf, const char **str, NEOSTRING *line,
 	s+=2;
 	value = neos_strip(s);
 
+#ifdef _MSC_VER
+        FILE *f = _popen(value, "r");
+#else
         FILE *f = popen(value, "r");
+#endif
 	if (f == NULL)
         {
 	  err = nerr_raise(NERR_PARSE,

--- a/hphp/neo/neo_hdf.h
+++ b/hphp/neo/neo_hdf.h
@@ -12,12 +12,12 @@
 #ifndef incl_HPHP_NEO_HDF_H_
 #define incl_HPHP_NEO_HDF_H_ 1
 
-__BEGIN_DECLS
 
 #include <stdio.h>
 #include "hphp/neo/neo_err.h"
 #include "hphp/neo/neo_hash.h"
 
+__BEGIN_DECLS
 #define FORCE_HASH_AT 10
 
 typedef struct _hdf HDF;

--- a/hphp/neo/neo_misc.c
+++ b/hphp/neo/neo_misc.c
@@ -15,10 +15,19 @@
 #include <stdarg.h>
 #include <stdlib.h>
 #include <ctype.h>
-#include <sys/time.h>
 #include <sys/types.h>
 #include <string.h>
+
+#ifdef _MSC_VER
+#include <io.h>
+// Because someone thought this was a good place to put
+// timeval.
+#include <WinSock2.h>
+#else
+#include <sys/time.h>
 #include <unistd.h>
+#endif
+
 #include "neo_misc.h"
 #include "neo_err.h"
 
@@ -32,7 +41,11 @@ void ne_vwarn (const char *fmt, va_list ap)
 
   now = time(NULL);
 
+#ifdef _MSC_VER
+  localtime_s(&now, &my_tm);
+#else
   localtime_r(&now, &my_tm);
+#endif
 
   strftime(tbuf, sizeof(tbuf), "%m/%d %H:%M:%S", &my_tm);
 

--- a/hphp/neo/neo_misc.h
+++ b/hphp/neo/neo_misc.h
@@ -34,6 +34,13 @@
 
 #define PATH_BUF_SIZE 512
 
+#ifdef _MSC_VER
+#include <sys/stat.h>
+#define S_IXUSR 0
+#define S_IWUSR _S_IWRITE
+#define S_IRUSR _S_IREAD
+#endif
+
 #ifndef S_IXGRP
 #define S_IXGRP S_IXUSR
 #endif
@@ -55,10 +62,12 @@
 
 /* Format string checking for compilers that support it (GCC style) */
 
+#ifndef ATTRIBUTE_PRINTF
 #if __GNUC__ > 2 || __GNUC__ == 2 && __GNUC_MINOR__ > 6
 #define ATTRIBUTE_PRINTF(a1,a2) __attribute__((__format__ (__printf__, a1, a2)))
 #else
 #define ATTRIBUTE_PRINTF(a1,a2)
+#endif
 #endif
 
 
@@ -97,7 +106,7 @@ typedef unsigned short int UINT16;
 typedef short int INT16;
 typedef unsigned char UINT8;
 /* This was conflicting with a cygwin header definition */
-#ifdef __CYGWIN__
+#if defined(__CYGWIN__) || defined(_MSC_VER)
 typedef signed char INT8;
 #else
 typedef char INT8;

--- a/hphp/neo/neo_str.c
+++ b/hphp/neo/neo_str.c
@@ -11,13 +11,20 @@
 
 #include "cs_config.h"
 
-#include <unistd.h>
 #include <ctype.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
 #include <stdarg.h>
+
+#ifdef _MSC_VER
+#include <io.h>
+#else
+#include <unistd.h>
+#endif
+
 #include <onigposix.h>
+
 #include "neo_bool.h"
 #include "neo_misc.h"
 #include "neo_err.h"

--- a/hphp/neo/neo_str.h
+++ b/hphp/neo/neo_str.h
@@ -16,6 +16,7 @@ __BEGIN_DECLS
 
 #include <stdarg.h>
 #include <stdio.h>
+#include "hphp/neo/neo_bool.h"
 #include "hphp/neo/neo_misc.h"
 
 /* This modifies the string its called with by replacing all the white

--- a/hphp/neo/neo_str.h
+++ b/hphp/neo/neo_str.h
@@ -71,7 +71,7 @@ void string_clear (NEOSTRING *str);
 NEOERR *string_array_split (ULIST **list, char *s, const char *sep,
                             int max);
 
-char reg_search (const char *re, const char *str);
+BOOL reg_search (const char *re, const char *str);
 
 /* NEOS_ESCAPE details the support escape contexts/modes handled
  * by various NEOS helper methods and reused in CS itself. */

--- a/hphp/neo/ulocks.c
+++ b/hphp/neo/ulocks.c
@@ -14,9 +14,49 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
-#include <unistd.h>
 #include <string.h>
 #include <errno.h>
+
+#ifdef _MSC_VER
+#include <io.h>
+#include <Windows.h>
+
+#define O_NDELAY 0
+#define	LOCK_EX	2
+#define	LOCK_NB	4
+#define	LOCK_UN	8
+
+#define F_LOCK 0
+#define F_ULOCK LOCK_UN
+
+int lockf(int fd, int operation, int unused) {
+  HANDLE h = (HANDLE)_get_osfhandle(fd);
+  if (h == INVALID_HANDLE_VALUE)
+    return -1;
+
+  LARGE_INTEGER fileSize;
+  if (!GetFileSizeEx(h, &fileSize))
+    return -1;
+
+  if (operation & LOCK_UN) {
+    if (!UnlockFile(h, 0, 0, fileSize.LowPart, (DWORD)fileSize.HighPart))
+      return -1;
+  }
+  else {
+    int flags = 0;
+    OVERLAPPED ov;
+    if (operation & LOCK_NB)
+      flags |= LOCKFILE_FAIL_IMMEDIATELY;
+    if (operation & LOCK_EX)
+      flags |= LOCKFILE_EXCLUSIVE_LOCK;
+    if (!LockFileEx(h, flags, 0, fileSize.LowPart, (DWORD)fileSize.HighPart, &ov))
+      return -1;
+  }
+  return 0;
+}
+#else
+#include <unistd.h>
+#endif
 
 #include "neo_misc.h"
 #include "neo_err.h"

--- a/hphp/neo/ulocks.c
+++ b/hphp/neo/ulocks.c
@@ -22,9 +22,9 @@
 #include <Windows.h>
 
 #define O_NDELAY 0
-#define	LOCK_EX	2
-#define	LOCK_NB	4
-#define	LOCK_UN	8
+#define LOCK_EX 2
+#define LOCK_NB 4
+#define LOCK_UN 8
 
 #define F_LOCK 0
 #define F_ULOCK LOCK_UN


### PR DESCRIPTION
Most of the changes are pretty straight forward #ifdefs to include the correct headers, or implement it for windows.

The changes to the casts in the calls to `uListGet` in `neo_err.c` are because MSVC, correctly, complains about the argument types not matching.

There is also a change in the return type of reg_search in `neo_str.h`. It is defined in the C file with a return value of BOOL, and, on posix, a char is the size of a bool, so this was never noticed. On windows however, a BOOL is not the size of a char, causing errors, which is why I noticed this at all. That is the only externally-facing API change. It's worth noting though that that function is never actually called in HHVM or neo itself.