### PR TITLE
Port the parser to MSVC

### DIFF
--- a/hphp/parser/hphp.tab.cpp
+++ b/hphp/parser/hphp.tab.cpp
@@ -180,8 +180,8 @@
 
 
 // macros for rules
-#define BEXP(e...) _p->onBinaryOpExp(e);
-#define UEXP(e...) _p->onUnaryOpExp(e);
+#define BEXP(...) _p->onBinaryOpExp(__VA_ARGS__);
+#define UEXP(...) _p->onUnaryOpExp(__VA_ARGS__);
 
 using namespace HPHP::HPHP_PARSER_NS;
 

--- a/hphp/parser/hphp.y
+++ b/hphp/parser/hphp.y
@@ -100,8 +100,8 @@
 
 
 // macros for rules
-#define BEXP(e...) _p->onBinaryOpExp(e);
-#define UEXP(e...) _p->onUnaryOpExp(e);
+#define BEXP(...) _p->onBinaryOpExp(__VA_ARGS__);
+#define UEXP(...) _p->onUnaryOpExp(__VA_ARGS__);
 
 using namespace HPHP::HPHP_PARSER_NS;
 

--- a/hphp/parser/scanner.cpp
+++ b/hphp/parser/scanner.cpp
@@ -132,11 +132,11 @@ Scanner::Scanner(const char *source, int len, int type,
 }
 
 void Scanner::computeMd5() {
-  auto startpos = m_stream->tellg();
+  size_t startpos = m_stream->tellg();
   always_assert(startpos != -1 &&
                 startpos <= std::numeric_limits<int32_t>::max());
   m_stream->seekg(0, std::ios::end);
-  auto length = m_stream->tellg();
+  size_t length = m_stream->tellg();
   always_assert(length != -1 &&
                 length <= std::numeric_limits<int32_t>::max());
   m_stream->seekg(0, std::ios::beg);

--- a/hphp/parser/scanner.h
+++ b/hphp/parser/scanner.h
@@ -25,6 +25,7 @@
 #include <limits.h>
 
 #include "hphp/util/exception.h"
+#include "hphp/util/portability.h"
 #include "hphp/parser/location.h"
 #include "hphp/parser/hphp.tab.hpp"
 


### PR DESCRIPTION
This switches a couple of macros from C99 forms to normal variadic forms.
This also changes a couple of locals from `auto` to `size_t` in order to convince MSVC to resolve to a single overload.
This also adds an include for `hphp/util/portability.h`, which will, in turn, include a few compatibility shims that are needed.