### PR TITLE
Remove return type annotation from odbc_fetch_array

### DIFF
--- a/hphp/hack/hhi/stdlib/builtins_odbc.hhi
+++ b/hphp/hack/hhi/stdlib/builtins_odbc.hhi
@@ -28,7 +28,7 @@ function odbc_exec(resource $connection_id,
 
 function odbc_execute(resource $result, ?array $parameters_array): bool;
 
-function odbc_fetch_array(resource $result, ?int $rownumber=0): mixed;
+function odbc_fetch_array(resource $result, ?int $rownumber=0);
 
 function odbc_num_rows(?resource $result): int;
 


### PR DESCRIPTION
According to [php.net](http://php.net/odbc_fetch_array) `odbc_fetch_array()` returns false in certain circumstances:

```
Returns an array that corresponds to the fetched row, or FALSE if there are no more rows.
```

Remove the type annotation to reflect this.