### PR TITLE
Explicitly read 2 characters for country code.

### DIFF
--- a/hphp/runtime/base/timezone.cpp
+++ b/hphp/runtime/base/timezone.cpp
@@ -216,7 +216,8 @@ Array TimeZone::GetNamesToCountryCodes() {
     const char* infoString = (const char*)&tzdb->data[table[i].pos];
     const char* countryCode = &infoString[5];
 
-    ret.set(String(table[i].id, CopyString), String(countryCode, 2, CopyString));
+    ret.set(String(table[i].id, CopyString),
+            String(countryCode, 2, CopyString));
   }
   return ret;
 }

--- a/hphp/runtime/base/timezone.cpp
+++ b/hphp/runtime/base/timezone.cpp
@@ -216,7 +216,7 @@ Array TimeZone::GetNamesToCountryCodes() {
     const char* infoString = (const char*)&tzdb->data[table[i].pos];
     const char* countryCode = &infoString[5];
 
-    ret.set(String(table[i].id, CopyString), String(countryCode, CopyString));
+    ret.set(String(table[i].id, CopyString), String(countryCode, 2, CopyString));
   }
   return ret;
 }


### PR DESCRIPTION
Because the country code string is not null-terminated when system tzdata
is used, only read 2 characters to avoid out of bounds access.