### PR TITLE
Adjust stack-trace for MSVC

### DIFF
--- a/hphp/util/stack-trace.cpp
+++ b/hphp/util/stack-trace.cpp
@@ -569,7 +569,13 @@ bool StackTraceBase::Addr2line(const char *filename, const char *address,
 #define DMGL_VERBOSE  (1 << 3)  /* Include implementation details. */
 
 extern "C" {
+#ifdef _MSC_VER
+  char* cplus_demangle(const char* mangled, int options) {
+    return strdup(mangled);
+  }
+#else
   extern char *cplus_demangle (const char *mangled, int options);
+#endif
 }
 
 std::string StackTrace::Demangle(const char *mangled) {


### PR DESCRIPTION
We don't have libiberty when under MSVC, so stub it out to just return the input string.

In reality, this should probably be refactored to use <cxxabi.h> instead.