### PR TITLE
Fix issue #5671 SplFixedArray::fromArray is slow

### DIFF
--- a/hphp/system/php/spl/datastructures/SplFixedArray.php
+++ b/hphp/system/php/spl/datastructures/SplFixedArray.php
@@ -246,14 +246,12 @@ class SplFixedArray implements \HH\Iterator, ArrayAccess, Countable {
   public static function fromArray($array, $save_indexes = true) {
     $fixed_array = new self;
     if ($save_indexes) {
+      $fixed_array->setSize(max(array_keys($array)) + 1);
       foreach ($array as $key => $value) {
         if (!is_numeric($key) || $key < 0) {
           throw new InvalidArgumentException(
             'array must contain only positive integer keys'
           );
-        }
-        if ($key >= $fixed_array->count()) {
-          $fixed_array->setSize($key + 1);
         }
         $fixed_array[$key] = $value;
       }


### PR DESCRIPTION
Fix issue #5671 SplFixedArray::fromArray is slow.

This sets the size to the max key value before setting the values, to avoid re-sizing the internal array for every element.