### PR TITLE
Set the WORKING_DIRECTORY for the ALL_SCAN_HEADER target

### DIFF
--- a/hphp/scan-methods/CMakeLists.txt
+++ b/hphp/scan-methods/CMakeLists.txt
@@ -1,5 +1,6 @@
 # Generate all-scan.h and all-scan-decl.h header files.
 add_custom_target(ALL_SCAN_HEADER ALL
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
   COMMAND ${CMAKE_COMMAND} -E touch all-scan.h
   COMMAND ${CMAKE_COMMAND} -E touch all-scan-decl.h
   VERBATIM)


### PR DESCRIPTION
When the ALL_SCAN_HEADER command was being run on Windows, the wrong working directory was being used, causing the headers to be created in the wrong directory. This sets the working directory explicitly to fix this.