### PR TITLE
Eliminate an unneeded struct qualifier

### DIFF
--- a/hphp/util/cache/cache-manager.h
+++ b/hphp/util/cache/cache-manager.h
@@ -120,7 +120,7 @@ class CacheManager : private boost::noncopyable {
   void dump() const;
 
  private:
-  using CacheMap = struct std::map<std::string, std::unique_ptr<CacheData>>;
+  using CacheMap = std::map<std::string, std::unique_ptr<CacheData>>;
 
   void addDirectories(const std::string& name);
 


### PR DESCRIPTION
MSVC doesn't like it, and it's not actually needed, so it's gone.