### PR TITLE
Switch uses of uint outside of ext-zend-compat to uint32_t

### DIFF
--- a/hphp/compiler/analysis/analysis_result.cpp
+++ b/hphp/compiler/analysis/analysis_result.cpp
@@ -671,7 +671,7 @@ void AnalysisResult::analyzeProgram(bool system /* = false */) {
 void AnalysisResult::analyzeProgramFinal() {
   AnalysisResultPtr ar = shared_from_this();
   setPhase(AnalysisResult::AnalyzeFinal);
-  for (uint i = 0; i < m_fileScopes.size(); i++) {
+  for (uint32_t i = 0; i < m_fileScopes.size(); i++) {
     m_fileScopes[i]->analyzeProgram(ar);
   }
 

--- a/hphp/compiler/analysis/emitter.cpp
+++ b/hphp/compiler/analysis/emitter.cpp
@@ -3095,7 +3095,7 @@ bool EmitterVisitor::visit(ConstructPtr node) {
       emitPop(e);
       return false;
     }
-    uint ncase = cases->getCount();
+    uint32_t ncase = cases->getCount();
     std::vector<Label> caseLabels(ncase);
     Label& brkTarget = registerBreak(sw, region.get(), 1, false)->m_label;
     Label& contTarget =
@@ -3156,7 +3156,7 @@ bool EmitterVisitor::visit(ConstructPtr node) {
       }
 
       int defI = -1;
-      for (uint i = 0; i < ncase; i++) {
+      for (uint32_t i = 0; i < ncase; i++) {
         CaseStatementPtr c(static_pointer_cast<CaseStatement>((*cases)[i]));
         ExpressionPtr condition = c->getCondition();
         if (condition) {
@@ -3189,7 +3189,7 @@ bool EmitterVisitor::visit(ConstructPtr node) {
         e.Jmp(brkTarget);
       }
     }
-    for (uint i = 0; i < ncase; i++) {
+    for (uint32_t i = 0; i < ncase; i++) {
       caseLabels[i].set(e);
       CaseStatementPtr c(static_pointer_cast<CaseStatement>((*cases)[i]));
       enterRegion(region);
@@ -6703,7 +6703,7 @@ void EmitterVisitor::emitMethodPrologue(Emitter& e, MethodStatementPtr meth) {
   }
 
   if (!m_curFunc->isMemoizeImpl) {
-    for (uint i = 0; i < m_curFunc->params.size(); i++) {
+    for (uint32_t i = 0; i < m_curFunc->params.size(); i++) {
       const TypeConstraint& tc = m_curFunc->params[i].typeConstraint;
       if (!tc.hasConstraint()) continue;
       emitVirtualLocal(i);
@@ -6885,7 +6885,7 @@ void EmitterVisitor::emitMemoizeProp(Emitter& e,
                                      MethodStatementPtr meth,
                                      Id localID,
                                      const std::vector<Id>& paramIDs,
-                                     uint numParams) {
+                                     uint32_t numParams) {
   assert(m_curFunc->isMemoizeWrapper);
 
   if (meth->is(Statement::KindOfFunctionStatement)) {
@@ -6904,7 +6904,7 @@ void EmitterVisitor::emitMemoizeProp(Emitter& e,
   }
 
   assert(numParams <= paramIDs.size());
-  for (uint i = 0; i < numParams; i++) {
+  for (uint32_t i = 0; i < numParams; i++) {
     if (i == 0 && m_curFunc->hasMemoizeSharedProp) {
       e.Int(m_curFunc->memoizeSharedPropIndex);
     } else {
@@ -7063,7 +7063,7 @@ void EmitterVisitor::emitMemoizeMethod(MethodStatementPtr meth,
   }
   {
     FPIRegionRecorder fpi(this, m_ue, m_evalStack, fpiStart);
-    for (uint i = 0; i < numParams; i++) {
+    for (uint32_t i = 0; i < numParams; i++) {
       emitVirtualLocal(i);
       emitFPass(e, i, PassByRefKind::ErrorOnCell);
     }

--- a/hphp/compiler/analysis/emitter.h
+++ b/hphp/compiler/analysis/emitter.h
@@ -763,7 +763,7 @@ public:
   void emitDeprecationWarning(Emitter& e, MethodStatementPtr meth);
   void emitMethod(MethodStatementPtr meth);
   void emitMemoizeProp(Emitter& e, MethodStatementPtr meth, Id localID,
-                       const std::vector<Id>& paramIDs, uint numParams);
+                       const std::vector<Id>& paramIDs, uint32_t numParams);
   void addMemoizeProp(MethodStatementPtr meth);
   void emitMemoizeMethod(MethodStatementPtr meth, const StringData* methName);
   void emitConstMethodCallNoParams(Emitter& e, string name);

--- a/hphp/compiler/builtin_symbols.cpp
+++ b/hphp/compiler/builtin_symbols.cpp
@@ -259,7 +259,7 @@ ClassScopePtr BuiltinSymbols::ImportClassScopePtr(AnalysisResultPtr ar,
     ar, cls->getName().toCppString(), parent.toCppString(),
     stdIfaces, methods);
 
-  for (uint i = 0; i < methods.size(); ++i) {
+  for (uint32_t i = 0; i < methods.size(); ++i) {
     methods[i]->setOuterScope(cl);
   }
 

--- a/hphp/runtime/base/apc-local-array.cpp
+++ b/hphp/runtime/base/apc-local-array.cpp
@@ -131,13 +131,13 @@ ArrayData* APCLocalArray::loadElems() const {
   ArrayData* elems;
   if (m_arr->isPacked()) {
     PackedArrayInit ai(count);
-    for (uint i = 0; i < count; i++) {
+    for (uint32_t i = 0; i < count; i++) {
       ai.append(GetValueRef(this, i));
     }
     elems = ai.create();
   } else {
     ArrayInit ai(count, ArrayInit::Mixed{});
-    for (uint i = 0; i < count; i++) {
+    for (uint32_t i = 0; i < count; i++) {
       ai.add(getKey(i), GetValueRef(this, i), true);
     }
     elems = ai.create();

--- a/hphp/runtime/base/proxy-array.cpp
+++ b/hphp/runtime/base/proxy-array.cpp
@@ -443,7 +443,7 @@ void ProxyArray::proxyInit(uint32_t nSize,
 }
 
 req::ptr<ResourceData>
-ProxyArray::makeElementResource(void* pData, uint nDataSize,
+ProxyArray::makeElementResource(void* pData, uint32_t nDataSize,
                                 void** pDest) const {
   auto elt = req::make<ZendCustomElement>(pData, nDataSize, m_destructor);
   if (pDest) *pDest = elt->data();

--- a/hphp/runtime/base/proxy-array.h
+++ b/hphp/runtime/base/proxy-array.h
@@ -121,7 +121,7 @@ private:
    * Make a ZendCustomElement resource wrapping the given data block. If pDest
    * is non-null, it will be set to the newly-allocated location for the block.
    */
-  req::ptr<ResourceData> makeElementResource(void *pData, uint nDataSize,
+  req::ptr<ResourceData> makeElementResource(void *pData, uint32_t nDataSize,
                                              void **pDest) const;
 
   DtorFunc m_destructor;

--- a/hphp/runtime/ext/gd/ext_gd.cpp
+++ b/hphp/runtime/ext/gd/ext_gd.cpp
@@ -336,7 +336,7 @@ do { \
 } while (0)
 
 // original Zend name is _estrndup
-static char *php_strndup_impl(const char* s, uint length
+static char *php_strndup_impl(const char* s, uint32_t length
 #ifdef IM_MEMORY_CHECK
 , int ln
 #endif
@@ -1828,7 +1828,7 @@ php_open_plain_file(const String& filename, const char *mode, FILE **fpp) {
   return nullptr;
 }
 
-static int php_write(void *buf, uint size) {
+static int php_write(void *buf, uint32_t size) {
   g_context->write((const char *)buf, size);
   return size;
 }

--- a/hphp/runtime/ext/hotprofiler/ext_hotprofiler.h
+++ b/hphp/runtime/ext/hotprofiler/ext_hotprofiler.h
@@ -190,7 +190,7 @@ struct Profiler {
    */
   static inline uint8_t hprof_inline_hash(const char * str) {
     unsigned long h = 5381;
-    uint i = 0;
+    uint32_t i = 0;
     uint8_t res = 0;
 
     while (*str) {

--- a/hphp/runtime/ext/ipc/ext_ipc.cpp
+++ b/hphp/runtime/ext/ipc/ext_ipc.cpp
@@ -310,7 +310,7 @@ bool HHVM_FUNCTION(msg_receive,
   msgtype = (int)buffer->mtype;
   if (unserialize) {
     const char *bufText = (const char *)buffer->mtext;
-    uint bufLen = strlen(bufText);
+    uint32_t bufLen = strlen(bufText);
     VariableUnserializer vu(bufText, bufLen,
                             VariableUnserializer::Type::Serialize);
     try {

--- a/hphp/runtime/server/access-log.cpp
+++ b/hphp/runtime/server/access-log.cpp
@@ -44,7 +44,7 @@ namespace HPHP {
 
 AccessLog::~AccessLog() {
   signal(SIGCHLD, SIG_DFL);
-  for (uint i = 0; i < m_output.size(); ++i) {
+  for (uint32_t i = 0; i < m_output.size(); ++i) {
     if (m_output[i].log) {
       if (m_files[i].file[0] == '|') {
         pclose(m_output[i].log);
@@ -138,7 +138,7 @@ void AccessLog::log(Transport *transport, const VirtualHost *vhost) {
     threadData->flusher.recordWriteAndMaybeDropCaches(threadLog, bytes);
   }
   if (Logger::UseCronolog) {
-    for (uint i = 0; i < m_cronOutput.size(); ++i) {
+    for (uint32_t i = 0; i < m_cronOutput.size(); ++i) {
       Cronolog &cronOutput = *m_cronOutput[i];
       FILE *outFile = cronOutput.getOutputFile();
       if (!outFile) continue;
@@ -147,7 +147,7 @@ void AccessLog::log(Transport *transport, const VirtualHost *vhost) {
       cronOutput.flusher.recordWriteAndMaybeDropCaches(outFile, bytes);
     }
   } else {
-    for (uint i = 0; i < m_output.size(); ++i) {
+    for (uint32_t i = 0; i < m_output.size(); ++i) {
       LogFileData& output = m_output[i];
       FILE *outFile = output.log;
       if (!outFile) continue;

--- a/hphp/runtime/server/source-root-info.cpp
+++ b/hphp/runtime/server/source-root-info.cpp
@@ -233,7 +233,7 @@ std::string
 SourceRootInfo::parseSandboxServerVariable(const std::string &format) const {
   std::ostringstream res;
   bool control = false;
-  for (uint i = 0; i < format.size(); i++) {
+  for (uint32_t i = 0; i < format.size(); i++) {
     char c = format[i];
     if (control) {
       switch (c) {

--- a/hphp/runtime/vm/bytecode.cpp
+++ b/hphp/runtime/vm/bytecode.cpp
@@ -608,7 +608,7 @@ IMPLEMENT_THREAD_LOCAL(StackElms, t_se);
 const int Stack::sSurprisePageSize = sysconf(_SC_PAGESIZE);
 // We reserve the bottom page of each stack for use as the surprise
 // page, so the minimum useful stack size is the next power of two.
-const uint Stack::sMinStackElms = 2 * sSurprisePageSize / sizeof(TypedValue);
+const uint32_t Stack::sMinStackElms = 2 * sSurprisePageSize / sizeof(TypedValue);
 
 void Stack::ValidateStackSize() {
   if (RuntimeOption::EvalVMStackElms < sMinStackElms) {

--- a/hphp/runtime/vm/func.cpp
+++ b/hphp/runtime/vm/func.cpp
@@ -614,7 +614,7 @@ void Func::prettyPrint(std::ostream& out, const PrintOpts& opts) const {
   if (!opts.metadata) return;
 
   const ParamInfoVec& params = shared()->m_params;
-  for (uint i = 0; i < params.size(); ++i) {
+  for (uint32_t i = 0; i < params.size(); ++i) {
     if (params[i].funcletOff != InvalidAbsoluteOffset) {
       out << " DV for parameter " << i << " at " << params[i].funcletOff;
       if (params[i].phpCode) {

--- a/hphp/runtime/vm/jit/mc-generator.cpp
+++ b/hphp/runtime/vm/jit/mc-generator.cpp
@@ -1729,7 +1729,7 @@ template <typename T> void ClearContainer(T& container) {
 void
 CodeGenFixups::process_only(
   GrowableVector<IncomingBranch>* inProgressTailBranches) {
-  for (uint i = 0; i < m_pendingFixups.size(); i++) {
+  for (uint32_t i = 0; i < m_pendingFixups.size(); i++) {
     TCA tca = m_pendingFixups[i].m_tca;
     assertx(mcg->isValidCodeAddress(tca));
     mcg->fixupMap().recordFixup(tca, m_pendingFixups[i].m_fixup);
@@ -2508,7 +2508,7 @@ void MCGenerator::setJmpTransID(TCA jmp) {
 }
 
 void
-emitIncStat(CodeBlock& cb, uint64_t* tl_table, uint index, int n, bool force) {
+emitIncStat(CodeBlock& cb, uint64_t* tl_table, uint32_t index, int n, bool force) {
   if (!force && !Stats::enabled()) return;
   intptr_t disp = uintptr_t(&tl_table[index]) - tlsBase();
 

--- a/hphp/runtime/vm/unit-emitter-inl.h
+++ b/hphp/runtime/vm/unit-emitter-inl.h
@@ -124,7 +124,7 @@ void UnitEmitter::emitImpl(T n, int64_t pos) {
     m_bclen += sizeof(T);
   } else {
     assert(pos + sizeof(T) <= m_bclen);
-    for (uint i = 0; i < sizeof(T); ++i) {
+    for (uint32_t i = 0; i < sizeof(T); ++i) {
       m_bc[pos + i] = c[i];
     }
   }


### PR DESCRIPTION
MSVC doesn't define `uint` normally, and `uint32_t` is what is used everywhere except these places. `ext-zend-compat` defines `uint` for itself, so everything in there is fine to use it, but the rest of HHVM shouldn't be.