### PR TITLE
Remove an unneeded HANDLE being opened on Windows

### DIFF
--- a/hphp/util/embedded-data.cpp
+++ b/hphp/util/embedded-data.cpp
@@ -16,11 +16,6 @@
 
 #include "hphp/util/embedded-data.h"
 
-#if (defined(__CYGWIN__) || defined(__MINGW__) || defined(_MSC_VER))
-#include <windows.h>
-#include <winuser.h>
-#endif
-
 #include "hphp/util/current-executable.h"
 
 #include <folly/ScopeGuard.h>
@@ -34,6 +29,9 @@
 
 #ifdef __APPLE__
 #include <mach-o/getsect.h>
+#elif defined(__CYGWIN__) || defined(__MINGW__) || defined(_MSC_VER)
+#include <windows.h>
+#include <winuser.h>
 #else
 #include <libelf.h>
 #include <gelf.h>
@@ -45,32 +43,26 @@ bool get_embedded_data(const char *section, embedded_data* desc,
                        const std::string &filename /*= "" */) {
   std::string fname(filename.empty() ? current_executable_path() : filename);
 
-#if (defined(__CYGWIN__) || defined(__MINGW__) || defined(_MSC_VER))
-  HMODULE moduleHandle = GetModuleHandle(nullptr);
+#if defined(__CYGWIN__) || defined(__MINGW__) || defined(_MSC_VER)
   HGLOBAL loadedResource;
   HRSRC   resourceInfo;
   DWORD   resourceSize;
 
-  resourceInfo = FindResource(moduleHandle, section, RT_RCDATA);
-
-  if (!resourceInfo) {
+  resourceInfo = FindResource(NULL, section, RT_RCDATA);
+  if (!resourceInfo)
     return false;
-  }
 
-  loadedResource = LoadResource(moduleHandle, resourceInfo);
-
-  if (!loadedResource) {
+  loadedResource = LoadResource(NULL, resourceInfo);
+  if (!loadedResource)
     return false;
-  }
 
-  resourceSize = SizeofResource(moduleHandle, resourceInfo);
+  resourceSize = SizeofResource(NULL, resourceInfo);
 
   desc->m_filename = fname;
   desc->m_handle = loadedResource;
   desc->m_len = resourceSize;
 
   return true;
-
 #elif !defined(__APPLE__) // LINUX/ELF
   GElf_Shdr shdr;
   size_t shstrndx = -1;

--- a/hphp/util/embedded-data.cpp
+++ b/hphp/util/embedded-data.cpp
@@ -48,15 +48,17 @@ bool get_embedded_data(const char *section, embedded_data* desc,
   HRSRC   resourceInfo;
   DWORD   resourceSize;
 
-  resourceInfo = FindResource(NULL, section, RT_RCDATA);
-  if (!resourceInfo)
+  resourceInfo = FindResource(nullptr, section, RT_RCDATA);
+  if (!resourceInfo) {
     return false;
+  }
 
-  loadedResource = LoadResource(NULL, resourceInfo);
-  if (!loadedResource)
+  loadedResource = LoadResource(nullptr, resourceInfo);
+  if (!loadedResource) {
     return false;
+  }
 
-  resourceSize = SizeofResource(NULL, resourceInfo);
+  resourceSize = SizeofResource(nullptr, resourceInfo);
 
   desc->m_filename = fname;
   desc->m_handle = loadedResource;


### PR DESCRIPTION
`FindResource`, `LoadResource`, and `SizeofResource` all default to the module that was started up, the executable, so don't open a `HANDLE` explicitly, especially not one that's never closed.
This also handles some minor formatting changes, and finally, it moves the `#include`s for Windows around so that Windows doesn't try to include the elf headers.