### PR TITLE
Fix filter_var_array for FILTER_VALIDATE_BOOLEAN and falsy values

### DIFF
--- a/hphp/system/php/filter/filter_var_array.php
+++ b/hphp/system/php/filter/filter_var_array.php
@@ -4,7 +4,7 @@ function _filter_var_array_single($value, $filter, $options = array()) {
   $ret = filter_var($value, (int) $filter, $options);
 
   // Retry with default filter if failed.
-  if ($ret === false) {
+  if ($ret === false && $filter !== FILTER_VALIDATE_BOOLEAN) {
     $ret = filter_var($value, FILTER_DEFAULT, $options);
   }
 

--- a/hphp/test/slow/ext_filter/5836.php
+++ b/hphp/test/slow/ext_filter/5836.php
@@ -1,0 +1,22 @@
+<?php
+var_dump( filter_var_array(
+  array(
+    'zero' => '0',
+    'false' => 'false',
+    'no' => 'no',
+    'off' => 'off',
+    'empty' => '',
+    'null' => null,
+    'false-bool' => false,
+  ),
+  array(
+    'false' => array( 'filter' => FILTER_VALIDATE_BOOLEAN ),
+    'zero' => array( 'filter' => FILTER_VALIDATE_BOOLEAN ),
+    'false' => array( 'filter' => FILTER_VALIDATE_BOOLEAN ),
+    'no' => array( 'filter' => FILTER_VALIDATE_BOOLEAN ),
+    'off' => array( 'filter' => FILTER_VALIDATE_BOOLEAN ),
+    'empty' => array( 'filter' => FILTER_VALIDATE_BOOLEAN ),
+    'null' => array( 'filter' => FILTER_VALIDATE_BOOLEAN ),
+    'false-bool' => array( 'filter' => FILTER_VALIDATE_BOOLEAN ),
+  )
+) );

--- a/hphp/test/slow/ext_filter/5836.php.expect
+++ b/hphp/test/slow/ext_filter/5836.php.expect
@@ -1,0 +1,16 @@
+array(7) {
+  ["false"]=>
+  bool(false)
+  ["zero"]=>
+  bool(false)
+  ["no"]=>
+  bool(false)
+  ["off"]=>
+  bool(false)
+  ["empty"]=>
+  bool(false)
+  ["null"]=>
+  bool(false)
+  ["false-bool"]=>
+  bool(false)
+}


### PR DESCRIPTION
FILTER_VALIDATE_BOOLEAN is expected to return `false` for falsy input
values ("0", "false", "off", "no", "", `false`).

Fixes #5836