### PR TITLE
Include stdint.h in ext_bcmath

### DIFF
--- a/hphp/runtime/ext/bcmath/bcmath.h
+++ b/hphp/runtime/ext/bcmath/bcmath.h
@@ -33,6 +33,7 @@
 #define incl_HPHP_BCMATH_H_
 
 #include "hphp/runtime/ext/bcmath/config.h"
+#include <stdint.h>
 
 typedef enum {PLUS, MINUS} sign;
 


### PR DESCRIPTION
Otherwise MSVC won't be able to find the types that bcmath uses.