### PR TITLE
Remove global LDAP requirement

### DIFF
--- a/CMake/HPHPFindLibs.cmake
+++ b/CMake/HPHPFindLibs.cmake
@@ -334,10 +334,6 @@ add_definitions(${BZIP2_DEFINITIONS})
 find_package(ONIGURUMA REQUIRED)
 include_directories(${ONIGURUMA_INCLUDE_DIRS})
 
-# LDAP
-find_package(Ldap REQUIRED)
-include_directories(${LDAP_INCLUDE_DIR})
-
 # libpthreads
 find_package(PThread REQUIRED)
 include_directories(${LIBPTHREAD_INCLUDE_DIRS})
@@ -506,7 +502,6 @@ macro(hphp_link target)
     target_link_libraries(${target} ${LIBUODBC_LIBRARIES})
   endif()
 
-  target_link_libraries(${target} ${LDAP_LIBRARIES})
   target_link_libraries(${target} ${LBER_LIBRARIES})
 
   target_link_libraries(${target} ${LIBMEMCACHED_LIBRARY})


### PR DESCRIPTION
LDAP is currently required globally, but, with PR #5571 merged, the extension itself is able to require the library. What's more, the effected extension is one that will let itself be disabled quietely.