### PR TITLE
Use the gen-class-map target rather than a binary path

### DIFF
--- a/hphp/system/CMakeLists.txt
+++ b/hphp/system/CMakeLists.txt
@@ -4,7 +4,7 @@ auto_sources(IDL_SRCS "*.idl.json" "RECURSE"
 add_custom_command(
   OUTPUT "class_map.cpp" "constants.h"
   DEPENDS ${IDL_SRCS} gen-class-map
-  COMMAND "${CMAKE_CURRENT_BINARY_DIR}/../tools/bootstrap/gen-class-map"
+  COMMAND gen-class-map
   ARGS "--system"
        "${CMAKE_CURRENT_BINARY_DIR}/class_map.cpp"
        "${CMAKE_CURRENT_BINARY_DIR}/constants.h"


### PR DESCRIPTION
This is because the path it currently is using will only be valid for in-tree builds, and will never be valid for windows.
This changes it to use the target directly, and lets CMake choose the correct path to the binary.