### PR TITLE
Don't expose HHVM by default

### DIFF
--- a/hphp/runtime/base/runtime-option.cpp
+++ b/hphp/runtime/base/runtime-option.cpp
@@ -181,7 +181,7 @@ std::string RuntimeOption::ForceCompressionURL;
 std::string RuntimeOption::ForceCompressionCookie;
 std::string RuntimeOption::ForceCompressionParam;
 bool RuntimeOption::EnableKeepAlive = true;
-bool RuntimeOption::ExposeHPHP = true;
+bool RuntimeOption::ExposeHPHP = false;
 bool RuntimeOption::ExposeXFBServer = false;
 bool RuntimeOption::ExposeXFBDebug = false;
 std::string RuntimeOption::XFBDebugSSLKey;


### PR DESCRIPTION
As-per [issue #5691](https://github.com/facebook/hhvm/issues/5691), this sets `expose_php` to `false` by default.
Fixes #5691