### PR TITLE
MSVC is picky about its formatting strings

### DIFF
--- a/hphp/runtime/base/datatype-profiler.cpp
+++ b/hphp/runtime/base/datatype-profiler.cpp
@@ -65,7 +65,7 @@ DataTypeProfiler::~DataTypeProfiler() {
                m_resource.hits() +
                m_ref.hits();
   if (!total) return;
-  fprintf(stderr, "%s: total=%lu KindOfUninit=%.1f%% "
+  fprintf(stderr, "%s: total=%zu KindOfUninit=%.1f%% "
                   "KindOfNull=%.1f%% "
                   "KindOfBoolean=%.1f%% "
                   "KindOfInt64=%.1f%% "


### PR DESCRIPTION
So use `%zu` for the `size_t` argument, rather than `%lu`.