### PR TITLE
Maintain consistency in the formatting of the extension configs

### DIFF
--- a/hphp/runtime/ext/hh_client/config.cmake
+++ b/hphp/runtime/ext/hh_client/config.cmake
@@ -1,5 +1,4 @@
-HHVM_DEFINE_EXTENSION("hh_client"
-  REQUIRED
+HHVM_DEFINE_EXTENSION("hh_client" REQUIRED
   SOURCES
     ext_hh_client.cpp
   SYSTEMLIB


### PR DESCRIPTION
Because OCD can be good at times.
This just moves the `REQUIRED` attribute to the same line as the extension name, which is where it is for every other extension.