### PR TITLE
Remove return type annotation from odbc_prepare

### DIFF
--- a/hphp/hack/hhi/stdlib/builtins_odbc.hhi
+++ b/hphp/hack/hhi/stdlib/builtins_odbc.hhi
@@ -32,6 +32,6 @@ function odbc_fetch_array(resource $result, ?int $rownumber=0): mixed;
 
 function odbc_num_rows(?resource $result): int;
 
-function odbc_prepare(resource $connection_id, string $query_string);
+function odbc_prepare(resource $connection_id, string $query_string); // type ommitted, returns false on error
 
 function odbc_rollback(resource $connection_id): bool;

--- a/hphp/hack/hhi/stdlib/builtins_odbc.hhi
+++ b/hphp/hack/hhi/stdlib/builtins_odbc.hhi
@@ -32,6 +32,6 @@ function odbc_fetch_array(resource $result, ?int $rownumber=0): mixed;
 
 function odbc_num_rows(?resource $result): int;
 
-function odbc_prepare(resource $connection_id, string $query_string): mixed;
+function odbc_prepare(resource $connection_id, string $query_string);
 
 function odbc_rollback(resource $connection_id): bool;


### PR DESCRIPTION
According to [php.net](http://php.net/manual/en/function.odbc-prepare.php) `odbc_prepare()` returns false on failure:

```
Returns an ODBC result identifier if the SQL command was prepared successfully. Returns FALSE on error.
```

Remove the type annotation to reflect this.