### PR TITLE
Overload UnitEmitter::emitIVA for bool

### DIFF
--- a/hphp/runtime/vm/unit-emitter-inl.h
+++ b/hphp/runtime/vm/unit-emitter-inl.h
@@ -103,7 +103,7 @@ inline void UnitEmitter::emitDouble(double n, int64_t pos) {
 
 template<>
 inline void UnitEmitter::emitIVA(bool n) {
-  emitByte(n ? 2 : 0);
+  emitByte(n << 1);
 }
 
 template<typename T>

--- a/hphp/runtime/vm/unit-emitter-inl.h
+++ b/hphp/runtime/vm/unit-emitter-inl.h
@@ -101,6 +101,11 @@ inline void UnitEmitter::emitDouble(double n, int64_t pos) {
   emitImpl(n, pos);
 }
 
+template<>
+inline void UnitEmitter::emitIVA(bool n) {
+  emitByte(n ? 2 : 0);
+}
+
 template<typename T>
 void UnitEmitter::emitIVA(T n) {
   if (LIKELY((n & 0x7f) == n)) {


### PR DESCRIPTION
This shuts up MSVC which warns that `'&': unsafe operation: no value of type 'bool' promoted to type 'int' can equal the given constant`. I believe this also fixes the codegen that MSVC would otherwise do, as the warning was referring to the `if` statement.