### PR TITLE
Fix an invalid escape sequence in a string

### DIFF
--- a/hphp/runtime/debugger/cmd/cmd_exception.cpp
+++ b/hphp/runtime/debugger/cmd/cmd_exception.cpp
@@ -40,7 +40,7 @@ void CmdException::help(DebuggerClient &client) {
   client.helpTitle("Exception Command");
   client.helpCmds(
     "[e]xception {cls}",            "breaks if class of exception throws",
-    "[e]xception {ns}\{cls}",       "breaks if class of exception throws",
+    "[e]xception {ns}\\{cls}",      "breaks if class of exception throws",
     "[e]xception error",            "breaks on errors, warnings and notices",
     "[e]xception {above}@{url}",    "breaks only if url also matches",
     "",                             "",


### PR DESCRIPTION
More specifically, a string in the help for the `exception` debugger command intended to have a literal backslash, but failed to escape it properly. MSVC complains about it, so this fixes it.