### PR TITLE
Add an MSVC section to HPHPSetup.cmake

### DIFF
--- a/CMake/HPHPSetup.cmake
+++ b/CMake/HPHPSetup.cmake
@@ -50,6 +50,9 @@ elseif(CYGWIN)
   set(ENABLE_FASTCGI 0)
   set(HHVM_ANCHOR_SYMS
   -Wl,--whole-archive ${HHVM_WHOLE_ARCHIVE_LIBRARIES} -Wl,--no-whole-archive)
+elseif (MSVC)
+  set(ENABLE_FASTCGI 0)
+  set(HHVM_ANCHOR_SYMS ${HHVM_WHOLE_ARCHIVE_LIBRARIES})
 else()
   set(ENABLE_FASTCGI 1)
   set(HHVM_ANCHOR_SYMS


### PR DESCRIPTION
Because otherwise it will try to pass arguments that are completely invalid.
This also disables FastCGI for MSVC builds. This may eventually change. This does not currently anchor the symbols correctly, but does at least deal with the invalid arguments.