### PR TITLE
Add MSVC format string checking support

### DIFF
--- a/hphp/compiler/analysis/exceptions.h
+++ b/hphp/compiler/analysis/exceptions.h
@@ -30,7 +30,7 @@ namespace HPHP {
 struct AnalysisTimeFatalException : Exception {
   AnalysisTimeFatalException(const std::string& file,
                              int line,
-                             const char* msg, ...) ATTRIBUTE_PRINTF(4,5)
+     ATTRIBUTE_PRINTF_STRING const char* msg, ...) ATTRIBUTE_PRINTF(4,5)
     : m_file(file)
     , m_line(line)
   {

--- a/hphp/compiler/code_generator.h
+++ b/hphp/compiler/code_generator.h
@@ -136,10 +136,13 @@ public:
   /**
    * Output strings.
    */
-  void printf(const char *fmt, ...) ATTRIBUTE_PRINTF(2,3);
-  void indentBegin(const char *fmt, ...) ATTRIBUTE_PRINTF(2,3);
+  void printf(ATTRIBUTE_PRINTF_STRING const char *fmt, ...)
+    ATTRIBUTE_PRINTF(2,3);
+  void indentBegin(ATTRIBUTE_PRINTF_STRING const char *fmt, ...)
+    ATTRIBUTE_PRINTF(2,3);
   void indentBegin();
-  void indentEnd(const char *fmt, ...) ATTRIBUTE_PRINTF(2,3);
+  void indentEnd(ATTRIBUTE_PRINTF_STRING const char *fmt, ...)
+    ATTRIBUTE_PRINTF(2,3);
   void indentEnd();
   void printRaw(const char *msg) { print(msg, false);}
   /**
@@ -151,8 +154,10 @@ public:
   void namespaceEnd();
   bool ensureInNamespace();
   bool ensureOutOfNamespace();
-  void ifdefBegin(bool ifdef, const char *fmt, ...) ATTRIBUTE_PRINTF(3,4);
-  void ifdefEnd(const char *fmt, ...) ATTRIBUTE_PRINTF(2,3);
+  void ifdefBegin(bool ifdef, ATTRIBUTE_PRINTF_STRING const char *fmt, ...)
+    ATTRIBUTE_PRINTF(3,4);
+  void ifdefEnd(ATTRIBUTE_PRINTF_STRING const char *fmt, ...)
+    ATTRIBUTE_PRINTF(2,3);
   void printDocComment(const std::string comment);
   const char *getGlobals(AnalysisResultPtr ar);
   static std::string EscapeLabel(const std::string &name, bool *binary = nullptr);
@@ -315,7 +320,8 @@ private:
   public: void print(const char *msg, bool indent = true);
 
  private:
-  void print(const char *fmt, va_list ap) ATTRIBUTE_PRINTF(2,0);
+  void print(ATTRIBUTE_PRINTF_STRING const char *fmt, va_list ap)
+    ATTRIBUTE_PRINTF(2,0);
   void printSubstring(const char *start, int length);
   void printIndent();
   std::string getFormattedName(const std::string &file);

--- a/hphp/compiler/construct.h
+++ b/hphp/compiler/construct.h
@@ -244,9 +244,9 @@ public:
   }
   void resetScope(BlockScopeRawPtr scope);
   void parseTimeFatal(FileScopeRawPtr fs, Compiler::ErrorType error,
-                      const char *fmt, ...) ATTRIBUTE_PRINTF(4,5);
-  void analysisTimeFatal(Compiler::ErrorType error, const char *fmt, ...)
-    ATTRIBUTE_PRINTF(3,4);
+    ATTRIBUTE_PRINTF_STRING const char *fmt, ...) ATTRIBUTE_PRINTF(4,5);
+  void analysisTimeFatal(Compiler::ErrorType error,
+    ATTRIBUTE_PRINTF_STRING const char *fmt, ...) ATTRIBUTE_PRINTF(3,4);
   virtual int getLocalEffects() const { return UnknownEffect;}
   int getChildrenEffects() const;
   int getContainedEffects() const;

--- a/hphp/compiler/parser/parser.h
+++ b/hphp/compiler/parser/parser.h
@@ -126,7 +126,8 @@ public:
   // implementing ParserBase
   virtual bool parseImpl();
   bool parse();
-  virtual void error(const char* fmt, ...) ATTRIBUTE_PRINTF(2,3);
+  virtual void error(ATTRIBUTE_PRINTF_STRING const char* fmt, ...)
+    ATTRIBUTE_PRINTF(2,3);
   IMPLEMENT_XHP_ATTRIBUTES;
 
   virtual void fatal(const Location* loc, const char* msg);

--- a/hphp/parser/parse-time-fatal-exception.h
+++ b/hphp/parser/parse-time-fatal-exception.h
@@ -9,7 +9,7 @@ namespace HPHP {
 class ParseTimeFatalException : public Exception {
 public:
   ParseTimeFatalException(const std::string& file, int line,
-                          const char* msg, ...) ATTRIBUTE_PRINTF(4,5)
+    ATTRIBUTE_PRINTF_STRING const char* msg, ...) ATTRIBUTE_PRINTF(4,5)
   : m_file(file), m_line(line) {
     va_list ap; va_start(ap, msg); format(msg, ap); va_end(ap);
   }

--- a/hphp/parser/parser.h
+++ b/hphp/parser/parser.h
@@ -112,7 +112,8 @@ public:
   /**
    * Raise a parser error.
    */
-  virtual void error(const char* fmt, ...) ATTRIBUTE_PRINTF(2,3) = 0;
+  virtual void error(ATTRIBUTE_PRINTF_STRING const char* fmt, ...)
+    ATTRIBUTE_PRINTF(2,3) = 0;
 
   /**
    * Public accessors.

--- a/hphp/parser/scanner.h
+++ b/hphp/parser/scanner.h
@@ -275,8 +275,10 @@ public:
     incLoc(rawText, rawLeng, type);
   }
   // also used for YY_FATAL_ERROR in hphp.x
-  void error(const char* fmt, ...) ATTRIBUTE_PRINTF(2,3);
-  void warn(const char* fmt, ...) ATTRIBUTE_PRINTF(2,3);
+  void error(ATTRIBUTE_PRINTF_STRING const char* fmt, ...)
+    ATTRIBUTE_PRINTF(2,3);
+  void warn(ATTRIBUTE_PRINTF_STRING const char* fmt, ...)
+    ATTRIBUTE_PRINTF(2,3);
   std::string escape(const char *str, int len, char quote_type) const;
 
   /**

--- a/hphp/runtime/base/builtin-functions.h
+++ b/hphp/runtime/base/builtin-functions.h
@@ -168,11 +168,12 @@ void handle_destructor_exception(const char* situation = "Destructor");
  *
  * Don't use in new code.
  */
-void throw_bad_type_exception(const char *fmt, ...) ATTRIBUTE_PRINTF(1,2);
+void throw_bad_type_exception(ATTRIBUTE_PRINTF_STRING const char *fmt, ...)
+  ATTRIBUTE_PRINTF(1,2);
 void throw_expected_array_exception(const char* fn = nullptr);
 void throw_expected_array_or_collection_exception(const char* fn = nullptr);
-void throw_invalid_argument(const char *fmt, ...) ATTRIBUTE_PRINTF(1,2)
-   __attribute__((__cold__));
+void throw_invalid_argument(ATTRIBUTE_PRINTF_STRING const char *fmt, ...)
+  ATTRIBUTE_PRINTF(1,2) __attribute__((__cold__));
 
 /**
  * Unsetting ClassName::StaticProperty.

--- a/hphp/runtime/base/exceptions.h
+++ b/hphp/runtime/base/exceptions.h
@@ -53,7 +53,8 @@ struct ExtendedException : Exception {
   explicit ExtendedException();
   explicit ExtendedException(const std::string& msg);
   explicit ExtendedException(SkipFrame frame, const std::string& msg);
-  explicit ExtendedException(const char* fmt, ...) ATTRIBUTE_PRINTF(2,3);
+  explicit ExtendedException(ATTRIBUTE_PRINTF_STRING const char* fmt, ...)
+    ATTRIBUTE_PRINTF(2,3);
   ExtendedException(const ExtendedException& other);
   ExtendedException(ExtendedException&& other) noexcept;
   ~ExtendedException();
@@ -90,7 +91,8 @@ struct FatalErrorException : ExtendedException {
   explicit FatalErrorException(const char *msg)
     : ExtendedException("%s", msg)
   {}
-  FatalErrorException(int, const char *msg, ...) ATTRIBUTE_PRINTF(3,4);
+  FatalErrorException(int, ATTRIBUTE_PRINTF_STRING const char *msg, ...)
+    ATTRIBUTE_PRINTF(3,4);
   FatalErrorException(const std::string&, const Array& backtrace,
                       bool isRecoverable = false);
 

--- a/hphp/runtime/base/extended-logger.h
+++ b/hphp/runtime/base/extended-logger.h
@@ -35,10 +35,14 @@ public:
   static void Info(const std::string &msg);
   static void Verbose(const std::string &msg);
 
-  static void Error(const char *fmt, ...) ATTRIBUTE_PRINTF(1,2);
-  static void Warning(const char *fmt, ...) ATTRIBUTE_PRINTF(1,2);
-  static void Info(const char *fmt, ...) ATTRIBUTE_PRINTF(1,2);
-  static void Verbose(const char *fmt, ...) ATTRIBUTE_PRINTF(1,2);
+  static void Error(ATTRIBUTE_PRINTF_STRING const char *fmt, ...)
+    ATTRIBUTE_PRINTF(1,2);
+  static void Warning(ATTRIBUTE_PRINTF_STRING const char *fmt, ...)
+    ATTRIBUTE_PRINTF(1,2);
+  static void Info(ATTRIBUTE_PRINTF_STRING const char *fmt, ...)
+    ATTRIBUTE_PRINTF(1,2);
+  static void Verbose(ATTRIBUTE_PRINTF_STRING const char *fmt, ...)
+    ATTRIBUTE_PRINTF(1,2);
 
   // Log additional injected stacktrace.
   static void Log(LogLevelType level, const Array& stackTrace, bool escape = true,

--- a/hphp/runtime/base/runtime-error.h
+++ b/hphp/runtime/base/runtime-error.h
@@ -72,27 +72,35 @@ enum class ErrorMode {
 };
 
 ATTRIBUTE_NORETURN void raise_error(const std::string&);
-ATTRIBUTE_NORETURN void raise_error(const char*, ...) ATTRIBUTE_PRINTF(1, 2);
+ATTRIBUTE_NORETURN void raise_error(ATTRIBUTE_PRINTF_STRING const char*, ...)
+  ATTRIBUTE_PRINTF(1, 2);
 ATTRIBUTE_NORETURN void raise_error_without_first_frame(const std::string&);
 void raise_recoverable_error(const std::string &msg);
-void raise_recoverable_error(const char *fmt, ...) ATTRIBUTE_PRINTF(1, 2);
+void raise_recoverable_error(ATTRIBUTE_PRINTF_STRING const char *fmt, ...)
+  ATTRIBUTE_PRINTF(1, 2);
 void raise_recoverable_error_without_first_frame(const std::string &msg);
 void raise_strict_warning(const std::string &msg);
-void raise_strict_warning(const char *fmt, ...) ATTRIBUTE_PRINTF(1, 2);
+void raise_strict_warning(ATTRIBUTE_PRINTF_STRING const char *fmt, ...)
+  ATTRIBUTE_PRINTF(1, 2);
 void raise_strict_warning_without_first_frame(const std::string &msg);
 void raise_warning(const std::string &msg);
-void raise_warning(const char *fmt, ...) ATTRIBUTE_PRINTF(1, 2);
+void raise_warning(ATTRIBUTE_PRINTF_STRING const char *fmt, ...)
+  ATTRIBUTE_PRINTF(1, 2);
 void raise_warning_without_first_frame(const std::string &msg);
 void raise_notice(const std::string &msg);
-void raise_notice(const char *fmt, ...) ATTRIBUTE_PRINTF(1, 2);
+void raise_notice(ATTRIBUTE_PRINTF_STRING const char *fmt, ...)
+  ATTRIBUTE_PRINTF(1, 2);
 void raise_notice_without_first_frame(const std::string &msg);
 void raise_deprecated(const std::string &msg);
-void raise_deprecated(const char *fmt, ...) ATTRIBUTE_PRINTF(1, 2);
+void raise_deprecated(ATTRIBUTE_PRINTF_STRING const char *fmt, ...)
+  ATTRIBUTE_PRINTF(1, 2);
 void raise_deprecated_without_first_frame(const std::string &msg);
 void raise_warning_unsampled(const std::string &msg);
-void raise_warning_unsampled(const char *fmt, ...) ATTRIBUTE_PRINTF(1, 2);
+void raise_warning_unsampled(ATTRIBUTE_PRINTF_STRING const char *fmt, ...)
+  ATTRIBUTE_PRINTF(1, 2);
 void raise_message(ErrorMode mode, const char *fmt, va_list ap);
-void raise_message(ErrorMode mode, const char *fmt, ...) ATTRIBUTE_PRINTF(2, 3);
+void raise_message(ErrorMode mode,
+  ATTRIBUTE_PRINTF_STRING const char *fmt, ...) ATTRIBUTE_PRINTF(2, 3);
 void raise_message(ErrorMode mode, bool skipTop, const std::string& msg);
 void raise_param_type_warning(
     const char* func_name,

--- a/hphp/runtime/base/string-buffer.h
+++ b/hphp/runtime/base/string-buffer.h
@@ -191,7 +191,8 @@ struct StringBuffer {
   /*
    * Append to this string using a printf-style format specification.
    */
-  void printf(const char* format, ...) ATTRIBUTE_PRINTF(2,3);
+  void printf(ATTRIBUTE_PRINTF_STRING const char* format, ...)
+    ATTRIBUTE_PRINTF(2,3);
 
   /*
    * Read a file into this buffer. Use a larger page size to read more bytes

--- a/hphp/runtime/debugger/debugger_client.h
+++ b/hphp/runtime/debugger/debugger_client.h
@@ -163,11 +163,16 @@ public:
   /**
    * Output functions
    */
-  void print  (const char *fmt, ...) ATTRIBUTE_PRINTF(2,3);
-  void help   (const char *fmt, ...) ATTRIBUTE_PRINTF(2,3);
-  void info   (const char *fmt, ...) ATTRIBUTE_PRINTF(2,3);
-  void output (const char *fmt, ...) ATTRIBUTE_PRINTF(2,3);
-  void error  (const char *fmt, ...) ATTRIBUTE_PRINTF(2,3);
+  void print  (ATTRIBUTE_PRINTF_STRING const char *fmt, ...)
+    ATTRIBUTE_PRINTF(2,3);
+  void help   (ATTRIBUTE_PRINTF_STRING const char *fmt, ...)
+    ATTRIBUTE_PRINTF(2,3);
+  void info   (ATTRIBUTE_PRINTF_STRING const char *fmt, ...)
+    ATTRIBUTE_PRINTF(2,3);
+  void output (ATTRIBUTE_PRINTF_STRING const char *fmt, ...)
+    ATTRIBUTE_PRINTF(2,3);
+  void error  (ATTRIBUTE_PRINTF_STRING const char *fmt, ...)
+    ATTRIBUTE_PRINTF(2,3);
 
   void print  (const String& s);
   void help   (const String& s);
@@ -191,7 +196,7 @@ public:
             int line2 = 0,
             int charFocus0 = 0, int lineFocus1 = 0, int charFocus1 = 0);
   void shortCode(BreakPointInfoPtr bp);
-  char ask(const char *fmt, ...) ATTRIBUTE_PRINTF(2,3);
+  char ask(ATTRIBUTE_PRINTF_STRING const char *fmt, ...) ATTRIBUTE_PRINTF(2,3);
 
   std::string wrap(const std::string &s);
   void helpTitle(const char *title);

--- a/hphp/runtime/ext/domdocument/ext_domdocument.cpp
+++ b/hphp/runtime/ext/domdocument/ext_domdocument.cpp
@@ -116,7 +116,7 @@ IMPLEMENT_GET_CLASS_FUNCTION(DOMImplementation)
 IMPLEMENT_GET_CLASS_FUNCTION(DOMXPath)
 
 static void php_libxml_internal_error_handler(int error_type, void *ctx,
-                                              const char *fmt,
+                      ATTRIBUTE_PRINTF_STRING const char *fmt,
                                               va_list ap) ATTRIBUTE_PRINTF(3,0);
 static void php_libxml_internal_error_handler(int error_type, void *ctx,
                                               const char *fmt,
@@ -187,7 +187,7 @@ static void php_libxml_internal_error_handler(int error_type, void *ctx,
  */
 
 static void php_libxml_ctx_error(void *ctx,
-                          const char *msg, ...) ATTRIBUTE_PRINTF(2,3);
+  ATTRIBUTE_PRINTF_STRING const char *msg, ...) ATTRIBUTE_PRINTF(2,3);
 static void php_libxml_ctx_error(void *ctx,
                           const char *msg, ...) {
   va_list args;
@@ -199,7 +199,7 @@ static void php_libxml_ctx_error(void *ctx,
 }
 
 static void php_libxml_ctx_warning(void *ctx,
-                            const char *msg, ...) ATTRIBUTE_PRINTF(2,3);
+    ATTRIBUTE_PRINTF_STRING const char *msg, ...) ATTRIBUTE_PRINTF(2,3);
 static void php_libxml_ctx_warning(void *ctx,
                             const char *msg, ...) {
   va_list args;

--- a/hphp/runtime/ext/gd/ext_gd.cpp
+++ b/hphp/runtime/ext/gd/ext_gd.cpp
@@ -1094,7 +1094,7 @@ static int get_php_tiff_bytes_per_format(int format) {
 #define TAG_FMT_DOUBLE    12
 
 static int php_vspprintf(char **pbuf, size_t max_len,
-                         const char *fmt, ...) ATTRIBUTE_PRINTF(3,4);
+  ATTRIBUTE_PRINTF_STRING const char *fmt, ...) ATTRIBUTE_PRINTF(3,4);
 static int php_vspprintf(char **pbuf, size_t max_len,
                          const char *fmt, ...) {
   va_list arglist;
@@ -1114,7 +1114,7 @@ static int php_vspprintf(char **pbuf, size_t max_len,
 }
 
 static int php_vspprintf_ap(char **pbuf, size_t max_len,
-                            const char *fmt, va_list ap) ATTRIBUTE_PRINTF(3,0);
+    ATTRIBUTE_PRINTF_STRING const char *fmt, va_list ap) ATTRIBUTE_PRINTF(3,0);
 static int php_vspprintf_ap(char **pbuf, size_t max_len,
                             const char *fmt, va_list ap) {
   char *buf;

--- a/hphp/runtime/ext/imagick/ext_imagick.h
+++ b/hphp/runtime/ext/imagick/ext_imagick.h
@@ -100,7 +100,7 @@ IMAGICK_DEFINE_CLASS(ImagickPixelIterator)
 
 template<typename T>
 ATTRIBUTE_NORETURN
-void imagickThrow(const char* fmt, ...)
+void imagickThrow(ATTRIBUTE_PRINTF_STRING const char* fmt, ...)
   ATTRIBUTE_PRINTF(1, 2);
 
 template<typename T>

--- a/hphp/runtime/ext/pdo/pdo_driver.h
+++ b/hphp/runtime/ext/pdo/pdo_driver.h
@@ -679,7 +679,7 @@ void pdo_raise_impl_error(sp_PDOResource rsrc, sp_PDOStatement stmt,
 void pdo_raise_impl_error(sp_PDOResource rsrc, PDOStatement* stmt,
                           const char *sqlstate, const char *supp);
 void throw_pdo_exception(const Variant& code, const Variant& info,
-                         const char *fmt, ...) ATTRIBUTE_PRINTF(3,4);
+  ATTRIBUTE_PRINTF_STRING const char *fmt, ...) ATTRIBUTE_PRINTF(3,4);
 
 ///////////////////////////////////////////////////////////////////////////////
 }

--- a/hphp/runtime/ext/soap/soap.h
+++ b/hphp/runtime/ext/soap/soap.h
@@ -183,7 +183,8 @@ public:
 
 class SoapException : public ExtendedException {
 public:
-  SoapException(const char *fmt, ...) ATTRIBUTE_PRINTF(2,3);
+  SoapException(ATTRIBUTE_PRINTF_STRING const char *fmt, ...)
+    ATTRIBUTE_PRINTF(2,3);
 };
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/hphp/runtime/ext/spl/ext_spl.cpp
+++ b/hphp/runtime/ext/spl/ext_spl.cpp
@@ -51,7 +51,8 @@ const StaticString
   s_directory_iterator("DirectoryIterator");
 
 
-void throw_spl_exception(const char *fmt, ...) ATTRIBUTE_PRINTF(1,2);
+void throw_spl_exception(ATTRIBUTE_PRINTF_STRING const char *fmt, ...)
+  ATTRIBUTE_PRINTF(1,2);
 void throw_spl_exception(const char *fmt, ...) {
   va_list ap;
   va_start(ap, fmt);

--- a/hphp/runtime/ext/xsl/ext_xsl.cpp
+++ b/hphp/runtime/ext/xsl/ext_xsl.cpp
@@ -54,8 +54,8 @@ static xmlChar *xslt_string_to_xpathexpr(const char *);
 static void xslt_ext_function_php(xmlXPathParserContextPtr, int, int);
 static void xslt_ext_function_string_php(xmlXPathParserContextPtr, int);
 static void xslt_ext_function_object_php(xmlXPathParserContextPtr, int);
-static void xslt_ext_error_handler(void *, const char *, ...)
-  ATTRIBUTE_PRINTF(2,3);
+static void xslt_ext_error_handler(void *,
+  ATTRIBUTE_PRINTF_STRING const char *, ...) ATTRIBUTE_PRINTF(2,3);
 
 ///////////////////////////////////////////////////////////////////////////////
 // NativeData

--- a/hphp/runtime/server/server.h
+++ b/hphp/runtime/server/server.h
@@ -373,7 +373,8 @@ private:
  */
 class ServerException : public Exception {
 public:
-  ServerException(const char *fmt, ...) ATTRIBUTE_PRINTF(2,3);
+  ServerException(ATTRIBUTE_PRINTF_STRING const char *fmt, ...)
+    ATTRIBUTE_PRINTF(2,3);
 };
 
 class FailedToListenException : public ServerException {

--- a/hphp/runtime/vm/repo-helpers.h
+++ b/hphp/runtime/vm/repo-helpers.h
@@ -44,7 +44,8 @@ enum RepoId {
 };
 
 struct RepoExc : std::exception {
-  RepoExc(const char* fmt, ...) ATTRIBUTE_PRINTF(2, 3) {
+  RepoExc(ATTRIBUTE_PRINTF_STRING const char* fmt, ...)
+    ATTRIBUTE_PRINTF(2, 3) {
     va_list(ap);
     va_start(ap, fmt);
     char* msg;

--- a/hphp/runtime/vm/srckey.h
+++ b/hphp/runtime/vm/srckey.h
@@ -176,7 +176,8 @@ using SrcKeySet = hphp_hash_set<SrcKey,SrcKey::Hasher>;
 std::string show(SrcKey sk);
 std::string showShort(SrcKey sk);
 
-void sktrace(SrcKey sk, const char *fmt, ...) ATTRIBUTE_PRINTF(2,3);
+void sktrace(SrcKey sk, ATTRIBUTE_PRINTF_STRING const char *fmt, ...)
+  ATTRIBUTE_PRINTF(2,3);
 #define SKTRACE(level, sk, ...) \
   ONTRACE(level, sktrace(sk, __VA_ARGS__))
 

--- a/hphp/runtime/vm/verifier/pretty.h
+++ b/hphp/runtime/vm/verifier/pretty.h
@@ -71,8 +71,8 @@ void printGml(const Unit*);
  *
  * The Func* may be nullptr.
  */
-void verify_error(const Unit*, const Func*, const char* fmt, ...)
-  ATTRIBUTE_PRINTF(3,4);
+void verify_error(const Unit*, const Func*,
+  ATTRIBUTE_PRINTF_STRING const char* fmt, ...) ATTRIBUTE_PRINTF(3,4);
 
 }}
 

--- a/hphp/util/compatibility.h
+++ b/hphp/util/compatibility.h
@@ -39,7 +39,8 @@ extern __thread int64_t s_extra_request_microseconds;
 
 #if defined(__APPLE__) || defined(__FreeBSD__)
 char *strndup(const char* str, size_t len);
-int dprintf(int fd, const char *format, ...) ATTRIBUTE_PRINTF(2,3);
+int dprintf(int fd, ATTRIBUTE_PRINTF_STRING const char *format, ...)
+  ATTRIBUTE_PRINTF(2,3);
 typedef int clockid_t;
 int pipe2(int pipefd[2], int flags);
 #endif

--- a/hphp/util/exception.h
+++ b/hphp/util/exception.h
@@ -30,13 +30,15 @@ struct IMarker;
 
 struct Exception : std::exception {
   explicit Exception() = default;
-  explicit Exception(const char *fmt, ...) ATTRIBUTE_PRINTF(2,3);
+  explicit Exception(ATTRIBUTE_PRINTF_STRING const char *fmt, ...)
+    ATTRIBUTE_PRINTF(2,3);
   explicit Exception(const std::string& msg);
   Exception(const Exception &e);
 
   // Try not to use this function (or the other varargs-based things) in new
   // code.  (You probably shouldn't be using Exception directly either.)
-  void format(const char *fmt, va_list ap) ATTRIBUTE_PRINTF(2,0);
+  void format(ATTRIBUTE_PRINTF_STRING const char *fmt, va_list ap)
+    ATTRIBUTE_PRINTF(2,0);
 
   void setMessage(const char *msg) { m_msg = msg ? msg : "";}
 

--- a/hphp/util/hdf.h
+++ b/hphp/util/hdf.h
@@ -380,7 +380,8 @@ private:
  */
 class HdfException : public Exception {
 public:
-  HdfException(const char *fmt, ...) ATTRIBUTE_PRINTF(2,3);
+  HdfException(ATTRIBUTE_PRINTF_STRING const char *fmt, ...)
+    ATTRIBUTE_PRINTF(2,3);
   EXCEPTION_COMMON_IMPL(HdfException);
 };
 

--- a/hphp/util/logger.h
+++ b/hphp/util/logger.h
@@ -64,10 +64,14 @@ public:
   static void Info(const std::string &msg);
   static void Verbose(const std::string &msg);
 
-  static void Error(const char *fmt, ...) ATTRIBUTE_PRINTF(1,2);
-  static void Warning(const char *fmt, ...) ATTRIBUTE_PRINTF(1,2);
-  static void Info(const char *fmt, ...) ATTRIBUTE_PRINTF(1,2);
-  static void Verbose(const char *fmt, ...) ATTRIBUTE_PRINTF(1,2);
+  static void Error(ATTRIBUTE_PRINTF_STRING const char *fmt, ...)
+    ATTRIBUTE_PRINTF(1,2);
+  static void Warning(ATTRIBUTE_PRINTF_STRING const char *fmt, ...)
+    ATTRIBUTE_PRINTF(1,2);
+  static void Info(ATTRIBUTE_PRINTF_STRING const char *fmt, ...)
+    ATTRIBUTE_PRINTF(1,2);
+  static void Verbose(ATTRIBUTE_PRINTF_STRING const char *fmt, ...)
+    ATTRIBUTE_PRINTF(1,2);
 
   template<typename... Args> static void FError(Args&&... args);
   template<typename... Args> static void FWarning(Args&&... args);
@@ -116,10 +120,10 @@ protected:
   };
   static DECLARE_THREAD_LOCAL(ThreadData, s_threadData);
 
-  static void Log(LogLevelType level, const char *fmt, va_list ap)
-    ATTRIBUTE_PRINTF(2,0);
-  static void LogEscapeMore(LogLevelType level, const char *fmt, va_list ap)
-    ATTRIBUTE_PRINTF(2,0);
+  static void Log(LogLevelType level,
+    ATTRIBUTE_PRINTF_STRING const char *fmt, va_list ap) ATTRIBUTE_PRINTF(2,0);
+  static void LogEscapeMore(LogLevelType level,
+    ATTRIBUTE_PRINTF_STRING const char *fmt, va_list ap) ATTRIBUTE_PRINTF(2,0);
   static void Log(LogLevelType level, const std::string &msg,
                   const StackTrace *stackTrace,
                   bool escape = false, bool escapeMore = false);

--- a/hphp/util/portability.h
+++ b/hphp/util/portability.h
@@ -17,6 +17,7 @@
 #define incl_HPHP_PORTABILITY_H_
 
 #include <folly/Likely.h> // defining LIKELY/UNLIKELY is part of this header
+#include <folly/Portability.h>
 #include <folly/CPortability.h> // defining FOLLY_DISABLE_ADDRESS_SANITIZER
 
 //////////////////////////////////////////////////////////////////////
@@ -49,6 +50,11 @@
 #ifdef ATTRIBUTE_PRINTF
 # undef ATTRIBUTE_PRINTF
 #endif
+#ifdef ATTRIBUTE_PRINTF_STRING
+# undef ATTRIBUTE_PRINTF_STRING
+#endif
+
+#define ATTRIBUTE_PRINTF_STRING FOLLY_PRINTF_FORMAT
 
 #ifdef _MSC_VER
 #define ATTRIBUTE_NORETURN __declspec(noreturn)

--- a/hphp/util/ringbuffer.h
+++ b/hphp/util/ringbuffer.h
@@ -85,7 +85,8 @@ extern RingBufferEntry* g_ring_ptr;
 extern std::atomic<int> g_ringIdx;
 
 const char* ringbufferName(RingBufferType t);
-void vtraceRingbuffer(const char* fmt, va_list ap) ATTRIBUTE_PRINTF(1,0);
+void vtraceRingbuffer(ATTRIBUTE_PRINTF_STRING const char* fmt, va_list ap)
+  ATTRIBUTE_PRINTF(1,0);
 void ringbufferMsg(const char* msg, size_t msgLen,
                    RingBufferType t = RBTypeMsg);
 void ringbufferEntry(RingBufferType t, uint64_t sk, uint64_t data);

--- a/hphp/util/string-vsnprintf.h
+++ b/hphp/util/string-vsnprintf.h
@@ -29,8 +29,8 @@ namespace HPHP {
  * Printf into a std::string using a va_list.
  */
 void string_vsnprintf(std::string& msg,
-                      const char* fmt,
-                      va_list ap) ATTRIBUTE_PRINTF(2,0);
+  ATTRIBUTE_PRINTF_STRING const char* fmt,
+                          va_list ap) ATTRIBUTE_PRINTF(2,0);
 
 //////////////////////////////////////////////////////////////////////
 

--- a/hphp/util/text-util.h
+++ b/hphp/util/text-util.h
@@ -66,7 +66,7 @@ const void *buffer_append(const void *buf1, int size1,
  * printf into a std::string.
  */
 void string_printf(std::string &msg,
-                   const char *fmt, ...) ATTRIBUTE_PRINTF(2,3);
+  ATTRIBUTE_PRINTF_STRING const char *fmt, ...) ATTRIBUTE_PRINTF(2,3);
 
 /**
  * Escaping strings for code generation.

--- a/hphp/util/trace.h
+++ b/hphp/util/trace.h
@@ -236,7 +236,8 @@ std::string prettyNode(const char* name, const P1& p1, const P2& p2) {
     string(")");
 }
 
-void traceRelease(const char*, ...) ATTRIBUTE_PRINTF(1,2);
+void traceRelease(ATTRIBUTE_PRINTF_STRING const char*, ...)
+  ATTRIBUTE_PRINTF(1,2);
 void traceRelease(const std::string& s);
 
 template<typename... Args>
@@ -248,7 +249,8 @@ void ftraceRelease(Args&&... args) {
 #define TRACE_RB(n, ...)                                        \
   ONTRACE(n, HPHP::Trace::traceRingBufferRelease(__VA_ARGS__)); \
   TRACE(n, __VA_ARGS__);
-void traceRingBufferRelease(const char* fmt, ...) ATTRIBUTE_PRINTF(1,2);
+void traceRingBufferRelease(ATTRIBUTE_PRINTF_STRING const char* fmt, ...)
+  ATTRIBUTE_PRINTF(1,2);
 
 extern int levels[NumModules];
 extern __thread int tl_levels[NumModules];
@@ -358,13 +360,14 @@ inline void itraceImpl(const char* fmtRaw, Args&&... args) {
 #define ITRACE_MOD(mod, level, ...)                             \
   ONTRACE_MOD(mod, level, Trace::itraceImpl(__VA_ARGS__));
 
-void trace(const char *, ...) ATTRIBUTE_PRINTF(1,2);
+void trace(ATTRIBUTE_PRINTF_STRING const char *, ...) ATTRIBUTE_PRINTF(1,2);
 void trace(const std::string&);
 
 template<typename Pretty>
 inline void trace(Pretty p) { trace(p.pretty() + std::string("\n")); }
 
-void vtrace(const char *fmt, va_list args) ATTRIBUTE_PRINTF(1,0);
+void vtrace(ATTRIBUTE_PRINTF_STRING const char *fmt, va_list args)
+  ATTRIBUTE_PRINTF(1,0);
 void dumpRingbuffer();
 
 //////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This is done by adding an `ATTRIBUTE_PRINTF_STRING` define, which is based on the `FOLLY_PRINTF_FORMAT` define. This define is placed on the argument containing the format string itself.