### PR TITLE
Add MSVC support to hphp/util/portability.h

### DIFF
--- a/hphp/util/portability.h
+++ b/hphp/util/portability.h
@@ -50,17 +50,30 @@
 # undef ATTRIBUTE_PRINTF
 #endif
 
-#define ATTRIBUTE_UNUSED   __attribute__((__unused__))
-#define ATTRIBUTE_NORETURN __attribute__((__noreturn__))
+#ifdef _MSC_VER
+#define ATTRIBUTE_NORETURN __declspec(noreturn)
+#define ATTRIBUTE_PRINTF(a1, a2)
+#define ATTRIBUTE_TLS __declspec(thread)
+#define ATTRIBUTE_UNUSED
 
+#define ALWAYS_INLINE __forceinline
+#define EXTERNALLY_VISIBLE
+#define FLATTEN
+#define NEVER_INLINE __declspec(noinline)
+#define UNUSED
+#else
+#define ATTRIBUTE_NORETURN __attribute__((__noreturn__))
 #define ATTRIBUTE_PRINTF(a1, a2) \
   __attribute__((__format__ (__printf__, a1, a2)))
+#define ATTRIBUTE_TLS __thread
+#define ATTRIBUTE_UNUSED   __attribute__((__unused__))
 
 #define ALWAYS_INLINE      inline __attribute__((__always_inline__))
+#define EXTERNALLY_VISIBLE __attribute__((__externally_visible__))
+#define FLATTEN            __attribute__((__flatten__))
 #define NEVER_INLINE       __attribute__((__noinline__))
 #define UNUSED             __attribute__((__unused__))
-#define FLATTEN            __attribute__((__flatten__))
-#define EXTERNALLY_VISIBLE __attribute__((__externally_visible__))
+#endif
 
 #ifdef DEBUG
 # define DEBUG_ONLY /* nop */

--- a/hphp/util/portability.h
+++ b/hphp/util/portability.h
@@ -53,7 +53,9 @@
 #ifdef _MSC_VER
 #define ATTRIBUTE_NORETURN __declspec(noreturn)
 #define ATTRIBUTE_PRINTF(a1, a2)
-#define ATTRIBUTE_TLS __declspec(thread)
+#ifndef __thread
+# define __thread __declspec(thread)
+#endif
 #define ATTRIBUTE_UNUSED
 
 #define ALWAYS_INLINE __forceinline
@@ -65,7 +67,6 @@
 #define ATTRIBUTE_NORETURN __attribute__((__noreturn__))
 #define ATTRIBUTE_PRINTF(a1, a2) \
   __attribute__((__format__ (__printf__, a1, a2)))
-#define ATTRIBUTE_TLS __thread
 #define ATTRIBUTE_UNUSED   __attribute__((__unused__))
 
 #define ALWAYS_INLINE      inline __attribute__((__always_inline__))


### PR DESCRIPTION
This also adds `ATTRIBUTE_TLS`, the changes using this attribute will come in a separate PR.
This also puts the attributes in alphabetical order, with the `ATTRIBUTE_*` declarations and the top, and everything else after.