### PR TITLE
Implement DEBUGGER_IF for MSVC

### DIFF
--- a/hphp/util/debug.h
+++ b/hphp/util/debug.h
@@ -24,7 +24,12 @@
 /*
  * Conditionally drop into the debugger
  */
-#define DEBUGGER()    kill(getpid(), SIGTRAP)
+#ifdef _MSC_VER
+#include <intrin.h>
+#define DEBUGGER() __debugbreak()
+#else
+#define DEBUGGER() kill(getpid(), SIGTRAP)
+#endif
 
 /*
  * DEBUGGER_IF: use like always_assert(), i.e., do not rely on side effects


### PR DESCRIPTION
Use `__debugbreak()` to achieve the desired effect, rather than `SIGTRAP`, which will do nothing on Windows.