### PR TITLE
Use the portable version of clock_gettime in ext_curl.

### DIFF
--- a/hphp/runtime/ext/curl/ext_curl.cpp
+++ b/hphp/runtime/ext/curl/ext_curl.cpp
@@ -159,7 +159,7 @@ public:
 
     // wait until the user-specified timeout for an available handle
     struct timespec ts;
-    clock_gettime(CLOCK_REALTIME, &ts);
+    gettime(CLOCK_REALTIME, &ts);
     ts.tv_sec += m_waitTimeout / 1000;
     ts.tv_nsec += 1000000 * (m_waitTimeout % 1000);
     while (m_handleStack.empty()) {


### PR DESCRIPTION
clock_gettime is replaced by gettime.