### PR TITLE
SSLSocket::enableCrypto should return bool

### DIFF
--- a/hphp/runtime/base/ssl-socket.cpp
+++ b/hphp/runtime/base/ssl-socket.cpp
@@ -633,7 +633,7 @@ bool SSLSocket::enableCrypto(bool activate /* = true */) {
           (tvs.tv_sec + (double) tvs.tv_usec / 1000000);
         if (timeout < 0) {
           raise_warning("SSL: connection timeout");
-          return -1;
+          return false;
         }
       } else {
         n = SSL_accept(m_data->m_handle);


### PR DESCRIPTION
And it does, at least the signature says it does. It does however still try to return `-1` in one place, which MSVC doesn't like.
This replaces the `return -1` with `return false`.