### PR TITLE
Don't use C99 named struct initializers to initialize the ABIs

### DIFF
--- a/hphp/runtime/vm/jit/abi-x64.h
+++ b/hphp/runtime/vm/jit/abi-x64.h
@@ -204,23 +204,23 @@ constexpr int kNumServiceReqArgRegs =
 #define GENDATAOFF(nm) int(offsetof(Generator, nm))
 
 UNUSED const Abi abi {
-  .gpUnreserved   = kGPUnreserved,
-  .gpReserved     = kGPReserved,
-  .simdUnreserved = kXMMUnreserved,
-  .simdReserved   = kXMMReserved,
-  .calleeSaved    = kCalleeSaved,
-  .sf             = kSF,
-  .canSpill       = true,
+  kGPUnreserved,
+  kGPReserved,
+  kXMMUnreserved,
+  kXMMReserved,
+  kCalleeSaved,
+  kSF,
+  true,
 };
 
 UNUSED const Abi cross_trace_abi {
-  .gpUnreserved   = abi.gp() & kScratchCrossTraceRegs,
-  .gpReserved     = abi.gp() - kScratchCrossTraceRegs,
-  .simdUnreserved = abi.simd() & kScratchCrossTraceRegs,
-  .simdReserved   = abi.simd() - kScratchCrossTraceRegs,
-  .calleeSaved    = abi.calleeSaved & kScratchCrossTraceRegs,
-  .sf             = abi.sf,
-  .canSpill       = false
+  abi.gp() & kScratchCrossTraceRegs,
+  abi.gp() - kScratchCrossTraceRegs,
+  abi.simd() & kScratchCrossTraceRegs,
+  abi.simd() - kScratchCrossTraceRegs,
+  abi.calleeSaved & kScratchCrossTraceRegs,
+  abi.sf,
+  false
 };
 
 //////////////////////////////////////////////////////////////////////

--- a/hphp/runtime/vm/jit/vasm-emit.cpp
+++ b/hphp/runtime/vm/jit/vasm-emit.cpp
@@ -72,12 +72,12 @@ auto const vauto_gp = x64::rAsm | reg::r11;
 auto const vauto_simd = reg::xmm5 | reg::xmm6 | reg::xmm7;
 
 const Abi vauto_abi {
-  .gpUnreserved = vauto_gp,
-  .gpReserved = x64::abi.gp() - vauto_gp,
-  .simdUnreserved = vauto_simd,
-  .simdReserved = x64::abi.simd() - vauto_simd,
-  .calleeSaved = x64::abi.calleeSaved,
-  .sf = x64::abi.sf
+  vauto_gp,
+  x64::abi.gp() - vauto_gp,
+  vauto_simd,
+  x64::abi.simd() - vauto_simd,
+  x64::abi.calleeSaved,
+  x64::abi.sf
 };
 
 Vauto::~Vauto() {


### PR DESCRIPTION
MSVC doesn't support them, so use a normal comma deliminated one instead. The fields are already in the correct order.