### PR TITLE
Use sizeof(decltype()) for checking the size of members

### DIFF
--- a/hphp/compiler/analysis/symbol_table.h
+++ b/hphp/compiler/analysis/symbol_table.h
@@ -224,7 +224,7 @@ private:
 
   };
   static_assert(
-    sizeof(m_flags_val) == sizeof(m_flags),
+    sizeof(decltype(m_flags_val)) == sizeof(decltype(m_flags)),
     "m_flags_val must cover all the flags");
 
   ConstructPtr        m_declaration;

--- a/hphp/runtime/base/typed-value.h
+++ b/hphp/runtime/base/typed-value.h
@@ -113,7 +113,7 @@ constexpr size_t alignTypedValue(size_t sz) {
  */
 struct TypedValueAux : TypedValue {
   static constexpr size_t auxOffset = offsetof(TypedValue, m_aux);
-  static const size_t auxSize = sizeof(m_aux);
+  static const size_t auxSize = sizeof(decltype(m_aux));
   int32_t& hash() { return m_aux.u_hash; }
   const int32_t& hash() const { return m_aux.u_hash; }
   int32_t& rdsHandle() { return m_aux.u_rdsHandle; }

--- a/hphp/runtime/vm/jit/phys-reg.h
+++ b/hphp/runtime/vm/jit/phys-reg.h
@@ -381,7 +381,7 @@ struct RegSet {
 
 private:
   uint64_t m_bits;
-  static_assert(sizeof(m_bits) * 8 >= PhysReg::kMaxRegs, "");
+  static_assert(sizeof(decltype(m_bits)) * 8 >= PhysReg::kMaxRegs, "");
 };
 
 inline RegSet operator|(PhysReg r1, PhysReg r2) {


### PR DESCRIPTION
Because MSVC doesn't like it when you try to do `sizeof(myInstanceMember)`, so get the size of the type of the member instead.