### PR TITLE
Make NEVER_INLINE usages MSVC compatible

### DIFF
--- a/hphp/runtime/base/request-local.h
+++ b/hphp/runtime/base/request-local.h
@@ -79,7 +79,7 @@ struct RequestLocal {
     return (m_node.m_p != nullptr) && m_node.m_p->getInited();
   }
 
-  void create() NEVER_INLINE;
+  NEVER_INLINE void create();
 
   static void OnThreadExit(void * p) {
     ThreadLocalNode<T> * pNode = (ThreadLocalNode<T>*)p;

--- a/hphp/runtime/base/thread-init-fini.h
+++ b/hphp/runtime/base/thread-init-fini.h
@@ -22,10 +22,10 @@
 namespace HPHP {
 ///////////////////////////////////////////////////////////////////////////////
 
-void init_thread_locals(void *arg = nullptr)
-  NEVER_INLINE;
-void finish_thread_locals(void *arg = nullptr)
-  NEVER_INLINE;
+NEVER_INLINE
+void init_thread_locals(void *arg = nullptr);
+NEVER_INLINE
+void finish_thread_locals(void *arg = nullptr);
 
 struct InitFiniNode {
   enum class When {

--- a/hphp/runtime/base/type-variant.cpp
+++ b/hphp/runtime/base/type-variant.cpp
@@ -60,10 +60,11 @@ const VarNR NAN_varNR(std::numeric_limits<double>::quiet_NaN());
 const Variant empty_string_variant_ref(staticEmptyString(),
                                        Variant::StaticStrInit{});
 
+NEVER_INLINE
 static void unserializeProp(VariableUnserializer *uns,
                             ObjectData *obj, const String& key,
                             Class* ctx, const String& realKey,
-                            int nProp) NEVER_INLINE;
+                            int nProp);
 
 ///////////////////////////////////////////////////////////////////////////////
 // static strings

--- a/hphp/runtime/ext/asio/ext_waitable-wait-handle.h
+++ b/hphp/runtime/ext/asio/ext_waitable-wait-handle.h
@@ -66,8 +66,9 @@ class c_WaitableWaitHandle : public c_WaitHandle {
   void detectCycle(c_WaitableWaitHandle* child) const;
 
  private:
+  NEVER_INLINE 
   void throwCycleException(c_WaitableWaitHandle* child) const
-    NEVER_INLINE ATTRIBUTE_NORETURN;
+    ATTRIBUTE_NORETURN;
 };
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/hphp/util/thread-local.h
+++ b/hphp/util/thread-local.h
@@ -184,7 +184,7 @@ struct ThreadLocal {
     return m_node.m_p;
   }
 
-  void create() NEVER_INLINE;
+  NEVER_INLINE void create();
 
   bool isNull() const { return m_node.m_p == nullptr; }
 
@@ -225,13 +225,13 @@ void ThreadLocal<T>::create() {
  */
 template<typename T>
 struct ThreadLocalNoCheck {
-  T *getCheck() const NEVER_INLINE;
+  NEVER_INLINE T *getCheck() const;
   T* getNoCheck() const {
     assert(m_node.m_p);
     return m_node.m_p;
   }
 
-  void create() NEVER_INLINE;
+  NEVER_INLINE void create();
 
   bool isNull() const { return m_node.m_p == nullptr; }
 
@@ -285,7 +285,7 @@ class ThreadLocalSingleton {
 public:
   ThreadLocalSingleton() { s_inited = true; }
 
-  static T *getCheck() NEVER_INLINE;
+  NEVER_INLINE static T *getCheck();
 
   static T* getNoCheck() {
     assert(s_inited);
@@ -531,7 +531,7 @@ public:
 #endif
   }
 
-  T *getCheck() const NEVER_INLINE;
+  NEVER_INLINE T *getCheck() const;
 
   T* getNoCheck() const {
     T *obj = (T*)pthread_getspecific(m_key);
@@ -605,7 +605,7 @@ class ThreadLocalSingleton {
 public:
   ThreadLocalSingleton() { getKey(); }
 
-  static T *getCheck() NEVER_INLINE;
+  NEVER_INLINE static T *getCheck();
   static T* getNoCheck() {
     assert(s_inited);
     T *obj = (T*)pthread_getspecific(s_key);


### PR DESCRIPTION
Because MSVC doesn't like `__declspec()` attributes after the arguments.
Hopefully I got all the uses in this PR, but I didn't check every single use of the attribute, as the vast majority are already placed before the function name.

This will conflict with #5632 (D41565) due to a spot in the asio extension where both `ATTRIBUTE_NORETURN` and `NEVER_INLINE` attributes needed to be moved.