### PR TITLE
Fix issue #5853 PHPUnit Phar signatures are broken

### DIFF
--- a/hphp/system/php/phar/Phar.php
+++ b/hphp/system/php/phar/Phar.php
@@ -1027,20 +1027,20 @@ class Phar extends RecursiveDirectoryIterator
 
       $pos = strlen($data) - 8;
       $this->signatureFlags = self::bytesToInt($data, $pos, 4);
-      switch (($this->signatureFlags & 0xF)) {
-        case 1 << (self::MD5 - 1):
+      switch ($this->signatureFlags) {
+        case self::MD5:
           $digestSize = 16;
           $digestName = "md5";
           break;
-        case 1 << (self::SHA1 - 1):
+        case self::SHA1:
           $digestSize = 20;
           $digestName = "sha1";
           break;
-        case 1 << (self::SHA256 - 1):
+        case self::SHA256:
           $digestSize = 32;
           $digestName = "sha256";
           break;
-        case 1 << (self::SHA512 - 1):
+        case self::SHA512:
           $digestSize = 64;
           $digestName = "sha512";
           break;


### PR DESCRIPTION
The signature flags were being used completely wrong, the signature flags aren't flags, as shown in [php-src/phar.c:779](https://github.com/php/php-src/blob/master/ext/phar/phar.c#L779).
Previously only MD5 and SHA1 signatures were being validated correctly, due to how the shifts were setup. (`MD5` is `1`, `SHA1` is `2`)
This checks the "flags" correctly, and errors correctly if an openssl signature was encountered.

Fixes issue [#5853](https://github.com/facebook/hhvm/issues/5853).