### PR TITLE
Change NULL to null for error reporting and internal type queries.

### DIFF
--- a/hphp/runtime/base/type-string.cpp
+++ b/hphp/runtime/base/type-string.cpp
@@ -569,7 +569,7 @@ StaticString& StaticString::operator=(const StaticString &str) {
 }
 
 const StaticString
-  s_NULL("NULL"),
+  s_null("null"),
   s_boolean("boolean"),
   s_integer("integer"),
   s_double("double"),
@@ -582,7 +582,7 @@ const StaticString
 StaticString getDataTypeString(DataType t) {
   switch (t) {
     case KindOfUninit:
-    case KindOfNull:       return s_NULL;
+    case KindOfNull:       return s_null;
     case KindOfBoolean:    return s_boolean;
     case KindOfInt64:      return s_integer;
     case KindOfDouble:     return s_double;

--- a/hphp/runtime/ext/std/ext_std_variable.cpp
+++ b/hphp/runtime/ext/std/ext_std_variable.cpp
@@ -43,11 +43,18 @@ const StaticString
   s_string("string"),
   s_object("object"),
   s_array("array"),
+  s_NULL("NULL"),
   s_null("null");
 
 String HHVM_FUNCTION(gettype, const Variant& v) {
   if (v.getType() == KindOfResource && v.toCResRef().isInvalid()) {
     return s_unknown_type;
+  }
+  /* Although getDataTypeString also handles the null type, it returns "null"
+   * (lower case). Unfortunately, PHP returns "NULL" (upper case) for
+   * gettype(). So we make an exception here. */
+  if (v.isNull()) {
+    return s_NULL;
   }
   return getDataTypeString(v.getType());
 }

--- a/hphp/runtime/ext/wddx/ext_wddx.cpp
+++ b/hphp/runtime/ext/wddx/ext_wddx.cpp
@@ -150,7 +150,7 @@ String WddxPacket::getWddxEncoded(const String& varType,
                                   const String& varValue,
                                   const String& varName,
                                   bool hasVarTag) {
-  if (varType.compare("NULL") == 0) {
+  if (varType.compare("NULL") == 0 || varType.compare("null") == 0) {
     return wrapValue("<null/>", "", "", varName, hasVarTag);
   }
   if (varType.compare("boolean") == 0) {

--- a/hphp/test/slow/ext_hash/hash_equals_error.php.expectf
+++ b/hphp/test/slow/ext_hash/hash_equals_error.php.expectf
@@ -1,6 +1,6 @@
 
-Warning: hash_equals(): Expected user_string to be a string, NULL given in %s
+Warning: hash_equals(): Expected user_string to be a string, null given in %s
 bool(false)
 
-Warning: hash_equals(): Expected known_string to be a string, NULL given in %s
+Warning: hash_equals(): Expected known_string to be a string, null given in %s
 bool(false)

--- a/hphp/test/slow/invalid_argument/1380.php.expectf
+++ b/hphp/test/slow/invalid_argument/1380.php.expectf
@@ -1,4 +1,4 @@
-Warning: mysql_fetch_array() expects parameter 1 to be resource, NULL given in %s/test/slow/invalid_argument/1380.php on line 3
+Warning: mysql_fetch_array() expects parameter 1 to be resource, null given in %s/test/slow/invalid_argument/1380.php on line 3
 NULL
 
 Warning: supplied argument is not a valid MySQL result resource in %s/test/slow/invalid_argument/1380.php on line 4

--- a/hphp/test/slow/nullsafe/nullsafe-call-3.php.expect
+++ b/hphp/test/slow/nullsafe/nullsafe-call-3.php.expect
@@ -1,10 +1,10 @@
 object(E)#3 (0) {
 }
-BadMethodCallException: Call to a member function bar() on a non-object (NULL)
-BadMethodCallException: Call to a member function bar() on a non-object (NULL)
-BadMethodCallException: Call to a member function bar() on a non-object (NULL)
+BadMethodCallException: Call to a member function bar() on a non-object (null)
+BadMethodCallException: Call to a member function bar() on a non-object (null)
+BadMethodCallException: Call to a member function bar() on a non-object (null)
 object(F)#8 (0) {
 }
-BadMethodCallException: Call to a member function bar() on a non-object (NULL)
-BadMethodCallException: Call to a member function bar() on a non-object (NULL)
-BadMethodCallException: Call to a member function bar() on a non-object (NULL)
+BadMethodCallException: Call to a member function bar() on a non-object (null)
+BadMethodCallException: Call to a member function bar() on a non-object (null)
+BadMethodCallException: Call to a member function bar() on a non-object (null)

--- a/hphp/test/slow/nullsafe/nullsafe-call-4.php.expect
+++ b/hphp/test/slow/nullsafe/nullsafe-call-4.php.expect
@@ -1,3 +1,3 @@
 object(F)#4 (0) {
 }
-BadMethodCallException: Call to a member function baz() on a non-object (NULL)
+BadMethodCallException: Call to a member function baz() on a non-object (null)

--- a/hphp/test/slow/object_method/bad-inlining.php.expectf
+++ b/hphp/test/slow/object_method/bad-inlining.php.expectf
@@ -2,7 +2,7 @@ int(1)
 
 Notice: Undefined variable: x in %s/slow/object_method/bad-inlining.php on line 26
 
-Fatal error: Uncaught exception 'BadMethodCallException' with message 'Call to a member function foo() on a non-object (NULL)' in %s/slow/object_method/bad-inlining.php:15
+Fatal error: Uncaught exception 'BadMethodCallException' with message 'Call to a member function foo() on a non-object (null)' in %s/slow/object_method/bad-inlining.php:15
 Stack trace:
 #0 %s/slow/object_method/bad-inlining.php(19): foo()
 #1 {main}


### PR DESCRIPTION
This addresses an incompatibility with PHP 5 for displaying a string version
for the null type.

PHP 5 returns "NULL" through gettype():
https://github.com/php/php-src/blob/master/ext/standard/type.c#L34

HHVM returns "NULL" through getDataTypeString():
https://github.com/facebook/hhvm/blob/master/hphp/runtime/base/type-string.cpp#L571

However, when asking in an extension for the type of a null value, or with
parameter parsing errors, PHP and HHVM where doing something different.

PHP returns "null":
https://github.com/php/php-src/blob/master/Zend/zend_API.c#L162

and HHVM reuses getDataTypeString() and hence uses "NULL":
https://github.com/facebook/hhvm/blob/master/hphp/runtime/base/type-string.cpp#L571

This patches changes getDataTypeString() to return "null" to be in line with
PHP 5, and has a special case before getDataTypeString() gets triggered with
gettype() to return "NULL".