### PR TITLE
Double-Inc

### DIFF
--- a/hphp/runtime/base/countable.h
+++ b/hphp/runtime/base/countable.h
@@ -102,12 +102,13 @@ inline bool check_refcount_ns_nz(int32_t count) {
   void incRefCount() const {                                            \
     assert(!MemoryManager::sweeping());                                 \
     assert(check_refcount(m_hdr.count));                                \
-    if (isRefCounted()) { ++m_hdr.count; }                              \
+    if (isRefCounted()) { m_hdr.count += 2; }                           \
   }                                                                     \
                                                                         \
   void setRefCount(RefCount count) {                                    \
     assert(count == StaticValue || !MemoryManager::sweeping());         \
     assert(check_refcount(m_hdr.count));                                \
+    assert(count < 2);                                                  \
     m_hdr.count = count;                                                \
     assert(check_refcount(m_hdr.count));                                \
   }                                                                     \

--- a/hphp/runtime/base/countable.h
+++ b/hphp/runtime/base/countable.h
@@ -167,7 +167,7 @@ inline bool check_refcount_ns_nz(int32_t count) {
   void incRefCount() const {                            \
     assert(!MemoryManager::sweeping());                 \
     assert(check_refcount_ns(m_hdr.count));             \
-    ++m_hdr.count;                                      \
+    m_hdr.count += 2;                                   \
   }                                                     \
                                                         \
   RefCount decRefCount() const {                        \

--- a/hphp/runtime/vm/jit/code-gen-helpers-x64.cpp
+++ b/hphp/runtime/vm/jit/code-gen-helpers-x64.cpp
@@ -160,7 +160,7 @@ void emitIncRefGenericRegSafe(Asm& as, PhysReg base, int disp, PhysReg tmpReg) {
     as.   loadq  (base[disp + TVOFF(m_data)], tmpReg);
     { // if !static
       IfCountNotStatic ins(as, tmpReg);
-      as. incl(tmpReg[FAST_REFCOUNT_OFFSET]);
+      as. addq(2, tmpReg[FAST_REFCOUNT_OFFSET]);
     } // endif
   } // endif
 }

--- a/hphp/runtime/vm/jit/code-gen-helpers-x64.cpp
+++ b/hphp/runtime/vm/jit/code-gen-helpers-x64.cpp
@@ -139,7 +139,7 @@ void emitIncRef(Vout& v, Vreg base) {
   }
   // emit incref
   auto const sf = v.makeReg();
-  v << inclm{base[FAST_REFCOUNT_OFFSET], sf};
+  v << addqim{2, base[FAST_REFCOUNT_OFFSET], sf};
   emitAssertFlagsNonNegative(v, sf);
 }
 


### PR DESCRIPTION
Submitting PR so that we can run internal analysis on this diff. 

This diff is exactly the same as master, except incref's are now by two instead of by one. This emulates the behaviour of a 1-bit refcount, in that objects that are ever incref'd will never return to a refcount of 1, meaning they are not freed.

It also changes behaviour of reference types by failing to demote them back to values when appropriate, so it will fail some tests, as well as any tests that rely on precise destruction which is not guaranteed with this diff.