### PR TITLE
Only enable money_format if strfmon is available

### DIFF
--- a/CMake/HPHPFindLibs.cmake
+++ b/CMake/HPHPFindLibs.cmake
@@ -40,6 +40,12 @@ if (FEATURES_HEADER)
   add_definitions("-DHAVE_FEATURES_H=1")
 endif()
 
+# strfmon
+CHECK_FUNCTION_EXISTS(strfmon HAVE_STRFMON)
+if (HAVE_STRFMON)
+  add_definitions("-DHAVE_STRFMON=1")
+endif()
+
 # google-glog
 find_package(Glog REQUIRED)
 include_directories(${LIBGLOG_INCLUDE_DIR})

--- a/hphp/runtime/base/string-util.cpp
+++ b/hphp/runtime/base/string-util.cpp
@@ -410,10 +410,12 @@ String StringUtil::DecodeFileUrl(const String& input) {
 ///////////////////////////////////////////////////////////////////////////////
 // formatting
 
+#ifdef HAVE_STRFMON
 String StringUtil::MoneyFormat(const char *format, double value) {
   assert(format);
   return string_money_format(format, value);
 }
+#endif
 
 ///////////////////////////////////////////////////////////////////////////////
 // hashing

--- a/hphp/runtime/base/string-util.h
+++ b/hphp/runtime/base/string-util.h
@@ -147,11 +147,13 @@ public:
    * path part is returned. If it is not, an empty string is returned.
    */
   static String DecodeFileUrl(const String& input);
-
+  
+#ifdef HAVE_STRFMON
   /**
    * Formatting.
    */
   static String MoneyFormat(const char *format, double value);
+#endif
 
   /**
    * Hashing

--- a/hphp/runtime/base/zend-string.cpp
+++ b/hphp/runtime/base/zend-string.cpp
@@ -22,7 +22,9 @@
 #include "hphp/util/lock.h"
 #include "hphp/util/overflow.h"
 #include <math.h>
+#ifdef HAVE_STRFMON
 #include <monetary.h>
+#endif
 
 #include "hphp/util/bstring.h"
 #include "hphp/runtime/base/exceptions.h"
@@ -1725,6 +1727,7 @@ int string_levenshtein(const char *s1, int l1, const char *s2, int l2,
   return c0;
 }
 
+#ifdef HAVE_STRFMON
 ///////////////////////////////////////////////////////////////////////////////
 
 String string_money_format(const char *format, double value) {
@@ -1753,6 +1756,7 @@ String string_money_format(const char *format, double value) {
   ret.setSize(str_len);
   return ret;
 }
+#endif
 
 ///////////////////////////////////////////////////////////////////////////////
 

--- a/hphp/runtime/base/zend-string.h
+++ b/hphp/runtime/base/zend-string.h
@@ -232,7 +232,9 @@ void string_translate(char *str, int len, const char *str_from,
 /**
  * Formatting.
  */
+#ifdef HAVE_STRFMON
 String string_money_format(const char *format, double value);
+#endif
 
 String string_number_format(double d, int dec,
                             const String& dec_point,

--- a/hphp/runtime/ext/string/ext_string.cpp
+++ b/hphp/runtime/ext/string/ext_string.cpp
@@ -898,6 +898,7 @@ int64_t HHVM_FUNCTION(ord,
   return (int64_t)(unsigned char)str[0];
 }
 
+#ifdef HAVE_STRFMON
 Variant HHVM_FUNCTION(money_format,
                       const String& format,
                       double number) {
@@ -905,6 +906,7 @@ Variant HHVM_FUNCTION(money_format,
   if (s.isNull()) return false;
   return s;
 }
+#endif
 
 String HHVM_FUNCTION(number_format,
                      double number,
@@ -2163,7 +2165,9 @@ public:
     HHVM_FE(sscanf);
     HHVM_FE(chr);
     HHVM_FE(ord);
+#ifdef HAVE_STRFMON
     HHVM_FE(money_format);
+#endif
     HHVM_FE(number_format);
     HHVM_FE(strcmp);
     HHVM_FE(strncmp);

--- a/hphp/runtime/ext/string/ext_string.h
+++ b/hphp/runtime/ext/string/ext_string.h
@@ -218,9 +218,11 @@ TypedValue* HHVM_FN(sscanf)(ActRec* ar);
 String HHVM_FUNCTION(chr, const Variant& ascii);
 int64_t HHVM_FUNCTION(ord,
                       const String& str);
+#ifdef HAVE_STRFMON
 Variant HHVM_FUNCTION(money_format,
                       const String& format,
                       double number);
+#endif
 String HHVM_FUNCTION(number_format,
                      double number,
                      int decimals = 0,


### PR DESCRIPTION
This disables `money_format` and the chain of functions it depends on if `strfmon` is not available.

This will require `HAVE_STRFMON` to be defined for the internal build.