### PR TITLE
Support detection of the home directory on Windows when creating the global repo

### DIFF
--- a/hphp/runtime/vm/repo.cpp
+++ b/hphp/runtime/vm/repo.cpp
@@ -566,6 +566,19 @@ void Repo::initCentral() {
     }
   }
 
+  // Try "$HOMEDRIVE$HOMEPATH/.hhvm.hhbc"
+  char* HOMEDRIVE = getenv("HOMEDRIVE");
+  if (HOMEDRIVE != nullptr) {
+    char* HOMEPATH = getenv("HOMEPATH");
+    if (HOMEPATH != nullptr) {
+      std::string centralPath = HOMEDRIVE;
+      centralPath += HOMEPATH;
+      centralPath += "\\.hhvm.hhbc";
+      if (tryPath(centralPath.c_str()))
+        return;
+    }
+  }
+
   error = "Failed to initialize central HHBC repository:\n" + error;
   // Database initialization failed; this is an unrecoverable state.
   Logger::Error("%s", error.c_str());

--- a/hphp/runtime/vm/repo.cpp
+++ b/hphp/runtime/vm/repo.cpp
@@ -566,6 +566,7 @@ void Repo::initCentral() {
     }
   }
 
+#ifdef _WIN32
   // Try "$HOMEDRIVE$HOMEPATH/.hhvm.hhbc"
   char* HOMEDRIVE = getenv("HOMEDRIVE");
   if (HOMEDRIVE != nullptr) {
@@ -578,6 +579,7 @@ void Repo::initCentral() {
         return;
     }
   }
+#endif
 
   error = "Failed to initialize central HHBC repository:\n" + error;
   // Database initialization failed; this is an unrecoverable state.


### PR DESCRIPTION
Because the `HOME` environment variable is not set on Windows, and there is no password database to lookup the home directory in on Windows.
The order and which checks are used should be the same as what Qt uses to determine the home directory. If it isn't, then I blame Stack Overflow.