### PR TITLE
Don't require libXSLT globally

### DIFF
--- a/CMake/HPHPFindLibs.cmake
+++ b/CMake/HPHPFindLibs.cmake
@@ -146,10 +146,6 @@ find_package(LibXml2 REQUIRED)
 include_directories(${LIBXML2_INCLUDE_DIR})
 add_definitions(${LIBXML2_DEFINITIONS})
 
-find_package(LibXslt REQUIRED)
-include_directories(${LIBXSLT_INCLUDE_DIR})
-add_definitions(${LIBXSLT_DEFINITIONS})
-
 find_package(EXPAT REQUIRED)
 include_directories(${EXPAT_INCLUDE_DIRS})
 
@@ -496,8 +492,6 @@ macro(hphp_link target)
   target_link_libraries(${target} ${BZIP2_LIBRARIES})
 
   target_link_libraries(${target} ${LIBXML2_LIBRARIES})
-  target_link_libraries(${target} ${LIBXSLT_LIBRARIES})
-  target_link_libraries(${target} ${LIBXSLT_EXSLT_LIBRARIES})
   target_link_libraries(${target} ${EXPAT_LIBRARY})
   target_link_libraries(${target} ${ONIGURUMA_LIBRARIES})
   target_link_libraries(${target} ${Mcrypt_LIB})


### PR DESCRIPTION
`ext_xsl` now handles the requirement itself.