### PR TITLE
Add CMake checks for cxxabi.h, unwind.h, and strfmon

### DIFF
--- a/CMake/HPHPFindLibs.cmake
+++ b/CMake/HPHPFindLibs.cmake
@@ -40,6 +40,24 @@ if (FEATURES_HEADER)
   add_definitions("-DHAVE_FEATURES_H=1")
 endif()
 
+# cxxabi.h
+FIND_PATH(CXXABI_HEADER cxxabi.h)
+if (CXXABI_HEADER)
+  add_definitions("-DHAVE_CXXABI_H=1")
+endif()
+
+# unwind.h
+FIND_PATH(UNWIND_HEADER unwind.h)
+if (UNWIND_HEADER)
+  add_definitions("-DHAVE_UNWIND_H=1")
+endif()
+
+# strfmon
+CHECK_FUNCTION_EXISTS(strfmon HAVE_STRFMON)
+if (HAVE_STRFMON)
+  add_definitions("-DHAVE_STRFMON=1")
+endif()
+
 # google-glog
 find_package(Glog REQUIRED)
 include_directories(${LIBGLOG_INCLUDE_DIR})


### PR DESCRIPTION
These will be needed by later PRs to disable pieces for windows. These are done together so the changes for FB's internal build can be done together. The uses of these will each be in separate PRs.

This requires that the following defines be added to FB's internal build system:
```
HAVE_CXXABI_H
HAVE_UNWIND_H
HAVE_STRFMON
```
And, hopefully not breaking Phabricator this time...