### PR TITLE
Make a few assignment operators in ext_icu not infinitely recurse

### DIFF
--- a/hphp/runtime/ext/icu/ext_icu_collator.h
+++ b/hphp/runtime/ext/icu/ext_icu_collator.h
@@ -15,7 +15,6 @@ class Collator : public IntlError {
   Collator() {}
   Collator(const Collator&) = delete;
   Collator& operator=(const Collator& src) {
-    *this = src;
     char stack[U_COL_SAFECLONE_BUFFERSIZE];
     int32_t stack_size = sizeof(stack);
     UErrorCode error = U_ZERO_ERROR;

--- a/hphp/runtime/ext/icu/ext_icu_collator.h
+++ b/hphp/runtime/ext/icu/ext_icu_collator.h
@@ -15,6 +15,7 @@ class Collator : public IntlError {
   Collator() {}
   Collator(const Collator&) = delete;
   Collator& operator=(const Collator& src) {
+    IntlError::operator =(src);
     char stack[U_COL_SAFECLONE_BUFFERSIZE];
     int32_t stack_size = sizeof(stack);
     UErrorCode error = U_ZERO_ERROR;

--- a/hphp/runtime/ext/icu/ext_icu_uconverter.h
+++ b/hphp/runtime/ext/icu/ext_icu_uconverter.h
@@ -16,6 +16,7 @@ public:
   IntlUConverter() {}
   IntlUConverter(const IntlUConverter& src) = delete;
   IntlUConverter& operator=(const IntlUConverter& src) {
+    IntlError::operator =(src);
     char *buffer[U_CNV_SAFECLONE_BUFFERSIZE];
     int32_t bufferSize = U_CNV_SAFECLONE_BUFFERSIZE;
     UErrorCode error = U_ZERO_ERROR;

--- a/hphp/runtime/ext/icu/ext_icu_uconverter.h
+++ b/hphp/runtime/ext/icu/ext_icu_uconverter.h
@@ -16,7 +16,6 @@ public:
   IntlUConverter() {}
   IntlUConverter(const IntlUConverter& src) = delete;
   IntlUConverter& operator=(const IntlUConverter& src) {
-    *this = src;
     char *buffer[U_CNV_SAFECLONE_BUFFERSIZE];
     int32_t bufferSize = U_CNV_SAFECLONE_BUFFERSIZE;
     UErrorCode error = U_ZERO_ERROR;

--- a/hphp/runtime/ext/icu/ext_icu_ucsdet.h
+++ b/hphp/runtime/ext/icu/ext_icu_ucsdet.h
@@ -79,6 +79,7 @@ class EncodingMatch : public IntlError {
   EncodingMatch() {}
   EncodingMatch(const EncodingMatch&) = delete;
   EncodingMatch& operator=(const EncodingMatch& src) {
+    IntlError::operator =(src);
     m_match = src.m_match;
     return *this;
   }

--- a/hphp/runtime/ext/icu/ext_icu_ucsdet.h
+++ b/hphp/runtime/ext/icu/ext_icu_ucsdet.h
@@ -79,7 +79,7 @@ class EncodingMatch : public IntlError {
   EncodingMatch() {}
   EncodingMatch(const EncodingMatch&) = delete;
   EncodingMatch& operator=(const EncodingMatch& src) {
-    *this = src;
+    m_match = src.m_match;
     return *this;
   }
   ~EncodingMatch() {}

--- a/hphp/runtime/ext/icu/ext_icu_uspoof.h
+++ b/hphp/runtime/ext/icu/ext_icu_uspoof.h
@@ -29,6 +29,7 @@ class SpoofChecker : public IntlError {
   }
   SpoofChecker(const SpoofChecker&) = delete;
   SpoofChecker& operator=(const SpoofChecker& src) {
+    IntlError::operator =(src);
     UErrorCode error = U_ZERO_ERROR;
     m_checker = uspoof_clone(src.m_checker, &error);
     if (U_FAILURE(error)) {

--- a/hphp/runtime/ext/icu/ext_icu_uspoof.h
+++ b/hphp/runtime/ext/icu/ext_icu_uspoof.h
@@ -29,7 +29,6 @@ class SpoofChecker : public IntlError {
   }
   SpoofChecker(const SpoofChecker&) = delete;
   SpoofChecker& operator=(const SpoofChecker& src) {
-    *this = src;
     UErrorCode error = U_ZERO_ERROR;
     m_checker = uspoof_clone(src.m_checker, &error);
     if (U_FAILURE(error)) {


### PR DESCRIPTION
Because, as MSVC rightfully warns, `hphp\runtime\ext\icu\ext_icu_collator.h(28): warning C4717: 'HPHP::Intl::Collator::operator=': recursive on all control paths, function will cause runtime stack overflow`
I checked the ubuntu binary, and this is in-fact infinitely recursive in that build as well.