### PR TITLE
Convert all places using __thread to ATTRIBUTE_TLS

### DIFF
--- a/hphp/hhbbc/index.cpp
+++ b/hphp/hhbbc/index.cpp
@@ -1490,7 +1490,7 @@ Type context_sensitive_return_type(const Index& index,
   auto const callInsensitiveType = finfo->returnTy;
 
   constexpr auto max_interp_nexting_level = 2;
-  static __thread uint32_t interp_nesting_level;
+  static ATTRIBUTE_TLS uint32_t interp_nesting_level;
 
   // TODO(#3788877): more heuristics here would be useful.  (And even
   // functions without params might be worth interpreting in a

--- a/hphp/hhvm/global-variables.cpp
+++ b/hphp/hhvm/global-variables.cpp
@@ -22,8 +22,8 @@ namespace HPHP {
 
 //////////////////////////////////////////////////////////////////////
 
-static __thread GlobalsArray* g_variables;
-static __thread EnvConstants* g_envConstants;
+static ATTRIBUTE_TLS GlobalsArray* g_variables;
+static ATTRIBUTE_TLS EnvConstants* g_envConstants;
 
 GlobalsArray* get_global_variables() {
   assert(g_variables);

--- a/hphp/runtime/base/array-iterator.cpp
+++ b/hphp/runtime/base/array-iterator.cpp
@@ -49,7 +49,7 @@ const StaticString
   s_key("key"),
   s_current("current");
 
-__thread MIterTable tl_miter_table;
+ATTRIBUTE_TLS MIterTable tl_miter_table;
 
 //////////////////////////////////////////////////////////////////////
 

--- a/hphp/runtime/base/array-iterator.h
+++ b/hphp/runtime/base/array-iterator.h
@@ -581,7 +581,7 @@ struct MIterTable {
   TlsPodBag<Ent,req::Allocator<Ent>> extras;
 };
 static_assert(sizeof(MIterTable) == 2*64, "");
-extern __thread MIterTable tl_miter_table;
+extern ATTRIBUTE_TLS MIterTable tl_miter_table;
 
 void free_strong_iterators(ArrayData*);
 ArrayData* move_strong_iterators(ArrayData* dest, ArrayData* src);

--- a/hphp/runtime/base/file.cpp
+++ b/hphp/runtime/base/file.cpp
@@ -68,7 +68,7 @@ FileData::~FileData() {
 
 StaticString File::s_resource_name("stream");
 
-int __thread s_pcloseRet;
+int ATTRIBUTE_TLS s_pcloseRet;
 
 const int File::CHUNK_SIZE = FileData::CHUNK_SIZE;
 const int File::USE_INCLUDE_PATH = 1;

--- a/hphp/runtime/base/file.h
+++ b/hphp/runtime/base/file.h
@@ -34,7 +34,7 @@ namespace HPHP {
 class StreamContext;
 class StreamFilter;
 
-extern int __thread s_pcloseRet;
+extern int ATTRIBUTE_TLS s_pcloseRet;
 
 // This structure holds the request allocated data members of File.  The
 // purpose of the class is to allow File (and subclasses) to be managed by

--- a/hphp/runtime/base/object-data.cpp
+++ b/hphp/runtime/base/object-data.cpp
@@ -55,7 +55,7 @@ namespace HPHP {
 //////////////////////////////////////////////////////////////////////
 
 // current maximum object identifier
-__thread int ObjectData::os_max_id;
+ATTRIBUTE_TLS int ObjectData::os_max_id;
 
 TRACE_SET_MOD(runtime);
 
@@ -1226,7 +1226,7 @@ struct PropRecurInfo {
   RecurSet* activeSet;
 };
 
-__thread PropRecurInfo propRecurInfo;
+ATTRIBUTE_TLS PropRecurInfo propRecurInfo;
 
 template<class Invoker>
 bool magic_prop_impl(TypedValue* retval,

--- a/hphp/runtime/base/object-data.h
+++ b/hphp/runtime/base/object-data.h
@@ -92,7 +92,7 @@ struct ObjectData {
   static const StaticString s_serializedNativeDataKey;
 
  private:
-  static __thread int os_max_id;
+  static ATTRIBUTE_TLS int os_max_id;
 
  public:
   static void resetMaxId();

--- a/hphp/runtime/base/preg.cpp
+++ b/hphp/runtime/base/preg.cpp
@@ -228,7 +228,7 @@ IMPLEMENT_THREAD_LOCAL(PCREglobals, tl_pcre_globals);
 static PCRECache s_pcreCache;
 
 // The last pcre error code is available for the whole thread.
-static __thread int tl_last_error_code;
+static ATTRIBUTE_TLS int tl_last_error_code;
 
 ///////////////////////////////////////////////////////////////////////////////
 // pcre_cache_entry implementation

--- a/hphp/runtime/base/program-functions.cpp
+++ b/hphp/runtime/base/program-functions.cpp
@@ -201,7 +201,7 @@ String k_PHP_BINDIR;
 String k_PHP_OS;
 String k_PHP_SAPI;
 
-static __thread bool s_sessionInitialized{false};
+static ATTRIBUTE_TLS bool s_sessionInitialized{false};
 
 static void process_cmd_arguments(int argc, char **argv) {
   php_global_set(s_argc, Variant(argc));

--- a/hphp/runtime/base/rds.cpp
+++ b/hphp/runtime/base/rds.cpp
@@ -302,8 +302,8 @@ void bindOnLinkImpl(std::atomic<Handle>& handle,
 
 //////////////////////////////////////////////////////////////////////
 
-__thread void* tl_base = nullptr;
-static __thread std::aligned_storage<
+ATTRIBUTE_TLS void* tl_base = nullptr;
+static ATTRIBUTE_TLS std::aligned_storage<
   sizeof(Array),
   alignof(Array)
 >::type s_constantsStorage;

--- a/hphp/runtime/base/rds.h
+++ b/hphp/runtime/base/rds.h
@@ -131,7 +131,7 @@ folly::Range<const char*> persistentSection();
 /*
  * The thread-local pointer to the base of RDS.
  */
-extern __thread void* tl_base;
+extern ATTRIBUTE_TLS void* tl_base;
 
 //////////////////////////////////////////////////////////////////////
 

--- a/hphp/runtime/base/request-local.h
+++ b/hphp/runtime/base/request-local.h
@@ -109,16 +109,16 @@ void RequestLocal<T>::create() {
 }
 
 #define IMPLEMENT_REQUEST_LOCAL(T,f) \
-  __thread RequestLocal<T> f
+  ATTRIBUTE_TLS RequestLocal<T> f
 
 #define DECLARE_STATIC_REQUEST_LOCAL(T,f) \
-  static __thread RequestLocal<T> f
+  static ATTRIBUTE_TLS RequestLocal<T> f
 
 #define IMPLEMENT_STATIC_REQUEST_LOCAL(T,f) \
-  static __thread RequestLocal<T> f
+  static ATTRIBUTE_TLS RequestLocal<T> f
 
 #define DECLARE_EXTERN_REQUEST_LOCAL(T,f) \
-  extern __thread RequestLocal<T> f
+  extern ATTRIBUTE_TLS RequestLocal<T> f
 
 #else // defined(USE_GCC_FAST_TLS)
 

--- a/hphp/runtime/base/resource-data.cpp
+++ b/hphp/runtime/base/resource-data.cpp
@@ -27,7 +27,7 @@ namespace HPHP {
 ///////////////////////////////////////////////////////////////////////////////
 
 // resources have a separate id space
-__thread int ResourceData::os_max_resource_id;
+ATTRIBUTE_TLS int ResourceData::os_max_resource_id;
 
 ResourceData::ResourceData() {
   m_hdr.init(0, HeaderKind::Resource, 1);

--- a/hphp/runtime/base/resource-data.h
+++ b/hphp/runtime/base/resource-data.h
@@ -40,7 +40,7 @@ struct IMarker;
  */
 class ResourceData {
  private:
-  static __thread int os_max_resource_id;
+  static ATTRIBUTE_TLS int os_max_resource_id;
 
  public:
   static void resetMaxId() { os_max_resource_id = 0; }

--- a/hphp/runtime/base/stats.cpp
+++ b/hphp/runtime/base/stats.cpp
@@ -37,10 +37,10 @@ const char* g_counterNames[] = {
 #undef STAT
 #undef O
 };
-__thread uint64_t tl_counters[kNumStatCounters];
+ATTRIBUTE_TLS uint64_t tl_counters[kNumStatCounters];
 
 typedef hphp_const_char_map<hphp_const_char_map<uint64_t>> StatGroupMap;
-__thread StatGroupMap* tl_stat_groups = nullptr;
+ATTRIBUTE_TLS StatGroupMap* tl_stat_groups = nullptr;
 
 void init() {
   if (!enabledAny()) return;
@@ -48,7 +48,7 @@ void init() {
   tl_stat_groups = new StatGroupMap();
 }
 
-static __thread int64_t epoch;
+static ATTRIBUTE_TLS int64_t epoch;
 void dump() {
   if (!enabledAny()) return;
 

--- a/hphp/runtime/base/stats.h
+++ b/hphp/runtime/base/stats.h
@@ -112,7 +112,7 @@ enum StatCounter {
 #undef O
 
 extern const char* g_counterNames[kNumStatCounters];
-extern __thread uint64_t tl_counters[kNumStatCounters];
+extern ATTRIBUTE_TLS uint64_t tl_counters[kNumStatCounters];
 
 inline bool enabled() {
   return Trace::moduleEnabled(Trace::stats, 1);

--- a/hphp/runtime/base/thread-info.cpp
+++ b/hphp/runtime/base/thread-info.cpp
@@ -47,7 +47,7 @@ Mutex s_thread_info_mutex;
  * Either null, or populated by initialization of ThreadInfo as an approximation
  * of the highest address of the current thread's stack.
  */
-__thread char* t_stackbase = nullptr;
+ATTRIBUTE_TLS char* t_stackbase = nullptr;
 
 ///////////////////////////////////////////////////////////////////////////////
 }

--- a/hphp/runtime/base/variable-serializer.cpp
+++ b/hphp/runtime/base/variable-serializer.cpp
@@ -101,7 +101,7 @@ void VariableSerializer::popObjectInfo() {
   m_objectInfos.pop_back();
 }
 
-__thread int64_t VariableSerializer::serializationSizeLimit =
+ATTRIBUTE_TLS int64_t VariableSerializer::serializationSizeLimit =
   StringData::MaxSize;
 
 void VariableSerializer::popResourceInfo() {

--- a/hphp/runtime/base/variable-serializer.h
+++ b/hphp/runtime/base/variable-serializer.h
@@ -57,7 +57,7 @@ public:
     if (m_arrayIds) delete m_arrayIds;
   }
 
-  static __thread int64_t serializationSizeLimit;
+  static ATTRIBUTE_TLS int64_t serializationSizeLimit;
 
   /**
    * Top level entry function called by f_ functions.

--- a/hphp/runtime/ext/icu/icu.cpp
+++ b/hphp/runtime/ext/icu/icu.cpp
@@ -60,7 +60,7 @@ void IntlError::clearError(bool clearGlobalError /*= true */) {
 /////////////////////////////////////////////////////////////////////////////
 // INI Setting
 
-static __thread std::string* s_defaultLocale;
+static ATTRIBUTE_TLS std::string* s_defaultLocale;
 
 void IntlExtension::bindIniSettings() {
   // TODO: t5226715 We shouldn't need to check s_defaultLocale here,

--- a/hphp/runtime/ext/memcache/ext_memcache.cpp
+++ b/hphp/runtime/ext/memcache/ext_memcache.cpp
@@ -49,7 +49,7 @@ struct MEMCACHEGlobals final {
   std::string hash_function;
 };
 
-static __thread MEMCACHEGlobals* s_memcache_globals;
+static ATTRIBUTE_TLS MEMCACHEGlobals* s_memcache_globals;
 #define MEMCACHEG(name) s_memcache_globals->name
 
 const StaticString s_MemcacheData("MemcacheData");

--- a/hphp/runtime/ext/memcached/ext_memcached.cpp
+++ b/hphp/runtime/ext/memcached/ext_memcached.cpp
@@ -210,7 +210,7 @@ const StaticString
 struct MEMCACHEDGlobals final {
   std::string sess_prefix;
 };
-static __thread MEMCACHEDGlobals* s_memcached_globals;
+static ATTRIBUTE_TLS MEMCACHEDGlobals* s_memcached_globals;
 #define MEMCACHEDG(name) s_memcached_globals->name
 
 namespace {

--- a/hphp/runtime/ext/session/ext_session.cpp
+++ b/hphp/runtime/ext/session/ext_session.cpp
@@ -145,7 +145,7 @@ public:
   String id;
 };
 
-static __thread SessionRequestData* s_session;
+static ATTRIBUTE_TLS SessionRequestData* s_session;
 
 void SessionRequestData::requestShutdownImpl() {
   if (mod_is_open()) {

--- a/hphp/runtime/ext/std/ext_std_math.cpp
+++ b/hphp/runtime/ext/std/ext_std_math.cpp
@@ -406,7 +406,7 @@ struct RandomBuf {
   }           state;
 };
 
-static __thread RandomBuf s_state;
+static ATTRIBUTE_TLS RandomBuf s_state;
 
 static void randinit(uint32_t seed) {
   if (s_state.state == RandomBuf::Uninit) {

--- a/hphp/runtime/ext_zend_compat/hhvm/zend-object-store.cpp
+++ b/hphp/runtime/ext_zend_compat/hhvm/zend-object-store.cpp
@@ -20,7 +20,7 @@
 
 namespace HPHP {
 
-__thread RequestLocal<ZendObjectStore> ZendObjectStore::tl_instance;
+ATTRIBUTE_TLS RequestLocal<ZendObjectStore> ZendObjectStore::tl_instance;
 
 void ZendObjectStore::requestShutdown() {
   m_store.clear();

--- a/hphp/runtime/ext_zend_compat/hhvm/zend-object-store.h
+++ b/hphp/runtime/ext_zend_compat/hhvm/zend-object-store.h
@@ -54,7 +54,7 @@ struct ZendObjectStore final : RequestEventHandler {
   zend_object_handle cloneObject(zend_object_handle handle);
 
 private:
-  static __thread RequestLocal<ZendObjectStore> tl_instance;
+  static ATTRIBUTE_TLS RequestLocal<ZendObjectStore> tl_instance;
 
   std::vector<zend_object_store_bucket> m_store;
   zend_object_handle m_free_list_head;

--- a/hphp/runtime/ext_zend_compat/hhvm/zend-request-local.h
+++ b/hphp/runtime/ext_zend_compat/hhvm/zend-request-local.h
@@ -24,7 +24,7 @@
 
 namespace HPHP {
 
-#define ZEND_REQUEST_LOCAL_VECTOR(T, F, N) static __thread HPHP::RequestLocal<HPHP::ZendRequestLocalVector<T, F> > N;
+#define ZEND_REQUEST_LOCAL_VECTOR(T, F, N) static ATTRIBUTE_TLS HPHP::RequestLocal<HPHP::ZendRequestLocalVector<T, F> > N;
 template <class T, class F>
 struct ZendRequestLocalVector final : RequestEventHandler {
   static_assert(std::is_pointer<T>::value,
@@ -50,7 +50,7 @@ private:
   F m_destroy_callback;
 };
 
-#define ZEND_REQUEST_LOCAL_MAP(K, V, N) static __thread HPHP::RequestLocal<HPHP::ZendRequestLocalMap<K,V> > N;
+#define ZEND_REQUEST_LOCAL_MAP(K, V, N) static ATTRIBUTE_TLS HPHP::RequestLocal<HPHP::ZendRequestLocalMap<K,V> > N;
 template <class K, class V>
 struct ZendRequestLocalMap final : RequestEventHandler {
   typedef std::unordered_map<K, V> container;

--- a/hphp/runtime/server/http-request-handler.cpp
+++ b/hphp/runtime/server/http-request-handler.cpp
@@ -51,7 +51,7 @@ using std::vector;
 ///////////////////////////////////////////////////////////////////////////////
 
 static ReadWriteMutex s_proxyMutex;
-static __thread unsigned int s_randState = 0xfaceb00c;
+static ATTRIBUTE_TLS unsigned int s_randState = 0xfaceb00c;
 
 static bool matchAnyPattern(const std::string &path,
                             const std::vector<std::string> &patterns) {

--- a/hphp/runtime/vm/bytecode.cpp
+++ b/hphp/runtime/vm/bytecode.cpp
@@ -7539,8 +7539,8 @@ void PrintTCCallerInfo() {
 }
 
 // thread-local cached coverage info
-static __thread Unit* s_prev_unit;
-static __thread int s_prev_line;
+static ATTRIBUTE_TLS Unit* s_prev_unit;
+static ATTRIBUTE_TLS int s_prev_line;
 
 void recordCodeCoverage(PC pc) {
   Unit* unit = vmfp()->m_func->unit();

--- a/hphp/runtime/vm/hh-utils.cpp
+++ b/hphp/runtime/vm/hh-utils.cpp
@@ -69,7 +69,7 @@ void checkHHConfig(const Unit* unit) {
 /**
  * The default of "true" here is correct -- see autoTypecheckRequestInit().
  */
-static __thread bool tl_doneAutoTypecheck = true;
+static ATTRIBUTE_TLS bool tl_doneAutoTypecheck = true;
 
 /**
  * autoTypecheckRequestInit() and autoTypecheckRequestExit() work together to

--- a/hphp/runtime/vm/jit/ir-builder.cpp
+++ b/hphp/runtime/vm/jit/ir-builder.cpp
@@ -510,7 +510,7 @@ SSATmp* IRBuilder::preOptimize(IRInstruction* inst) {
 SSATmp* IRBuilder::optimizeInst(IRInstruction* inst,
                                 CloneFlag doClone,
                                 Block* srcBlock) {
-  static DEBUG_ONLY __thread int instNest = 0;
+  static DEBUG_ONLY ATTRIBUTE_TLS int instNest = 0;
   if (debug) ++instNest;
   SCOPE_EXIT { if (debug) --instNest; };
   DEBUG_ONLY auto indent = [&] { return std::string(instNest * 2, ' '); };

--- a/hphp/runtime/vm/jit/mc-generator.cpp
+++ b/hphp/runtime/vm/jit/mc-generator.cpp
@@ -118,8 +118,8 @@ static const char* const kPerfCounterNames[] = {
 };
 #undef TPC
 
-__thread int64_t s_perfCounters[tpc_num_counters];
-static __thread size_t s_initialTCSize;
+ATTRIBUTE_TLS int64_t s_perfCounters[tpc_num_counters];
+static ATTRIBUTE_TLS size_t s_initialTCSize;
 
 // The global MCGenerator object.
 MCGenerator* mcg;
@@ -1180,13 +1180,13 @@ class FreeRequestStubTrigger {
 #ifdef DEBUG
 
 struct DepthGuard {
-  static __thread int m_depth;
+  static ATTRIBUTE_TLS int m_depth;
   DepthGuard()  { m_depth++; TRACE(2, "DepthGuard: %d {\n", m_depth); }
   ~DepthGuard() { TRACE(2, "DepthGuard: %d }\n", m_depth); m_depth--; }
 
   bool depthOne() const { return m_depth == 1; }
 };
-__thread int DepthGuard::m_depth;
+ATTRIBUTE_TLS int DepthGuard::m_depth;
 
 #else
 
@@ -2110,7 +2110,7 @@ void MCGenerator::codeEmittedThisRequest(size_t& requestEntry,
 }
 
 namespace {
-__thread std::unordered_map<const ActRec*, TCA>* tl_debuggerCatches{nullptr};
+ATTRIBUTE_TLS std::unordered_map<const ActRec*, TCA>* tl_debuggerCatches{nullptr};
 }
 
 void pushDebuggerCatch(const ActRec* fp) {

--- a/hphp/runtime/vm/jit/mc-generator.h
+++ b/hphp/runtime/vm/jit/mc-generator.h
@@ -444,7 +444,7 @@ enum TransPerfCounter {
 };
 #undef TPC
 
-extern __thread int64_t s_perfCounters[];
+extern ATTRIBUTE_TLS int64_t s_perfCounters[];
 #define INC_TPC(n) ++jit::s_perfCounters[jit::tpc_##n];
 
 /*

--- a/hphp/runtime/vm/jit/timer.cpp
+++ b/hphp/runtime/vm/jit/timer.cpp
@@ -36,7 +36,7 @@ namespace {
 
 //////////////////////////////////////////////////////////////////////
 
-__thread Timer::Counter s_counters[Timer::kNumTimers];
+ATTRIBUTE_TLS Timer::Counter s_counters[Timer::kNumTimers];
 
 struct TimerName { const char* str; Timer::Name name; };
 const TimerName s_names[] = {

--- a/hphp/runtime/vm/jit/write-lease.cpp
+++ b/hphp/runtime/vm/jit/write-lease.cpp
@@ -24,7 +24,7 @@
 namespace HPHP { namespace jit {
 TRACE_SET_MOD(txlease);
 
-static __thread bool threadCanAcquire = true;
+static ATTRIBUTE_TLS bool threadCanAcquire = true;
 
 bool Lease::amOwner() const {
   return m_held && m_owner == pthread_self();

--- a/hphp/runtime/vm/ringbuffer-print.cpp
+++ b/hphp/runtime/vm/ringbuffer-print.cpp
@@ -50,7 +50,7 @@ void dumpEntry(const RingBufferEntry* e) {
     }
     case RBTypeFuncEntry:
     case RBTypeFuncExit: {
-      static __thread int indentDepth = 0;
+      static ATTRIBUTE_TLS int indentDepth = 0;
       // Quick and dirty attempt at dtrace -F style function nesting.
       // Looks like:
       //

--- a/hphp/runtime/vm/treadmill.cpp
+++ b/hphp/runtime/vm/treadmill.cpp
@@ -66,7 +66,7 @@ std::atomic<GenCount> s_oldestRequestInFlight(0);
  * allocates a new thread id from s_nextThreadIdx with fetch_add.
  */
 std::atomic<int64_t> s_nextThreadIdx{0};
-__thread int64_t s_thisThreadIdx{-1};
+ATTRIBUTE_TLS int64_t s_thisThreadIdx{-1};
 
 //////////////////////////////////////////////////////////////////////
 

--- a/hphp/runtime/vm/type-profile.cpp
+++ b/hphp/runtime/vm/type-profile.cpp
@@ -54,10 +54,10 @@ void profileInit() {
  * In server mode, we exclude warmup document requests from profiling, then
  * record samples for EvalJitProfileInterpRequests standard requests.
  */
-bool __thread profileOn = false;
+bool ATTRIBUTE_TLS profileOn = false;
 static bool warmingUp;
 static int64_t numRequests;
-bool __thread standardRequest = true;
+bool ATTRIBUTE_TLS standardRequest = true;
 static std::atomic<bool> singleJitLock;
 static std::atomic<int> singleJitRequests;
 static std::atomic<int> relocateRequests;

--- a/hphp/runtime/vm/type-profile.h
+++ b/hphp/runtime/vm/type-profile.h
@@ -42,12 +42,12 @@ int64_t requestCount();
  */
 void profileIncrementFuncCounter(const Func*);
 
-extern __thread bool profileOn;
+extern ATTRIBUTE_TLS bool profileOn;
 inline bool isProfileRequest() {
   return profileOn;
 }
 
-extern __thread bool standardRequest;
+extern ATTRIBUTE_TLS bool standardRequest;
 inline bool isStandardRequest() {
   return standardRequest;
 }

--- a/hphp/runtime/vm/vm-regs.cpp
+++ b/hphp/runtime/vm/vm-regs.cpp
@@ -21,7 +21,7 @@
 namespace HPHP {
 
 // Register dirtiness: thread-private.
-__thread VMRegState tl_regState = VMRegState::CLEAN;
+ATTRIBUTE_TLS VMRegState tl_regState = VMRegState::CLEAN;
 
 VMRegAnchor::VMRegAnchor()
   : m_old(tl_regState)

--- a/hphp/runtime/vm/vm-regs.h
+++ b/hphp/runtime/vm/vm-regs.h
@@ -55,7 +55,7 @@ enum class VMRegState : uint8_t {
   CLEAN,
   DIRTY
 };
-extern __thread VMRegState tl_regState;
+extern ATTRIBUTE_TLS VMRegState tl_regState;
 
 inline void checkVMRegState() {
   assert(tl_regState == VMRegState::CLEAN);

--- a/hphp/util/alloc.cpp
+++ b/hphp/util/alloc.cpp
@@ -90,8 +90,8 @@ void flush_thread_caches() {
 #endif
 }
 
-__thread uintptr_t s_stackLimit;
-__thread size_t s_stackSize;
+ATTRIBUTE_TLS uintptr_t s_stackLimit;
+ATTRIBUTE_TLS size_t s_stackSize;
 const size_t s_pageSize =  sysconf(_SC_PAGESIZE);
 
 static NEVER_INLINE uintptr_t get_stack_top() {
@@ -176,7 +176,7 @@ void flush_thread_stack() {
   }
 }
 
-int32_t __thread s_numaNode;
+int32_t ATTRIBUTE_TLS s_numaNode;
 
 #if !defined USE_JEMALLOC || !defined HAVE_NUMA
 void enable_numa(bool local) {}

--- a/hphp/util/alloc.h
+++ b/hphp/util/alloc.h
@@ -213,8 +213,8 @@ class ScopedMem {
   void* m_ptr;
 };
 
-extern __thread uintptr_t s_stackLimit;
-extern __thread size_t s_stackSize;
+extern ATTRIBUTE_TLS uintptr_t s_stackLimit;
+extern ATTRIBUTE_TLS size_t s_stackSize;
 void init_stack_limits(pthread_attr_t* attr);
 
 extern const size_t s_pageSize;
@@ -222,7 +222,7 @@ extern const size_t s_pageSize;
 /*
  * The numa node this thread is bound to
  */
-extern __thread int32_t s_numaNode;
+extern ATTRIBUTE_TLS int32_t s_numaNode;
 /*
  * enable the numa support in hhvm,
  * and determine whether threads should default to using

--- a/hphp/util/assertions.cpp
+++ b/hphp/util/assertions.cpp
@@ -29,7 +29,7 @@ namespace HPHP {
 
 static AssertFailLogger s_logger;
 
-__thread AssertDetailImpl* AssertDetailImpl::s_head = nullptr;
+ATTRIBUTE_TLS AssertDetailImpl* AssertDetailImpl::s_head = nullptr;
 
 ///////////////////////////////////////////////////////////////////////////////
 

--- a/hphp/util/assertions.h
+++ b/hphp/util/assertions.h
@@ -129,7 +129,7 @@ private:
   virtual std::string run() const = 0;
 
 private:
-  static __thread AssertDetailImpl* s_head;
+  static ATTRIBUTE_TLS AssertDetailImpl* s_head;
 
   const char* m_name;
   AssertDetailImpl* m_next{nullptr};

--- a/hphp/util/compatibility.cpp
+++ b/hphp/util/compatibility.cpp
@@ -107,7 +107,7 @@ static int gettime_helper(clockid_t which_clock, struct timespec *tp) {
 #endif
 }
 
-__thread int64_t s_extra_request_microseconds;
+ATTRIBUTE_TLS int64_t s_extra_request_microseconds;
 int gettime(clockid_t which_clock, struct timespec* tp) {
   auto ret = gettime_helper(which_clock, tp);
 #ifdef CLOCK_THREAD_CPUTIME_ID

--- a/hphp/util/compatibility.h
+++ b/hphp/util/compatibility.h
@@ -28,7 +28,7 @@ namespace HPHP {
 
 #define PHP_DIR_SEPARATOR '/'
 
-extern __thread int64_t s_extra_request_microseconds;
+extern ATTRIBUTE_TLS int64_t s_extra_request_microseconds;
 
 #if defined(__APPLE__) || defined(__FreeBSD__)
 char *strndup(const char* str, size_t len);

--- a/hphp/util/rank.cpp
+++ b/hphp/util/rank.cpp
@@ -26,8 +26,8 @@
 namespace HPHP {
 #ifdef DEBUG
 static const int kMaxLockDepth=256;
-static __thread Rank tl_rankStack[kMaxLockDepth];
-static __thread int tl_curRankDepth;
+static ATTRIBUTE_TLS Rank tl_rankStack[kMaxLockDepth];
+static ATTRIBUTE_TLS int tl_curRankDepth;
 
 Rank currentRank() {
   // Our current rank is the most recent ranked lock we've acquired.

--- a/hphp/util/ringbuffer.cpp
+++ b/hphp/util/ringbuffer.cpp
@@ -33,8 +33,8 @@ namespace Trace {
  * Thread-private ascii ringbuffer.
  */
 static const int kMaxRBBytes = 1 << 19; // 512KB
-__thread int  tl_rbPtr;
-__thread char* tl_ring_ptr;
+ATTRIBUTE_TLS int  tl_rbPtr;
+ATTRIBUTE_TLS char* tl_ring_ptr;
 
 const char* ringbufferName(RingBufferType t) {
   switch (t) {

--- a/hphp/util/test/tls-pod-bag.cpp
+++ b/hphp/util/test/tls-pod-bag.cpp
@@ -36,7 +36,7 @@ using Vec = TlsPodBag<Ty,std::allocator<Ty>>;
 //////////////////////////////////////////////////////////////////////
 
 TEST(TlsPodBag, Simple) {
-  static __thread Vec v = {};
+  static ATTRIBUTE_TLS Vec v = {};
   EXPECT_TRUE(v.empty());
 
   constexpr auto kCount = 15;
@@ -78,7 +78,7 @@ TEST(TlsPodBag, Simple) {
 }
 
 TEST(TlsPodBag, More) {
-  static __thread Vec v = {};
+  static ATTRIBUTE_TLS Vec v = {};
 
   constexpr auto kBase = 1024;
   constexpr auto kTop = 1024;

--- a/hphp/util/thread-local.h
+++ b/hphp/util/thread-local.h
@@ -310,10 +310,10 @@ public:
   }
 
 private:
-  static __thread T *s_singleton;
+  static ATTRIBUTE_TLS T *s_singleton;
   typedef typename std::aligned_storage<sizeof(T), sizeof(void*)>::type
           StorageType;
-  static __thread StorageType s_storage;
+  static ATTRIBUTE_TLS StorageType s_storage;
   static bool s_inited; // no-fast-TLS requires construction so be consistent
 };
 
@@ -331,8 +331,8 @@ T *ThreadLocalSingleton<T>::getCheck() {
   return s_singleton;
 }
 
-template<typename T> __thread T *ThreadLocalSingleton<T>::s_singleton;
-template<typename T> __thread typename ThreadLocalSingleton<T>::StorageType
+template<typename T> ATTRIBUTE_TLS T *ThreadLocalSingleton<T>::s_singleton;
+template<typename T> ATTRIBUTE_TLS typename ThreadLocalSingleton<T>::StorageType
                               ThreadLocalSingleton<T>::s_storage;
 
 
@@ -384,19 +384,19 @@ struct ThreadLocalProxy {
  */
 
 #define DECLARE_THREAD_LOCAL(T, f) \
-  __thread ThreadLocal<T> f
+  ATTRIBUTE_TLS ThreadLocal<T> f
 #define IMPLEMENT_THREAD_LOCAL(T, f) \
-  __thread HPHP::ThreadLocal<T> f
+  ATTRIBUTE_TLS HPHP::ThreadLocal<T> f
 
 #define DECLARE_THREAD_LOCAL_NO_CHECK(T, f) \
-  __thread ThreadLocalNoCheck<T> f
+  ATTRIBUTE_TLS ThreadLocalNoCheck<T> f
 #define IMPLEMENT_THREAD_LOCAL_NO_CHECK(T, f) \
-  __thread ThreadLocalNoCheck<T> f
+  ATTRIBUTE_TLS ThreadLocalNoCheck<T> f
 
 #define DECLARE_THREAD_LOCAL_PROXY(T, N, f) \
-  __thread ThreadLocalProxy<T, N> f
+  ATTRIBUTE_TLS ThreadLocalProxy<T, N> f
 #define IMPLEMENT_THREAD_LOCAL_PROXY(T, N, f) \
-  __thread ThreadLocalProxy<T, N> f
+  ATTRIBUTE_TLS ThreadLocalProxy<T, N> f
 
 #else /* USE_GCC_FAST_TLS */
 

--- a/hphp/util/trace.cpp
+++ b/hphp/util/trace.cpp
@@ -40,8 +40,8 @@ TRACE_SET_MOD(tprefix);
 namespace Trace {
 
 int levels[NumModules];
-__thread int tl_levels[NumModules];
-__thread int indentDepth = 0;
+ATTRIBUTE_TLS int tl_levels[NumModules];
+ATTRIBUTE_TLS int indentDepth = 0;
 
 static FILE* out;
 

--- a/hphp/util/trace.h
+++ b/hphp/util/trace.h
@@ -250,7 +250,7 @@ void ftraceRelease(Args&&... args) {
 void traceRingBufferRelease(const char* fmt, ...) ATTRIBUTE_PRINTF(1,2);
 
 extern int levels[NumModules];
-extern __thread int tl_levels[NumModules];
+extern ATTRIBUTE_TLS int tl_levels[NumModules];
 const char* moduleName(Module mod);
 inline bool moduleEnabledRelease(Module tm, int level = 1) {
   return levels[tm] + tl_levels[tm] >= level;
@@ -333,7 +333,7 @@ const bool enabled = true;
  * indentation. Create an Indent object on the stack to increase the nesting
  * level, then use ITRACE just as you would use FTRACE.
  */
-extern __thread int indentDepth;
+extern ATTRIBUTE_TLS int indentDepth;
 struct Indent {
   explicit Indent(int n = 2) : n(n) { indentDepth += n; }
   ~Indent()                         { indentDepth -= n; }


### PR DESCRIPTION
Because MSVC doesn't support `__thread`, and uses `__declspec(thread)` instead.

This modifies a lot of files, but each of the changes is small.

Depends: #5629