### PR TITLE
Fix resource generation on Windows

### DIFF
--- a/CMake/HPHPFunctions.cmake
+++ b/CMake/HPHPFunctions.cmake
@@ -104,7 +104,7 @@ function(append_systemlib TARGET SOURCE SECTNAME)
     # for each library append the following line to embed.rc
     # $sectionname RCDATA "$source"
     add_custom_command(TARGET generate_rc
-      COMMAND echo "\"${SECTNAME}\" RCDATA \"${SOURCE}\"" >> embed.rc
+      COMMAND echo "${SECTNAME} RCDATA \"${SOURCE}\"" >> embed.rc
       COMMENT "Adding ${SOURCE} as ${SECTNAME} to embed.rc"
       )
   else()
@@ -140,7 +140,13 @@ macro(embed_systemlib_byname TARGET SLIB)
   string(MD5 SLIB_HASH_NAME ${SLIB_EXTNAME})
   # Some platforms limit section names to 16 characters :(
   string(SUBSTRING ${SLIB_HASH_NAME} 0 12 SLIB_HASH_NAME_SHORT)
-  append_systemlib(${TARGET} ${SLIB} "ext.${SLIB_HASH_NAME_SHORT}")
+  if (CYGWIN OR MINGW OR MSVC)
+    # The dot would be causing the RC lexer to begin a number in the
+    # middle of our resource name, so use an underscore instead.
+    append_systemlib(${TARGET} ${SLIB} "ext_${SLIB_HASH_NAME_SHORT}")
+  else()
+    append_systemlib(${TARGET} ${SLIB} "ext.${SLIB_HASH_NAME_SHORT}")
+  endif()
 endmacro()
 
 function(embed_all_systemlibs TARGET ROOT DEST)

--- a/hphp/hhvm/CMakeLists.txt
+++ b/hphp/hhvm/CMakeLists.txt
@@ -3,9 +3,9 @@ auto_sources(files "*.cpp" "")
 list(APPEND CXX_SOURCES ${files})
 
 # Windows targets use a generate rc file for embedding libraries
-if(CYGWIN OR MSVC OR MING)
+if(CYGWIN OR MSVC OR MINGW)
   add_custom_target(generate_embed
-    COMMAND echo // THIS IS A GENERATED FILE > ${CMAKE_CURRENT_BINARY_DIR}/embed.rc
+    COMMAND echo LANGUAGE 0, 0 > ${CMAKE_CURRENT_BINARY_DIR}/embed.rc
     COMMENT "generating embed.rc")
 
   # this is a cmake trick to allow items added later to depend properly

--- a/hphp/runtime/ext/extension.cpp
+++ b/hphp/runtime/ext/extension.cpp
@@ -90,7 +90,11 @@ void Extension::CompileSystemlib(const std::string &slib,
 void Extension::loadSystemlib(const std::string& name) {
   std::string n = name.empty() ?
     std::string(m_name.data(), m_name.size()) : name;
+#if defined(__CYGWIN__) || defined(__MINGW__) || defined(_MSC_VER)
+  std::string section("ext_");
+#else
   std::string section("ext.");
+#endif
   section += HHVM_FN(md5)(n, false).substr(0, 12).data();
   std::string hhas;
   std::string slib = get_systemlib(&hhas, section, m_dsoName);


### PR DESCRIPTION
Because RC doesn't know that double quotes aren't part of the name of a resource.

While my previous fix did get it compiling, it was flawed in-that it caused double quotes to be included as part of the actual name of the resource. This takes a different approach to solving the problem at hand, and replaces the `.` which was causing the problem, with an `_` instead.
This also properly assigns the resources to the neutral culture, rather than whatever the culture of the build machine is.
This also fixes a minor typo in the name of the `MINGW` variable in the `if` statement controlling resource generation in the `CMakeLists` file for HHVM.