### PR TITLE
Explicitly exclude StringPiece from FormatValue in trace.h

### DIFF
--- a/hphp/util/trace.h
+++ b/hphp/util/trace.h
@@ -445,7 +445,8 @@ namespace folly {
 template<typename Val>
 struct FormatValue<Val,
                    typename std::enable_if<
-                     HPHP::has_toString<Val, std::string() const>::value,
+                     HPHP::has_toString<Val, std::string() const>::value
+                     && !std::is_same<Val, StringPiece>::value,
                      void
                    >::type> {
   explicit FormatValue(const Val& val) : m_val(val) {}

--- a/hphp/util/trace.h
+++ b/hphp/util/trace.h
@@ -445,8 +445,11 @@ namespace folly {
 template<typename Val>
 struct FormatValue<Val,
                    typename std::enable_if<
-                     HPHP::has_toString<Val, std::string() const>::value
-                     && !std::is_same<Val, StringPiece>::value,
+                     HPHP::has_toString<Val, std::string() const>::value &&
+                     // This is here because MSVC decides that StringPiece matches
+                     // both this overload as well as the FormatValue overload for
+                     // string-y types in folly itself.
+                     !std::is_same<Val, StringPiece>::value,
                      void
                    >::type> {
   explicit FormatValue(const Val& val) : m_val(val) {}


### PR DESCRIPTION
For some reason, MSVC seems to have decided that StringPiece is able to match the constraint, and thus complains that multiple template instantiations could be valid.
This explicitly checks that `Val` is not `StringPiece`, which is good enough to solve the problem.