### PR TITLE
define CURLE_OPERATION_TIMEDOUT

### DIFF
--- a/hphp/runtime/ext/curl/ext_curl.cpp
+++ b/hphp/runtime/ext/curl/ext_curl.cpp
@@ -2207,6 +2207,7 @@ const StaticString s_CURLE_LIBRARY_NOT_FOUND("CURLE_LIBRARY_NOT_FOUND");
 const StaticString s_CURLE_MALFORMAT_USER("CURLE_MALFORMAT_USER");
 const StaticString s_CURLE_OBSOLETE("CURLE_OBSOLETE");
 const StaticString s_CURLE_OK("CURLE_OK");
+const StaticString s_CURLE_OPERATION_TIMEDOUT("CURLE_OPERATION_TIMEDOUT");
 const StaticString s_CURLE_OPERATION_TIMEOUTED("CURLE_OPERATION_TIMEOUTED");
 const StaticString s_CURLE_OUT_OF_MEMORY("CURLE_OUT_OF_MEMORY");
 const StaticString s_CURLE_PARTIAL_FILE("CURLE_PARTIAL_FILE");
@@ -2600,6 +2601,9 @@ class CurlExtension final : public Extension {
     );
     Native::registerConstant<KindOfInt64>(
       s_CURLE_OK.get(), k_CURLE_OK
+    );
+    Native::registerConstant<KindOfInt64>(
+      s_CURLE_OPERATION_TIMEDOUT.get(), k_CURLE_OPERATION_TIMEOUTED
     );
     Native::registerConstant<KindOfInt64>(
       s_CURLE_OPERATION_TIMEOUTED.get(), k_CURLE_OPERATION_TIMEOUTED


### PR DESCRIPTION
this is the constant documented by PHP and curl
http://php.net/manual/en/function.curl-errno.php
http://curl.haxx.se/libcurl/c/libcurl-errors.html

Running the following script in php and hhvm shows how
php defines both constants but hhvm defines only the undocumented one.

<?php

$timedout = CURLE_OPERATION_TIMEDOUT;
$timeouted = CURLE_OPERATION_TIMEOUTED;

$a = ['timedout' => $timedout, 'timeouted' => $timeouted];
var_dump($a);