### PR TITLE
Use UTF8 string literals where appropriate

### DIFF
--- a/hphp/runtime/ext/icu/LifeEventTokenizer.cpp
+++ b/hphp/runtime/ext/icu/LifeEventTokenizer.cpp
@@ -24,7 +24,7 @@ namespace HPHP {
 
 
 // Rules for ICU's RuleBasedBreakIterator class.
-const char* strRules = "\n\
+const char* strRules = u8"\n\
 !!chain;\n\
 $CR           = [\\p{Word_Break = CR}];\n\
 $LF           = [\\p{Word_Break = LF}];\n\

--- a/hphp/runtime/vm/jit/refcount-opts.cpp
+++ b/hphp/runtime/vm/jit/refcount-opts.cpp
@@ -2431,10 +2431,10 @@ std::string show(const Node* node) {
       switch (node->type) {
       case NT::Empty:   return "empty";
       case NT::Halt:    return "halt";
-      case NT::Sig:     return "\u03c3";
+      case NT::Sig:     return u8"\u03c3";
       case NT::Dec:     return sformat("dec({})", to_dec(node)->inst->id());
       case NT::Phi:
-        return sformat("\u03c6({},{})", to_phi(node)->pred_list_sz,
+        return sformat(u8"\u03c6({},{})", to_phi(node)->pred_list_sz,
           to_phi(node)->back_edge_preds);
       case NT::Inc:
         return sformat("inc({})", to_inc(node)->inst->id());

--- a/hphp/runtime/vm/jit/vasm-xls.cpp
+++ b/hphp/runtime/vm/jit/vasm-xls.cpp
@@ -2143,10 +2143,10 @@ LiveRange Vxls::findBlockRange(unsigned pos) {
 enum Mode { Light, Heavy };
 template<class Pred>
 const char* draw(Interval* parent, unsigned pos, Mode m, Pred covers) {
-                               // Light     Heavy
-  static const char* top[]    = { "\u2575", "\u2579" };
-  static const char* bottom[] = { "\u2577", "\u257B" };
-  static const char* both[]   = { "\u2502", "\u2503" };
+                                  // Light     Heavy
+  static const char* top[]    = { u8"\u2575", u8"\u2579" };
+  static const char* bottom[] = { u8"\u2577", u8"\u257B" };
+  static const char* both[]   = { u8"\u2502", u8"\u2503" };
   static const char* empty[]  = { " ", " " };
   auto f = [&](unsigned pos) {
     for (auto ivl = parent; ivl; ivl = ivl->next) {


### PR DESCRIPTION
Because MSVC requires them to be utf8 string literals in order to accept them at all.