### PR TITLE
Use decltype rather than typeof

### DIFF
--- a/hphp/runtime/base/string-buffer.cpp
+++ b/hphp/runtime/base/string-buffer.cpp
@@ -370,7 +370,7 @@ void CstrBuffer::append(StringSlice slice) {
   auto const data = slice.ptr;
   auto const len = slice.len;
 
-  static_assert(std::is_unsigned<typeof(len)>::value,
+  static_assert(std::is_unsigned<decltype(len)>::value,
                 "len is supposed to be unsigned");
   assert(m_buffer);
 

--- a/hphp/runtime/ext/async_mysql/ext_async_mysql.cpp
+++ b/hphp/runtime/ext/async_mysql/ext_async_mysql.cpp
@@ -1104,7 +1104,7 @@ void HHVM_METHOD(AsyncMysqlRowBlockIterator, next) {
 bool HHVM_METHOD(AsyncMysqlRowBlockIterator, valid) {
   auto* data = Native::data<AsyncMysqlRowBlockIterator>(this_);
 
-  static_assert(std::is_unsigned<typeof(data->m_row_number)>::value,
+  static_assert(std::is_unsigned<decltype(data->m_row_number)>::value,
                 "m_row_number should be unsigned");
   int64_t count = HHVM_MN(AsyncMysqlRowBlock, count)(
     data->m_row_block.get());
@@ -1222,7 +1222,7 @@ void HHVM_METHOD(AsyncMysqlRowIterator, next) {
 bool HHVM_METHOD(AsyncMysqlRowIterator, valid) {
   auto* data = Native::data<AsyncMysqlRowIterator>(this_);
 
-  static_assert(std::is_unsigned<typeof(data->m_field_number)>::value,
+  static_assert(std::is_unsigned<decltype(data->m_field_number)>::value,
                 "m_field_number should be unsigned");
   int64_t count = HHVM_MN(AsyncMysqlRow, count)(data->m_row.get());
   return data->m_field_number < count;

--- a/hphp/runtime/ext/collections/ext_collections-pair.h
+++ b/hphp/runtime/ext/collections/ext_collections-pair.h
@@ -49,7 +49,7 @@ struct PairIterator {
   }
 
   bool valid() const {
-    static_assert(std::is_unsigned<typeof(m_pos)>::value,
+    static_assert(std::is_unsigned<decltype(m_pos)>::value,
                   "m_pos should be unsigned");
     return m_obj && (m_pos < 2);
   }

--- a/hphp/runtime/vm/jit/irgen-interpone.cpp
+++ b/hphp/runtime/vm/jit/irgen-interpone.cpp
@@ -97,7 +97,7 @@ folly::Optional<Type> interpOutputType(IRGS& env,
   using namespace jit::InstrFlags;
   auto localType = [&]{
     auto locId = localInputId(inst);
-    static_assert(std::is_unsigned<typeof(locId)>::value,
+    static_assert(std::is_unsigned<decltype(locId)>::value,
                   "locId should be unsigned");
     assertx(locId < curFunc(env)->numLocals());
     return env.irb->localType(locId, DataTypeSpecific);


### PR DESCRIPTION
`typeof` is a GCC specific extension, which means MSVC doesn't implement it. `decltype` however, is a C++11 standard form that does the exact same thing, so use it instead.