### PR TITLE
Register the thread exit handler to pthread_self on Mac.

### DIFF
--- a/hphp/util/thread-local.cpp
+++ b/hphp/util/thread-local.cpp
@@ -51,9 +51,11 @@ ThreadLocalManager& ThreadLocalManager::GetManager() {
 
 #ifdef __APPLE__
 ThreadLocalManager::ThreadLocalList::ThreadLocalList() {
+  pthread_t self = pthread_self();
   handler.__routine = ThreadLocalManager::OnThreadExit;
   handler.__arg = this;
-  handler.__next = pthread_self()->__cleanup_stack;
+  handler.__next = self->__cleanup_stack;
+  self->__cleanup_stack = &handler;
 }
 #endif
 


### PR DESCRIPTION
Otherwise ThreadLocalManager::OnThreadExit won't be called when the
thread exits.