### PR TITLE
gmp_cmp returns ints

### DIFF
--- a/hphp/hack/hhi/stdlib/builtins_gmp.hhi
+++ b/hphp/hack/hhi/stdlib/builtins_gmp.hhi
@@ -31,7 +31,7 @@ function gmp_clrbit(mixed &$a,
                     int $index): void;
 
 function gmp_cmp(mixed $a,
-                 mixed $b): mixed;
+                 mixed $b): int;
 
 function gmp_com(mixed $a): mixed;
 


### PR DESCRIPTION
According to [php.net](http://php.net/manual/en/function.gmp-cmp.php), `gmp_cmp()` returns int. This example enumerates all the possible return types:

```
$cmp1 = gmp_cmp("1234.5", "1000.3"); // greater than
$cmp2 = gmp_cmp("1000", "1234"); // less than
$cmp3 = gmp_cmp("1234", "1234"); // equal to

var_dump($cmp1); // int(1)
var_dump($cmp2); // int(0)
var_dump($cmp3); // int(-1)
```