### PR TITLE
Port the hash assembly code to MSVC

### DIFF
--- a/hphp/util/CMakeLists.txt
+++ b/hphp/util/CMakeLists.txt
@@ -5,6 +5,8 @@ list(APPEND CXX_SOURCES ${files})
 set(ASM_SOURCES)
 auto_sources(asmfiles "*.S" "RECURSE" "${CMAKE_CURRENT_SOURCE_DIR}")
 list(APPEND ASM_SOURCES ${asmfiles})
+auto_sources(asmfiles "*.asm" "RECURSE" "${CMAKE_CURRENT_SOURCE_DIR}")
+list(APPEND ASM_SOURCES ${asmfiles})
 
 # Disable Channeled JSON until we're sure it's going to stick
 # sgolemon(2014-02-19)

--- a/hphp/util/etch-masm.inc
+++ b/hphp/util/etch-masm.inc
@@ -1,0 +1,32 @@
+; This performs the same thing as etch-helpers.h, except
+; that this is for MASM instead.
+if 0
+  ; The Linux / Mac ABI
+  ; This is here to make testing to ensure
+  ; no errors were made in translation much
+  ; easier.
+  ARG1 equ rdi
+  ARG2 equ rsi
+  ARG2_4 equ esi
+  ARG3 equ rdx
+  ARG3_4 equ edx
+  ARG3_1 equ dl
+  ARG4 equ rcx
+  ARG4_4 equ ecx
+  ARG4_1 equ cl
+  ARG5 equ r8
+  ARG6 equ r9
+else
+  ; The Windows ABI
+  ARG1 equ rcx
+  ARG2 equ rdx
+  ARG2_4 equ edx
+  ARG3 equ r8
+  ARG3_4 equ r8d
+  ARG3_1 equ r8b
+  ARG4 equ r9
+  ARG4_4 equ r9d
+  ARG4_1 equ r9b
+  ARG5 equ r10
+  ARG6 equ r11
+endif

--- a/hphp/util/hash-crc.asm
+++ b/hphp/util/hash-crc.asm
@@ -1,0 +1,167 @@
+include <etch-masm.inc>
+
+; Not that, when porting, the loop instructions have been changed
+; to `dec ARG4_4; jnz myDest`
+
+hash_string_i_crcSeg SEGMENT ALIGN(16) READ EXECUTE 'CODE'
+hash_string_i_crc PROC
+  or eax, -1
+  neg ARG2_4
+  je i_end
+  mov ARG4_4, ARG2_4
+  mov ARG5, 0dfdfdfdfdfdfdfdfh
+  jmp iheader
+
+iloop:
+  add ARG1, 8
+  crc32 rax, ARG3
+
+iheader:
+  mov ARG3, ARG5
+  and ARG3, [ARG1]
+  add ARG4_4, 8
+  jnc iloop
+
+  shl ARG4_4, 3
+  xchg ARG4_1, CL
+  shl ARG3, CL
+  xchg CL, ARG4_1
+  crc32 rax, ARG3
+
+i_end:
+  shr eax, 1
+  ret
+hash_string_i_crc ENDP
+hash_string_i_crcSeg ENDS
+
+hash_string_i_unaligned_crcSeg SEGMENT ALIGN(16) READ EXECUTE 'CODE'
+hash_string_i_unaligned_crc PROC
+  or eax, -1
+  sub ARG2_4, 8
+  mov ARG5, 0dfdfdfdfdfdfdfdfh
+  js iutail
+
+iuloop:
+  mov ARG3, [ARG1]
+  and ARG3, ARG5
+  add ARG1, 8
+  crc32 rax, ARG3
+  sub ARG2_4, 8
+  jns iuloop
+
+iutail:
+  add ARG2_4, 8
+  je iuend
+  mov ARG4_4, ARG2_4
+  xor ARG3_4, ARG3_4
+
+iutailloop:
+  mov ARG3_1, [ARG1]
+  inc ARG1
+  ror ARG3, 8
+  dec ARG4_4
+  jnz iutailloop
+  and ARG3, ARG5
+  crc32 rax, ARG3
+
+iuend:
+  shr eax, 1
+  ret
+hash_string_i_unaligned_crc ENDP
+hash_string_i_unaligned_crcSeg ENDS
+
+hash_string_cs_crcSeg SEGMENT ALIGN(16) READ EXECUTE 'CODE'
+hash_string_cs_crc PROC
+  or eax, -1
+  neg ARG2_4
+  je csend
+  mov ARG4_4, ARG2_4
+  jmp csheader
+
+csloop:
+  add ARG1, 8
+  crc32 rax, ARG3
+
+csheader:
+  mov ARG3, [ARG1]
+  add ARG4_4, 8
+  jnc csloop
+
+  shl ARG4_4, 3
+  xchg ARG4_1, CL
+  shl ARG3, CL
+  xchg CL, ARG4_1
+  crc32 rax, ARG3
+
+csend:
+  shr eax, 1
+  ret
+hash_string_cs_crc ENDP
+hash_string_cs_crcSeg ENDS
+
+hash_string_cs_unaligned_crcSeg SEGMENT ALIGN(16) READ EXECUTE 'CODE'
+hash_string_cs_unaligned_crc PROC
+  or eax, -1
+  sub ARG2_4, 8
+  js csutail
+
+csuloop:
+  mov ARG3, [ARG1]
+  add ARG1, 8
+  crc32 rax, ARG3
+  sub ARG2_4, 8
+  jns csuloop
+
+csutail:
+  add ARG2_4, 8
+  je csuend
+  mov ARG4_4, ARG2_4
+  xor ARG3_4, ARG3_4
+
+csutailloop:
+  mov ARG3_1, [ARG1]
+  inc ARG1
+  ror ARG3, 8
+  dec ARG4_4
+  jnz csutailloop
+  crc32 rax, ARG3
+
+csuend:
+  shr eax, 1
+  ret
+hash_string_cs_unaligned_crc ENDP
+hash_string_cs_unaligned_crcSeg ENDS
+
+; The following is the asm version of HPHP::StringData::hashHelper
+g_hashHelper_crcSeg SEGMENT ALIGN(16) READ EXECUTE 'CODE'
+g_hashHelper_crc PROC
+  mov ARG4_4, [ARG1 + 10h]
+  or eax, -1
+  test ARG4_4, ARG4_4
+  jz hend
+  mov ARG3, [ARG1]
+
+hloop:
+  mov ARG2, 0dfdfdfdfdfdfdfdfh
+  and ARG2, [ARG3]
+  sub ARG4_4, 8
+  jle htail
+  crc32 rax, ARG2
+  add ARG3, 8
+  jmp hloop
+
+htail:
+  shl ARG4_4, 3
+  neg ARG4_4
+  xchg ARG4_1, CL
+  shl ARG2, CL
+  xchg CL, ARG4_1
+  crc32 rax, ARG2
+
+hend:
+  shr eax, 1
+  or [ARG1 + 14h], eax
+  ret
+g_hashHelper_crc ENDP
+g_hashHelper_crcSeg ENDS
+END

--- a/hphp/util/hash.h
+++ b/hphp/util/hash.h
@@ -22,7 +22,7 @@
 
 #include "hphp/util/portability.h"
 
-#if defined __x86_64__
+#if defined(__x86_64__) || defined(_MSC_VER)
 #  if (!defined USE_SSECRC)
 #    define USE_SSECRC
 #  endif


### PR DESCRIPTION
Well, MASM.
This ports the asm versions of the crc hash functions to MSVC.
This shouldn't break anything even if the ASM_MASM language hasn't been enabled, which is why it's in a separate PR.