### PR TITLE
Improve HHVM reporting performance

### DIFF
--- a/hphp/runtime/base/runtime-error.cpp
+++ b/hphp/runtime/base/runtime-error.cpp
@@ -52,10 +52,12 @@ static inline bool checkReportLevel(ErrorMode mode) {
 }
 
 #define CHECK_REPORT_LEVEL(mode) \
-   VMRegAnchor _;   \
-   if (checkReportLevel(mode)) { \
-      return; \
-   } 
+   do { \
+     VMRegAnchor _;   \
+     if (checkReportLevel(mode)) { \
+       return; \
+     } \
+   } while(0)
 
 /*
  * Careful in these functions: they can be called when tl_regState is

--- a/hphp/runtime/base/runtime-error.cpp
+++ b/hphp/runtime/base/runtime-error.cpp
@@ -22,6 +22,7 @@
 #include "hphp/runtime/vm/repo-global-data.h"
 #include "hphp/util/logger.h"
 #include "hphp/util/string-vsnprintf.h"
+#include "hphp/runtime/vm/vm-regs.h"
 
 #ifdef ERROR
 # undef ERROR
@@ -32,6 +33,29 @@
 
 namespace HPHP {
 ///////////////////////////////////////////////////////////////////////////////
+static int64_t g_warning_counter = 0;
+static int64_t g_notice_counter = 0;
+
+static inline bool checkReportLevel(ErrorMode mode) {
+  int errnum = static_cast<int>(mode);
+  if (!g_context->errorNeedsHandling(errnum, true,
+                              ExecutionContext::ErrorThrowMode::Never)) {
+    return true;
+  } else if (RuntimeOption::WarningFrequency <= 0 ||
+        (g_warning_counter++) % RuntimeOption::WarningFrequency != 0) {
+      return true;
+  } else if (RuntimeOption::NoticeFrequency <= 0 ||
+             (g_notice_counter++) % RuntimeOption::NoticeFrequency != 0) {
+    return true;
+  }
+  return false;
+}
+
+#define CHECK_REPORT_LEVEL(mode) \
+   VMRegAnchor _;   \
+   if (checkReportLevel(mode)) { \
+      return; \
+   } 
 
 /*
  * Careful in these functions: they can be called when tl_regState is
@@ -40,6 +64,7 @@ namespace HPHP {
  */
 
 void raise_error(const std::string &msg) {
+  CHECK_REPORT_LEVEL(ErrorMode::ERROR);
   raise_message(ErrorMode::ERROR, false, msg);
   always_assert(0);
 }
@@ -72,6 +97,7 @@ void raise_recoverable_error(const std::string &msg) {
 }
 
 void raise_recoverable_error_without_first_frame(const std::string &msg) {
+  CHECK_REPORT_LEVEL(ErrorMode::RECOVERABLE_ERROR);
   raise_message(ErrorMode::RECOVERABLE_ERROR, true, msg);
 }
 
@@ -103,6 +129,7 @@ void raise_disallowed_dynamic_call(const std::string& msg) {
 }
 
 void raise_recoverable_error(const char *fmt, ...) {
+  CHECK_REPORT_LEVEL(ErrorMode::RECOVERABLE_ERROR);
   std::string msg;
   va_list ap;
   va_start(ap, fmt);
@@ -118,10 +145,12 @@ void raise_strict_warning(const std::string &msg) {
 }
 
 void raise_strict_warning_without_first_frame(const std::string &msg) {
+  CHECK_REPORT_LEVEL(ErrorMode::STRICT);
   raise_message(ErrorMode::STRICT, true, msg);
 }
 
 void raise_strict_warning(const char *fmt, ...) {
+  CHECK_REPORT_LEVEL(ErrorMode::STRICT);
   std::string msg;
   va_list ap;
   va_start(ap, fmt);
@@ -130,17 +159,18 @@ void raise_strict_warning(const char *fmt, ...) {
   raise_strict_warning(msg);
 }
 
-static int64_t g_warning_counter = 0;
 
 void raise_warning(const std::string &msg) {
   raise_message(ErrorMode::WARNING, false, msg);
 }
 
 void raise_warning_without_first_frame(const std::string &msg) {
+  CHECK_REPORT_LEVEL(ErrorMode::WARNING);
   raise_message(ErrorMode::WARNING, true, msg);
 }
 
 void raise_warning(const char *fmt, ...) {
+  CHECK_REPORT_LEVEL(ErrorMode::WARNING);
   std::string msg;
   va_list ap;
   va_start(ap, fmt);
@@ -204,10 +234,12 @@ void raise_notice(const std::string &msg) {
 }
 
 void raise_notice_without_first_frame(const std::string &msg) {
+  CHECK_REPORT_LEVEL(ErrorMode::NOTICE);
   raise_message(ErrorMode::NOTICE, true, msg);
 }
 
 void raise_notice(const char *fmt, ...) {
+  CHECK_REPORT_LEVEL(ErrorMode::NOTICE);
   std::string msg;
   va_list ap;
   va_start(ap, fmt);
@@ -217,14 +249,17 @@ void raise_notice(const char *fmt, ...) {
 }
 
 void raise_deprecated(const std::string &msg) {
+  CHECK_REPORT_LEVEL(ErrorMode::PHP_DEPRECATED);
   raise_message(ErrorMode::PHP_DEPRECATED, false, msg);
 }
 
 void raise_deprecated_without_first_frame(const std::string &msg) {
+  CHECK_REPORT_LEVEL(ErrorMode::PHP_DEPRECATED);
   raise_message(ErrorMode::PHP_DEPRECATED, true, msg);
 }
 
 void raise_deprecated(const char *fmt, ...) {
+  CHECK_REPORT_LEVEL(ErrorMode::PHP_DEPRECATED);
   std::string msg;
   va_list ap;
   va_start(ap, fmt);
@@ -308,19 +343,9 @@ void raise_message(ErrorMode mode,
     HANDLE_ERROR(false, Always, "\nFatal error: ", skipTop);
   } else if (mode == ErrorMode::RECOVERABLE_ERROR) {
     HANDLE_ERROR(true, IfUnhandled, "\nCatchable fatal error: ", skipTop);
-  } else if (!g_context->errorNeedsHandling(errnum, true,
-                              ExecutionContext::ErrorThrowMode::Never)) {
-    return;
   } else if (mode == ErrorMode::WARNING) {
-    if (RuntimeOption::WarningFrequency <= 0 ||
-        (g_warning_counter++) % RuntimeOption::WarningFrequency != 0) {
-      return;
-    }
     HANDLE_ERROR(true, Never, "\nWarning: ", skipTop);
-  } else if (RuntimeOption::NoticeFrequency <= 0 ||
-             (g_notice_counter++) % RuntimeOption::NoticeFrequency != 0) {
-    return;
-  } else {
+  }  else {
     switch (mode) {
       case ErrorMode::STRICT:
         HANDLE_ERROR(true, Never, "\nStrict Warning: ", skipTop);

--- a/hphp/runtime/base/runtime-error.cpp
+++ b/hphp/runtime/base/runtime-error.cpp
@@ -138,8 +138,6 @@ void raise_recoverable_error(const char *fmt, ...) {
   raise_recoverable_error(msg);
 }
 
-static int64_t g_notice_counter = 0;
-
 void raise_strict_warning(const std::string &msg) {
   raise_message(ErrorMode::STRICT, false, msg);
 }

--- a/hphp/runtime/base/runtime-error.h
+++ b/hphp/runtime/base/runtime-error.h
@@ -71,9 +71,9 @@ enum class ErrorMode {
   UPGRADEABLE_ERROR = WARNING | USER_WARNING | NOTICE | USER_NOTICE
 };
 
-ATTRIBUTE_NORETURN void raise_error(const std::string&);
-ATTRIBUTE_NORETURN void raise_error(const char*, ...) ATTRIBUTE_PRINTF(1, 2);
-ATTRIBUTE_NORETURN void raise_error_without_first_frame(const std::string&);
+ void raise_error(const std::string&);
+ void raise_error(const char*, ...) ATTRIBUTE_PRINTF(1, 2);
+ void raise_error_without_first_frame(const std::string&);
 void raise_recoverable_error(const std::string &msg);
 void raise_recoverable_error(const char *fmt, ...) ATTRIBUTE_PRINTF(1, 2);
 void raise_recoverable_error_without_first_frame(const std::string &msg);


### PR DESCRIPTION
HHVM new version create msg varible before compare report level,this way can reduce hhvm more performance.
Found that the problem is my colleague @wwbmmm and I have fixed this problem.