### PR TITLE
Remove the global FastLZ requirement

### DIFF
--- a/CMake/HHVMExtensionConfig.cmake
+++ b/CMake/HHVMExtensionConfig.cmake
@@ -694,7 +694,9 @@ function (HHVM_EXTENSION_INTERNAL_HANDLE_LIBRARY_DEPENDENCY extensionID dependen
         # to figure that out, and complains about it. The OLD behavior here tells cmake
         # to simply not emit the dependency for itself. (which doesn't really exist to
         # begin with)
-        cmake_policy(SET CMP0038 OLD)
+        if(POLICY CMP0038)
+          cmake_policy(SET CMP0038 OLD)
+        endif()
         link_libraries("$<$<NOT:$<STREQUAL:fastlz,$<TARGET_PROPERTY:NAME>>>:$<TARGET_NAME:fastlz>>")
       endif()
       add_definitions("-DHAVE_LIBFASTLZ")

--- a/CMake/HHVMExtensionConfig.cmake
+++ b/CMake/HHVMExtensionConfig.cmake
@@ -617,7 +617,6 @@ function (HHVM_EXTENSION_INTERNAL_HANDLE_LIBRARY_DEPENDENCY extensionID dependen
     ${libraryName} STREQUAL "boost" OR
     ${libraryName} STREQUAL "bz2" OR
     ${libraryName} STREQUAL "editline" OR
-    ${libraryName} STREQUAL "fastlz" OR
     ${libraryName} STREQUAL "folly" OR
     ${libraryName} STREQUAL "iconv" OR
     ${libraryName} STREQUAL "lz4" OR
@@ -670,6 +669,35 @@ function (HHVM_EXTENSION_INTERNAL_HANDLE_LIBRARY_DEPENDENCY extensionID dependen
       include_directories(${EXPAT_INCLUDE_DIRS})
       link_libraries(${EXPAT_LIBRARY})
       add_definitions("-DHAVE_LIBEXPAT")
+    endif()
+  elseif (${libraryName} STREQUAL "fastlz")
+    find_package(FastLZ ${requiredVersion})
+    if (NOT FASTLZ_INCLUDE_DIR OR NOT LIBFASTLZ_LIBRARY)
+      if (NOT DEFINED HHVM_USE_BUNDLED_FASTLZ OR HHVM_USE_BUNDLED_FASTLZ)
+        message(STATUS "Failed to find fastlz, so using bundled version.")
+        set(HHVM_USE_BUNDLED_FASTLZ ON CACHE BOOL "If true, use the bundled fastlz library rather than the system one.")
+      else()
+        message("Was told not to use the bundled fastlz, but failed to find the system one!")
+        HHVM_EXTENSION_INTERNAL_SET_FAILED_DEPENDENCY(${extensionID} ${dependencyName})
+        return()
+      endif()
+    endif()
+
+    if (${addPaths})
+      if (NOT DEFINED HHVM_USE_BUNDLED_FASTLZ OR NOT HHVM_USE_BUNDLED_FASTLZ)
+        include_directories(${FASTLZ_INCLUDE_DIR})
+        link_libraries(${LIBFASTLZ_LIBRARY})
+      else()
+        include_directories("${TP_DIR}/fastlz")
+        # Shut newer versions of CMake up, because this generator command does in fact,
+        # only emit the dependency if the target is not fastlz, CMake just can't seem
+        # to figure that out, and complains about it. The OLD behavior here tells cmake
+        # to simply not emit the dependency for itself. (which doesn't really exist to
+        # begin with)
+        cmake_policy(SET CMP0038 OLD)
+        link_libraries("$<$<NOT:$<STREQUAL:fastlz,$<TARGET_PROPERTY:NAME>>>:$<TARGET_NAME:fastlz>>")
+      endif()
+      add_definitions("-DHAVE_LIBFASTLZ")
     endif()
   elseif (${libraryName} STREQUAL "fribidi")
     find_package(fribidi ${requiredVersion})

--- a/CMake/HPHPFindLibs.cmake
+++ b/CMake/HPHPFindLibs.cmake
@@ -171,12 +171,6 @@ if (LZ4_INCLUDE_DIR)
   include_directories(${LZ4_INCLUDE_DIR})
 endif()
 
-# fastlz
-find_package(FastLZ)
-if (FASTLZ_INCLUDE_DIR)
-  include_directories(${FASTLZ_INCLUDE_DIR})
-endif()
-
 # libzip
 find_package(LibZip)
 if (LIBZIP_INCLUDE_DIR_ZIP AND LIBZIP_INCLUDE_DIR_ZIPCONF)
@@ -545,12 +539,6 @@ macro(hphp_link target)
     target_link_libraries(${target} ${PCRE_LIBRARY})
   else()
     target_link_libraries(${target} pcre)
-  endif()
-
-  if (LIBFASTLZ_LIBRARY)
-    target_link_libraries(${target} ${LIBFASTLZ_LIBRARY})
-  else()
-    target_link_libraries(${target} fastlz)
   endif()
 
   target_link_libraries(${target} timelib)

--- a/CMake/HPHPSetup.cmake
+++ b/CMake/HPHPSetup.cmake
@@ -254,10 +254,6 @@ if (NOT PCRE_LIBRARY)
   include_directories("${TP_DIR}/pcre")
 endif()
 
-if (NOT FASTLZ_LIBRARY)
-  include_directories("${TP_DIR}/fastlz")
-endif()
-
 include_directories("${TP_DIR}/timelib")
 include_directories("${TP_DIR}/libafdt/src")
 include_directories("${TP_DIR}/libmbfl")


### PR DESCRIPTION
The only thing that uses fastlz currently is `ext_memcached`, if we already aren't building that, we don't need it.

This one is a bit more fun than the rest, because fastlz currently falls back to a bundled version if the system doesn't have it.

This also adds the ability to force the use of the bundled version via `HHVM_USE_BUNDLED_FASTLZ`. This ability will not however work until the way the 3rd party repo handles it is also adjusted.

Now, obviously I can't tell CMake to link fastlz against itself, so I use a generator expression to enable the library in the link string only if the target is not named "fastlz". This works fine, however, some versions of CMake complain that I'm still trying to make fastlz dependent upon itself. To get CMake to be quiet about this, we set policy CMP0038 to the OLD behavior, which is to simply ignore that dependency. (the NEW behavior is to error)

For this to work fully, changes to the third-party repo will also be needed (enable fastlz only if `HHVM_USE_BUNDLED_FASTLZ` is both defined and `true`, rather than checking if `FASTLZ_INCLUDE_DIR` is valid), but it still works without any changes to it.