### PR TITLE
Improve make-lexer.sh to not emit local paths

### DIFF
--- a/hphp/parser/make-lexer.sh
+++ b/hphp/parser/make-lexer.sh
@@ -24,18 +24,19 @@ if [ $? -ne 0 ] ; then
   exit 1
 fi
 
+SED=`which sed`
+if [ ! -x "$SED" ]; then
+  echo "sed not found" 1>&2
+  exit 1
+fi
+
+$SED -i \
+  -e "1i// @""generated" \
+  -e "s@/.*lex.yy.cpp@lex.yy.cpp@g" \
+  -e "s@/.*hphp.ll@hphp.ll@g" \
+  $OUTFILE
+
 # We still want the files in our tree since they are checked in
 if [ -n "${INSTALL_DIR}" ]; then
-
-  SED=`which sed`
-  if [ ! -x "$SED" ]; then
-    echo "sed not found" 1>&2
-    exit 1
-  fi
-
-  $SED -i \
-    -e "1i// @""generated" \
-    -e "s@/.*lex.yy.cpp@lex.yy.cpp@" \
-    $OUTFILE
   cp $OUTFILE ${DIR}/lex.yy.cpp
 fi


### PR DESCRIPTION
* Do sed replacements even if INSTALL_DIR is not specified
* Do replacements on hphp.ll as well as lex.yy.cpp
* Make path replacement regexes global (`@g`)

Otherwise you end up with local paths in the generated lexer.