### PR TITLE
E_STRICT notice when mktime called with no arguments. #4611

### DIFF
--- a/hphp/runtime/ext/datetime/ext_datetime.cpp
+++ b/hphp/runtime/ext/datetime/ext_datetime.cpp
@@ -625,6 +625,9 @@ Variant HHVM_FUNCTION(mktime,
   month = month < INT_MAX ? month : INT_MAX;
   day = day < INT_MAX ? day : INT_MAX;
   year = year < INT_MAX ? year : INT_MAX;
+  if (hour == INT_MAX && minute == INT_MAX && second == INT_MAX && month == INT_MAX && day == INT_MAX && year == INT_MAX) {
+    raise_strict_warning("mktime(): You should be using the time() function instead");
+  }
   bool error;
   int64_t ts = TimeStamp::Get(error, hour, minute, second, month, day, year,
                               false);

--- a/hphp/test/slow/ext_datetime/mktime.php.expect
+++ b/hphp/test/slow/ext_datetime/mktime.php.expect
@@ -7,3 +7,5 @@ bool(true)
 bool(true)
 bool(true)
 bool(true)
+
+Strict Warning: mktime(): You should be using the time() function instead in /home/noony/hhvm/toto.php on line 3


### PR DESCRIPTION
Fixes #4611 