### PR TITLE
Remove global requirement of LibExpat

### DIFF
--- a/CMake/HPHPFindLibs.cmake
+++ b/CMake/HPHPFindLibs.cmake
@@ -150,9 +150,6 @@ find_package(LibXslt REQUIRED)
 include_directories(${LIBXSLT_INCLUDE_DIR})
 add_definitions(${LIBXSLT_DEFINITIONS})
 
-find_package(EXPAT REQUIRED)
-include_directories(${EXPAT_INCLUDE_DIRS})
-
 # libsqlite3
 find_package(LibSQLite)
 if (LIBSQLITE_INCLUDE_DIR)
@@ -498,7 +495,6 @@ macro(hphp_link target)
   target_link_libraries(${target} ${LIBXML2_LIBRARIES})
   target_link_libraries(${target} ${LIBXSLT_LIBRARIES})
   target_link_libraries(${target} ${LIBXSLT_EXSLT_LIBRARIES})
-  target_link_libraries(${target} ${EXPAT_LIBRARY})
   target_link_libraries(${target} ${ONIGURUMA_LIBRARIES})
   target_link_libraries(${target} ${Mcrypt_LIB})
 


### PR DESCRIPTION
Only `ext_xml` needs it, and the new extension mechanism already handles `libExpat`.