### PR TITLE
Add Windows ABI support for JIT.

### DIFF
--- a/hphp/runtime/vm/jit/abi-x64.h
+++ b/hphp/runtime/vm/jit/abi-x64.h
@@ -72,12 +72,21 @@ constexpr Reg64 rAsm         = reg::r10;
  * translator manages via its RegMap.
  */
 
+#if defined(__CYGWIN__) || defined(__MINGW__) || defined(_MSC_VER)
+const RegSet kGPCallerSaved =
+  reg::rax | reg::rcx | reg::rdx |
+  reg::r8  | reg::r9  | reg::r10 | reg::r11;
+
+const RegSet kGPCalleeSaved =
+  reg::rbx | reg::rsi | reg::rdi | reg::r13 | reg::r14 | reg::r15;
+#else
 const RegSet kGPCallerSaved =
   reg::rax | reg::rcx | reg::rdx | reg::rsi | reg::rdi |
   reg::r8  | reg::r9  | reg::r10 | reg::r11;
 
 const RegSet kGPCalleeSaved =
   reg::rbx | reg::r13 | reg::r14 | reg::r15;
+#endif
 
 const RegSet kGPUnreserved = kGPCallerSaved | kGPCalleeSaved;
 
@@ -163,9 +172,15 @@ const RegSet kScratchCrossTraceRegs = kXMMCallerSaved |
  */
 
 // x64 INTEGER class argument registers.
+#if defined(__CYGWIN__) || defined(__MINGW__) || defined(_MSC_VER)
+const PhysReg argNumToRegName[] = {
+  reg::rcx, reg::rdx, reg::r8, reg::r9
+};
+#else
 const PhysReg argNumToRegName[] = {
   reg::rdi, reg::rsi, reg::rdx, reg::rcx, reg::r8, reg::r9
 };
+#endif
 const int kNumRegisterArgs = sizeof(argNumToRegName) / sizeof(PhysReg);
 
 inline RegSet argSet(int n) {
@@ -177,10 +192,16 @@ inline RegSet argSet(int n) {
 }
 
 // x64 SSE class argument registers.
+#if defined(__CYGWIN__) || defined(__MINGW__) || defined(_MSC_VER)
+const PhysReg argNumToSIMDRegName[] = {
+  reg::xmm0, reg::xmm1, reg::xmm2, reg::xmm3,
+};
+#else
 const PhysReg argNumToSIMDRegName[] = {
   reg::xmm0, reg::xmm1, reg::xmm2, reg::xmm3,
   reg::xmm4, reg::xmm5, reg::xmm6, reg::xmm7,
 };
+#endif
 const int kNumSIMDRegisterArgs = sizeof(argNumToSIMDRegName) / sizeof(PhysReg);
 
 /*

--- a/hphp/runtime/vm/jit/translator-asm-helpers.S
+++ b/hphp/runtime/vm/jit/translator-asm-helpers.S
@@ -3,12 +3,14 @@
  *
  * This helper routine is written in assembly to take care of the details
  * when transferring control between jitted code and the translator.
- *   rdi / x0:  Cell* vm_sp
- *   rsi / x1:  Cell* vm_fp
- *   rdx / x2:  unsigned char* start
- *   rcx / x4:  ActRec* firstAR
- *   r8  / x5:  uint8_t* targetCacheBase
- *   r9  / x6:  ActRec* calleeAR
+ *
+ * The columns are registers of Linux and Mac ABI / Windows ABI / ARM ABI.
+ *   rdi / rcx   / x0:  Cell* vm_sp
+ *   rsi / rdx   / x1:  Cell* vm_fp
+ *   rdx / r8    / x2:  unsigned char* start
+ *   rcx / r9    / x4:  ActRec* firstAR
+ *   r8  / stack / x5:  uint8_t* targetCacheBase
+ *   r9  / stack / x6:  ActRec* calleeAR
  */
 
 #include "hphp/util/etch-helpers.h"
@@ -22,17 +24,22 @@
 ETCH_NAME(enterTCHelper):
   // Prologue
   CFI(startproc)             // amongst other things, cfa reg is now rsp, and offset is 8
+
+  // On Windows, get the 5th and 6th arguments from the stack.
+  ETCH_GET_ARG5
+  ETCH_GET_ARG6
+
   push %rbp
   CFI2(adjust_cfa_offset, 8) // cfa is now 8 bytes further from rsp than it was before
   CFI3C(offset, rbp, -16)    // Where to find previous value of rbp, relative to cfa
 
   // Set firstAR->m_sfp to point to this frame.
-  mov %rsp, (%rcx)
+  mov %rsp, (ETCH_ARG4)
 
   // Set up special registers used for translated code.
-  mov %rdi, %rbx          // rVmSp
-  mov %r8,  %r12          // rVmTl
-  mov %rsi, %rbp          // rVmFp
+  mov ETCH_ARG1, %rbx          // rVmSp
+  mov ETCH_ARG5, %r12          // rVmTl
+  mov ETCH_ARG2, %rbp          // rVmFp
 
   sub $8, %rsp // align native stack
   CFI2(adjust_cfa_offset, 8)
@@ -48,11 +55,11 @@ ETCH_NAME(enterTCHelper):
    * on the RSB but the ret to callToExit always mispredicts anyway, and this
    * keeps the RSB balanced.
    */
-  test %r9, %r9
+  test ETCH_ARG6, ETCH_ARG6
   jz ETCH_LABEL(enterTCHelper$callTC)
   push ETCH_NAME_REL(enterTCExit)
-  push 0x8(%r9)
-  mov %r9, %rbp
+  push 0x8(ETCH_ARG6)
+  mov ETCH_ARG6, %rbp
   call ETCH_LABEL(enterTCHelper$prologue)
 
   /*
@@ -63,7 +70,7 @@ ETCH_NAME(enterTCHelper):
    * 16-byte aligned.
    */
 ETCH_LABEL(enterTCHelper$callTC):
-  call *%rdx
+  call *ETCH_ARG3
 
   /*
    * enterTCExit is never called directly; this exists to give the jit
@@ -87,7 +94,7 @@ ETCH_NAME(enterTCExit):
 
 ETCH_LABEL(enterTCHelper$prologue):
   pop %rax
-  jmp *%rdx
+  jmp *ETCH_ARG3
 
   CFI(endproc)
   ETCH_SIZE(enterTCHelper)
@@ -115,8 +122,8 @@ ETCH_NAME(handleSRHelper):
   CFI2(adjust_cfa_offset, 0x30)
 
   // call mcg->handleServiceRequest(%rsp)
-  mov ETCH_NAME(mcg)(%rip), %rdi
-  mov %rsp, %rsi
+  mov ETCH_NAME(mcg)(%rip), ETCH_ARG1
+  mov %rsp, ETCH_ARG2
   call MCGenerator_handleServiceRequest
 
   // Pop the ServiceReqInfo off the stack.

--- a/hphp/util/etch-helpers.h
+++ b/hphp/util/etch-helpers.h
@@ -14,6 +14,14 @@
 #define ETCH_LABEL(x)   .L##x
 #define ETCH_TYPE(x, y) /* Not used on Windows */
 #define ETCH_NAME_REL(x) $ x
+#define ETCH_ARG1       %rcx
+#define ETCH_ARG2       %rdx
+#define ETCH_ARG3       %r8
+#define ETCH_ARG4       %r9
+#define ETCH_ARG5       %r10  /* Use r10 here */
+#define ETCH_ARG6       %r11  /* Use r11 here */
+#define ETCH_GET_ARG5   mov 0x28(%rsp), %r10  /* Get the argument from the stack to r10 */
+#define ETCH_GET_ARG6   mov 0x30(%rsp), %r11  /* Get the argument from the stack to r11 */
 #elif defined(__APPLE__)
 #define CFI(x)          .cfi_##x
 #define CFI2(x, y)      .cfi_##x y
@@ -27,6 +35,14 @@
 #define ETCH_LABEL(x)   .L##_##x
 #define ETCH_TYPE(x, y) /* not used on OSX */
 #define ETCH_NAME_REL(x) _##x@GOTPCREL(%rip)
+#define ETCH_ARG1       %rdi
+#define ETCH_ARG2       %rsi
+#define ETCH_ARG3       %rdx
+#define ETCH_ARG4       %rcx
+#define ETCH_ARG5       %r8
+#define ETCH_ARG6       %r9
+#define ETCH_GET_ARG5   /* not used on OSX */
+#define ETCH_GET_ARG6   /* not used on OSX */
 #else
 #define CFI(x)          .cfi_##x
 #define CFI2(x, y)      .cfi_##x y
@@ -40,6 +56,14 @@
 #define ETCH_LABEL(x)   .L##x
 #define ETCH_TYPE(x, y) .type x, y
 #define ETCH_NAME_REL(x) $ x
+#define ETCH_ARG1       %rdi
+#define ETCH_ARG2       %rsi
+#define ETCH_ARG3       %rdx
+#define ETCH_ARG4       %rcx
+#define ETCH_ARG5       %r8
+#define ETCH_ARG6       %r9
+#define ETCH_GET_ARG5   /* not used on Linux */
+#define ETCH_GET_ARG6   /* not used on Linux */
 #endif
 
 #endif // incl_ETCH_HELPERS_H


### PR DESCRIPTION
Windows uses a different calling convension. Arguments passing and
caller/callee saved registers are added. About 30% quick tests pass
in JIT mode after this change.

https://msdn.microsoft.com/en-us/library/zthk2dkh.aspx
https://msdn.microsoft.com/en-us/library/6t169e9c.aspx