### PR TITLE
Remove unneeded cxxabi.h include in gen-ext-hhvm

### DIFF
--- a/hphp/tools/bootstrap/gen-ext-hhvm.cpp
+++ b/hphp/tools/bootstrap/gen-ext-hhvm.cpp
@@ -15,7 +15,6 @@
 */
 
 #include <algorithm>
-#include <cxxabi.h>
 #include <fstream>
 #include <sstream>
 #include <iostream>


### PR DESCRIPTION
This header isn't needed by the tool, nor is it available on MSVC.