### PR TITLE
Call the gen-infotabs target rather than the binary directly

### DIFF
--- a/hphp/runtime/ext_hhvm/CMakeLists.txt
+++ b/hphp/runtime/ext_hhvm/CMakeLists.txt
@@ -73,7 +73,7 @@ endforeach()
 add_custom_command(
   OUTPUT ${INFOTABS_SOURCE}
   DEPENDS ${CXX_HEADERS} gen-infotabs
-  COMMAND "${CMAKE_CURRENT_BINARY_DIR}/../../tools/bootstrap/gen-infotabs"
+  COMMAND gen-infotabs
   ARGS ${INFOTABS_SOURCE} ${INFOTABS_HEADER} ${HPHP_IDLS})
 list(APPEND CXX_SOURCES ${INFOTABS_SOURCE})
 


### PR DESCRIPTION
Because the binary will be in a different location on Windows and in out of tree builds.