### PR TITLE
Attempt to fix issue #5776 hh_server parser doesn't gracefully recover from missing visibility modifier

### DIFF
--- a/hphp/hack/src/parsing/parser_hack.ml
+++ b/hphp/hack/src/parsing/parser_hack.ml
@@ -1260,7 +1260,7 @@ and class_toplevel_word env word =
     on_class_member_word env
   | _ ->
       error_expect env "modifier";
-      []
+      class_member_def env
 
 and on_class_member_word env =
   (* variable | method | type const*)


### PR DESCRIPTION
This is my attempt to fix issue #5776, however, as I'm on windows, I can't test to see if it actually works. If my understanding of how the parser works is correct though, this should achieve the desired effect.