### PR TITLE
Fix resource generation on Windows

### DIFF
--- a/CMake/HPHPFunctions.cmake
+++ b/CMake/HPHPFunctions.cmake
@@ -104,9 +104,9 @@ function(append_systemlib TARGET SOURCE SECTNAME)
     # for each library append the following line to embed.rc
     # $sectionname RCDATA "$source"
     add_custom_command(TARGET generate_rc
-      COMMAND echo "${SECTNAME} RCDATA \"${SOURCE}\"" >> embed.rc
+      COMMAND echo "\"${SECTNAME}\" RCDATA \"${SOURCE}\"" >> embed.rc
       COMMENT "Adding ${SOURCE} as ${SECTNAME} to embed.rc"
-      VERBATIM)
+      )
   else()
     if (APPLE)
       set(${TARGET}_SLIBS ${${TARGET}_SLIBS} -Wl,-sectcreate,__text,${SECTNAME},${SOURCE} PARENT_SCOPE)

--- a/hphp/hhvm/CMakeLists.txt
+++ b/hphp/hhvm/CMakeLists.txt
@@ -5,7 +5,7 @@ list(APPEND CXX_SOURCES ${files})
 # Windows targets use a generate rc file for embedding libraries
 if(CYGWIN OR MSVC OR MING)
   add_custom_target(generate_embed
-    COMMAND echo \"// THIS IS A GENERATED FILE \" > ${CMAKE_CURRENT_SOURCE_DIR}/embed.rc
+    COMMAND echo // THIS IS A GENERATED FILE > ${CMAKE_CURRENT_BINARY_DIR}/embed.rc
     COMMENT "generating embed.rc")
 
   # this is a cmake trick to allow items added later to depend properly
@@ -13,10 +13,10 @@ if(CYGWIN OR MSVC OR MING)
     DEPENDS generate_embed
     COMMENT "Generating RC file")
 
-    list(APPEND CXX_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/embed.rc)
+    list(APPEND CXX_SOURCES ${CMAKE_CURRENT_BINARY_DIR}/embed.rc)
     set_directory_properties(PROPERTIES ADDITIONAL_MAKE_CLEAN_FILES
-      ${CMAKE_CURRENT_SOURCE_DIR}/embed.rc)
-    set_source_files_properties(${CMAKE_CURRENT_SOURCE_DIR}/embed.rc
+      ${CMAKE_CURRENT_BINARY_DIR}/embed.rc)
+    set_source_files_properties(${CMAKE_CURRENT_BINARY_DIR}/embed.rc
       PROPERTIES GENERATED TRUE)
 endif()
 


### PR DESCRIPTION
I'm not entirely sure why it wasn't working before, but I believe it was caused by an issue with CMake itself. Hopefully this still works on the previous environement as well, but I know it works for me now on Windows with MSVC.
This also makes it work properly with out-of-tree builds.