### PR TITLE
Fix type annotation for fgets(), add type information for key()

### DIFF
--- a/hphp/hack/hhi/stdlib/builtins_spl.hhi
+++ b/hphp/hack/hhi/stdlib/builtins_spl.hhi
@@ -122,7 +122,7 @@ class SplFileObject extends SplFileInfo
     string $enclosure = "\"",
     string $escape = "\\",
   ): array;
-  public function fgets(): string;
+  public function fgets();
   public function fgetss(?string $allowable_tags = null): string;
   public function flock(int $operation, mixed &$wouldblock = false): bool;
   public function fpassthru(): int;
@@ -149,6 +149,7 @@ class SplFileObject extends SplFileInfo
   /* (always) returns null -- violates RecursiveIterator interface */
   public function getChildren();
   public function hasChildren(): bool;
+  public function key(): int;
   public function next(): void;
   public function rewind(): void;
   public function seek(int $line_pos): void;


### PR DESCRIPTION
fgets() can sometimes return null. [According to the php.net docs](http://php.net/manual/en/splfileobject.fgets.php):

```
Returns a string containing the next line from the file, or FALSE on error.
```

After talking with @jwatzman in IRC we decided it was best to remove the type annotation for fgets().

This PR also adds the key function to the SplFileObjectClass. key() always returns an int [according to php.net](http://php.net/manual/en/splfileobject.key.php):

```
Returns the current line number.
```