### PR TITLE
Make ATTRIBUTE_NORETURN usages MSVC compatible

### DIFF
--- a/hphp/runtime/base/builtin-functions.h
+++ b/hphp/runtime/base/builtin-functions.h
@@ -117,13 +117,13 @@ Variant o_invoke_failed(const char *cls, const char *meth,
 bool is_constructor_name(const char* func);
 void throw_instance_method_fatal(const char *name);
 
-void throw_iterator_not_valid() ATTRIBUTE_NORETURN;
-void throw_collection_modified() ATTRIBUTE_NORETURN;
-void throw_collection_property_exception() ATTRIBUTE_NORETURN;
-void throw_collection_compare_exception() ATTRIBUTE_NORETURN;
-void throw_param_is_not_container() ATTRIBUTE_NORETURN;
-void throw_cannot_modify_immutable_object(const char* className)
-  ATTRIBUTE_NORETURN;
+ATTRIBUTE_NORETURN void throw_iterator_not_valid();
+ATTRIBUTE_NORETURN void throw_collection_modified();
+ATTRIBUTE_NORETURN void throw_collection_property_exception();
+ATTRIBUTE_NORETURN void throw_collection_compare_exception();
+ATTRIBUTE_NORETURN void throw_param_is_not_container();
+ATTRIBUTE_NORETURN
+void throw_cannot_modify_immutable_object(const char* className);
 void check_collection_compare(ObjectData* obj);
 void check_collection_compare(ObjectData* obj1, ObjectData* obj2);
 void check_collection_cast_to_array();

--- a/hphp/runtime/base/enum-cache.h
+++ b/hphp/runtime/base/enum-cache.h
@@ -69,7 +69,7 @@ public:
   static void deleteValues(const Class* klass);
 
   // Helper that raises a PHP exception
-  static void failLookup(const Variant& msg) ATTRIBUTE_NORETURN;
+  ATTRIBUTE_NORETURN static void failLookup(const Variant& msg);
 
 private:
   // Class* to intptr_ti key helpers

--- a/hphp/runtime/base/exceptions.h
+++ b/hphp/runtime/base/exceptions.h
@@ -156,11 +156,11 @@ public:
  *
  * In newer code you'll generally want to use raise_error.
  */
-void throw_null_pointer_exception() ATTRIBUTE_NORETURN;
-void throw_invalid_object_type(const char* clsName) ATTRIBUTE_NORETURN;
-void throw_not_implemented(const char* feature) ATTRIBUTE_NORETURN;
-void throw_not_supported(const char* feature, const char* reason)
-  ATTRIBUTE_NORETURN;
+ATTRIBUTE_NORETURN void throw_null_pointer_exception();
+ATTRIBUTE_NORETURN void throw_invalid_object_type(const char* clsName);
+ATTRIBUTE_NORETURN void throw_not_implemented(const char* feature);
+ATTRIBUTE_NORETURN
+void throw_not_supported(const char* feature, const char* reason);
 
 //////////////////////////////////////////////////////////////////////
 

--- a/hphp/runtime/base/req-ptr.h
+++ b/hphp/runtime/base/req-ptr.h
@@ -274,14 +274,14 @@ inline auto deref(const P& p) -> decltype(P().get()) {
   return p.get();
 }
 
-extern void throw_null_pointer_exception() ATTRIBUTE_NORETURN;
-void throw_invalid_object_type(ResourceData* p) ATTRIBUTE_NORETURN;
-void throw_invalid_object_type(ObjectData* p) ATTRIBUTE_NORETURN;
-void throw_invalid_object_type(const Variant& p) ATTRIBUTE_NORETURN;
-void throw_invalid_object_type(const Resource& p) ATTRIBUTE_NORETURN;
-void throw_invalid_object_type(const Object& p) ATTRIBUTE_NORETURN;
+ATTRIBUTE_NORETURN extern void throw_null_pointer_exception();
+ATTRIBUTE_NORETURN void throw_invalid_object_type(ResourceData* p);
+ATTRIBUTE_NORETURN void throw_invalid_object_type(ObjectData* p);
+ATTRIBUTE_NORETURN void throw_invalid_object_type(const Variant& p);
+ATTRIBUTE_NORETURN void throw_invalid_object_type(const Resource& p);
+ATTRIBUTE_NORETURN void throw_invalid_object_type(const Object& p);
 template <typename T>
-void throw_invalid_object_type(const req::ptr<T>& p) ATTRIBUTE_NORETURN;
+ATTRIBUTE_NORETURN void throw_invalid_object_type(const req::ptr<T>& p);
 template <typename T>
 void throw_invalid_object_type(const req::ptr<T>& p) {
   throw_invalid_object_type(p.get());

--- a/hphp/runtime/base/runtime-error.h
+++ b/hphp/runtime/base/runtime-error.h
@@ -71,9 +71,9 @@ enum class ErrorMode {
   UPGRADEABLE_ERROR = WARNING | USER_WARNING | NOTICE | USER_NOTICE
 };
 
-void raise_error(const std::string&) ATTRIBUTE_NORETURN;
-void raise_error(const char*, ...) ATTRIBUTE_PRINTF(1, 2) ATTRIBUTE_NORETURN;
-void raise_error_without_first_frame(const std::string&) ATTRIBUTE_NORETURN;
+ATTRIBUTE_NORETURN void raise_error(const std::string&);
+ATTRIBUTE_NORETURN void raise_error(const char*, ...) ATTRIBUTE_PRINTF(1, 2);
+ATTRIBUTE_NORETURN void raise_error_without_first_frame(const std::string&);
 void raise_recoverable_error(const std::string &msg);
 void raise_recoverable_error(const char *fmt, ...) ATTRIBUTE_PRINTF(1, 2);
 void raise_recoverable_error_without_first_frame(const std::string &msg);

--- a/hphp/runtime/ext/asio/ext_await-all-wait-handle.cpp
+++ b/hphp/runtime/ext/asio/ext_await-all-wait-handle.cpp
@@ -52,25 +52,25 @@ void delete_AwaitAllWaitHandle(ObjectData* od, const Class*) {
 namespace {
   StaticString s_awaitAll("<await-all>");
 
-  NEVER_INLINE __attribute__((__noreturn__))
+  NEVER_INLINE ATTRIBUTE_NORETURN
   void failArray() {
     SystemLib::throwInvalidArgumentExceptionObject(
       "Expected dependencies to be an array");
   }
 
-  NEVER_INLINE __attribute__((__noreturn__))
+  NEVER_INLINE ATTRIBUTE_NORETURN
   void failMap() {
     SystemLib::throwInvalidArgumentExceptionObject(
       "Expected dependencies to be a Map");
   }
 
-  NEVER_INLINE __attribute__((__noreturn__))
+  NEVER_INLINE ATTRIBUTE_NORETURN
   void failVector() {
     SystemLib::throwInvalidArgumentExceptionObject(
       "Expected dependencies to be a Vector");
   }
 
-  NEVER_INLINE __attribute__((__noreturn__))
+  NEVER_INLINE ATTRIBUTE_NORETURN
   void failWaitHandle() {
     SystemLib::throwInvalidArgumentExceptionObject(
       "Expected dependencies to be a collection of WaitHandle instances");

--- a/hphp/runtime/ext/asio/ext_gen-array-wait-handle.cpp
+++ b/hphp/runtime/ext/asio/ext_gen-array-wait-handle.cpp
@@ -47,7 +47,7 @@ void c_GenArrayWaitHandle::ti_setoncreatecallback(const Variant& callback) {
   AsioSession::Get()->setOnGenArrayCreate(callback);
 }
 
-NEVER_INLINE __attribute__((__noreturn__))
+NEVER_INLINE ATTRIBUTE_NORETURN
 static void fail() {
   SystemLib::throwInvalidArgumentExceptionObject(
     "Expected dependencies to be an array of WaitHandle instances");

--- a/hphp/runtime/ext/asio/ext_waitable-wait-handle.h
+++ b/hphp/runtime/ext/asio/ext_waitable-wait-handle.h
@@ -66,8 +66,9 @@ class c_WaitableWaitHandle : public c_WaitHandle {
   void detectCycle(c_WaitableWaitHandle* child) const;
 
  private:
+  ATTRIBUTE_NORETURN
   void throwCycleException(c_WaitableWaitHandle* child) const
-    NEVER_INLINE ATTRIBUTE_NORETURN;
+    NEVER_INLINE;
 };
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/hphp/runtime/ext/collections/ext_collections-idl.cpp
+++ b/hphp/runtime/ext/collections/ext_collections-idl.cpp
@@ -65,8 +65,8 @@ const Cell container_as_cell(const Variant& container) {
 
 ///////////////////////////////////////////////////////////////////////////////
 
-static void throwIntOOB(int64_t key, bool isVector = false)
-  ATTRIBUTE_NORETURN;
+ATTRIBUTE_NORETURN
+static void throwIntOOB(int64_t key, bool isVector = false);
 
 void throwIntOOB(int64_t key, bool isVector /* = false */) {
   String msg(50, ReserveString);
@@ -82,7 +82,7 @@ void throwOOB(int64_t key) {
   throwIntOOB(key, true);
 }
 
-static void throwStrOOB(StringData* key) ATTRIBUTE_NORETURN;
+ATTRIBUTE_NORETURN static void throwStrOOB(StringData* key);
 
 void throwStrOOB(StringData* key) {
   const size_t maxDisplaySize = 100;

--- a/hphp/runtime/ext/collections/ext_collections-idl.h
+++ b/hphp/runtime/ext/collections/ext_collections-idl.h
@@ -84,7 +84,7 @@ using ExtCollectionObjectData = ExtObjectDataFlags<
   ObjectData::NoDestructor |
   ObjectData::HasClone>;
 
-void throwOOB(int64_t key) ATTRIBUTE_NORETURN;
+ATTRIBUTE_NORETURN void throwOOB(int64_t key);
 
 ///////////////////////////////////////////////////////////////////////////////
 // class BaseVector: encapsulates functionality that is common to both
@@ -459,7 +459,7 @@ class BaseVector : public ExtCollectionObjectData {
    */
   void mutateImpl();
 
-  static void throwBadKeyType() ATTRIBUTE_NORETURN;
+  ATTRIBUTE_NORETURN static void throwBadKeyType();
 
   // Fields
 #ifndef USE_LOWPTR
@@ -573,7 +573,7 @@ class c_Vector : public BaseVector {
   Object t_immutable();
   String t___tostring();
 
-  static void throwOOB(int64_t key) ATTRIBUTE_NORETURN;
+  ATTRIBUTE_NORETURN static void throwOOB(int64_t key);
 
   void sort(int sort_flags, bool ascending);
   bool usort(const Variant& cmp_function);
@@ -837,8 +837,8 @@ class HashCollection : public ExtCollectionObjectData {
     }
   }
 
-  void throwTooLarge() ATTRIBUTE_NORETURN;
-  void throwReserveTooLarge() ATTRIBUTE_NORETURN;
+  ATTRIBUTE_NORETURN void throwTooLarge();
+  ATTRIBUTE_NORETURN void throwReserveTooLarge();
   int32_t* warnUnbalanced(size_t n, int32_t* ei) const;
 
   /**
@@ -1240,8 +1240,8 @@ class HashCollection : public ExtCollectionObjectData {
  */
 class BaseMap : public HashCollection {
  protected:
-  static void throwOOB(int64_t key) ATTRIBUTE_NORETURN;
-  static void throwOOB(StringData* key) ATTRIBUTE_NORETURN;
+  ATTRIBUTE_NORETURN static void throwOOB(int64_t key);
+  ATTRIBUTE_NORETURN static void throwOOB(StringData* key);
 
  public:
   TypedValue* at(int64_t key) const;
@@ -1354,7 +1354,7 @@ class BaseMap : public HashCollection {
   ~BaseMap();
 
  public:
-  static void throwBadKeyType() ATTRIBUTE_NORETURN;
+  ATTRIBUTE_NORETURN static void throwBadKeyType();
 
  private:
   friend void collections::deepCopy(TypedValue*);
@@ -1670,9 +1670,9 @@ class BaseSet : public HashCollection {
   static Clone(ObjectData* obj);
 
   // Static methods
-  static void throwOOB(int64_t key) ATTRIBUTE_NORETURN;
-  static void throwOOB(StringData* key) ATTRIBUTE_NORETURN;
-  static void throwNoMutableIndexAccess() ATTRIBUTE_NORETURN;
+  ATTRIBUTE_NORETURN static void throwOOB(int64_t key);
+  ATTRIBUTE_NORETURN static void throwOOB(StringData* key);
+  ATTRIBUTE_NORETURN static void throwNoMutableIndexAccess();
 
   static Array ToArray(const ObjectData* obj);
   static bool ToBool(const ObjectData* obj);
@@ -1819,7 +1819,7 @@ class BaseSet : public HashCollection {
  private:
   // Helpers
 
-  static void throwBadValueType() ATTRIBUTE_NORETURN;
+  ATTRIBUTE_NORETURN static void throwBadValueType();
 
  private:
 
@@ -2009,7 +2009,7 @@ class c_Pair : public ExtObjectDataFlags<ObjectData::IsCollection|
   Object t_immutable();
   String t___tostring();
 
-  static void throwOOB(int64_t key) ATTRIBUTE_NORETURN;
+  ATTRIBUTE_NORETURN static void throwOOB(int64_t key);
 
   /**
    * Most methods that operate on Pairs can safely assume that all Pairs have
@@ -2086,7 +2086,7 @@ class c_Pair : public ExtObjectDataFlags<ObjectData::IsCollection|
   static constexpr uint32_t dataOffset() { return offsetof(c_Pair, elm0); }
 
  private:
-  static void throwBadKeyType() ATTRIBUTE_NORETURN;
+  ATTRIBUTE_NORETURN static void throwBadKeyType();
 
 #ifndef USE_LOWPTR
   // Add 4 bytes here to keep m_size aligned the same way as in BaseVector and

--- a/hphp/runtime/ext/imagick/ext_imagick.h
+++ b/hphp/runtime/ext/imagick/ext_imagick.h
@@ -99,8 +99,9 @@ IMAGICK_DEFINE_CLASS(ImagickPixelIterator)
 #undef IMAGICK_DEFINE_CLASS
 
 template<typename T>
+ATTRIBUTE_NORETURN 
 void imagickThrow(const char* fmt, ...)
-  ATTRIBUTE_PRINTF(1, 2) ATTRIBUTE_NORETURN;
+  ATTRIBUTE_PRINTF(1, 2);
 
 template<typename T>
 void imagickThrow(const char* fmt, ...) {

--- a/hphp/runtime/ext/thrift/compact.cpp
+++ b/hphp/runtime/ext/thrift/compact.cpp
@@ -43,7 +43,7 @@ enum TError {
   ERR_BAD_VERSION = 4
 };
 
-static void thrift_error(const String& what, TError why) ATTRIBUTE_NORETURN;
+ATTRIBUTE_NORETURN static void thrift_error(const String& what, TError why);
 static void thrift_error(const String& what, TError why) {
   throw create_object(s_TProtocolException, make_packed_array(what, why));
 }

--- a/hphp/runtime/vm/jit/code-gen-x64.cpp
+++ b/hphp/runtime/vm/jit/code-gen-x64.cpp
@@ -100,9 +100,10 @@ using namespace jit::reg;
 
 ///////////////////////////////////////////////////////////////////////////////
 
+ATTRIBUTE_NORETURN
 void cgPunt(const char* file, int line, const char* func, uint32_t bcOff,
             const Func* vmFunc, bool resumed,
-            TransID profTransId) ATTRIBUTE_NORETURN;
+            TransID profTransId);
 
 void cgPunt(const char* file, int line, const char* func, uint32_t bcOff,
             const Func* vmFunc, bool resumed, TransID profTransId) {

--- a/hphp/runtime/vm/jit/target-cache.cpp
+++ b/hphp/runtime/vm/jit/target-cache.cpp
@@ -149,7 +149,7 @@ namespace MethodCache {
 namespace {
 ///////////////////////////////////////////////////////////////////////////////
 
-NEVER_INLINE __attribute__((__noreturn__))
+NEVER_INLINE ATTRIBUTE_NORETURN
 void raiseFatal(ActRec* ar, Class* cls, StringData* name, Class* ctx) {
   try {
     g_context->lookupMethodCtx(

--- a/hphp/runtime/vm/jit/translator-runtime.h
+++ b/hphp/runtime/vm/jit/translator-runtime.h
@@ -223,7 +223,7 @@ void registerLiveObj(ObjectData* obj);
 /*
  * Throw a VMSwitchMode exception.
  */
-void throwSwitchMode() ATTRIBUTE_NORETURN;
+ATTRIBUTE_NORETURN void throwSwitchMode();
 
 namespace MInstrHelpers {
 StringData* stringGetI(StringData*, uint64_t);

--- a/hphp/runtime/vm/member-operations.h
+++ b/hphp/runtime/vm/member-operations.h
@@ -145,9 +145,9 @@ void objOffsetSet(ObjectData* base, const Variant& offset, TypedValue* val,
 void objOffsetAppend(ObjectData* base, TypedValue* val, bool validate=true);
 void objOffsetUnset(ObjectData* base, const Variant& offset);
 
-void throw_cannot_use_newelem_for_lval_read() ATTRIBUTE_NORETURN;
+ATTRIBUTE_NORETURN void throw_cannot_use_newelem_for_lval_read();
 
-void unknownBaseType(const TypedValue*) ATTRIBUTE_NORETURN;
+ATTRIBUTE_NORETURN void unknownBaseType(const TypedValue*);
 
 // Post: base is a Cell*
 ALWAYS_INLINE void opPre(TypedValue*& base, DataType& type) {

--- a/hphp/system/systemlib.h
+++ b/hphp/system/systemlib.h
@@ -102,24 +102,25 @@ Object AllocLazyKVZipIterableObject(const Variant& mp);
 Object AllocLazyIterableViewObject(const Variant& iterable);
 Object AllocLazyKeyedIterableViewObject(const Variant& iterable);
 
-void throwExceptionObject(const Variant& message) ATTRIBUTE_NORETURN;
-void throwBadMethodCallExceptionObject(const Variant& message)
-  ATTRIBUTE_NORETURN;
-void throwInvalidArgumentExceptionObject(const Variant& message)
-  ATTRIBUTE_NORETURN;
-void throwRuntimeExceptionObject(const Variant& message) ATTRIBUTE_NORETURN;
-void throwOutOfBoundsExceptionObject(const Variant& message) ATTRIBUTE_NORETURN;
-void throwInvalidOperationExceptionObject(const Variant& message)
-  ATTRIBUTE_NORETURN;
+ATTRIBUTE_NORETURN void throwExceptionObject(const Variant& message);
+ATTRIBUTE_NORETURN
+void throwBadMethodCallExceptionObject(const Variant& message);
+ATTRIBUTE_NORETURN
+void throwInvalidArgumentExceptionObject(const Variant& message);
+ATTRIBUTE_NORETURN void throwRuntimeExceptionObject(const Variant& message);
+ATTRIBUTE_NORETURN void throwOutOfBoundsExceptionObject(const Variant& message);
+ATTRIBUTE_NORETURN
+void throwInvalidOperationExceptionObject(const Variant& message);
+ATTRIBUTE_NORETURN
 void throwDOMExceptionObject(const Variant& message,
-                             const Variant& code) ATTRIBUTE_NORETURN;
+                             const Variant& code);
+ATTRIBUTE_NORETURN
 void throwSoapFaultObject(const Variant& code,
                           const Variant& message,
                           const Variant& actor = null_variant,
                           const Variant& detail = null_variant,
                           const Variant& name = null_variant,
-                          const Variant& header = null_variant)
-  ATTRIBUTE_NORETURN;
+                          const Variant& header = null_variant);
 
 
 /**

--- a/hphp/tools/tc-print/tc-print.h
+++ b/hphp/tools/tc-print/tc-print.h
@@ -22,7 +22,7 @@
 #include "hphp/tools/tc-print/offline-trans-data.h"
 #include "hphp/tools/tc-print/repo-wrapper.h"
 
-void error(const std::string& msg) ATTRIBUTE_NORETURN;
+ATTRIBUTE_NORETURN void error(const std::string& msg);
 
 extern HPHP::jit::RepoWrapper* g_repo;
 extern HPHP::jit::OfflineTransData* g_transData;

--- a/hphp/util/assertions.h
+++ b/hphp/util/assertions.h
@@ -66,17 +66,19 @@ namespace HPHP {
  *
  * These are intended for use primarily by the assert macros below.
  */
+ATTRIBUTE_NORETURN
 void assert_fail(const char* e,
                  const char* file,
                  unsigned int line,
                  const char* func,
-                 const std::string& msg) __attribute__((__noreturn__));
+                 const std::string& msg);
 
+ATTRIBUTE_NORETURN
 void assert_fail_no_log(const char* e,
                         const char* file,
                         unsigned int line,
                         const char* func,
-                        const std::string& msg) __attribute__((__noreturn__));
+                        const std::string& msg);
 
 void assert_log_failure(const char* title, const std::string& msg);
 

--- a/hphp/util/assertions.h
+++ b/hphp/util/assertions.h
@@ -28,6 +28,8 @@
 #include <folly/Format.h>
 #include <folly/Preprocessor.h>
 
+#include "hphp/util/portability.h"
+
 ///////////////////////////////////////////////////////////////////////////////
 
 #define IMPLIES(a, b) (!(a) || (b))

--- a/hphp/util/safe-cast.h
+++ b/hphp/util/safe-cast.h
@@ -22,6 +22,7 @@
 #include <folly/Conv.h>
 
 #include "hphp/util/compilation-flags.h"
+#include "hphp/util/portability.h"
 
 namespace HPHP {
 

--- a/hphp/util/safe-cast.h
+++ b/hphp/util/safe-cast.h
@@ -27,8 +27,8 @@ namespace HPHP {
 
 //////////////////////////////////////////////////////////////////////
 
-void safe_cast_failure(const std::string&, const char*, const char*)
-  __attribute__((__noreturn__));
+ATTRIBUTE_NORETURN
+void safe_cast_failure(const std::string&, const char*, const char*);
 
 //////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
MSVC only accepts `__declspec` attributes before the name of the function. GCC accepts the attributes both before and after the name. This moves all uses of `ATTRIBUTE_NORETURN` to before the function definition, so that they are compatible with MSVC.