### PR TITLE
Remove the store operation after loading from the same location.

### DIFF
--- a/hphp/runtime/vm/jit/store-elim.cpp
+++ b/hphp/runtime/vm/jit/store-elim.cpp
@@ -1181,6 +1181,56 @@ void compute_placement_possible(
     });
 }
 
+// Remove the store operation after loading from the same location.
+void load_store_optimize_block(Block* block) {
+  FTRACE(2, "  load-store-elim visiting B{}\n", block->id());
+  auto it = block->instrs().begin();
+
+  while (it != block->instrs().end()) {
+    auto const effect1 = memory_effects(*it);
+    auto prev = it;
+    ++it;
+
+    match<void>(
+      effect1,
+      [&] (PureLoad pureLoad) {
+        if (it != block->instrs().end()) {
+          auto const effect2 = memory_effects(*it);
+          match<void>(
+            effect2,
+            [&] (PureStore pureStore) {
+              if (pureLoad.src == pureStore.dst &&
+                  prev->dst() == pureStore.value) {
+                FTRACE(2, "    {}\n      {}\n"
+                          "    {}\n      {}\n",
+                          prev->toString(), show(effect1),
+                          it->toString(), show(effect2));
+                it = block->erase(&(*it));
+              }
+            },
+            [&] (IrrelevantEffects) {},
+            [&] (UnknownEffects)    {},
+            [&] (PureLoad l)        {},
+            [&] (GeneralEffects l)  {},
+            [&] (ReturnEffects l)   {},
+            [&] (ExitEffects l)     {},
+            [&] (CallEffects l)     {},
+            [&] (PureSpillFrame l)  {}
+          );
+        }
+      },
+      [&] (IrrelevantEffects) {},
+      [&] (UnknownEffects)    {},
+      [&] (GeneralEffects l)  {},
+      [&] (ReturnEffects l)   {},
+      [&] (ExitEffects l)     {},
+      [&] (CallEffects l)     {},
+      [&] (PureStore l)       {},
+      [&] (PureSpillFrame l)  {}
+    );
+  }
+}
+
 //////////////////////////////////////////////////////////////////////
 
 }
@@ -1284,6 +1334,10 @@ void optimizeStores(IRUnit& unit) {
   }
   if (genv.needsReflow) {
     reflowTypes(genv.unit);
+  }
+
+  for (auto& block : poBlockList) {
+    load_store_optimize_block(block);
   }
 }
 


### PR DESCRIPTION
There are occurrences of storing immediately after loading the same
location. Add a pass to remove the store operation.

Example:
```
    (18) t4:BoxedInitCell = LdStk<BoxedInitCell,IRSPOff 1> t1:StkPtr
        load       [%rbp - 0x20] => %rbx

    (19) StStk<IRSPOff 1> t1:StkPtr, t4:BoxedInitCell
        storebi    80, [%rbp - 0x18]
        store      %rbx, [%rbp - 0x20]
```

Same patterns also exist when TransKind is Profile, but store-elim does not
run in Profile mode.