### PR TITLE
[MSVC] Use php_crypt_r on MSVC

### DIFF
--- a/hphp/zend/CMakeLists.txt
+++ b/hphp/zend/CMakeLists.txt
@@ -9,7 +9,21 @@ list(APPEND CXX_SOURCES ${files})
 set(HEADER_SOURCES)
 auto_sources(files "*.h" "RECURSE")
 list(APPEND HEADER_SOURCES ${files})
-HHVM_PUBLIC_HEADERS(zend ${files})
+
+if (NOT MSVC)
+  list(REMOVE_ITEM C_SOURCES
+    ${CMAKE_CURRENT_SOURCE_DIR}/crypt-freesec.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/crypt-sha256.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/crypt-sha512.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/php-crypt_r.c
+  )
+  list(REMOVE_ITEM HEADER_SOURCES
+    ${CMAKE_CURRENT_SOURCE_DIR}/crypt-freesec.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/php-crypt_r.h
+  )
+endif()
+
+HHVM_PUBLIC_HEADERS(zend ${HEADER_SOURCES})
 
 add_library(hphp_zend STATIC ${C_SOURCES} ${CXX_SOURCES} ${HEADER_SOURCES})
 auto_source_group("hphp_zend" "${CMAKE_CURRENT_SOURCE_DIR}"

--- a/hphp/zend/crypt-freesec.c
+++ b/hphp/zend/crypt-freesec.c
@@ -1,0 +1,723 @@
+/*
+  $Id$
+*/
+/*
+ * This version is derived from the original implementation of FreeSec
+ * (release 1.1) by David Burren.  I've reviewed the changes made in
+ * OpenBSD (as of 2.7) and modified the original code in a similar way
+ * where applicable.  I've also made it reentrant and made a number of
+ * other changes.
+ * - Solar Designer <solar at openwall.com>
+ */
+
+/*
+ * FreeSec: libcrypt for NetBSD
+ *
+ * Copyright (c) 1994 David Burren
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the author nor the names of other contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ *  $Owl: Owl/packages/glibc/crypt_freesec.c,v 1.4 2005/11/16 13:08:32 solar Exp $
+ *  $Id$
+ *
+ * This is an original implementation of the DES and the crypt(3) interfaces
+ * by David Burren <davidb at werj.com.au>.
+ *
+ * An excellent reference on the underlying algorithm (and related
+ * algorithms) is:
+ *
+ *  B. Schneier, Applied Cryptography: protocols, algorithms,
+ *  and source code in C, John Wiley & Sons, 1994.
+ *
+ * Note that in that book's description of DES the lookups for the initial,
+ * pbox, and final permutations are inverted (this has been brought to the
+ * attention of the author).  A list of errata for this book has been
+ * posted to the sci.crypt newsgroup by the author and is available for FTP.
+ *
+ * ARCHITECTURE ASSUMPTIONS:
+ *  This code used to have some nasty ones, but these have been removed
+ *  by now.  The code requires a 32-bit integer type, though.
+ */
+
+#include <sys/types.h>
+#include <string.h>
+
+#include "crypt-freesec.h"
+
+#define _PASSWORD_EFMT1 '_'
+
+static u_char  IP[64] = {
+  58, 50, 42, 34, 26, 18, 10,  2, 60, 52, 44, 36, 28, 20, 12,  4,
+  62, 54, 46, 38, 30, 22, 14,  6, 64, 56, 48, 40, 32, 24, 16,  8,
+  57, 49, 41, 33, 25, 17,  9,  1, 59, 51, 43, 35, 27, 19, 11,  3,
+  61, 53, 45, 37, 29, 21, 13,  5, 63, 55, 47, 39, 31, 23, 15,  7
+};
+
+static u_char  key_perm[56] = {
+  57, 49, 41, 33, 25, 17,  9,  1, 58, 50, 42, 34, 26, 18,
+  10,  2, 59, 51, 43, 35, 27, 19, 11,  3, 60, 52, 44, 36,
+  63, 55, 47, 39, 31, 23, 15,  7, 62, 54, 46, 38, 30, 22,
+  14,  6, 61, 53, 45, 37, 29, 21, 13,  5, 28, 20, 12,  4
+};
+
+static u_char  key_shifts[16] = {
+  1, 1, 2, 2, 2, 2, 2, 2, 1, 2, 2, 2, 2, 2, 2, 1
+};
+
+static u_char  comp_perm[48] = {
+  14, 17, 11, 24,  1,  5,  3, 28, 15,  6, 21, 10,
+  23, 19, 12,  4, 26,  8, 16,  7, 27, 20, 13,  2,
+  41, 52, 31, 37, 47, 55, 30, 40, 51, 45, 33, 48,
+  44, 49, 39, 56, 34, 53, 46, 42, 50, 36, 29, 32
+};
+
+/*
+ *  No E box is used, as it's replaced by some ANDs, shifts, and ORs.
+ */
+
+static u_char  sbox[8][64] = {
+  {
+    14,  4, 13,  1,  2, 15, 11,  8,  3, 10,  6, 12,  5,  9,  0,  7,
+     0, 15,  7,  4, 14,  2, 13,  1, 10,  6, 12, 11,  9,  5,  3,  8,
+     4,  1, 14,  8, 13,  6,  2, 11, 15, 12,  9,  7,  3, 10,  5,  0,
+    15, 12,  8,  2,  4,  9,  1,  7,  5, 11,  3, 14, 10,  0,  6, 13
+  },
+  {
+    15,  1,  8, 14,  6, 11,  3,  4,  9,  7,  2, 13, 12,  0,  5, 10,
+     3, 13,  4,  7, 15,  2,  8, 14, 12,  0,  1, 10,  6,  9, 11,  5,
+     0, 14,  7, 11, 10,  4, 13,  1,  5,  8, 12,  6,  9,  3,  2, 15,
+    13,  8, 10,  1,  3, 15,  4,  2, 11,  6,  7, 12,  0,  5, 14,  9
+  },
+  {
+    10,  0,  9, 14,  6,  3, 15,  5,  1, 13, 12,  7, 11,  4,  2,  8,
+    13,  7,  0,  9,  3,  4,  6, 10,  2,  8,  5, 14, 12, 11, 15,  1,
+    13,  6,  4,  9,  8, 15,  3,  0, 11,  1,  2, 12,  5, 10, 14,  7,
+     1, 10, 13,  0,  6,  9,  8,  7,  4, 15, 14,  3, 11,  5,  2, 12
+  },
+  {
+     7, 13, 14,  3,  0,  6,  9, 10,  1,  2,  8,  5, 11, 12,  4, 15,
+    13,  8, 11,  5,  6, 15,  0,  3,  4,  7,  2, 12,  1, 10, 14,  9,
+    10,  6,  9,  0, 12, 11,  7, 13, 15,  1,  3, 14,  5,  2,  8,  4,
+     3, 15,  0,  6, 10,  1, 13,  8,  9,  4,  5, 11, 12,  7,  2, 14
+  },
+  {
+     2, 12,  4,  1,  7, 10, 11,  6,  8,  5,  3, 15, 13,  0, 14,  9,
+    14, 11,  2, 12,  4,  7, 13,  1,  5,  0, 15, 10,  3,  9,  8,  6,
+     4,  2,  1, 11, 10, 13,  7,  8, 15,  9, 12,  5,  6,  3,  0, 14,
+    11,  8, 12,  7,  1, 14,  2, 13,  6, 15,  0,  9, 10,  4,  5,  3
+  },
+  {
+    12,  1, 10, 15,  9,  2,  6,  8,  0, 13,  3,  4, 14,  7,  5, 11,
+    10, 15,  4,  2,  7, 12,  9,  5,  6,  1, 13, 14,  0, 11,  3,  8,
+     9, 14, 15,  5,  2,  8, 12,  3,  7,  0,  4, 10,  1, 13, 11,  6,
+     4,  3,  2, 12,  9,  5, 15, 10, 11, 14,  1,  7,  6,  0,  8, 13
+  },
+  {
+     4, 11,  2, 14, 15,  0,  8, 13,  3, 12,  9,  7,  5, 10,  6,  1,
+    13,  0, 11,  7,  4,  9,  1, 10, 14,  3,  5, 12,  2, 15,  8,  6,
+     1,  4, 11, 13, 12,  3,  7, 14, 10, 15,  6,  8,  0,  5,  9,  2,
+     6, 11, 13,  8,  1,  4, 10,  7,  9,  5,  0, 15, 14,  2,  3, 12
+  },
+  {
+    13,  2,  8,  4,  6, 15, 11,  1, 10,  9,  3, 14,  5,  0, 12,  7,
+     1, 15, 13,  8, 10,  3,  7,  4, 12,  5,  6, 11,  0, 14,  9,  2,
+     7, 11,  4,  1,  9, 12, 14,  2,  0,  6, 10, 13, 15,  3,  5,  8,
+     2,  1, 14,  7,  4, 10,  8, 13, 15, 12,  9,  0,  3,  5,  6, 11
+  }
+};
+
+static u_char  pbox[32] = {
+  16,  7, 20, 21, 29, 12, 28, 17,  1, 15, 23, 26,  5, 18, 31, 10,
+   2,  8, 24, 14, 32, 27,  3,  9, 19, 13, 30,  6, 22, 11,  4, 25
+};
+
+static uint32_t bits32[32] =
+{
+  0x80000000, 0x40000000, 0x20000000, 0x10000000,
+  0x08000000, 0x04000000, 0x02000000, 0x01000000,
+  0x00800000, 0x00400000, 0x00200000, 0x00100000,
+  0x00080000, 0x00040000, 0x00020000, 0x00010000,
+  0x00008000, 0x00004000, 0x00002000, 0x00001000,
+  0x00000800, 0x00000400, 0x00000200, 0x00000100,
+  0x00000080, 0x00000040, 0x00000020, 0x00000010,
+  0x00000008, 0x00000004, 0x00000002, 0x00000001
+};
+
+static u_char  bits8[8] = { 0x80, 0x40, 0x20, 0x10, 0x08, 0x04, 0x02, 0x01 };
+
+static unsigned char  ascii64[] =
+   "./0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+/*    0000000000111111111122222222223333333333444444444455555555556666 */
+/*    0123456789012345678901234567890123456789012345678901234567890123 */
+
+static u_char m_sbox[4][4096];
+static uint32_t psbox[4][256];
+static uint32_t ip_maskl[8][256], ip_maskr[8][256];
+static uint32_t fp_maskl[8][256], fp_maskr[8][256];
+static uint32_t key_perm_maskl[8][128], key_perm_maskr[8][128];
+static uint32_t comp_maskl[8][128], comp_maskr[8][128];
+
+static inline int
+ascii_to_bin(char ch)
+{
+  signed char sch = ch;
+  int retval;
+
+  retval = sch - '.';
+  if (sch >= 'A') {
+    retval = sch - ('A' - 12);
+    if (sch >= 'a')
+      retval = sch - ('a' - 38);
+  }
+  retval &= 0x3f;
+
+  return(retval);
+}
+
+/*
+ * When we choose to "support" invalid salts, nevertheless disallow those
+ * containing characters that would violate the passwd file format.
+ */
+static inline int
+ascii_is_unsafe(char ch)
+{
+  return !ch || ch == '\n' || ch == ':';
+}
+
+void
+_crypt_extended_init(void)
+{
+  int i, j, b, k, inbit, obit;
+  uint32_t *p, *il, *ir, *fl, *fr;
+  uint32_t *bits28, *bits24;
+  u_char inv_key_perm[64];
+  u_char u_key_perm[56];
+  u_char inv_comp_perm[56];
+  u_char init_perm[64], final_perm[64];
+  u_char u_sbox[8][64];
+  u_char un_pbox[32];
+
+  bits24 = (bits28 = bits32 + 4) + 4;
+
+  /*
+   * Invert the S-boxes, reordering the input bits.
+   */
+  for (i = 0; i < 8; i++)
+    for (j = 0; j < 64; j++) {
+      b = (j & 0x20) | ((j & 1) << 4) | ((j >> 1) & 0xf);
+      u_sbox[i][j] = sbox[i][b];
+    }
+
+  /*
+   * Convert the inverted S-boxes into 4 arrays of 8 bits.
+   * Each will handle 12 bits of the S-box input.
+   */
+  for (b = 0; b < 4; b++)
+    for (i = 0; i < 64; i++)
+      for (j = 0; j < 64; j++)
+        m_sbox[b][(i << 6) | j] =
+          (u_sbox[(b << 1)][i] << 4) |
+          u_sbox[(b << 1) + 1][j];
+
+  /*
+   * Set up the initial & final permutations into a useful form, and
+   * initialise the inverted key permutation.
+   */
+  for (i = 0; i < 64; i++) {
+    init_perm[final_perm[i] = IP[i] - 1] = i;
+    inv_key_perm[i] = 255;
+  }
+
+  /*
+   * Invert the key permutation and initialise the inverted key
+   * compression permutation.
+   */
+  for (i = 0; i < 56; i++) {
+    u_key_perm[i] = key_perm[i] - 1;
+    inv_key_perm[key_perm[i] - 1] = i;
+    inv_comp_perm[i] = 255;
+  }
+
+  /*
+   * Invert the key compression permutation.
+   */
+  for (i = 0; i < 48; i++) {
+    inv_comp_perm[comp_perm[i] - 1] = i;
+  }
+
+  /*
+   * Set up the OR-mask arrays for the initial and final permutations,
+   * and for the key initial and compression permutations.
+   */
+  for (k = 0; k < 8; k++) {
+    for (i = 0; i < 256; i++) {
+      *(il = &ip_maskl[k][i]) = 0;
+      *(ir = &ip_maskr[k][i]) = 0;
+      *(fl = &fp_maskl[k][i]) = 0;
+      *(fr = &fp_maskr[k][i]) = 0;
+      for (j = 0; j < 8; j++) {
+        inbit = 8 * k + j;
+        if (i & bits8[j]) {
+          if ((obit = init_perm[inbit]) < 32)
+            *il |= bits32[obit];
+          else
+            *ir |= bits32[obit-32];
+          if ((obit = final_perm[inbit]) < 32)
+            *fl |= bits32[obit];
+          else
+            *fr |= bits32[obit - 32];
+        }
+      }
+    }
+    for (i = 0; i < 128; i++) {
+      *(il = &key_perm_maskl[k][i]) = 0;
+      *(ir = &key_perm_maskr[k][i]) = 0;
+      for (j = 0; j < 7; j++) {
+        inbit = 8 * k + j;
+        if (i & bits8[j + 1]) {
+          if ((obit = inv_key_perm[inbit]) == 255)
+            continue;
+          if (obit < 28)
+            *il |= bits28[obit];
+          else
+            *ir |= bits28[obit - 28];
+        }
+      }
+      *(il = &comp_maskl[k][i]) = 0;
+      *(ir = &comp_maskr[k][i]) = 0;
+      for (j = 0; j < 7; j++) {
+        inbit = 7 * k + j;
+        if (i & bits8[j + 1]) {
+          if ((obit=inv_comp_perm[inbit]) == 255)
+            continue;
+          if (obit < 24)
+            *il |= bits24[obit];
+          else
+            *ir |= bits24[obit - 24];
+        }
+      }
+    }
+  }
+
+  /*
+   * Invert the P-box permutation, and convert into OR-masks for
+   * handling the output of the S-box arrays setup above.
+   */
+  for (i = 0; i < 32; i++)
+    un_pbox[pbox[i] - 1] = i;
+
+  for (b = 0; b < 4; b++)
+    for (i = 0; i < 256; i++) {
+      *(p = &psbox[b][i]) = 0;
+      for (j = 0; j < 8; j++) {
+        if (i & bits8[j])
+          *p |= bits32[un_pbox[8 * b + j]];
+      }
+    }
+}
+
+static void
+des_init_local(struct php_crypt_extended_data *data)
+{
+  data->old_rawkey0 = data->old_rawkey1 = 0;
+  data->saltbits = 0;
+  data->old_salt = 0;
+
+  data->initialized = 1;
+}
+
+static void
+setup_salt(uint32_t salt, struct php_crypt_extended_data *data)
+{
+  uint32_t  obit, saltbit, saltbits;
+  int  i;
+
+  if (salt == data->old_salt)
+    return;
+  data->old_salt = salt;
+
+  saltbits = 0;
+  saltbit = 1;
+  obit = 0x800000;
+  for (i = 0; i < 24; i++) {
+    if (salt & saltbit)
+      saltbits |= obit;
+    saltbit <<= 1;
+    obit >>= 1;
+  }
+  data->saltbits = saltbits;
+}
+
+static int
+des_setkey(const char *key, struct php_crypt_extended_data *data)
+{
+  uint32_t  k0, k1, rawkey0, rawkey1;
+  int  shifts, round;
+
+  rawkey0 =
+    (uint32_t)(u_char)key[3] |
+    ((uint32_t)(u_char)key[2] << 8) |
+    ((uint32_t)(u_char)key[1] << 16) |
+    ((uint32_t)(u_char)key[0] << 24);
+  rawkey1 =
+    (uint32_t)(u_char)key[7] |
+    ((uint32_t)(u_char)key[6] << 8) |
+    ((uint32_t)(u_char)key[5] << 16) |
+    ((uint32_t)(u_char)key[4] << 24);
+
+  if ((rawkey0 | rawkey1)
+      && rawkey0 == data->old_rawkey0
+      && rawkey1 == data->old_rawkey1) {
+    /*
+     * Already setup for this key.
+     * This optimisation fails on a zero key (which is weak and
+     * has bad parity anyway) in order to simplify the starting
+     * conditions.
+     */
+    return(0);
+  }
+  data->old_rawkey0 = rawkey0;
+  data->old_rawkey1 = rawkey1;
+
+  /*
+   *  Do key permutation and split into two 28-bit subkeys.
+   */
+  k0 = key_perm_maskl[0][rawkey0 >> 25]
+     | key_perm_maskl[1][(rawkey0 >> 17) & 0x7f]
+     | key_perm_maskl[2][(rawkey0 >> 9) & 0x7f]
+     | key_perm_maskl[3][(rawkey0 >> 1) & 0x7f]
+     | key_perm_maskl[4][rawkey1 >> 25]
+     | key_perm_maskl[5][(rawkey1 >> 17) & 0x7f]
+     | key_perm_maskl[6][(rawkey1 >> 9) & 0x7f]
+     | key_perm_maskl[7][(rawkey1 >> 1) & 0x7f];
+  k1 = key_perm_maskr[0][rawkey0 >> 25]
+     | key_perm_maskr[1][(rawkey0 >> 17) & 0x7f]
+     | key_perm_maskr[2][(rawkey0 >> 9) & 0x7f]
+     | key_perm_maskr[3][(rawkey0 >> 1) & 0x7f]
+     | key_perm_maskr[4][rawkey1 >> 25]
+     | key_perm_maskr[5][(rawkey1 >> 17) & 0x7f]
+     | key_perm_maskr[6][(rawkey1 >> 9) & 0x7f]
+     | key_perm_maskr[7][(rawkey1 >> 1) & 0x7f];
+  /*
+   *  Rotate subkeys and do compression permutation.
+   */
+  shifts = 0;
+  for (round = 0; round < 16; round++) {
+    uint32_t  t0, t1;
+
+    shifts += key_shifts[round];
+
+    t0 = (k0 << shifts) | (k0 >> (28 - shifts));
+    t1 = (k1 << shifts) | (k1 >> (28 - shifts));
+
+    data->de_keysl[15 - round] =
+    data->en_keysl[round] = comp_maskl[0][(t0 >> 21) & 0x7f]
+        | comp_maskl[1][(t0 >> 14) & 0x7f]
+        | comp_maskl[2][(t0 >> 7) & 0x7f]
+        | comp_maskl[3][t0 & 0x7f]
+        | comp_maskl[4][(t1 >> 21) & 0x7f]
+        | comp_maskl[5][(t1 >> 14) & 0x7f]
+        | comp_maskl[6][(t1 >> 7) & 0x7f]
+        | comp_maskl[7][t1 & 0x7f];
+
+    data->de_keysr[15 - round] =
+    data->en_keysr[round] = comp_maskr[0][(t0 >> 21) & 0x7f]
+        | comp_maskr[1][(t0 >> 14) & 0x7f]
+        | comp_maskr[2][(t0 >> 7) & 0x7f]
+        | comp_maskr[3][t0 & 0x7f]
+        | comp_maskr[4][(t1 >> 21) & 0x7f]
+        | comp_maskr[5][(t1 >> 14) & 0x7f]
+        | comp_maskr[6][(t1 >> 7) & 0x7f]
+        | comp_maskr[7][t1 & 0x7f];
+  }
+  return(0);
+}
+
+static int
+do_des(uint32_t l_in, uint32_t r_in, uint32_t *l_out, uint32_t *r_out,
+  int count, struct php_crypt_extended_data *data)
+{
+  /*
+   *  l_in, r_in, l_out, and r_out are in pseudo-"big-endian" format.
+   */
+  uint32_t  l, r, *kl, *kr, *kl1, *kr1;
+  uint32_t  f, r48l, r48r, saltbits;
+  int  round;
+
+  if (count == 0) {
+    return(1);
+  } else if (count > 0) {
+    /*
+     * Encrypting
+     */
+    kl1 = data->en_keysl;
+    kr1 = data->en_keysr;
+  } else {
+    /*
+     * Decrypting
+     */
+    count = -count;
+    kl1 = data->de_keysl;
+    kr1 = data->de_keysr;
+  }
+
+  /*
+   *  Do initial permutation (IP).
+   */
+  l = ip_maskl[0][l_in >> 24]
+    | ip_maskl[1][(l_in >> 16) & 0xff]
+    | ip_maskl[2][(l_in >> 8) & 0xff]
+    | ip_maskl[3][l_in & 0xff]
+    | ip_maskl[4][r_in >> 24]
+    | ip_maskl[5][(r_in >> 16) & 0xff]
+    | ip_maskl[6][(r_in >> 8) & 0xff]
+    | ip_maskl[7][r_in & 0xff];
+  r = ip_maskr[0][l_in >> 24]
+    | ip_maskr[1][(l_in >> 16) & 0xff]
+    | ip_maskr[2][(l_in >> 8) & 0xff]
+    | ip_maskr[3][l_in & 0xff]
+    | ip_maskr[4][r_in >> 24]
+    | ip_maskr[5][(r_in >> 16) & 0xff]
+    | ip_maskr[6][(r_in >> 8) & 0xff]
+    | ip_maskr[7][r_in & 0xff];
+
+  saltbits = data->saltbits;
+  while (count--) {
+    /*
+     * Do each round.
+     */
+    kl = kl1;
+    kr = kr1;
+    round = 16;
+    while (round--) {
+      /*
+       * Expand R to 48 bits (simulate the E-box).
+       */
+      r48l  = ((r & 0x00000001) << 23)
+        | ((r & 0xf8000000) >> 9)
+        | ((r & 0x1f800000) >> 11)
+        | ((r & 0x01f80000) >> 13)
+        | ((r & 0x001f8000) >> 15);
+
+      r48r  = ((r & 0x0001f800) << 7)
+        | ((r & 0x00001f80) << 5)
+        | ((r & 0x000001f8) << 3)
+        | ((r & 0x0000001f) << 1)
+        | ((r & 0x80000000) >> 31);
+      /*
+       * Do salting for crypt() and friends, and
+       * XOR with the permuted key.
+       */
+      f = (r48l ^ r48r) & saltbits;
+      r48l ^= f ^ *kl++;
+      r48r ^= f ^ *kr++;
+      /*
+       * Do sbox lookups (which shrink it back to 32 bits)
+       * and do the pbox permutation at the same time.
+       */
+      f = psbox[0][m_sbox[0][r48l >> 12]]
+        | psbox[1][m_sbox[1][r48l & 0xfff]]
+        | psbox[2][m_sbox[2][r48r >> 12]]
+        | psbox[3][m_sbox[3][r48r & 0xfff]];
+      /*
+       * Now that we've permuted things, complete f().
+       */
+      f ^= l;
+      l = r;
+      r = f;
+    }
+    r = l;
+    l = f;
+  }
+  /*
+   * Do final permutation (inverse of IP).
+   */
+  *l_out  = fp_maskl[0][l >> 24]
+    | fp_maskl[1][(l >> 16) & 0xff]
+    | fp_maskl[2][(l >> 8) & 0xff]
+    | fp_maskl[3][l & 0xff]
+    | fp_maskl[4][r >> 24]
+    | fp_maskl[5][(r >> 16) & 0xff]
+    | fp_maskl[6][(r >> 8) & 0xff]
+    | fp_maskl[7][r & 0xff];
+  *r_out  = fp_maskr[0][l >> 24]
+    | fp_maskr[1][(l >> 16) & 0xff]
+    | fp_maskr[2][(l >> 8) & 0xff]
+    | fp_maskr[3][l & 0xff]
+    | fp_maskr[4][r >> 24]
+    | fp_maskr[5][(r >> 16) & 0xff]
+    | fp_maskr[6][(r >> 8) & 0xff]
+    | fp_maskr[7][r & 0xff];
+  return(0);
+}
+
+static int
+des_cipher(const char *in, char *out, uint32_t salt, int count,
+  struct php_crypt_extended_data *data)
+{
+  uint32_t  l_out, r_out, rawl, rawr;
+  int  retval;
+
+  setup_salt(salt, data);
+
+  rawl =
+    (uint32_t)(u_char)in[3] |
+    ((uint32_t)(u_char)in[2] << 8) |
+    ((uint32_t)(u_char)in[1] << 16) |
+    ((uint32_t)(u_char)in[0] << 24);
+  rawr =
+    (uint32_t)(u_char)in[7] |
+    ((uint32_t)(u_char)in[6] << 8) |
+    ((uint32_t)(u_char)in[5] << 16) |
+    ((uint32_t)(u_char)in[4] << 24);
+
+  retval = do_des(rawl, rawr, &l_out, &r_out, count, data);
+
+  out[0] = l_out >> 24;
+  out[1] = l_out >> 16;
+  out[2] = l_out >> 8;
+  out[3] = l_out;
+  out[4] = r_out >> 24;
+  out[5] = r_out >> 16;
+  out[6] = r_out >> 8;
+  out[7] = r_out;
+
+  return(retval);
+}
+
+char *
+_crypt_extended_r(const char *key, const char *setting,
+  struct php_crypt_extended_data *data)
+{
+  int    i;
+  uint32_t  count, salt, l, r0, r1, keybuf[2];
+  u_char    *p, *q;
+
+  if (!data->initialized)
+    des_init_local(data);
+
+  /*
+   * Copy the key, shifting each character up by one bit
+   * and padding with zeros.
+   */
+  q = (u_char *) keybuf;
+  while (q - (u_char *) keybuf < sizeof(keybuf)) {
+    *q++ = *key << 1;
+    if (*key)
+      key++;
+  }
+  if (des_setkey((u_char *) keybuf, data))
+    return(NULL);
+
+  if (*setting == _PASSWORD_EFMT1) {
+    /*
+     * "new"-style:
+     *  setting - underscore, 4 chars of count, 4 chars of salt
+     *  key - unlimited characters
+     */
+    for (i = 1, count = 0; i < 5; i++) {
+      int value = ascii_to_bin(setting[i]);
+      if (ascii64[value] != setting[i])
+        return(NULL);
+      count |= value << (i - 1) * 6;
+    }
+    if (!count)
+      return(NULL);
+
+    for (i = 5, salt = 0; i < 9; i++) {
+      int value = ascii_to_bin(setting[i]);
+      if (ascii64[value] != setting[i])
+        return(NULL);
+      salt |= value << (i - 5) * 6;
+    }
+
+    while (*key) {
+      /*
+       * Encrypt the key with itself.
+       */
+      if (des_cipher((u_char *) keybuf, (u_char *) keybuf,
+          0, 1, data))
+        return(NULL);
+      /*
+       * And XOR with the next 8 characters of the key.
+       */
+      q = (u_char *) keybuf;
+      while (q - (u_char *) keybuf < sizeof(keybuf) && *key)
+        *q++ ^= *key++ << 1;
+
+      if (des_setkey((u_char *) keybuf, data))
+        return(NULL);
+    }
+    memcpy(data->output, setting, 9);
+    data->output[9] = '\0';
+    p = (u_char *) data->output + 9;
+  } else {
+    /*
+     * "old"-style:
+     *  setting - 2 chars of salt
+     *  key - up to 8 characters
+     */
+    count = 25;
+
+    if (ascii_is_unsafe(setting[0]) || ascii_is_unsafe(setting[1]))
+      return(NULL);
+
+    salt = (ascii_to_bin(setting[1]) << 6)
+         |  ascii_to_bin(setting[0]);
+
+    data->output[0] = setting[0];
+    data->output[1] = setting[1];
+    p = (u_char *) data->output + 2;
+  }
+  setup_salt(salt, data);
+  /*
+   * Do it.
+   */
+  if (do_des(0, 0, &r0, &r1, count, data))
+    return(NULL);
+  /*
+   * Now encode the result...
+   */
+  l = (r0 >> 8);
+  *p++ = ascii64[(l >> 18) & 0x3f];
+  *p++ = ascii64[(l >> 12) & 0x3f];
+  *p++ = ascii64[(l >> 6) & 0x3f];
+  *p++ = ascii64[l & 0x3f];
+
+  l = (r0 << 16) | ((r1 >> 16) & 0xffff);
+  *p++ = ascii64[(l >> 18) & 0x3f];
+  *p++ = ascii64[(l >> 12) & 0x3f];
+  *p++ = ascii64[(l >> 6) & 0x3f];
+  *p++ = ascii64[l & 0x3f];
+
+  l = r1 << 2;
+  *p++ = ascii64[(l >> 12) & 0x3f];
+  *p++ = ascii64[(l >> 6) & 0x3f];
+  *p++ = ascii64[l & 0x3f];
+  *p = 0;
+
+  return(data->output);
+}

--- a/hphp/zend/crypt-freesec.c
+++ b/hphp/zend/crypt-freesec.c
@@ -67,8 +67,6 @@
 
 #include "crypt-freesec.h"
 
-#define _PASSWORD_EFMT1 '_'
-
 static u_char  IP[64] = {
   58, 50, 42, 34, 26, 18, 10,  2, 60, 52, 44, 36, 28, 20, 12,  4,
   62, 54, 46, 38, 30, 22, 14,  6, 64, 56, 48, 40, 32, 24, 16,  8,
@@ -632,7 +630,7 @@ _crypt_extended_r(const char *key, const char *setting,
   if (des_setkey((u_char *) keybuf, data))
     return(NULL);
 
-  if (*setting == _PASSWORD_EFMT1) {
+  if (*setting == '_') {
     /*
      * "new"-style:
      *  setting - underscore, 4 chars of count, 4 chars of salt

--- a/hphp/zend/crypt-freesec.h
+++ b/hphp/zend/crypt-freesec.h
@@ -1,0 +1,37 @@
+/* $Id$ */
+
+#ifndef _CRYPT_FREESEC_H
+#define _CRYPT_FREESEC_H
+
+#if _MSC_VER
+# ifndef inline
+# define inline __inline
+# endif
+#endif
+
+#include <stdint.h>
+typedef unsigned char u_char;
+
+#define MD5_HASH_MAX_LEN 120
+
+struct php_crypt_extended_data {
+	int initialized;
+	uint32_t saltbits;
+	uint32_t old_salt;
+	uint32_t en_keysl[16], en_keysr[16];
+	uint32_t de_keysl[16], de_keysr[16];
+	uint32_t old_rawkey0, old_rawkey1;
+	char output[21];
+};
+
+/*
+ * _crypt_extended_init() must be called explicitly before first use of
+ * _crypt_extended_r().
+ */
+
+void _crypt_extended_init(void);
+
+char *_crypt_extended_r(const char *key, const char *setting,
+	struct php_crypt_extended_data *data);
+
+#endif

--- a/hphp/zend/crypt-freesec.h
+++ b/hphp/zend/crypt-freesec.h
@@ -1,13 +1,7 @@
 /* $Id$ */
 
-#ifndef _CRYPT_FREESEC_H
-#define _CRYPT_FREESEC_H
-
-#if _MSC_VER
-# ifndef inline
-# define inline __inline
-# endif
-#endif
+#ifndef incl_CRYPT_FREESEC_H
+#define incl_CRYPT_FREESEC_H
 
 #include <stdint.h>
 typedef unsigned char u_char;
@@ -15,13 +9,13 @@ typedef unsigned char u_char;
 #define MD5_HASH_MAX_LEN 120
 
 struct php_crypt_extended_data {
-	int initialized;
-	uint32_t saltbits;
-	uint32_t old_salt;
-	uint32_t en_keysl[16], en_keysr[16];
-	uint32_t de_keysl[16], de_keysr[16];
-	uint32_t old_rawkey0, old_rawkey1;
-	char output[21];
+  int initialized;
+  uint32_t saltbits;
+  uint32_t old_salt;
+  uint32_t en_keysl[16], en_keysr[16];
+  uint32_t de_keysl[16], de_keysr[16];
+  uint32_t old_rawkey0, old_rawkey1;
+  char output[21];
 };
 
 /*
@@ -32,6 +26,6 @@ struct php_crypt_extended_data {
 void _crypt_extended_init(void);
 
 char *_crypt_extended_r(const char *key, const char *setting,
-	struct php_crypt_extended_data *data);
+  struct php_crypt_extended_data *data);
 
 #endif

--- a/hphp/zend/crypt-sha256.c
+++ b/hphp/zend/crypt-sha256.c
@@ -1,0 +1,576 @@
+/* SHA256-based Unix crypt implementation.
+   Released into the Public Domain by Ulrich Drepper <drepper@redhat.com>.  */
+/* Windows VC++ port by Pierre Joye <pierre@php.net> */
+
+#include <errno.h>
+#include <limits.h>
+
+#define __alignof__ __alignof
+#define alloca _alloca
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <Windows.h>
+
+char * __php_stpncpy(char *dst, const char *src, size_t len)
+{
+  size_t n = strlen(src);
+  if (n > len) {
+    n = len;
+  }
+  return strncpy(dst, src, len) + n;
+}
+
+void * __php_mempcpy(void * dst, const void * src, size_t len)
+{
+  return (((char *)memcpy(dst, src, len)) + len);
+}
+
+#ifndef MIN
+# define MIN(a, b) (((a) < (b)) ? (a) : (b))
+#endif
+#ifndef MAX
+# define MAX(a, b) (((a) > (b)) ? (a) : (b))
+#endif
+
+/* Structure to save state of computation between the single steps.  */
+struct sha256_ctx {
+  uint32_t H[8];
+
+  uint32_t total[2];
+  uint32_t buflen;
+  char buffer[128]; /* NB: always correctly aligned for uint32_t.  */
+};
+
+#define SWAP(n) (((n) << 24) | (((n) & 0xff00) << 8) | (((n) >> 8) & 0xff00) | ((n) >> 24))
+
+/* This array contains the bytes used to pad the buffer to the next
+   64-byte boundary.  (FIPS 180-2:5.1.1)  */
+static const unsigned char fillbuf[64] = { 0x80, 0 /* , 0, 0, ...  */ };
+
+
+/* Constants for SHA256 from FIPS 180-2:4.2.2.  */
+static const uint32_t K[64] = {
+  0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5,
+  0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
+  0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3,
+  0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
+  0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc,
+  0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+  0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7,
+  0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967,
+  0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13,
+  0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
+  0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3,
+  0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+  0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5,
+  0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+  0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208,
+  0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2
+};
+
+
+/* Process LEN bytes of BUFFER, accumulating context into CTX.
+   It is assumed that LEN % 64 == 0.  */
+static void sha256_process_block (const void *buffer, size_t len, struct sha256_ctx *ctx) {
+  const uint32_t *words = buffer;
+  size_t nwords = len / sizeof (uint32_t);
+  unsigned int t;
+
+  uint32_t a = ctx->H[0];
+  uint32_t b = ctx->H[1];
+  uint32_t c = ctx->H[2];
+  uint32_t d = ctx->H[3];
+  uint32_t e = ctx->H[4];
+  uint32_t f = ctx->H[5];
+  uint32_t g = ctx->H[6];
+  uint32_t h = ctx->H[7];
+
+  /* First increment the byte count.  FIPS 180-2 specifies the possible
+   length of the file up to 2^64 bits.  Here we only compute the
+   number of bytes.  Do a double word increment.  */
+  ctx->total[0] += (uint32_t)len;
+  if (ctx->total[0] < len) {
+    ++ctx->total[1];
+  }
+
+  /* Process all bytes in the buffer with 64 bytes in each round of
+   the loop.  */
+  while (nwords > 0) {
+    uint32_t W[64];
+    uint32_t a_save = a;
+    uint32_t b_save = b;
+    uint32_t c_save = c;
+    uint32_t d_save = d;
+    uint32_t e_save = e;
+    uint32_t f_save = f;
+    uint32_t g_save = g;
+    uint32_t h_save = h;
+
+  /* Operators defined in FIPS 180-2:4.1.2.  */
+#define Ch(x, y, z) ((x & y) ^ (~x & z))
+#define Maj(x, y, z) ((x & y) ^ (x & z) ^ (y & z))
+#define S0(x) (CYCLIC (x, 2) ^ CYCLIC (x, 13) ^ CYCLIC (x, 22))
+#define S1(x) (CYCLIC (x, 6) ^ CYCLIC (x, 11) ^ CYCLIC (x, 25))
+#define R0(x) (CYCLIC (x, 7) ^ CYCLIC (x, 18) ^ (x >> 3))
+#define R1(x) (CYCLIC (x, 17) ^ CYCLIC (x, 19) ^ (x >> 10))
+
+  /* It is unfortunate that C does not provide an operator for
+  cyclic rotation.  Hope the C compiler is smart enough.  */
+#define CYCLIC(w, s) ((w >> s) | (w << (32 - s)))
+
+    /* Compute the message schedule according to FIPS 180-2:6.2.2 step 2.  */
+    for (t = 0; t < 16; ++t) {
+      W[t] = SWAP (*words);
+      ++words;
+    }
+    for (t = 16; t < 64; ++t)
+      W[t] = R1 (W[t - 2]) + W[t - 7] + R0 (W[t - 15]) + W[t - 16];
+
+    /* The actual computation according to FIPS 180-2:6.2.2 step 3.  */
+    for (t = 0; t < 64; ++t) {
+      uint32_t T1 = h + S1 (e) + Ch (e, f, g) + K[t] + W[t];
+      uint32_t T2 = S0 (a) + Maj (a, b, c);
+      h = g;
+      g = f;
+      f = e;
+      e = d + T1;
+      d = c;
+      c = b;
+      b = a;
+      a = T1 + T2;
+    }
+
+    /* Add the starting values of the context according to FIPS 180-2:6.2.2
+    step 4.  */
+    a += a_save;
+    b += b_save;
+    c += c_save;
+    d += d_save;
+    e += e_save;
+    f += f_save;
+    g += g_save;
+    h += h_save;
+
+    /* Prepare for the next round.  */
+    nwords -= 16;
+  }
+
+  /* Put checksum in context given as argument.  */
+  ctx->H[0] = a;
+  ctx->H[1] = b;
+  ctx->H[2] = c;
+  ctx->H[3] = d;
+  ctx->H[4] = e;
+  ctx->H[5] = f;
+  ctx->H[6] = g;
+  ctx->H[7] = h;
+}
+
+
+/* Initialize structure containing state of computation.
+   (FIPS 180-2:5.3.2)  */
+static void sha256_init_ctx(struct sha256_ctx *ctx) {
+  ctx->H[0] = 0x6a09e667;
+  ctx->H[1] = 0xbb67ae85;
+  ctx->H[2] = 0x3c6ef372;
+  ctx->H[3] = 0xa54ff53a;
+  ctx->H[4] = 0x510e527f;
+  ctx->H[5] = 0x9b05688c;
+  ctx->H[6] = 0x1f83d9ab;
+  ctx->H[7] = 0x5be0cd19;
+
+  ctx->total[0] = ctx->total[1] = 0;
+  ctx->buflen = 0;
+}
+
+
+/* Process the remaining bytes in the internal buffer and the usual
+   prolog according to the standard and write the result to RESBUF.
+
+   IMPORTANT: On some systems it is required that RESBUF is correctly
+   aligned for a 32 bits value.  */
+static void * sha256_finish_ctx(struct sha256_ctx *ctx, void *resbuf) {
+  /* Take yet unprocessed bytes into account.  */
+  uint32_t bytes = ctx->buflen;
+  size_t pad;
+  unsigned int i;
+
+  /* Now count remaining bytes.  */
+  ctx->total[0] += bytes;
+  if (ctx->total[0] < bytes) {
+    ++ctx->total[1];
+  }
+
+  pad = bytes >= 56 ? 64 + 56 - bytes : 56 - bytes;
+  memcpy(&ctx->buffer[bytes], fillbuf, pad);
+
+  /* Put the 64-bit file length in *bits* at the end of the buffer.  */
+  *(uint32_t *) &ctx->buffer[bytes + pad + 4] = SWAP (ctx->total[0] << 3);
+  *(uint32_t *) &ctx->buffer[bytes + pad] = SWAP ((ctx->total[1] << 3) |
+              (ctx->total[0] >> 29));
+
+  /* Process last bytes.  */
+  sha256_process_block(ctx->buffer, bytes + pad + 8, ctx);
+
+  /* Put result from CTX in first 32 bytes following RESBUF.  */
+  for (i = 0; i < 8; ++i) {
+    ((uint32_t *) resbuf)[i] = SWAP(ctx->H[i]);
+  }
+
+  return resbuf;
+}
+
+
+static void sha256_process_bytes(const void *buffer, size_t len, struct sha256_ctx *ctx) {
+  /* When we already have some bits in our internal buffer concatenate
+   both inputs first.  */
+  if (ctx->buflen != 0) {
+    size_t left_over = ctx->buflen;
+    size_t add = 128 - left_over > len ? len : 128 - left_over;
+
+      memcpy(&ctx->buffer[left_over], buffer, add);
+      ctx->buflen += (uint32_t)add;
+
+    if (ctx->buflen > 64) {
+      sha256_process_block(ctx->buffer, ctx->buflen & ~63, ctx);
+      ctx->buflen &= 63;
+      /* The regions in the following copy operation cannot overlap.  */
+      memcpy(ctx->buffer, &ctx->buffer[(left_over + add) & ~63], ctx->buflen);
+    }
+
+    buffer = (const char *) buffer + add;
+    len -= add;
+  }
+
+  /* Process available complete blocks.  */
+  if (len >= 64) {
+# define UNALIGNED_P(p) (((uintptr_t) p) % __alignof__ (uint32_t) != 0)
+    if (UNALIGNED_P (buffer))
+      while (len > 64) {
+        sha256_process_block(memcpy(ctx->buffer, buffer, 64), 64, ctx);
+        buffer = (const char *) buffer + 64;
+        len -= 64;
+      } else {
+        sha256_process_block(buffer, len & ~63, ctx);
+        buffer = (const char *) buffer + (len & ~63);
+        len &= 63;
+      }
+  }
+
+  /* Move remaining bytes into internal buffer.  */
+  if (len > 0) {
+    size_t left_over = ctx->buflen;
+
+    memcpy(&ctx->buffer[left_over], buffer, len);
+    left_over += len;
+    if (left_over >= 64) {
+      sha256_process_block(ctx->buffer, 64, ctx);
+      left_over -= 64;
+      memcpy(ctx->buffer, &ctx->buffer[64], left_over);
+    }
+    ctx->buflen = (uint32_t)left_over;
+  }
+}
+
+
+/* Define our magic string to mark salt for SHA256 "encryption"
+   replacement.  */
+static const char sha256_salt_prefix[] = "$5$";
+
+/* Prefix for optional rounds specification.  */
+static const char sha256_rounds_prefix[] = "rounds=";
+
+/* Maximum salt string length.  */
+#define SALT_LEN_MAX 16
+/* Default number of rounds if not explicitly specified.  */
+#define ROUNDS_DEFAULT 5000
+/* Minimum number of rounds.  */
+#define ROUNDS_MIN 1000
+/* Maximum number of rounds.  */
+#define ROUNDS_MAX 999999999
+
+/* Table with characters for base64 transformation.  */
+static const char b64t[64] =
+"./0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+
+char * php_sha256_crypt_r(const char *key, const char *salt, char *buffer, int buflen)
+{
+#if _MSC <= 1300
+# pragma pack(push, 16)
+  unsigned char alt_result[32];
+  unsigned char temp_result[32];
+# pragma pack(pop)
+#else
+  __declspec(align(32)) unsigned char alt_result[32];
+  __declspec(align(32)) unsigned char temp_result[32];
+#endif
+
+  struct sha256_ctx ctx;
+  struct sha256_ctx alt_ctx;
+  size_t salt_len;
+  size_t key_len;
+  size_t cnt;
+  char *cp;
+  char *copied_key = NULL;
+  char *copied_salt = NULL;
+  char *p_bytes;
+  char *s_bytes;
+  /* Default number of rounds.  */
+  size_t rounds = ROUNDS_DEFAULT;
+  char rounds_custom = 0;
+
+  /* Find beginning of salt string.  The prefix should normally always
+  be present.  Just in case it is not.  */
+  if (strncmp(sha256_salt_prefix, salt, sizeof(sha256_salt_prefix) - 1) == 0) {
+    /* Skip salt prefix.  */
+    salt += sizeof(sha256_salt_prefix) - 1;
+  }
+
+  if (strncmp(salt, sha256_rounds_prefix, sizeof(sha256_rounds_prefix) - 1) == 0) {
+    const char *num = salt + sizeof(sha256_rounds_prefix) - 1;
+    char *endp;
+    size_t srounds = _strtoui64(num, &endp, 10);
+    if (*endp == '$') {
+      salt = endp + 1;
+      rounds = MAX(ROUNDS_MIN, MIN(srounds, ROUNDS_MAX));
+      rounds_custom = 1;
+    }
+  }
+
+  salt_len = MIN(strcspn(salt, "$"), SALT_LEN_MAX);
+  key_len = strlen(key);
+
+  if ((key - (char *) 0) % __alignof__ (uint32_t) != 0) {
+    char *tmp = (char *) alloca(key_len + __alignof__(uint32_t));
+    key = copied_key = memcpy(tmp + __alignof__(uint32_t) - (tmp - (char *) 0) % __alignof__(uint32_t), key, key_len);
+  }
+
+  if ((salt - (char *) 0) % __alignof__(uint32_t) != 0) {
+    char *tmp = (char *) alloca(salt_len + 1 + __alignof__(uint32_t));
+    salt = copied_salt =
+    memcpy(tmp + __alignof__(uint32_t) - (tmp - (char *) 0) % __alignof__ (uint32_t), salt, salt_len);
+    copied_salt[salt_len] = 0;
+  }
+
+  /* Prepare for the real work.  */
+  sha256_init_ctx(&ctx);
+
+  /* Add the key string.  */
+  sha256_process_bytes(key, key_len, &ctx);
+
+  /* The last part is the salt string.  This must be at most 16
+   characters and it ends at the first `$' character (for
+   compatibility with existing implementations).  */
+  sha256_process_bytes(salt, salt_len, &ctx);
+
+
+  /* Compute alternate SHA256 sum with input KEY, SALT, and KEY.  The
+   final result will be added to the first context.  */
+  sha256_init_ctx(&alt_ctx);
+
+  /* Add key.  */
+  sha256_process_bytes(key, key_len, &alt_ctx);
+
+  /* Add salt.  */
+  sha256_process_bytes(salt, salt_len, &alt_ctx);
+
+  /* Add key again.  */
+  sha256_process_bytes(key, key_len, &alt_ctx);
+
+  /* Now get result of this (32 bytes) and add it to the other
+   context.  */
+  sha256_finish_ctx(&alt_ctx, alt_result);
+
+  /* Add for any character in the key one byte of the alternate sum.  */
+  for (cnt = key_len; cnt > 32; cnt -= 32) {
+    sha256_process_bytes(alt_result, 32, &ctx);
+  }
+  sha256_process_bytes(alt_result, cnt, &ctx);
+
+  /* Take the binary representation of the length of the key and for every
+  1 add the alternate sum, for every 0 the key.  */
+  for (cnt = key_len; cnt > 0; cnt >>= 1) {
+    if ((cnt & 1) != 0) {
+      sha256_process_bytes(alt_result, 32, &ctx);
+    } else {
+      sha256_process_bytes(key, key_len, &ctx);
+    }
+  }
+
+  /* Create intermediate result.  */
+  sha256_finish_ctx(&ctx, alt_result);
+
+  /* Start computation of P byte sequence.  */
+  sha256_init_ctx(&alt_ctx);
+
+  /* For every character in the password add the entire password.  */
+  for (cnt = 0; cnt < key_len; ++cnt) {
+    sha256_process_bytes(key, key_len, &alt_ctx);
+  }
+
+  /* Finish the digest.  */
+  sha256_finish_ctx(&alt_ctx, temp_result);
+
+  /* Create byte sequence P.  */
+  cp = p_bytes = alloca(key_len);
+  for (cnt = key_len; cnt >= 32; cnt -= 32) {
+    cp = __php_mempcpy((void *)cp, (const void *)temp_result, 32);
+  }
+  memcpy(cp, temp_result, cnt);
+
+  /* Start computation of S byte sequence.  */
+  sha256_init_ctx(&alt_ctx);
+
+  /* For every character in the password add the entire password.  */
+  for (cnt = 0; cnt < (size_t) (16 + alt_result[0]); ++cnt) {
+    sha256_process_bytes(salt, salt_len, &alt_ctx);
+  }
+
+  /* Finish the digest.  */
+  sha256_finish_ctx(&alt_ctx, temp_result);
+
+  /* Create byte sequence S.  */
+  cp = s_bytes = alloca(salt_len);
+  for (cnt = salt_len; cnt >= 32; cnt -= 32) {
+    cp = __php_mempcpy(cp, temp_result, 32);
+  }
+  memcpy(cp, temp_result, cnt);
+
+  /* Repeatedly run the collected hash value through SHA256 to burn
+  CPU cycles.  */
+  for (cnt = 0; cnt < rounds; ++cnt) {
+    /* New context.  */
+    sha256_init_ctx(&ctx);
+
+    /* Add key or last result.  */
+    if ((cnt & 1) != 0) {
+      sha256_process_bytes(p_bytes, key_len, &ctx);
+    } else {
+      sha256_process_bytes(alt_result, 32, &ctx);
+    }
+
+    /* Add salt for numbers not divisible by 3.  */
+    if (cnt % 3 != 0) {
+      sha256_process_bytes(s_bytes, salt_len, &ctx);
+    }
+
+    /* Add key for numbers not divisible by 7.  */
+    if (cnt % 7 != 0) {
+      sha256_process_bytes(p_bytes, key_len, &ctx);
+    }
+
+    /* Add key or last result.  */
+    if ((cnt & 1) != 0) {
+      sha256_process_bytes(alt_result, 32, &ctx);
+    } else {
+      sha256_process_bytes(p_bytes, key_len, &ctx);
+    }
+
+    /* Create intermediate result.  */
+    sha256_finish_ctx(&ctx, alt_result);
+  }
+
+  /* Now we can construct the result string.  It consists of three
+  parts.  */
+  cp = __php_stpncpy(buffer, sha256_salt_prefix, MAX(0, buflen));
+  buflen -= sizeof(sha256_salt_prefix) - 1;
+
+  if (rounds_custom) {
+#ifdef PHP_WIN32
+    int n = _snprintf(cp, MAX(0, buflen), "%s" ZEND_ULONG_FMT "$", sha256_rounds_prefix, rounds);
+#else
+    int n = snprintf(cp, MAX(0, buflen), "%s%zu$", sha256_rounds_prefix, rounds);
+#endif
+    cp += n;
+    buflen -= n;
+  }
+
+  cp = __php_stpncpy(cp, salt, MIN ((size_t) MAX (0, buflen), salt_len));
+  buflen -= MIN(MAX (0, buflen), (int)salt_len);
+
+  if (buflen > 0) {
+    *cp++ = '$';
+    --buflen;
+  }
+
+#define b64_from_24bit(B2, B1, B0, N)                \
+  do {                        \
+    unsigned int w = ((B2) << 16) | ((B1) << 8) | (B0);            \
+    int n = (N);                    \
+    while (n-- > 0 && buflen > 0)                \
+      {                        \
+  *cp++ = b64t[w & 0x3f];                  \
+  --buflen;                    \
+  w >>= 6;                    \
+      }                        \
+  } while (0)
+
+  b64_from_24bit(alt_result[0], alt_result[10], alt_result[20], 4);
+  b64_from_24bit(alt_result[21], alt_result[1], alt_result[11], 4);
+  b64_from_24bit(alt_result[12], alt_result[22], alt_result[2], 4);
+  b64_from_24bit(alt_result[3], alt_result[13], alt_result[23], 4);
+  b64_from_24bit(alt_result[24], alt_result[4], alt_result[14], 4);
+  b64_from_24bit(alt_result[15], alt_result[25], alt_result[5], 4);
+  b64_from_24bit(alt_result[6], alt_result[16], alt_result[26], 4);
+  b64_from_24bit(alt_result[27], alt_result[7], alt_result[17], 4);
+  b64_from_24bit(alt_result[18], alt_result[28], alt_result[8], 4);
+  b64_from_24bit(alt_result[9], alt_result[19], alt_result[29], 4);
+  b64_from_24bit(0, alt_result[31], alt_result[30], 3);
+  if (buflen <= 0) {
+    errno = ERANGE;
+    buffer = NULL;
+  } else
+    *cp = '\0';    /* Terminate the string.  */
+
+  /* Clear the buffer for the intermediate result so that people
+     attaching to processes or reading core dumps cannot get any
+     information.  We do it in this way to clear correct_words[]
+     inside the SHA256 implementation as well.  */
+  sha256_init_ctx(&ctx);
+  sha256_finish_ctx(&ctx, alt_result);
+  RtlSecureZeroMemory(temp_result, sizeof(temp_result));
+  RtlSecureZeroMemory(p_bytes, key_len);
+  RtlSecureZeroMemory(s_bytes, salt_len);
+  RtlSecureZeroMemory(&ctx, sizeof(ctx));
+  RtlSecureZeroMemory(&alt_ctx, sizeof(alt_ctx));
+
+  if (copied_key != NULL) {
+    RtlSecureZeroMemory(copied_key, key_len);
+  }
+  if (copied_salt != NULL) {
+    RtlSecureZeroMemory(copied_salt, salt_len);
+  }
+
+  return buffer;
+}
+
+
+/* This entry point is equivalent to the `crypt' function in Unix
+   libcs.  */
+char * php_sha256_crypt(const char *key, const char *salt)
+{
+  /* We don't want to have an arbitrary limit in the size of the
+  password.  We can compute an upper bound for the size of the
+  result in advance and so we can prepare the buffer we pass to
+  `sha256_crypt_r'.  */
+  static char *buffer;
+  static int buflen;
+  int needed = (sizeof(sha256_salt_prefix) - 1
+      + sizeof(sha256_rounds_prefix) + 9 + 1
+      + (int)strlen(salt) + 1 + 43 + 1);
+
+  if (buflen < needed) {
+    char *new_buffer = (char *) realloc(buffer, needed);
+    if (new_buffer == NULL) {
+      return NULL;
+    }
+
+    buffer = new_buffer;
+    buflen = needed;
+  }
+
+  return php_sha256_crypt_r(key, salt, buffer, buflen);
+}

--- a/hphp/zend/crypt-sha512.c
+++ b/hphp/zend/crypt-sha512.c
@@ -1,0 +1,622 @@
+/* SHA512-based Unix crypt implementation.
+   Released into the Public Domain by Ulrich Drepper <drepper@redhat.com>.  */
+/* Windows VC++ port by Pierre Joye <pierre@php.net> */
+
+
+#define __alignof__ __alignof
+#define alloca _alloca
+
+#include <errno.h>
+#include <limits.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <Windows.h>
+
+// Defined in crypt-sha256.c
+extern void * __php_mempcpy(void * dst, const void * src, size_t len);
+extern char * __php_stpncpy(char *dst, const char *src, size_t len);
+
+#ifndef MIN
+# define MIN(a, b) (((a) < (b)) ? (a) : (b))
+#endif
+#ifndef MAX
+# define MAX(a, b) (((a) > (b)) ? (a) : (b))
+#endif
+
+/* See #51582 */
+#ifndef UINT64_C
+# define UINT64_C(value) __CONCAT(value, ULL)
+#endif
+
+/* Structure to save state of computation between the single steps.  */
+struct sha512_ctx
+{
+  uint64_t H[8];
+
+  uint64_t total[2];
+  uint64_t buflen;
+  char buffer[256];  /* NB: always correctly aligned for uint64_t.  */
+};
+
+
+#define SWAP(n) \
+  (((n) << 56)          \
+   | (((n) & 0xff00) << 40)      \
+   | (((n) & 0xff0000) << 24)      \
+   | (((n) & 0xff000000) << 8)      \
+   | (((n) >> 8) & 0xff000000)      \
+   | (((n) >> 24) & 0xff0000)      \
+   | (((n) >> 40) & 0xff00)      \
+   | ((n) >> 56))
+
+/* This array contains the bytes used to pad the buffer to the next
+   64-byte boundary.  (FIPS 180-2:5.1.2)  */
+static const unsigned char fillbuf[128] = { 0x80, 0 /* , 0, 0, ...  */ };
+
+/* Constants for SHA512 from FIPS 180-2:4.2.3.  */
+static const uint64_t K[80] = {
+  UINT64_C (0x428a2f98d728ae22), UINT64_C (0x7137449123ef65cd),
+  UINT64_C (0xb5c0fbcfec4d3b2f), UINT64_C (0xe9b5dba58189dbbc),
+  UINT64_C (0x3956c25bf348b538), UINT64_C (0x59f111f1b605d019),
+  UINT64_C (0x923f82a4af194f9b), UINT64_C (0xab1c5ed5da6d8118),
+  UINT64_C (0xd807aa98a3030242), UINT64_C (0x12835b0145706fbe),
+  UINT64_C (0x243185be4ee4b28c), UINT64_C (0x550c7dc3d5ffb4e2),
+  UINT64_C (0x72be5d74f27b896f), UINT64_C (0x80deb1fe3b1696b1),
+  UINT64_C (0x9bdc06a725c71235), UINT64_C (0xc19bf174cf692694),
+  UINT64_C (0xe49b69c19ef14ad2), UINT64_C (0xefbe4786384f25e3),
+  UINT64_C (0x0fc19dc68b8cd5b5), UINT64_C (0x240ca1cc77ac9c65),
+  UINT64_C (0x2de92c6f592b0275), UINT64_C (0x4a7484aa6ea6e483),
+  UINT64_C (0x5cb0a9dcbd41fbd4), UINT64_C (0x76f988da831153b5),
+  UINT64_C (0x983e5152ee66dfab), UINT64_C (0xa831c66d2db43210),
+  UINT64_C (0xb00327c898fb213f), UINT64_C (0xbf597fc7beef0ee4),
+  UINT64_C (0xc6e00bf33da88fc2), UINT64_C (0xd5a79147930aa725),
+  UINT64_C (0x06ca6351e003826f), UINT64_C (0x142929670a0e6e70),
+  UINT64_C (0x27b70a8546d22ffc), UINT64_C (0x2e1b21385c26c926),
+  UINT64_C (0x4d2c6dfc5ac42aed), UINT64_C (0x53380d139d95b3df),
+  UINT64_C (0x650a73548baf63de), UINT64_C (0x766a0abb3c77b2a8),
+  UINT64_C (0x81c2c92e47edaee6), UINT64_C (0x92722c851482353b),
+  UINT64_C (0xa2bfe8a14cf10364), UINT64_C (0xa81a664bbc423001),
+  UINT64_C (0xc24b8b70d0f89791), UINT64_C (0xc76c51a30654be30),
+  UINT64_C (0xd192e819d6ef5218), UINT64_C (0xd69906245565a910),
+  UINT64_C (0xf40e35855771202a), UINT64_C (0x106aa07032bbd1b8),
+  UINT64_C (0x19a4c116b8d2d0c8), UINT64_C (0x1e376c085141ab53),
+  UINT64_C (0x2748774cdf8eeb99), UINT64_C (0x34b0bcb5e19b48a8),
+  UINT64_C (0x391c0cb3c5c95a63), UINT64_C (0x4ed8aa4ae3418acb),
+  UINT64_C (0x5b9cca4f7763e373), UINT64_C (0x682e6ff3d6b2b8a3),
+  UINT64_C (0x748f82ee5defb2fc), UINT64_C (0x78a5636f43172f60),
+  UINT64_C (0x84c87814a1f0ab72), UINT64_C (0x8cc702081a6439ec),
+  UINT64_C (0x90befffa23631e28), UINT64_C (0xa4506cebde82bde9),
+  UINT64_C (0xbef9a3f7b2c67915), UINT64_C (0xc67178f2e372532b),
+  UINT64_C (0xca273eceea26619c), UINT64_C (0xd186b8c721c0c207),
+  UINT64_C (0xeada7dd6cde0eb1e), UINT64_C (0xf57d4f7fee6ed178),
+  UINT64_C (0x06f067aa72176fba), UINT64_C (0x0a637dc5a2c898a6),
+  UINT64_C (0x113f9804bef90dae), UINT64_C (0x1b710b35131c471b),
+  UINT64_C (0x28db77f523047d84), UINT64_C (0x32caab7b40c72493),
+  UINT64_C (0x3c9ebe0a15c9bebc), UINT64_C (0x431d67c49c100d4c),
+  UINT64_C (0x4cc5d4becb3e42b6), UINT64_C (0x597f299cfc657e2a),
+  UINT64_C (0x5fcb6fab3ad6faec), UINT64_C (0x6c44198c4a475817)
+  };
+
+
+/* Process LEN bytes of BUFFER, accumulating context into CTX.
+   It is assumed that LEN % 128 == 0.  */
+static void
+sha512_process_block(const void *buffer, size_t len, struct sha512_ctx *ctx) {
+  const uint64_t *words = buffer;
+  size_t nwords = len / sizeof(uint64_t);
+  uint64_t a = ctx->H[0];
+  uint64_t b = ctx->H[1];
+  uint64_t c = ctx->H[2];
+  uint64_t d = ctx->H[3];
+  uint64_t e = ctx->H[4];
+  uint64_t f = ctx->H[5];
+  uint64_t g = ctx->H[6];
+  uint64_t h = ctx->H[7];
+
+  /* First increment the byte count.  FIPS 180-2 specifies the possible
+   length of the file up to 2^128 bits.  Here we only compute the
+   number of bytes.  Do a double word increment.  */
+  ctx->total[0] += len;
+  if (ctx->total[0] < len) {
+    ++ctx->total[1];
+  }
+
+  /* Process all bytes in the buffer with 128 bytes in each round of
+   the loop.  */
+  while (nwords > 0) {
+    uint64_t W[80];
+    uint64_t a_save = a;
+    uint64_t b_save = b;
+    uint64_t c_save = c;
+    uint64_t d_save = d;
+    uint64_t e_save = e;
+    uint64_t f_save = f;
+    uint64_t g_save = g;
+    uint64_t h_save = h;
+    unsigned int t;
+
+/* Operators defined in FIPS 180-2:4.1.2.  */
+#define Ch(x, y, z) ((x & y) ^ (~x & z))
+#define Maj(x, y, z) ((x & y) ^ (x & z) ^ (y & z))
+#define S0(x) (CYCLIC (x, 28) ^ CYCLIC (x, 34) ^ CYCLIC (x, 39))
+#define S1(x) (CYCLIC (x, 14) ^ CYCLIC (x, 18) ^ CYCLIC (x, 41))
+#define R0(x) (CYCLIC (x, 1) ^ CYCLIC (x, 8) ^ (x >> 7))
+#define R1(x) (CYCLIC (x, 19) ^ CYCLIC (x, 61) ^ (x >> 6))
+
+    /* It is unfortunate that C does not provide an operator for
+       cyclic rotation.  Hope the C compiler is smart enough.  */
+#define CYCLIC(w, s) ((w >> s) | (w << (64 - s)))
+
+    /* Compute the message schedule according to FIPS 180-2:6.3.2 step 2.  */
+    for (t = 0; t < 16; ++t) {
+      W[t] = SWAP (*words);
+      ++words;
+    }
+
+    for (t = 16; t < 80; ++t) {
+      W[t] = R1 (W[t - 2]) + W[t - 7] + R0 (W[t - 15]) + W[t - 16];
+    }
+
+    /* The actual computation according to FIPS 180-2:6.3.2 step 3.  */
+    for (t = 0; t < 80; ++t) {
+      uint64_t T1 = h + S1 (e) + Ch (e, f, g) + K[t] + W[t];
+      uint64_t T2 = S0 (a) + Maj (a, b, c);
+      h = g;
+      g = f;
+      f = e;
+      e = d + T1;
+      d = c;
+      c = b;
+      b = a;
+      a = T1 + T2;
+    }
+
+    /* Add the starting values of the context according to FIPS 180-2:6.3.2
+    step 4.  */
+    a += a_save;
+    b += b_save;
+    c += c_save;
+    d += d_save;
+    e += e_save;
+    f += f_save;
+    g += g_save;
+    h += h_save;
+
+    /* Prepare for the next round.  */
+    nwords -= 16;
+  }
+
+  /* Put checksum in context given as argument.  */
+  ctx->H[0] = a;
+  ctx->H[1] = b;
+  ctx->H[2] = c;
+  ctx->H[3] = d;
+  ctx->H[4] = e;
+  ctx->H[5] = f;
+  ctx->H[6] = g;
+  ctx->H[7] = h;
+}
+
+
+/* Initialize structure containing state of computation.
+   (FIPS 180-2:5.3.3)  */
+static void sha512_init_ctx (struct sha512_ctx *ctx) {
+  ctx->H[0] = UINT64_C (0x6a09e667f3bcc908);
+  ctx->H[1] = UINT64_C (0xbb67ae8584caa73b);
+  ctx->H[2] = UINT64_C (0x3c6ef372fe94f82b);
+  ctx->H[3] = UINT64_C (0xa54ff53a5f1d36f1);
+  ctx->H[4] = UINT64_C (0x510e527fade682d1);
+  ctx->H[5] = UINT64_C (0x9b05688c2b3e6c1f);
+  ctx->H[6] = UINT64_C (0x1f83d9abfb41bd6b);
+  ctx->H[7] = UINT64_C (0x5be0cd19137e2179);
+
+  ctx->total[0] = ctx->total[1] = 0;
+  ctx->buflen = 0;
+}
+
+
+/* Process the remaining bytes in the internal buffer and the usual
+  prolog according to the standard and write the result to RESBUF.
+
+  IMPORTANT: On some systems it is required that RESBUF is correctly
+  aligned for a 32 bits value. */
+static void * sha512_finish_ctx (struct sha512_ctx *ctx, void *resbuf) {
+  /* Take yet unprocessed bytes into account.  */
+  uint64_t bytes = ctx->buflen;
+  size_t pad;
+  unsigned int i;
+
+  /* Now count remaining bytes.  */
+  ctx->total[0] += bytes;
+  if (ctx->total[0] < bytes) {
+    ++ctx->total[1];
+  }
+
+  pad = bytes >= 112 ? 128 + 112 - (size_t)bytes : 112 - (size_t)bytes;
+  memcpy(&ctx->buffer[bytes], fillbuf, pad);
+
+  /* Put the 128-bit file length in *bits* at the end of the buffer.  */
+  *(uint64_t *) &ctx->buffer[bytes + pad + 8] = SWAP(ctx->total[0] << 3);
+  *(uint64_t *) &ctx->buffer[bytes + pad] = SWAP((ctx->total[1] << 3) |
+            (ctx->total[0] >> 61));
+
+  /* Process last bytes.  */
+  sha512_process_block(ctx->buffer, (size_t)(bytes + pad + 16), ctx);
+
+  /* Put result from CTX in first 64 bytes following RESBUF.  */
+  for (i = 0; i < 8; ++i) {
+    ((uint64_t *) resbuf)[i] = SWAP(ctx->H[i]);
+  }
+
+  return resbuf;
+}
+
+static void
+sha512_process_bytes(const void *buffer, size_t len, struct sha512_ctx *ctx) {
+  /* When we already have some bits in our internal buffer concatenate
+   both inputs first.  */
+  if (ctx->buflen != 0) {
+    size_t left_over = (size_t)ctx->buflen;
+    size_t add = (size_t)(256 - left_over > len ? len : 256 - left_over);
+
+    memcpy(&ctx->buffer[left_over], buffer, add);
+    ctx->buflen += add;
+
+    if (ctx->buflen > 128) {
+      sha512_process_block(ctx->buffer, ctx->buflen & ~127, ctx);
+
+      ctx->buflen &= 127;
+      /* The regions in the following copy operation cannot overlap.  */
+      memcpy(ctx->buffer, &ctx->buffer[(left_over + add) & ~127],
+          (size_t)ctx->buflen);
+    }
+
+    buffer = (const char *) buffer + add;
+    len -= add;
+  }
+
+  /* Process available complete blocks.  */
+  if (len >= 128) {
+#if !_STRING_ARCH_unaligned
+#define UNALIGNED_P(p) (((uintptr_t) p) % __alignof__ (uint64_t) != 0)
+    if (UNALIGNED_P(buffer))
+      while (len > 128) {
+        sha512_process_block(memcpy(ctx->buffer, buffer, 128), 128, ctx);
+        buffer = (const char *) buffer + 128;
+        len -= 128;
+      }
+    else
+#endif
+    {
+      sha512_process_block(buffer, len & ~127, ctx);
+      buffer = (const char *) buffer + (len & ~127);
+      len &= 127;
+    }
+  }
+
+  /* Move remaining bytes into internal buffer.  */
+  if (len > 0) {
+    size_t left_over = (size_t)ctx->buflen;
+
+    memcpy(&ctx->buffer[left_over], buffer, len);
+    left_over += len;
+    if (left_over >= 128) {
+      sha512_process_block(ctx->buffer, 128, ctx);
+      left_over -= 128;
+      memcpy(ctx->buffer, &ctx->buffer[128], left_over);
+    }
+    ctx->buflen = left_over;
+  }
+}
+
+
+/* Define our magic string to mark salt for SHA512 "encryption"
+   replacement.  */
+static const char sha512_salt_prefix[] = "$6$";
+
+/* Prefix for optional rounds specification.  */
+static const char sha512_rounds_prefix[] = "rounds=";
+
+/* Maximum salt string length.  */
+#define SALT_LEN_MAX 16
+/* Default number of rounds if not explicitly specified.  */
+#define ROUNDS_DEFAULT 5000
+/* Minimum number of rounds.  */
+#define ROUNDS_MIN 1000
+/* Maximum number of rounds.  */
+#define ROUNDS_MAX 999999999
+
+/* Table with characters for base64 transformation.  */
+static const char b64t[64] =
+"./0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+
+
+char *
+php_sha512_crypt_r(const char *key, const char *salt, char *buffer, int buflen) {
+#if _MSC <= 1300
+# pragma pack(push, 16)
+  unsigned char alt_result[64];
+  unsigned char temp_result[64];
+# pragma pack(pop)
+#else
+  __declspec(align(64)) unsigned char alt_result[64];
+  __declspec(align(64)) unsigned char temp_result[64];
+#endif
+  struct sha512_ctx ctx;
+  struct sha512_ctx alt_ctx;
+  size_t salt_len;
+  size_t key_len;
+  size_t cnt;
+  char *cp;
+  char *copied_key = NULL;
+  char *copied_salt = NULL;
+  char *p_bytes;
+  char *s_bytes;
+  /* Default number of rounds.  */
+  size_t rounds = ROUNDS_DEFAULT;
+  char rounds_custom = 0;
+
+  /* Find beginning of salt string.  The prefix should normally always
+   be present.  Just in case it is not.  */
+  if (strncmp(sha512_salt_prefix, salt, sizeof(sha512_salt_prefix) - 1) == 0) {
+    /* Skip salt prefix.  */
+    salt += sizeof(sha512_salt_prefix) - 1;
+  }
+
+  if (strncmp(salt, sha512_rounds_prefix, sizeof(sha512_rounds_prefix) - 1) == 0) {
+    const char *num = salt + sizeof(sha512_rounds_prefix) - 1;
+    char *endp;
+    size_t srounds = _strtoui64(num, &endp, 10);
+
+    if (*endp == '$') {
+      salt = endp + 1;
+      rounds = MAX(ROUNDS_MIN, MIN(srounds, ROUNDS_MAX));
+      rounds_custom = 1;
+    }
+  }
+
+  salt_len = MIN(strcspn(salt, "$"), SALT_LEN_MAX);
+  key_len = strlen(key);
+
+  if ((key - (char *) 0) % __alignof__ (uint64_t) != 0) {
+    char *tmp = (char *) alloca (key_len + __alignof__ (uint64_t));
+    key = copied_key =
+    memcpy(tmp + __alignof__(uint64_t) - (tmp - (char *) 0) % __alignof__(uint64_t), key, key_len);
+  }
+
+  if ((salt - (char *) 0) % __alignof__ (uint64_t) != 0) {
+    char *tmp = (char *) alloca(salt_len + 1 + __alignof__(uint64_t));
+    salt = copied_salt = memcpy(tmp + __alignof__(uint64_t) - (tmp - (char *) 0) % __alignof__(uint64_t), salt, salt_len);
+    copied_salt[salt_len] = 0;
+  }
+
+  /* Prepare for the real work.  */
+  sha512_init_ctx(&ctx);
+
+  /* Add the key string.  */
+  sha512_process_bytes(key, key_len, &ctx);
+
+  /* The last part is the salt string.  This must be at most 16
+   characters and it ends at the first `$' character (for
+   compatibility with existing implementations).  */
+  sha512_process_bytes(salt, salt_len, &ctx);
+
+
+  /* Compute alternate SHA512 sum with input KEY, SALT, and KEY.  The
+   final result will be added to the first context.  */
+  sha512_init_ctx(&alt_ctx);
+
+  /* Add key.  */
+  sha512_process_bytes(key, key_len, &alt_ctx);
+
+  /* Add salt.  */
+  sha512_process_bytes(salt, salt_len, &alt_ctx);
+
+  /* Add key again.  */
+  sha512_process_bytes(key, key_len, &alt_ctx);
+
+  /* Now get result of this (64 bytes) and add it to the other
+   context.  */
+  sha512_finish_ctx(&alt_ctx, alt_result);
+
+  /* Add for any character in the key one byte of the alternate sum.  */
+  for (cnt = key_len; cnt > 64; cnt -= 64) {
+    sha512_process_bytes(alt_result, 64, &ctx);
+  }
+  sha512_process_bytes(alt_result, cnt, &ctx);
+
+  /* Take the binary representation of the length of the key and for every
+   1 add the alternate sum, for every 0 the key.  */
+  for (cnt = key_len; cnt > 0; cnt >>= 1) {
+    if ((cnt & 1) != 0) {
+      sha512_process_bytes(alt_result, 64, &ctx);
+    } else {
+      sha512_process_bytes(key, key_len, &ctx);
+    }
+  }
+
+  /* Create intermediate result.  */
+  sha512_finish_ctx(&ctx, alt_result);
+
+  /* Start computation of P byte sequence.  */
+  sha512_init_ctx(&alt_ctx);
+
+  /* For every character in the password add the entire password.  */
+  for (cnt = 0; cnt < key_len; ++cnt) {
+    sha512_process_bytes(key, key_len, &alt_ctx);
+  }
+
+  /* Finish the digest.  */
+  sha512_finish_ctx(&alt_ctx, temp_result);
+
+  /* Create byte sequence P.  */
+  cp = p_bytes = alloca(key_len);
+  for (cnt = key_len; cnt >= 64; cnt -= 64) {
+    cp = __php_mempcpy((void *) cp, (const void *)temp_result, 64);
+  }
+
+  memcpy(cp, temp_result, cnt);
+
+  /* Start computation of S byte sequence.  */
+  sha512_init_ctx(&alt_ctx);
+
+  /* For every character in the password add the entire password.  */
+  for (cnt = 0; cnt < (size_t) (16 + alt_result[0]); ++cnt) {
+    sha512_process_bytes(salt, salt_len, &alt_ctx);
+  }
+
+  /* Finish the digest.  */
+  sha512_finish_ctx(&alt_ctx, temp_result);
+
+  /* Create byte sequence S.  */
+  cp = s_bytes = alloca(salt_len);
+  for (cnt = salt_len; cnt >= 64; cnt -= 64) {
+    cp = __php_mempcpy(cp, temp_result, 64);
+  }
+  memcpy(cp, temp_result, cnt);
+
+  /* Repeatedly run the collected hash value through SHA512 to burn
+   CPU cycles.  */
+  for (cnt = 0; cnt < rounds; ++cnt) {
+    /* New context.  */
+    sha512_init_ctx(&ctx);
+
+    /* Add key or last result.  */
+    if ((cnt & 1) != 0) {
+      sha512_process_bytes(p_bytes, key_len, &ctx);
+    } else {
+      sha512_process_bytes(alt_result, 64, &ctx);
+    }
+
+    /* Add salt for numbers not divisible by 3.  */
+    if (cnt % 3 != 0) {
+      sha512_process_bytes(s_bytes, salt_len, &ctx);
+    }
+
+    /* Add key for numbers not divisible by 7.  */
+    if (cnt % 7 != 0) {
+      sha512_process_bytes(p_bytes, key_len, &ctx);
+    }
+
+    /* Add key or last result.  */
+    if ((cnt & 1) != 0) {
+      sha512_process_bytes(alt_result, 64, &ctx);
+    } else {
+      sha512_process_bytes(p_bytes, key_len, &ctx);
+    }
+
+    /* Create intermediate result.  */
+    sha512_finish_ctx(&ctx, alt_result);
+  }
+
+  /* Now we can construct the result string.  It consists of three
+   parts.  */
+  cp = __php_stpncpy(buffer, sha512_salt_prefix, MAX(0, buflen));
+  buflen -= sizeof(sha512_salt_prefix) - 1;
+
+  if (rounds_custom) {
+    int n = _snprintf(cp, MAX(0, buflen), "%s%I64u$", sha512_rounds_prefix, rounds);
+    cp += n;
+    buflen -= n;
+  }
+
+  cp = __php_stpncpy(cp, salt, MIN((size_t) MAX(0, buflen), salt_len));
+  buflen -= (int) MIN((size_t) MAX(0, buflen), salt_len);
+
+  if (buflen > 0) {
+    *cp++ = '$';
+    --buflen;
+  }
+
+#define b64_from_24bit(B2, B1, B0, N)                    \
+  do {                                   \
+  unsigned int w = ((B2) << 16) | ((B1) << 8) | (B0);   \
+  int n = (N);                           \
+  while (n-- > 0 && buflen > 0)               \
+    {                                   \
+  *cp++ = b64t[w & 0x3f];                     \
+  --buflen;                               \
+  w >>= 6;                               \
+    }                                   \
+  } while (0)
+
+  b64_from_24bit(alt_result[0], alt_result[21], alt_result[42], 4);
+  b64_from_24bit(alt_result[22], alt_result[43], alt_result[1], 4);
+  b64_from_24bit(alt_result[44], alt_result[2], alt_result[23], 4);
+  b64_from_24bit(alt_result[3], alt_result[24], alt_result[45], 4);
+  b64_from_24bit(alt_result[25], alt_result[46], alt_result[4], 4);
+  b64_from_24bit(alt_result[47], alt_result[5], alt_result[26], 4);
+  b64_from_24bit(alt_result[6], alt_result[27], alt_result[48], 4);
+  b64_from_24bit(alt_result[28], alt_result[49], alt_result[7], 4);
+  b64_from_24bit(alt_result[50], alt_result[8], alt_result[29], 4);
+  b64_from_24bit(alt_result[9], alt_result[30], alt_result[51], 4);
+  b64_from_24bit(alt_result[31], alt_result[52], alt_result[10], 4);
+  b64_from_24bit(alt_result[53], alt_result[11], alt_result[32], 4);
+  b64_from_24bit(alt_result[12], alt_result[33], alt_result[54], 4);
+  b64_from_24bit(alt_result[34], alt_result[55], alt_result[13], 4);
+  b64_from_24bit(alt_result[56], alt_result[14], alt_result[35], 4);
+  b64_from_24bit(alt_result[15], alt_result[36], alt_result[57], 4);
+  b64_from_24bit(alt_result[37], alt_result[58], alt_result[16], 4);
+  b64_from_24bit(alt_result[59], alt_result[17], alt_result[38], 4);
+  b64_from_24bit(alt_result[18], alt_result[39], alt_result[60], 4);
+  b64_from_24bit(alt_result[40], alt_result[61], alt_result[19], 4);
+  b64_from_24bit(alt_result[62], alt_result[20], alt_result[41], 4);
+  b64_from_24bit(0, 0, alt_result[63], 2);
+
+  if (buflen <= 0) {
+    errno = ERANGE;
+    buffer = NULL;
+  } else {
+    *cp = '\0';    /* Terminate the string.  */
+  }
+
+  /* Clear the buffer for the intermediate result so that people
+   attaching to processes or reading core dumps cannot get any
+   information.  We do it in this way to clear correct_words[]
+   inside the SHA512 implementation as well.  */
+  sha512_init_ctx(&ctx);
+  sha512_finish_ctx(&ctx, alt_result);
+  RtlSecureZeroMemory(temp_result, sizeof(temp_result));
+  RtlSecureZeroMemory(p_bytes, key_len);
+  RtlSecureZeroMemory(s_bytes, salt_len);
+  RtlSecureZeroMemory(&ctx, sizeof(ctx));
+  RtlSecureZeroMemory(&alt_ctx, sizeof(alt_ctx));
+  if (copied_key != NULL) {
+    RtlSecureZeroMemory(copied_key, key_len);
+  }
+  if (copied_salt != NULL) {
+    RtlSecureZeroMemory(copied_salt, salt_len);
+  }
+
+  return buffer;
+}
+
+
+/* This entry point is equivalent to the `crypt' function in Unix
+   libcs.  */
+char *
+php_sha512_crypt(const char *key, const char *salt) {
+  /* We don't want to have an arbitrary limit in the size of the
+   password.  We can compute an upper bound for the size of the
+   result in advance and so we can prepare the buffer we pass to
+   `sha512_crypt_r'.  */
+  static char *buffer;
+  static int buflen;
+  int needed = (int)(sizeof(sha512_salt_prefix) - 1
+    + sizeof(sha512_rounds_prefix) + 9 + 1
+    + strlen(salt) + 1 + 86 + 1);
+
+  if (buflen < needed) {
+    char *new_buffer = (char *) realloc(buffer, needed);
+    if (new_buffer == NULL) {
+      return NULL;
+    }
+
+    buffer = new_buffer;
+    buflen = needed;
+  }
+
+  return php_sha512_crypt_r (key, salt, buffer, buflen);
+}

--- a/hphp/zend/php-crypt_r.c
+++ b/hphp/zend/php-crypt_r.c
@@ -1,0 +1,261 @@
+/* $Id$ */
+/*
+   +----------------------------------------------------------------------+
+   | PHP Version 7                                                        |
+   +----------------------------------------------------------------------+
+   | Copyright (c) 1997-2015 The PHP Group                                |
+   +----------------------------------------------------------------------+
+   | This source file is subject to version 3.01 of the PHP license,      |
+   | that is bundled with this package in the file LICENSE, and is        |
+   | available through the world-wide-web at the following url:           |
+   | http://www.php.net/license/3_01.txt                                  |
+   | If you did not receive a copy of the PHP license and are unable to   |
+   | obtain it through the world-wide-web, please send a note to          |
+   | license@php.net so we can mail you a copy immediately.               |
+   +----------------------------------------------------------------------+
+   | Authors: Pierre Alain Joye  <pajoye@php.net                          |
+   +----------------------------------------------------------------------+
+ */
+
+/*
+ * License for the Unix md5crypt implementation (md5_crypt):
+ *
+ * ----------------------------------------------------------------------------
+ * "THE BEER-WARE LICENSE" (Revision 42):
+ * <phk@login.dknet.dk> wrote this file.  As long as you retain this notice you
+ * can do whatever you want with this stuff. If we meet some day, and you think
+ * this stuff is worth it, you can buy me a beer in return.   Poul-Henning Kamp
+ * ----------------------------------------------------------------------------
+ *
+ * from FreeBSD: crypt.c,v 1.5 1996/10/14 08:34:02 phk Exp
+ * via OpenBSD: md5crypt.c,v 1.9 1997/07/23 20:58:27 kstailey Exp
+ * via NetBSD: md5crypt.c,v 1.4.2.1 2002/01/22 19:31:59 he Exp
+ *
+ */
+
+/*
+ * This has been modified to be used exclusively by MSVC
+ * for HHVM. It has also been reformatted for HHVM's coding
+ * standards.
+ */
+
+#include <string.h>
+#include <Windows.h>
+#include <wincrypt.h>
+
+#include <signal.h>
+#include "php-crypt_r.h"
+#include "crypt-freesec.h"
+
+void _crypt_extended_init_r() {
+  LONG volatile initialized = 0;
+
+  if (!initialized) {
+    InterlockedIncrement(&initialized);
+    _crypt_extended_init();
+  }
+}
+
+/* MD% crypt implementation using the windows CryptoApi */
+#define MD5_MAGIC "$1$"
+#define MD5_MAGIC_LEN 3
+
+static unsigned char itoa64[] =    /* 0 ... 63 => ascii - 64 */
+  "./0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+
+static void
+to64(char *s, int v, int n) {
+  while (--n >= 0) {
+    *s++ = itoa64[v & 0x3f];
+    v >>= 6;
+  }
+}
+
+char* php_md5_crypt_r(const char *pw, const char *salt, char *out) {
+  HCRYPTPROV hCryptProv;
+  HCRYPTHASH ctx, ctx1;
+  unsigned int i, pwl, sl;
+  const BYTE magic_md5[4] = "$1$";
+  const DWORD magic_md5_len = 3;
+  DWORD        dwHashLen;
+  int pl;
+  __int32 l;
+  const char *sp = salt;
+  const char *ep = salt;
+  char *p = NULL;
+  char *passwd = out;
+  unsigned char final[16];
+
+  /* Acquire a cryptographic provider context handle. */
+  if(!CryptAcquireContext(&hCryptProv, NULL, NULL, PROV_RSA_FULL, CRYPT_VERIFYCONTEXT)) {
+    return NULL;
+  }
+
+  pwl = (unsigned int) strlen(pw);
+
+  /* Refine the salt first */
+  sp = salt;
+
+  /* If it starts with the magic string, then skip that */
+  if (strncmp(sp, MD5_MAGIC, MD5_MAGIC_LEN) == 0) {
+    sp += MD5_MAGIC_LEN;
+  }
+
+  /* It stops at the first '$', max 8 chars */
+  for (ep = sp; *ep != '\0' && *ep != '$' && ep < (sp + 8); ep++) {
+    continue;
+  }
+
+  /* get the length of the true salt */
+  sl = (unsigned int)(ep - sp);
+
+  /* Create an empty hash object. */
+  if(!CryptCreateHash(hCryptProv, CALG_MD5, 0, 0, &ctx)) {
+    goto _destroyProv;
+  }
+
+  /* The password first, since that is what is most unknown */
+  if(!CryptHashData(ctx, (BYTE *)pw, pwl, 0)) {
+    goto _destroyCtx0;
+  }
+
+  /* Then our magic string */
+  if(!CryptHashData(ctx, magic_md5, magic_md5_len, 0)) {
+    goto _destroyCtx0;
+  }
+
+  /* Then the raw salt */
+  if(!CryptHashData( ctx, (BYTE *)sp, sl, 0)) {
+    goto _destroyCtx0;
+  }
+
+  /* MD5(pw,salt,pw), valid. */
+  /* Then just as many characters of the MD5(pw,salt,pw) */
+  if(!CryptCreateHash(hCryptProv, CALG_MD5, 0, 0, &ctx1)) {
+    goto _destroyCtx0;
+  }
+  if(!CryptHashData(ctx1, (BYTE *)pw, pwl, 0)) {
+    goto _destroyCtx1;
+  }
+  if(!CryptHashData(ctx1, (BYTE *)sp, sl, 0)) {
+    goto _destroyCtx1;
+  }
+  if(!CryptHashData(ctx1, (BYTE *)pw, pwl, 0)) {
+    goto _destroyCtx1;
+  }
+
+  dwHashLen = 16;
+  CryptGetHashParam(ctx1, HP_HASHVAL, final, &dwHashLen, 0);
+  /*  MD5(pw,salt,pw). Valid. */
+
+  for (pl = pwl; pl > 0; pl -= 16) {
+    CryptHashData(ctx, final, (DWORD)(pl > 16 ? 16 : pl), 0);
+  }
+
+  /* Don't leave anything around in vm they could use. */
+  RtlSecureZeroMemory(final, sizeof(final));
+
+  /* Then something really weird... */
+  for (i = pwl; i != 0; i >>= 1) {
+    if ((i & 1) != 0) {
+      CryptHashData(ctx, (const BYTE *)final, 1, 0);
+    } else {
+      CryptHashData(ctx, (const BYTE *)pw, 1, 0);
+    }
+  }
+
+  memcpy(passwd, MD5_MAGIC, MD5_MAGIC_LEN);
+
+  if (strncpy_s(passwd + MD5_MAGIC_LEN, MD5_HASH_MAX_LEN - MD5_MAGIC_LEN, sp, sl + 1) != 0) {
+    goto _destroyCtx1;
+  }
+  passwd[MD5_MAGIC_LEN + sl] = '\0';
+  strcat_s(passwd, MD5_HASH_MAX_LEN, "$");
+
+  dwHashLen = 16;
+
+  /* Fetch the ctx hash value */
+  CryptGetHashParam(ctx, HP_HASHVAL, final, &dwHashLen, 0);
+
+  for (i = 0; i < 1000; i++) {
+    if(!CryptCreateHash(hCryptProv, CALG_MD5, 0, 0, &ctx1)) {
+      goto _destroyCtx1;
+    }
+
+    if ((i & 1) != 0) {
+      if(!CryptHashData(ctx1, (BYTE *)pw, pwl, 0)) {
+        goto _destroyCtx1;
+      }
+    } else {
+      if(!CryptHashData(ctx1, (BYTE *)final, 16, 0)) {
+        goto _destroyCtx1;
+      }
+    }
+
+    if ((i % 3) != 0) {
+      if(!CryptHashData(ctx1, (BYTE *)sp, sl, 0)) {
+        goto _destroyCtx1;
+      }
+    }
+
+    if ((i % 7) != 0) {
+      if(!CryptHashData(ctx1, (BYTE *)pw, pwl, 0)) {
+        goto _destroyCtx1;
+      }
+    }
+
+    if ((i & 1) != 0) {
+      if(!CryptHashData(ctx1, (BYTE *)final, 16, 0)) {
+        goto _destroyCtx1;
+      }
+    } else {
+      if(!CryptHashData(ctx1, (BYTE *)pw, pwl, 0)) {
+        goto _destroyCtx1;
+      }
+    }
+
+    /* Fetch the ctx hash value */
+    dwHashLen = 16;
+    CryptGetHashParam(ctx1, HP_HASHVAL, final, &dwHashLen, 0);
+    if(!(CryptDestroyHash(ctx1))) {
+      goto _destroyCtx0;
+    }
+  }
+
+  ctx1 = (HCRYPTHASH) NULL;
+
+  p = passwd + sl + MD5_MAGIC_LEN + 1;
+
+  l = (final[ 0]<<16) | (final[ 6]<<8) | final[12]; to64(p,l,4); p += 4;
+  l = (final[ 1]<<16) | (final[ 7]<<8) | final[13]; to64(p,l,4); p += 4;
+  l = (final[ 2]<<16) | (final[ 8]<<8) | final[14]; to64(p,l,4); p += 4;
+  l = (final[ 3]<<16) | (final[ 9]<<8) | final[15]; to64(p,l,4); p += 4;
+  l = (final[ 4]<<16) | (final[10]<<8) | final[ 5]; to64(p,l,4); p += 4;
+  l = final[11]; to64(p,l,2); p += 2;
+
+  *p = '\0';
+
+  RtlSecureZeroMemory(final, sizeof(final));
+
+
+_destroyCtx1:
+  if (ctx1) {
+    if (!CryptDestroyHash(ctx1)) {
+
+    }
+  }
+
+_destroyCtx0:
+  CryptDestroyHash(ctx);
+
+_destroyProv:
+  /* Release the provider handle.*/
+  if(hCryptProv) {
+    if(!(CryptReleaseContext(hCryptProv, 0))) {
+      return NULL;
+    }
+  }
+
+  return out;
+}
+

--- a/hphp/zend/php-crypt_r.h
+++ b/hphp/zend/php-crypt_r.h
@@ -1,0 +1,55 @@
+/* $Id$ */
+/*
+   +----------------------------------------------------------------------+
+   | PHP Version 7                                                        |
+   +----------------------------------------------------------------------+
+   | Copyright (c) 1997-2015 The PHP Group                                |
+   +----------------------------------------------------------------------+
+   | This source file is subject to version 3.01 of the PHP license,      |
+   | that is bundled with this package in the file LICENSE, and is        |
+   | available through the world-wide-web at the following url:           |
+   | http://www.php.net/license/3_01.txt                                  |
+   | If you did not receive a copy of the PHP license and are unable to   |
+   | obtain it through the world-wide-web, please send a note to          |
+   | license@php.net so we can mail you a copy immediately.               |
+   +----------------------------------------------------------------------+
+   | Authors: Pierre Alain Joye  <pajoye@php.net                          |
+   +----------------------------------------------------------------------+
+ */
+
+#ifndef _CRYPT_WIHN32_H_
+#define _CRYPT_WIHN32_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+#include "crypt-freesec.h"
+
+#ifndef __const
+#define __CONST
+#else
+#define __CONST __const
+#endif
+
+void php_init_crypt_r();
+void php_shutdown_crypt_r();
+
+extern void _crypt_extended_init_r(void);
+
+/*PHPAPI char* crypt(const char *key, const char *salt);*/
+char *php_crypt_r (const char *__key, const char *__salt, struct php_crypt_extended_data * __data);
+
+#define MD5_HASH_MAX_LEN 120
+
+#include "crypt-blowfish.h"
+
+extern char * php_md5_crypt_r(const char *pw, const char *salt, char *out);
+extern char * php_sha512_crypt_r (const char *key, const char *salt, char *buffer, int buflen);
+extern char * php_sha256_crypt_r (const char *key, const char *salt, char *buffer, int buflen);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _CRYPT_WIHN32_H_ */

--- a/hphp/zend/php-crypt_r.h
+++ b/hphp/zend/php-crypt_r.h
@@ -26,12 +26,6 @@ extern "C"
 #endif
 #include "crypt-freesec.h"
 
-#ifndef __const
-#define __CONST
-#else
-#define __CONST __const
-#endif
-
 void php_init_crypt_r();
 void php_shutdown_crypt_r();
 

--- a/hphp/zend/php-crypt_r.h
+++ b/hphp/zend/php-crypt_r.h
@@ -37,10 +37,8 @@ void php_shutdown_crypt_r();
 
 extern void _crypt_extended_init_r(void);
 
-/*PHPAPI char* crypt(const char *key, const char *salt);*/
-char *php_crypt_r (const char *__key, const char *__salt, struct php_crypt_extended_data * __data);
-
 #define MD5_HASH_MAX_LEN 120
+#define PHP_MAX_SALT_LEN 123
 
 #include "crypt-blowfish.h"
 

--- a/hphp/zend/zend-string.cpp
+++ b/hphp/zend/zend-string.cpp
@@ -222,7 +222,7 @@ char *string_crypt(const char *key, const char *salt) {
         out = php_md5_crypt_r(key, salt, output);
         if (out)
           return strdup(out);
-        return NULL;
+        return nullptr;
       }
       else if (salt[0] == '$' && salt[1] == '6' && salt[2] == '$') {
         char output[PHP_MAX_SALT_LEN + 1];
@@ -230,7 +230,7 @@ char *string_crypt(const char *key, const char *salt) {
         crypt_res = php_sha512_crypt_r(key, salt, output, PHP_MAX_SALT_LEN);
         if (!crypt_res) {
           SecureZeroMemory(output, PHP_MAX_SALT_LEN + 1);
-          return NULL;
+          return nullptr;
         }
         else {
           char* result = strdup(output);
@@ -244,7 +244,7 @@ char *string_crypt(const char *key, const char *salt) {
         crypt_res = php_sha256_crypt_r(key, salt, output, PHP_MAX_SALT_LEN);
         if (!crypt_res) {
           SecureZeroMemory(output, PHP_MAX_SALT_LEN + 1);
-          return NULL;
+          return nullptr;
         }
         else {
           char* result = strdup(output);
@@ -263,7 +263,7 @@ char *string_crypt(const char *key, const char *salt) {
         crypt_res = php_crypt_blowfish_rn(key, salt, output, sizeof(output));
         if (!crypt_res) {
           SecureZeroMemory(output, PHP_MAX_SALT_LEN + 1);
-          return NULL;
+          return nullptr;
         }
         else {
           char* result = strdup(output);
@@ -272,7 +272,7 @@ char *string_crypt(const char *key, const char *salt) {
         }
       }
       else if (salt[0] == '*' && (salt[1] == '0' || salt[1] == '1')) {
-        return NULL;
+        return nullptr;
       }
       else {
         struct php_crypt_extended_data buffer;
@@ -282,7 +282,7 @@ char *string_crypt(const char *key, const char *salt) {
 
         char* crypt_res = _crypt_extended_r(key, salt, &buffer);
         if (!crypt_res || (salt[0] == '*' && salt[1] == '0'))
-          return NULL;
+          return nullptr;
         else
           return strdup(crypt_res);
       }

--- a/hphp/zend/zend-string.cpp
+++ b/hphp/zend/zend-string.cpp
@@ -156,8 +156,73 @@ int string_crc32(const char *p, int len) {
 // crypt
 
 #ifdef _MSC_VER
-#define PHP_CRYPT_R 1
+#define PHP_CRYPT_R_MSVC 1
 #include "hphp/zend/php-crypt_r.h"
+
+char* php_crypt_r_msvc(const char* key, const char* salt) {
+  if (salt[0] == '$' && salt[1] == '1' && salt[2] == '$') {
+    char output[MD5_HASH_MAX_LEN], *out;
+
+    out = php_md5_crypt_r(key, salt, output);
+    return out ? strdup(out) : nullptr;
+  } else if (salt[0] == '$' && salt[1] == '6' && salt[2] == '$') {
+    char output[PHP_MAX_SALT_LEN + 1];
+
+    char* crypt_res = php_sha512_crypt_r(key, salt, output, PHP_MAX_SALT_LEN);
+    if (!crypt_res) {
+      SecureZeroMemory(output, PHP_MAX_SALT_LEN + 1);
+      return nullptr;
+    } else {
+      char* result = strdup(output);
+      SecureZeroMemory(output, PHP_MAX_SALT_LEN + 1);
+      return result;
+    }
+  } else if (salt[0] == '$' && salt[1] == '5' && salt[2] == '$') {
+    char output[PHP_MAX_SALT_LEN + 1];
+
+    char* crypt_res = php_sha256_crypt_r(key, salt, output, PHP_MAX_SALT_LEN);
+    if (!crypt_res) {
+      SecureZeroMemory(output, PHP_MAX_SALT_LEN + 1);
+      return nullptr;
+    } else {
+      char* result = strdup(output);
+      SecureZeroMemory(output, PHP_MAX_SALT_LEN + 1);
+      return result;
+    }
+  } else if (
+    salt[0] == '$' &&
+    salt[1] == '2' &&
+    salt[3] == '$') {
+    char output[PHP_MAX_SALT_LEN + 1];
+
+    memset(output, 0, PHP_MAX_SALT_LEN + 1);
+
+    char* crypt_res = php_crypt_blowfish_rn(key, salt, output, sizeof(output));
+    if (!crypt_res) {
+      SecureZeroMemory(output, PHP_MAX_SALT_LEN + 1);
+      return nullptr;
+    } else {
+      char* result = strdup(output);
+      SecureZeroMemory(output, PHP_MAX_SALT_LEN + 1);
+      return result;
+    }
+  } else if (salt[0] == '*' && (salt[1] == '0' || salt[1] == '1')) {
+    return nullptr;
+  } else {
+    struct php_crypt_extended_data buffer;
+    /* DES Fallback */
+    memset(&buffer, 0, sizeof(buffer));
+    _crypt_extended_init_r();
+
+    char* crypt_res = _crypt_extended_r(key, salt, &buffer);
+    if (!crypt_res || (salt[0] == '*' && salt[1] == '0')) {
+      return nullptr;
+    } else {
+      return strdup(crypt_res);
+    }
+  }
+}
+
 #else
 #include <unistd.h>
 #if !defined(__APPLE__) && !defined(__FreeBSD__)
@@ -213,89 +278,19 @@ char *string_crypt(const char *key, const char *salt) {
 #  error "Data struct used by crypt_r() is unknown. Please report."
 # endif
     char *crypt_res = crypt_r(key, salt, &buffer);
-#elif defined(PHP_CRYPT_R)
-    char* crypt_res;
-    {
-      if (salt[0] == '$' && salt[1] == '1' && salt[2] == '$') {
-        char output[MD5_HASH_MAX_LEN], *out;
-
-        out = php_md5_crypt_r(key, salt, output);
-        if (out)
-          return strdup(out);
-        return nullptr;
-      }
-      else if (salt[0] == '$' && salt[1] == '6' && salt[2] == '$') {
-        char output[PHP_MAX_SALT_LEN + 1];
-
-        crypt_res = php_sha512_crypt_r(key, salt, output, PHP_MAX_SALT_LEN);
-        if (!crypt_res) {
-          SecureZeroMemory(output, PHP_MAX_SALT_LEN + 1);
-          return nullptr;
-        }
-        else {
-          char* result = strdup(output);
-          SecureZeroMemory(output, PHP_MAX_SALT_LEN + 1);
-          return result;
-        }
-      }
-      else if (salt[0] == '$' && salt[1] == '5' && salt[2] == '$') {
-        char output[PHP_MAX_SALT_LEN + 1];
-
-        crypt_res = php_sha256_crypt_r(key, salt, output, PHP_MAX_SALT_LEN);
-        if (!crypt_res) {
-          SecureZeroMemory(output, PHP_MAX_SALT_LEN + 1);
-          return nullptr;
-        }
-        else {
-          char* result = strdup(output);
-          SecureZeroMemory(output, PHP_MAX_SALT_LEN + 1);
-          return result;
-        }
-      }
-      else if (
-        salt[0] == '$' &&
-        salt[1] == '2' &&
-        salt[3] == '$') {
-        char output[PHP_MAX_SALT_LEN + 1];
-
-        memset(output, 0, PHP_MAX_SALT_LEN + 1);
-
-        crypt_res = php_crypt_blowfish_rn(key, salt, output, sizeof(output));
-        if (!crypt_res) {
-          SecureZeroMemory(output, PHP_MAX_SALT_LEN + 1);
-          return nullptr;
-        }
-        else {
-          char* result = strdup(output);
-          SecureZeroMemory(output, PHP_MAX_SALT_LEN + 1);
-          return result;
-        }
-      }
-      else if (salt[0] == '*' && (salt[1] == '0' || salt[1] == '1')) {
-        return nullptr;
-      }
-      else {
-        struct php_crypt_extended_data buffer;
-        /* DES Fallback */
-        memset(&buffer, 0, sizeof(buffer));
-        _crypt_extended_init_r();
-
-        char* crypt_res = _crypt_extended_r(key, salt, &buffer);
-        if (!crypt_res || (salt[0] == '*' && salt[1] == '0'))
-          return nullptr;
-        else
-          return strdup(crypt_res);
-      }
-    }
+#elif defined(PHP_CRYPT_R_MSVC)
+    return php_crypt_r_msvc(key, salt);
 #else
     static Mutex mutex;
     Lock lock(mutex);
     char *crypt_res = crypt(key,salt);
 #endif
 
+#ifndef PHP_CRYPT_R_MSVC
     if (crypt_res) {
       return strdup(crypt_res);
     }
+#endif
   }
 
   return ((salt[0] == '*') && (salt[1] == '0'))

--- a/hphp/zend/zend-string.cpp
+++ b/hphp/zend/zend-string.cpp
@@ -214,8 +214,79 @@ char *string_crypt(const char *key, const char *salt) {
 # endif
     char *crypt_res = crypt_r(key, salt, &buffer);
 #elif defined(PHP_CRYPT_R)
-    php_crypt_extended_data buffer;
-    char *crypt_res = php_crypt_r(key, salt, &buffer);
+    char* crypt_res;
+    {
+      if (salt[0] == '$' && salt[1] == '1' && salt[2] == '$') {
+        char output[MD5_HASH_MAX_LEN], *out;
+
+        out = php_md5_crypt_r(key, salt, output);
+        if (out)
+          return strdup(out);
+        return NULL;
+      }
+      else if (salt[0] == '$' && salt[1] == '6' && salt[2] == '$') {
+        char output[PHP_MAX_SALT_LEN + 1];
+
+        crypt_res = php_sha512_crypt_r(key, salt, output, PHP_MAX_SALT_LEN);
+        if (!crypt_res) {
+          SecureZeroMemory(output, PHP_MAX_SALT_LEN + 1);
+          return NULL;
+        }
+        else {
+          char* result = strdup(output);
+          SecureZeroMemory(output, PHP_MAX_SALT_LEN + 1);
+          return result;
+        }
+      }
+      else if (salt[0] == '$' && salt[1] == '5' && salt[2] == '$') {
+        char output[PHP_MAX_SALT_LEN + 1];
+
+        crypt_res = php_sha256_crypt_r(key, salt, output, PHP_MAX_SALT_LEN);
+        if (!crypt_res) {
+          SecureZeroMemory(output, PHP_MAX_SALT_LEN + 1);
+          return NULL;
+        }
+        else {
+          char* result = strdup(output);
+          SecureZeroMemory(output, PHP_MAX_SALT_LEN + 1);
+          return result;
+        }
+      }
+      else if (
+        salt[0] == '$' &&
+        salt[1] == '2' &&
+        salt[3] == '$') {
+        char output[PHP_MAX_SALT_LEN + 1];
+
+        memset(output, 0, PHP_MAX_SALT_LEN + 1);
+
+        crypt_res = php_crypt_blowfish_rn(key, salt, output, sizeof(output));
+        if (!crypt_res) {
+          SecureZeroMemory(output, PHP_MAX_SALT_LEN + 1);
+          return NULL;
+        }
+        else {
+          char* result = strdup(output);
+          SecureZeroMemory(output, PHP_MAX_SALT_LEN + 1);
+          return result;
+        }
+      }
+      else if (salt[0] == '*' && (salt[1] == '0' || salt[1] == '1')) {
+        return NULL;
+      }
+      else {
+        struct php_crypt_extended_data buffer;
+        /* DES Fallback */
+        memset(&buffer, 0, sizeof(buffer));
+        _crypt_extended_init_r();
+
+        char* crypt_res = _crypt_extended_r(key, salt, &buffer);
+        if (!crypt_res || (salt[0] == '*' && salt[1] == '0'))
+          return NULL;
+        else
+          return strdup(crypt_res);
+      }
+    }
 #else
     static Mutex mutex;
     Lock lock(mutex);

--- a/hphp/zend/zend-string.cpp
+++ b/hphp/zend/zend-string.cpp
@@ -155,9 +155,14 @@ int string_crc32(const char *p, int len) {
 ///////////////////////////////////////////////////////////////////////////////
 // crypt
 
+#ifdef _MSC_VER
+#define PHP_CRYPT_R 1
+#include "hphp/zend/php-crypt_r.h"
+#else
 #include <unistd.h>
 #if !defined(__APPLE__) && !defined(__FreeBSD__)
 # include <crypt.h>
+#endif
 #endif
 #include "hphp/zend/crypt-blowfish.h"
 
@@ -208,6 +213,9 @@ char *string_crypt(const char *key, const char *salt) {
 #  error "Data struct used by crypt_r() is unknown. Please report."
 # endif
     char *crypt_res = crypt_r(key, salt, &buffer);
+#elif defined(PHP_CRYPT_R)
+    php_crypt_extended_data buffer;
+    char *crypt_res = php_crypt_r(key, salt, &buffer);
 #else
     static Mutex mutex;
     Lock lock(mutex);


### PR DESCRIPTION
This pulls in the implementation of `php_crypt_r` from PHP. It has been specialized for MSVC, which is why this isn't done as a fallback for all platforms without `crypt_r`.