### PR TITLE
Remove the global LibBZip2 dependency

### DIFF
--- a/CMake/HHVMExtensionConfig.cmake
+++ b/CMake/HHVMExtensionConfig.cmake
@@ -615,7 +615,6 @@ function (HHVM_EXTENSION_INTERNAL_HANDLE_LIBRARY_DEPENDENCY extensionID dependen
   # Keep these in alphabetical order.
   if (
     ${libraryName} STREQUAL "boost" OR
-    ${libraryName} STREQUAL "bz2" OR
     ${libraryName} STREQUAL "editline" OR
     ${libraryName} STREQUAL "fastlz" OR
     ${libraryName} STREQUAL "folly" OR
@@ -634,6 +633,20 @@ function (HHVM_EXTENSION_INTERNAL_HANDLE_LIBRARY_DEPENDENCY extensionID dependen
     ${libraryName} STREQUAL "zlib"
   )
     # Nothing to do, they are included by default.
+  elseif (${libraryName} STREQUAL "bzip2")
+    find_package(BZip2 ${requiredVersion})
+    find_package(EXPAT ${requiredVersion})
+    if (NOT BZIP2_INCLUDE_DIR OR NOT BZIP2_LIBRARIES)
+      HHVM_EXTENSION_INTERNAL_SET_FAILED_DEPENDENCY(${extensionID} ${dependencyName})
+      return()
+    endif()
+
+    if (${addPaths})
+      include_directories(${BZIP2_INCLUDE_DIR})
+      add_definitions(${BZIP2_DEFINITIONS})
+      link_libraries(${BZIP2_LIBRARIES})
+      add_definitions("-DHAVE_LIBBZIP2")
+    endif()
   elseif (${libraryName} STREQUAL "curl")
     find_package(CURL ${requiredVersion})
     if (NOT CURL_INCLUDE_DIR OR NOT CURL_LIBRARIES)

--- a/CMake/HPHPFindLibs.cmake
+++ b/CMake/HPHPFindLibs.cmake
@@ -326,10 +326,6 @@ endif()
 find_package(ZLIB REQUIRED)
 include_directories(${ZLIB_INCLUDE_DIR})
 
-find_package(BZip2 REQUIRED)
-include_directories(${BZIP2_INCLUDE_DIR})
-add_definitions(${BZIP2_DEFINITIONS})
-
 # oniguruma
 find_package(ONIGURUMA REQUIRED)
 include_directories(${ONIGURUMA_INCLUDE_DIRS})
@@ -493,7 +489,6 @@ macro(hphp_link target)
   target_link_libraries(${target} ${TBB_LIBRARIES})
   target_link_libraries(${target} ${OPENSSL_LIBRARIES})
   target_link_libraries(${target} ${ZLIB_LIBRARIES})
-  target_link_libraries(${target} ${BZIP2_LIBRARIES})
 
   target_link_libraries(${target} ${LIBXML2_LIBRARIES})
   target_link_libraries(${target} ${LIBXSLT_LIBRARIES})

--- a/hphp/runtime/ext/bz2/config.cmake
+++ b/hphp/runtime/ext/bz2/config.cmake
@@ -7,6 +7,6 @@ HHVM_DEFINE_EXTENSION("bz2"
   SYSTEMLIB
     ext_bz2.php
   DEPENDS
-    libBz2
+    libBZip2
     libFolly
 )


### PR DESCRIPTION
Because the only thing in the repo that has the string `bzlib.h` in it, apart from pcre (in the third-party repo), which finds it on it's own, is `ext_bz2`.
This adds support to the extension config mechanism for handling LibBZip2.
This also renames the dependency in the configuration from `bz2` to `bzip2`, to better reflect the name of the actual library.