### PR TITLE
[MSVC] Teach HHVM about Windows paths

### DIFF
--- a/hphp/compiler/analysis/analysis_result.cpp
+++ b/hphp/compiler/analysis/analysis_result.cpp
@@ -997,8 +997,9 @@ std::string AnalysisResult::prepareFile(const char *root,
                                         bool chop,
                                         bool stripPath /* = true */) {
   std::string fullPath = root;
-  if (!fullPath.empty() && fullPath[fullPath.size() - 1] != '/') {
-    fullPath += "/";
+  if (!fullPath.empty() &&
+    !FileUtil::isDirSeparator(fullPath[fullPath.size() - 1])) {
+    fullPath += FileUtil::getDirSeparator();
   }
 
   auto file = fileName;
@@ -1015,7 +1016,7 @@ std::string AnalysisResult::prepareFile(const char *root,
     fullPath += file;
   }
   for (size_t pos = strlen(root); pos < fullPath.size(); pos++) {
-    if (fullPath[pos] == '/') {
+    if (FileUtil::isDirSeparator(fullPath[pos])) {
       mkdir(fullPath.substr(0, pos).c_str(), 0777);
     }
   }

--- a/hphp/compiler/package.cpp
+++ b/hphp/compiler/package.cpp
@@ -81,7 +81,7 @@ void Package::addInputList(const char *listFileName) {
     if (fileName[len - 1] == '\n') fileName[len - 1] = '\0';
     len = strlen(fileName);
     if (len) {
-      if (fileName[len - 1] == '/') {
+      if (FileUtil::isDirSeparator(fileName[len - 1])) {
         addDirectory(fileName, false);
       } else {
         addSourceFile(fileName);
@@ -284,7 +284,7 @@ bool Package::parseImpl(const char *fileName) {
   if (fileName[0] == 0) return false;
 
   std::string fullPath;
-  if (fileName[0] == '/') {
+  if (FileUtil::isDirSeparator(fileName[0])) {
     fullPath = fileName;
   } else {
     fullPath = m_root + fileName;

--- a/hphp/runtime/base/builtin-functions.cpp
+++ b/hphp/runtime/base/builtin-functions.cpp
@@ -824,7 +824,7 @@ static Variant invoke_file(const String& s,
 
 Variant include_impl_invoke(const String& file, bool once,
                             const char *currentDir) {
-  if (file[0] == '/') {
+  if (FileUtil::isAbsolutePath(file.toCppString())) {
     if (RuntimeOption::SandboxMode || !RuntimeOption::AlwaysUseRelativePath) {
       try {
         return invoke_file(file, once, currentDir);
@@ -887,7 +887,7 @@ String resolve_include(const String& file, const char* currentDir,
       return file;
     }
 
-  } else if (c_file[0] == '/') {
+  } else if (FileUtil::isAbsolutePath(file.toCppString())) {
     String can_path = FileUtil::canonicalize(file);
 
     if (tryFile(can_path, ctx)) {
@@ -913,7 +913,7 @@ String resolve_include(const String& file, const char* currentDir,
       auto const is_stream_wrapper =
         includePath.find("://") != std::string::npos;
 
-      if (!is_stream_wrapper && includePath[0] != '/') {
+      if (!is_stream_wrapper && !FileUtil::isAbsolutePath(includePath)) {
         path += (g_context->getCwd() + "/");
       }
 
@@ -937,7 +937,7 @@ String resolve_include(const String& file, const char* currentDir,
       }
     }
 
-    if (currentDir[0] == '/') {
+    if (FileUtil::isAbsolutePath(currentDir)) {
       String path(currentDir);
       path += "/";
       path += file;

--- a/hphp/runtime/base/file-util.cpp
+++ b/hphp/runtime/base/file-util.cpp
@@ -328,7 +328,7 @@ size_t FileUtil::dirname_helper(char *path, int len) {
 
   /* Strip trailing slashes */
   register char *end = path + len - 1;
-  while (end >= path && *end == '/') {
+  while (end >= path && (*end == '/' || *end == '\\')) {
     end--;
   }
   if (end < path) {
@@ -339,7 +339,7 @@ size_t FileUtil::dirname_helper(char *path, int len) {
   }
 
   /* Strip filename */
-  while (end >= path && *end != '/') {
+  while (end >= path && *end != '/' && *end != '\\') {
     end--;
   }
   if (end < path) {
@@ -350,7 +350,7 @@ size_t FileUtil::dirname_helper(char *path, int len) {
   }
 
   /* Strip slashes which came before the file name */
-  while (end >= path && *end == '/') {
+  while (end >= path && (*end == '/' || *end == '\\')) {
     end--;
   }
   if (end < path) {
@@ -521,7 +521,7 @@ String FileUtil::canonicalize(const char *addpath, size_t addlen,
       /* ./ */
     } else if (seglen == 2 && addpath[0] == '.' && addpath[1] == '.') {
       /* backpath (../) */
-      if (pathlen == 1 && path[0] == '/') {
+      if (pathlen == 1 && (path[0] == '/' || path[0] == '\\')) {
       } else if (pathlen == 0
                  || (pathlen == 3
                      && !memcmp(path + pathlen - 3, "../", 3))
@@ -536,7 +536,7 @@ String FileUtil::canonicalize(const char *addpath, size_t addlen,
         /* otherwise crop the prior segment */
         do {
           --pathlen;
-        } while (pathlen && path[pathlen - 1] != '/');
+        } while (pathlen && path[pathlen - 1] != '/' && path[pathlen - 1] != '\\');
       }
     } else {
       /* An actual segment, append it to the destination path */
@@ -556,6 +556,10 @@ String FileUtil::canonicalize(const char *addpath, size_t addlen,
   }
   ret.setSize(pathlen);
   return ret;
+}
+
+bool FileUtil::isAbsolutePath(const std::string& path) {
+  return boost::filesystem::absolute(path).string() == path;
 }
 
 std::string FileUtil::normalizeDir(const std::string &dirname) {

--- a/hphp/runtime/base/file-util.cpp
+++ b/hphp/runtime/base/file-util.cpp
@@ -333,7 +333,7 @@ size_t FileUtil::dirname_helper(char *path, int len) {
   }
   if (end < path) {
     /* The path only contained slashes */
-    path[0] = getDirSeperator();
+    path[0] = getDirSeparator();
     path[1] = '\0';
     return 1;
   }

--- a/hphp/runtime/base/file-util.cpp
+++ b/hphp/runtime/base/file-util.cpp
@@ -328,18 +328,18 @@ size_t FileUtil::dirname_helper(char *path, int len) {
 
   /* Strip trailing slashes */
   register char *end = path + len - 1;
-  while (end >= path && (*end == '/' || *end == '\\')) {
+  while (end >= path && isDirSeparator(*end)) {
     end--;
   }
   if (end < path) {
     /* The path only contained slashes */
-    path[0] = '/';
+    path[0] = getDirSeperator();
     path[1] = '\0';
     return 1;
   }
 
   /* Strip filename */
-  while (end >= path && *end != '/' && *end != '\\') {
+  while (end >= path && !isDirSeparator(*end)) {
     end--;
   }
   if (end < path) {
@@ -350,11 +350,11 @@ size_t FileUtil::dirname_helper(char *path, int len) {
   }
 
   /* Strip slashes which came before the file name */
-  while (end >= path && (*end == '/' || *end == '\\')) {
+  while (end >= path && isDirSeparator(*end)) {
     end--;
   }
   if (end < path) {
-    path[0] = '/';
+    path[0] = getDirSeparator();
     path[1] = '\0';
     return 1;
   }
@@ -389,8 +389,8 @@ String FileUtil::relativePath(const std::string& fromDir,
   size_t maxlen = (fromDir.size() + toFile.size()) * 3;
 
   // Sanity checks
-  if (fromDir[0] != '/' || toFile[0] != '/' ||
-      fromDir[fromDir.size() - 1] != '/') {
+  if (!isAbsolutePath(fromDir) || !isAbsolutePath(toFile) ||
+      !isDirSeparator(fromDir[fromDir.size() - 1])) {
     return empty_string();
   }
 
@@ -412,7 +412,7 @@ String FileUtil::relativePath(const std::string& fromDir,
   while (true) {
     int seg_len = 0;
     char cur = from_start[0];
-    while (cur && cur != '/') {
+    while (cur && !isDirSeparator(cur)) {
       ++seg_len;
       cur = from_start[seg_len];
     }
@@ -428,8 +428,9 @@ String FileUtil::relativePath(const std::string& fromDir,
   char cur = *from_start;
   char* path_end = path;
   while (cur) {
-    if (cur == '/') {
-      strcpy(path_end, "../");
+    if (isDirSeparator(cur)) {
+      strcpy(path_end, "..");
+      path_end[2] = getDirSeparator();
       maxlen -= 3;
       path_end += 3;
     }
@@ -437,8 +438,9 @@ String FileUtil::relativePath(const std::string& fromDir,
     cur = *from_start;
   }
 
-  if (from_start[-1] != '/') {
-    strcpy(path_end, "../");
+  if (!isDirSeparator(from_start[-1])) {
+    strcpy(path_end, "..");
+    path_end[2] = getDirSeparator();
     maxlen -= 3;
     path_end += 3;
   }
@@ -492,6 +494,7 @@ String FileUtil::canonicalize(const char *addpath, size_t addlen,
   String ret(maxlen-1, ReserveString);
   char *path = ret.mutableData();
 
+#ifndef _MSC_VER
   if (addpath[0] == '/' && collapse_slashes) {
     /* Ignore the given root path, strip off leading
      * '/'s to a single leading '/' from the addpath,
@@ -502,12 +505,13 @@ String FileUtil::canonicalize(const char *addpath, size_t addlen,
     path[0] = '/';
     pathlen = 1;
   }
+#endif
 
   while (*addpath) {
     /* Parse each segment, find the closing '/'
      */
     const char *next = addpath;
-    while (*next && (*next != '/')) {
+    while (*next && !isDirSeparator(*next)) {
       ++next;
     }
     seglen = next - addpath;
@@ -515,28 +519,34 @@ String FileUtil::canonicalize(const char *addpath, size_t addlen,
     if (seglen == 0) {
       /* / */
       if (!collapse_slashes) {
-        path[pathlen++] = '/';
+        path[pathlen++] = getDirSeparator();
       }
     } else if (seglen == 1 && addpath[0] == '.') {
       /* ./ */
     } else if (seglen == 2 && addpath[0] == '.' && addpath[1] == '.') {
       /* backpath (../) */
-      if (pathlen == 1 && (path[0] == '/' || path[0] == '\\')) {
+      if (pathlen == 1 && isDirSeparator(path[0])) {
       } else if (pathlen == 0
                  || (pathlen == 3
-                     && !memcmp(path + pathlen - 3, "../", 3))
+                     && !memcmp(path + pathlen - 3, "..", 2)
+                     && isDirSeparator(path[pathlen - 1]))
                  || (pathlen  > 3
-                     && !memcmp(path + pathlen - 4, "/../", 4))) {
+                     && isDirSeparator(path[pathlen - 4])
+                     && !memcmp(path + pathlen - 3, "..", 2)
+                     && isDirSeparator(path[pathlen - 1]))) {
         /* Append another backpath, including
          * trailing slash if present.
          */
-        memcpy(path + pathlen, "../", *next ? 3 : 2);
+        memcpy(path + pathlen, "..", 2);
+        if (*next) {
+          path[pathlen + 2] = getDirSeparator();
+        }
         pathlen += *next ? 3 : 2;
       } else {
         /* otherwise crop the prior segment */
         do {
           --pathlen;
-        } while (pathlen && path[pathlen - 1] != '/' && path[pathlen - 1] != '\\');
+        } while (pathlen && !isDirSeparator(path[pathlen - 1]));
       }
     } else {
       /* An actual segment, append it to the destination path */
@@ -554,12 +564,18 @@ String FileUtil::canonicalize(const char *addpath, size_t addlen,
 
     addpath = next;
   }
+
+#ifdef _MSC_VER
+  // Need to normalize to Windows directory separators, as the underlying
+  // system calls don't like unix path separators.
+  for (int i = 0; i < pathlen; i++) {
+    if (path[i] == '/') {
+      path[i] = '\\';
+    }
+  }
+#endif
   ret.setSize(pathlen);
   return ret;
-}
-
-bool FileUtil::isAbsolutePath(const std::string& path) {
-  return boost::filesystem::absolute(path).string() == path;
 }
 
 std::string FileUtil::normalizeDir(const std::string &dirname) {
@@ -570,8 +586,8 @@ std::string FileUtil::normalizeDir(const std::string &dirname) {
    */
   MemoryManager::TlsWrapper::getCheck();
   string ret = FileUtil::canonicalize(dirname).toCppString();
-  if (!ret.empty() && ret[ret.length() - 1] != '/') {
-    ret += '/';
+  if (!ret.empty() && !isDirSeparator(ret[ret.length() - 1])) {
+    ret += getDirSeparator();
   }
   return ret;
 }
@@ -581,11 +597,11 @@ void FileUtil::find(std::vector<std::string> &out,
                     const std::set<std::string> *excludeDirs /* = NULL */,
                     const std::set<std::string> *excludeFiles /* = NULL */) {
   if (!path) path = "";
-  if (*path == '/') path++;
+  if (isDirSeparator(*path)) path++;
 
   string spath = path;
-  if (spath.length() && spath[spath.length() - 1] != '/') {
-    spath += '/';
+  if (spath.length() && !isDirSeparator(spath[spath.length() - 1])) {
+    spath += getDirSeparator();
   }
   if (excludeDirs && excludeDirs->find(spath) != excludeDirs->end()) {
     return;
@@ -601,8 +617,8 @@ void FileUtil::find(std::vector<std::string> &out,
                   fullPath.c_str());
     return;
   }
-  if (fullPath[fullPath.length() - 1] != '/') {
-    fullPath += '/';
+  if (!isDirSeparator(fullPath[fullPath.length() - 1])) {
+    fullPath += getDirSeparator();
   }
 
   dirent *e;

--- a/hphp/runtime/base/file-util.h
+++ b/hphp/runtime/base/file-util.h
@@ -98,15 +98,15 @@ inline bool isDirSeparator(char c) {
 inline bool isAbsolutePath(const char* path) {
 #ifdef _MSC_VER
   int len = strlen(path);
-  if (len > 1) {
-    // NOTE: Boost actually checks if the last character of the first
-    // path element is a colon, rather than if the first character is an
-    // alpha followed by a colon. This is fine for now, as I don't know
-    // of any other forms of paths that would allow.
-    return (isDirSeparator(path[0]) && isDirSeparator(path[1])) ||
-      (isalpha(path[0]) && path[1] == ':');
+  if (len < 2) {
+    return false;
   }
-  return false;
+  // NOTE: Boost actually checks if the last character of the first
+  // path element is a colon, rather than if the first character is an
+  // alpha followed by a colon. This is fine for now, as I don't know
+  // of any other forms of paths that would allow.
+  return (isDirSeparator(path[0]) && isDirSeparator(path[1])) ||
+    (isalpha(path[0]) && path[1] == ':');
 #else
   return path[0] == '/';
 #endif

--- a/hphp/runtime/base/file-util.h
+++ b/hphp/runtime/base/file-util.h
@@ -83,7 +83,7 @@ String canonicalize(const char* path, size_t len,
 * Check if the given character is a directory separator
 * for the current platform.
 */
-bool isDirSeparator(char c) {
+inline bool isDirSeparator(char c) {
 #ifdef _MSC_VER
   return c == '/' || c == '\\';
 #else
@@ -95,7 +95,7 @@ bool isDirSeparator(char c) {
  * Check if the given path is an absolute path. This
  * does not guarantee that the path is canonicalized.
  */
-bool isAbsolutePath(const char* path) {
+inline bool isAbsolutePath(const char* path) {
 #ifdef _MSC_VER
   int len = strlen(path);
   if (len > 1) {
@@ -112,11 +112,11 @@ bool isAbsolutePath(const char* path) {
 #endif
 }
 
-bool isAbsolutePath(const String& path) {
+inline bool isAbsolutePath(const String& path) {
   return isAbsolutePath(path.data());
 }
 
-bool isAbsolutePath(const std::string& path) {
+inline bool isAbsolutePath(const std::string& path) {
   return isAbsolutePath((const char*)path.data());
 }
 
@@ -124,7 +124,7 @@ bool isAbsolutePath(const std::string& path) {
  * Get the preferred directory separator for the current
  * platform.
  */
-char getDirSeparator() {
+inline char getDirSeparator() {
 #ifdef _MSC_VER
   return '\\';
 #else

--- a/hphp/runtime/base/file-util.h
+++ b/hphp/runtime/base/file-util.h
@@ -80,17 +80,21 @@ String canonicalize(const char* path, size_t len,
                     bool collapse_slashes = true);
 
 /**
+* Check if the given character is a directory separator
+* for the current platform.
+*/
+bool isDirSeparator(char c) {
+#ifdef _MSC_VER
+  return c == '/' || c == '\\';
+#else
+  return c == '/';
+#endif
+}
+
+/**
  * Check if the given path is an absolute path. This
  * does not guarantee that the path is canonicalized.
  */
-bool isAbsolutePath(const String& path) {
-  return isAbsolutePath(path.data());
-}
-
-bool isAbsolutePath(const std::string& path) {
-  return isAbsolutePath(path.data());
-}
-
 bool isAbsolutePath(const char* path) {
 #ifdef _MSC_VER
   int len = strlen(path);
@@ -108,16 +112,12 @@ bool isAbsolutePath(const char* path) {
 #endif
 }
 
-/**
- * Check if the given character is a directory separator
- * for the current platform.
- */
-bool isDirSeparator(char c) {
-#ifdef _MSC_VER
-  return c == '/' || c == '\\';
-#else
-  return c == '/';
-#endif
+bool isAbsolutePath(const String& path) {
+  return isAbsolutePath(path.data());
+}
+
+bool isAbsolutePath(const std::string& path) {
+  return isAbsolutePath((const char*)path.data());
 }
 
 /**

--- a/hphp/runtime/base/file-util.h
+++ b/hphp/runtime/base/file-util.h
@@ -80,6 +80,12 @@ String canonicalize(const char* path, size_t len,
                     bool collapse_slashes = true);
 
 /**
+ * Check if the given path is an absolute path. This
+ * does not guarantee that the path is canonicalized.
+ */
+bool isAbsolutePath(const std::string& path);
+
+/**
  * Makes sure there is ending slash by changing "path/name" to "path/name/".
  */
 std::string normalizeDir(const std::string &dirname);

--- a/hphp/runtime/base/file-util.h
+++ b/hphp/runtime/base/file-util.h
@@ -83,7 +83,54 @@ String canonicalize(const char* path, size_t len,
  * Check if the given path is an absolute path. This
  * does not guarantee that the path is canonicalized.
  */
-bool isAbsolutePath(const std::string& path);
+bool isAbsolutePath(const String& path) {
+  return isAbsolutePath(path.data());
+}
+
+bool isAbsolutePath(const std::string& path) {
+  return isAbsolutePath(path.data());
+}
+
+bool isAbsolutePath(const char* path) {
+#ifdef _MSC_VER
+  int len = strlen(path);
+  if (len > 1) {
+    // NOTE: Boost actually checks if the last character of the first
+    // path element is a colon, rather than if the first character is an
+    // alpha followed by a colon. This is fine for now, as I don't know
+    // of any other forms of paths that would allow.
+    return (isDirSeparator(path[0]) && isDirSeparator(path[1])) ||
+      (isalpha(path[0]) && path[1] == ':');
+  }
+  return false;
+#else
+  return path[0] == '/';
+#endif
+}
+
+/**
+ * Check if the given character is a directory separator
+ * for the current platform.
+ */
+bool isDirSeparator(char c) {
+#ifdef _MSC_VER
+  return c == '/' || c == '\\';
+#else
+  return c == '/';
+#endif
+}
+
+/**
+ * Get the preferred directory separator for the current
+ * platform.
+ */
+char getDirSeparator() {
+#ifdef _MSC_VER
+  return '\\';
+#else
+  return '/';
+#endif
+}
 
 /**
  * Makes sure there is ending slash by changing "path/name" to "path/name/".

--- a/hphp/runtime/base/file.cpp
+++ b/hphp/runtime/base/file.cpp
@@ -92,7 +92,7 @@ String File::TranslatePathKeepRelative(const char* filename, uint32_t size) {
     }
 
     // disallow access with an absolute path
-    if (canonicalized.charAt(0) == '/') {
+    if (FileUtil::isAbsolutePath(canonicalized)) {
       return empty_string();
     }
 
@@ -112,7 +112,7 @@ String File::TranslatePath(const String& filename) {
     // Otherwise it would be canonicalized to CWD, which is inconsistent with
     // PHP and most filesystem utilities.
     return filename;
-  } else if (filename.charAt(0) != '/') {
+  } else if (!FileUtil::isAbsolutePath(filename)) {
     String cwd = g_context->getCwd();
     return TranslatePathKeepRelative(cwd + "/" + filename);
   } else {

--- a/hphp/runtime/base/unit-cache.cpp
+++ b/hphp/runtime/base/unit-cache.cpp
@@ -232,7 +232,7 @@ CachedUnit loadUnitNonRepoAuth(StringData* requestedPath,
     makeStaticString(
       // XXX: it seems weird we have to do this even though we already ran
       // resolveVmInclude.
-      (requestedPath->data()[0] == '/'
+      (FileUtil::isAbsolutePath(requestedPath->toCppString())
        ?  String{requestedPath}
         : String(SourceRootInfo::GetCurrentSourceRoot()) + StrNR(requestedPath)
       ).get()
@@ -366,7 +366,7 @@ bool findFileWrapper(const String& file, void* ctx) {
   // TranslatePath() will canonicalize the path and also check
   // whether the file is in an allowed directory.
   String translatedPath = File::TranslatePathKeepRelative(file);
-  if (file[0] != '/') {
+  if (!FileUtil::isAbsolutePath(file.toCppString())) {
     if (findFile(translatedPath.get(), context->s, context->allow_dir)) {
       context->path = translatedPath;
       return true;

--- a/hphp/runtime/base/unit-cache.cpp
+++ b/hphp/runtime/base/unit-cache.cpp
@@ -382,8 +382,9 @@ bool findFileWrapper(const String& file, void* ctx) {
   std::string server_root(SourceRootInfo::GetCurrentSourceRoot());
   if (server_root.empty()) {
     server_root = std::string(g_context->getCwd().data());
-    if (server_root.empty() || server_root[server_root.size() - 1] != '/') {
-      server_root += "/";
+    if (server_root.empty() ||
+        FileUtil::isDirSeparator(server_root[server_root.size() - 1])) {
+      server_root += FileUtil::getDirSeparator();
     }
   }
   String rel_path(FileUtil::relativePath(server_root, translatedPath.data()));

--- a/hphp/runtime/base/zend-string.cpp
+++ b/hphp/runtime/base/zend-string.cpp
@@ -1558,20 +1558,44 @@ String string_escape_shell_arg(const char *str) {
   String ret(safe_address(l, 4, 3), ReserveString); /* worst case */
   cmd = ret.mutableData();
 
+#ifdef _MSC_VER
+  cmd[y++] = '"';
+#else
   cmd[y++] = '\'';
+#endif
 
   for (x = 0; x < l; x++) {
     switch (str[x]) {
+#ifdef _MSC_VER
+    case '"':
+    case '%':
+    case '!':
+      cmd[y++] = ' ';
+      break;
+#else
     case '\'':
       cmd[y++] = '\'';
       cmd[y++] = '\\';
       cmd[y++] = '\'';
+#endif
       /* fall-through */
     default:
       cmd[y++] = str[x];
     }
   }
+#ifdef _MSC_VER
+  if (y > 0 && '\\' == cmd[y - 1]) {
+    int k = 0, n = y - 1;
+    for (; n >= 0 && '\\' == cmd[n]; n--, k++);
+    if (k % 2) {
+      cmd[y++] = '\\';
+    }
+  }
+
+  cmd[y++] = '"';
+#else
   cmd[y++] = '\'';
+#endif
   ret.setSize(y);
   return ret;
 }
@@ -1587,6 +1611,7 @@ String string_escape_shell_cmd(const char *str) {
 
   for (x = 0, y = 0; x < l; x++) {
     switch (str[x]) {
+#ifndef _MSC_VER
     case '"':
     case '\'':
       if (!p && (p = (char *)memchr(str + x + 1, str[x], l - x - 1))) {
@@ -1598,6 +1623,15 @@ String string_escape_shell_cmd(const char *str) {
       }
       cmd[y++] = str[x];
       break;
+#else
+      /* % is Windows specific for environmental variables, ^%PATH% will
+      output PATH while ^%PATH^% will not. escapeshellcmd->val will escape all % and !.
+      */
+      case '%':
+      case '!':
+      case '"':
+      case '\'':
+#endif
     case '#': /* This is character-set independent */
     case '&':
     case ';':
@@ -1619,7 +1653,11 @@ String string_escape_shell_cmd(const char *str) {
     case '\\':
     case '\x0A': /* excluding these two */
     case '\xFF':
+#ifdef _MSC_VER
+      cmd[y++] = '^';
+#else
       cmd[y++] = '\\';
+#endif
       /* fall-through */
     default:
       cmd[y++] = str[x];

--- a/hphp/runtime/base/zend-string.cpp
+++ b/hphp/runtime/base/zend-string.cpp
@@ -1624,13 +1624,14 @@ String string_escape_shell_cmd(const char *str) {
       cmd[y++] = str[x];
       break;
 #else
-      /* % is Windows specific for environmental variables, ^%PATH% will
-      output PATH while ^%PATH^% will not. escapeshellcmd->val will escape all % and !.
-      */
-      case '%':
-      case '!':
-      case '"':
-      case '\'':
+    /* % is Windows specific for environmental variables, ^%PATH% will
+    output PATH while ^%PATH^% will not. escapeshellcmd->val will
+    escape all % and !.
+    */
+    case '%':
+    case '!':
+    case '"':
+    case '\'':
 #endif
     case '#': /* This is character-set independent */
     case '&':

--- a/hphp/runtime/ext/extension-registry.cpp
+++ b/hphp/runtime/ext/extension-registry.cpp
@@ -1,4 +1,5 @@
 #include "hphp/runtime/ext/extension-registry.h"
+#include "hphp/runtime/base/file-util.h"
 #include "hphp/runtime/base/runtime-option.h"
 #include "hphp/runtime/vm/litstr-table.h"
 #include "hphp/runtime/version.h"
@@ -183,7 +184,7 @@ void moduleLoad(const IniSetting::Map& ini, Hdf hdf) {
     if (extLoc.empty()) {
       continue;
     }
-    if (extLoc[0] != '/') {
+    if (!FileUtil::isAbsolutePath(extLoc)) {
       if (extDir == "") {
         continue;
       }
@@ -198,7 +199,7 @@ void moduleLoad(const IniSetting::Map& ini, Hdf hdf) {
     if (extLoc.empty()) {
       continue;
     }
-    if (extLoc[0] != '/') {
+    if (!FileUtil::isAbsolutePath(extLoc)) {
       extLoc = RuntimeOption::DynamicExtensionPath + "/" + extLoc;
     }
 

--- a/hphp/runtime/ext/std/ext_std_file.cpp
+++ b/hphp/runtime/ext/std/ext_std_file.cpp
@@ -180,7 +180,7 @@ static int statSyscall(
     const String& path,
     struct stat* buf,
     bool useFileCache = false) {
-  bool isRelative = path.charAt(0) != '/';
+  bool isRelative = !FileUtil::isAbsolutePath(path);
   int pathIndex = 0;
   Stream::Wrapper* w = Stream::getWrapperFromURI(path, &pathIndex);
   if (!w) return -1;
@@ -1093,11 +1093,13 @@ static VFileType lookupVirtualFile(const String& filename) {
 
   String cwd;
   std::string root;
-  bool isRelative = (filename.charAt(0) != '/');
+  bool isRelative = !FileUtil::isAbsolutePath(filename);
   if (isRelative) {
     cwd = g_context->getCwd();
     root = RuntimeOption::SourceRoot;
-    if (cwd.empty() || cwd[cwd.size() - 1] != '/') root.pop_back();
+    if (cwd.empty() || FileUtil::isDirSeparator(cwd[cwd.size() - 1])) {
+      root.pop_back();
+    }
   }
 
   if (!isRelative || !root.compare(cwd.data())) {
@@ -1666,7 +1668,7 @@ String HHVM_FUNCTION(basename,
   const char *comp, *cend;
   comp = cend = c;
   for (int cnt = path.size(); cnt > 0; --cnt, ++c) {
-    if (*c == '/') {
+    if (FileUtil::isDirSeparator(*c)) {
       if (state == 1) {
         state = 0;
         cend = c;

--- a/hphp/runtime/ext/std/ext_std_file.h
+++ b/hphp/runtime/ext/std/ext_std_file.h
@@ -33,7 +33,11 @@ namespace HPHP {
 #define k_STDIN (BuiltinFiles::GetSTDIN())
 #define k_STDOUT (BuiltinFiles::GetSTDOUT())
 #define k_STDERR (BuiltinFiles::GetSTDERR())
+#ifdef _MSC_VER
+const StaticString s_DIRECTORY_SEPARATOR("\\");
+#else
 const StaticString s_DIRECTORY_SEPARATOR("/");
+#endif
 const int64_t k_FILE_USE_INCLUDE_PATH = 1;
 const int64_t k_FILE_IGNORE_NEW_LINES = 2;
 const int64_t k_FILE_SKIP_EMPTY_LINES = 4;

--- a/hphp/util/file-cache.h
+++ b/hphp/util/file-cache.h
@@ -21,6 +21,7 @@
 #include <string>
 #include <vector>
 
+#include "hphp/runtime/base/file-util.h"
 #include "hphp/util/cache/cache-manager.h"
 
 namespace HPHP {
@@ -63,7 +64,7 @@ class FileCache {
 
   // Check if path is file, directory, unknown, or not in cache
   VFileType getFileType(const char* name) const {
-    if (name && *name == '/') {
+    if (name && FileUtil::isAbsolutePath(name)) {
       return cache_manager_->getFileType(GetRelativePath(name).c_str());
     }
     return cache_manager_->getFileType(name);
@@ -71,7 +72,7 @@ class FileCache {
 
   // Read list of files in directory
   std::vector<std::string> readDirectory(const char* name) const {
-    if (name && *name == '/') {
+    if (name && FileUtil::isAbsolutePath(name)) {
       return cache_manager_->readDirectory(GetRelativePath(name).c_str());
     }
     return cache_manager_->readDirectory(name);


### PR DESCRIPTION
This adds a `FileUtil::isAbsolutePath` function that is used in-place of checks that were being done to see if a path was an absolute path.
This also replaces a couple of places that were doing these checks with calls to this function. This does not do this everywhere, and instead has only been done where it was causing errors when including files on Windows.
`FileUtil::dirname_helper` and `FileUtil::canonicalize` have both been taught that a backslash is also a directory separator.