### PR TITLE
Use utf8 string literals in zend-html

### DIFF
--- a/hphp/zend/zend-html.cpp
+++ b/hphp/zend/zend-html.cpp
@@ -428,12 +428,12 @@ static void init_entity_table() {
     XHPEntityMap[charset]["amp"] = "&";
     // XHP-specific entities
     XHPEntityMap[charset]["apos"] = "\'";
-    XHPEntityMap[charset]["cloud"] = "\u2601";
-    XHPEntityMap[charset]["umbrella"] = "\u2602";
-    XHPEntityMap[charset]["snowman"] = "\u2603";
-    XHPEntityMap[charset]["snowflake"] = "\u2745";
-    XHPEntityMap[charset]["comet"] = "\u2604";
-    XHPEntityMap[charset]["thunderstorm"] = "\u2608";
+    XHPEntityMap[charset]["cloud"] = u8"\u2601";
+    XHPEntityMap[charset]["umbrella"] = u8"\u2602";
+    XHPEntityMap[charset]["snowman"] = u8"\u2603";
+    XHPEntityMap[charset]["snowflake"] = u8"\u2745";
+    XHPEntityMap[charset]["comet"] = u8"\u2604";
+    XHPEntityMap[charset]["thunderstorm"] = u8"\u2608";
   }
 
   // the first element is an empty table
@@ -443,12 +443,12 @@ static void init_entity_table() {
   EntityMap[cs_terminator]["amp"] = "&";
   // XHP-specific entities
   XHPEntityMap[cs_terminator]["apos"] = "\'";
-  XHPEntityMap[cs_terminator]["cloud"] = "\u2601";
-  XHPEntityMap[cs_terminator]["umbrella"] = "\u2602";
-  XHPEntityMap[cs_terminator]["snowman"] = "\u2603";
-  XHPEntityMap[cs_terminator]["snowflake"] = "\u2745";
-  XHPEntityMap[cs_terminator]["comet"] = "\u2604";
-  XHPEntityMap[cs_terminator]["thunderstorm"] = "\u2608";
+  XHPEntityMap[cs_terminator]["cloud"] = u8"\u2601";
+  XHPEntityMap[cs_terminator]["umbrella"] = u8"\u2602";
+  XHPEntityMap[cs_terminator]["snowman"] = u8"\u2603";
+  XHPEntityMap[cs_terminator]["snowflake"] = u8"\u2745";
+  XHPEntityMap[cs_terminator]["comet"] = u8"\u2604";
+  XHPEntityMap[cs_terminator]["thunderstorm"] = u8"\u2608";
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -745,7 +745,7 @@ char *string_html_encode(const char *input, int &len,
         if (cond) { \
           p += (len) - 1; \
           if (should_skip) { break; } \
-          else if (should_replace) { strcpy(q, "\uFFFD"); q += 3; break; } \
+          else if (should_replace) { strcpy(q, u8"\uFFFD"); q += 3; break; } \
           else { goto exit_error; } \
         }
 
@@ -883,7 +883,7 @@ char *string_html_encode_extra(const char *input, int &len,
     return nullptr;
   }
   char *q = ret;
-  const char *rep = "\ufffd";
+  const char *rep = u8"\ufffd";
   int32_t srcPosBytes;
   for (srcPosBytes = 0; srcPosBytes < len; /* incremented in-loop */) {
     unsigned char c = input[srcPosBytes];


### PR DESCRIPTION
MSVC doesn't allow these character escapes unless they are UTF8 string literals. UTF8 string literals are part of the C++11 spec.