### PR TITLE
Don't use the coalescing operator

### DIFF
--- a/hphp/runtime/server/fastcgi/fastcgi-transport.h
+++ b/hphp/runtime/server/fastcgi/fastcgi-transport.h
@@ -197,7 +197,7 @@ struct FastCGITransport : public Transport, private Synchronizable {
 
   uint16_t getServerPort() override {
     auto port = getParamTyped<uint16_t>("SERVER_PORT");
-    return port ?: Transport::getServerPort();
+    return port ? port : Transport::getServerPort();
   }
 
   const char* getServerSoftware() override {


### PR DESCRIPTION
At least, I think that's what this thing was. Whatever it is, MSVC doesn't support it, so use something normal instead.