### PR TITLE
Have roundImpl explicitly accept a function pointer type

### DIFF
--- a/hphp/runtime/vm/jit/simplify.cpp
+++ b/hphp/runtime/vm/jit/simplify.cpp
@@ -1589,8 +1589,7 @@ SSATmp* simplifyCoerceCellToDbl(State& env, const IRInstruction* inst) {
   return nullptr;
 }
 
-template<class Oper>
-SSATmp* roundImpl(State& env, const IRInstruction* inst, Oper op) {
+SSATmp* roundImpl(State& env, const IRInstruction* inst, double (*op)(double)) {
   auto const src  = inst->src(0);
 
   if (src->hasConstVal()) {


### PR DESCRIPTION
Because MSVC overloads `ceil` and `floor` with `float`, `double`, and `long double` forms, we have to force it to select only one of those forms.
Unfortunately, there is not a specific name for the `double` overload, otherwise I'd just `#ifdef _MSC_VER` and use that other name.

If this was done as a template for speed reasons, then the same effect can be achieved with a force inline attribute.