### PR TITLE
Don't globally require MySQL

### DIFF
--- a/CMake/HPHPFindLibs.cmake
+++ b/CMake/HPHPFindLibs.cmake
@@ -58,34 +58,6 @@ if (LIBICONV_CONST)
   add_definitions("-DICONV_CONST=const")
 endif()
 
-# mysql checks - if we're using async mysql, we use webscalesqlclient from
-# third-party/ instead
-if (ENABLE_ASYNC_MYSQL)
-  include_directories(
-    ${TP_DIR}/re2/src/
-    ${TP_DIR}/squangle/src/
-    ${TP_DIR}/webscalesqlclient/src/include/
-  )
-  set(MYSQL_CLIENT_LIB_DIR ${TP_DIR}/webscalesqlclient/src/)
-  # Unlike the .so, the static library intentionally does not link against
-  # yassl, despite building it :/
-  set(MYSQL_CLIENT_LIBS
-    ${MYSQL_CLIENT_LIB_DIR}/libmysql/libwebscalesqlclient_r.a
-    ${MYSQL_CLIENT_LIB_DIR}/extra/yassl/libyassl.a
-    ${MYSQL_CLIENT_LIB_DIR}/extra/yassl/taocrypt/libtaocrypt.a
-  )
-else()
-  find_package(MySQL REQUIRED)
-  link_directories(${MYSQL_LIB_DIR})
-  include_directories(${MYSQL_INCLUDE_DIR})
-endif()
-MYSQL_SOCKET_SEARCH()
-if (MYSQL_UNIX_SOCK_ADDR)
-  add_definitions(-DPHP_MYSQL_UNIX_SOCK_ADDR="${MYSQL_UNIX_SOCK_ADDR}")
-else ()
-  message(FATAL_ERROR "Could not find MySQL socket path - if you install a MySQL server, this should be automatically detected. Alternatively, specify -DMYSQL_UNIX_SOCK_ADDR=/path/to/mysql.socket ; if you don't care about unix socket support for MySQL, specify -DMYSQL_UNIX_SOCK_ADDR=/dev/null")
-endif ()
-
 # libmemcached checks
 find_package(Libmemcached REQUIRED)
 if (LIBMEMCACHED_VERSION VERSION_LESS "0.39")

--- a/CMake/HPHPFindLibs.cmake
+++ b/CMake/HPHPFindLibs.cmake
@@ -415,7 +415,6 @@ macro(hphp_link target)
   endif()
 
   target_link_libraries(${target} ${Boost_LIBRARIES})
-  target_link_libraries(${target} ${MYSQL_CLIENT_LIBS})
   if (ENABLE_ASYNC_MYSQL)
     target_link_libraries(${target} squangle)
   endif()


### PR DESCRIPTION
Now that it's possible to easily disable extensions, and the only place in the core of HHVM that relied upon MySQL is moved into the MySQL extension where it belongs, MySQL is no longer needed to compile HHVM itself. The async and normal MySQL extensions handle adding the includes and linking themselves.