### PR TITLE
Use "binary" channels to avoid CRLF conversion on Windows

### DIFF
--- a/hphp/hack/src/client/clientRefactor.ml
+++ b/hphp/hack/src/client/clientRefactor.ml
@@ -37,13 +37,6 @@ let map_patches_to_filename acc res =
   | Some lst -> SMap.add fn (res :: lst) acc
   | None -> SMap.add fn [res] acc
 
-let read_file_to_string fn = 
-  let ic = open_in fn in
-  let len = in_channel_length ic in
-  let buf = Buffer.create len in
-  Buffer.add_channel buf ic len;
-  Buffer.contents buf
-
 let write_string_to_file fn str =
   let oc = open_out fn in
   output_string oc str;
@@ -60,7 +53,6 @@ let write_patches_to_buffer buf original_content patch_list =
     Buffer.add_string buf str_to_write;
     i := !i + size
   in
-  
   List.iter patch_list begin fun res ->
     let pos = get_pos res in
     let char_start, char_end = Pos.info_raw pos in
@@ -77,7 +69,7 @@ let write_patches_to_buffer buf original_content patch_list =
   add_original_content (String.length original_content - 1)
 
 let apply_patches_to_file fn patch_list =
-  let old_content = read_file_to_string fn in
+  let old_content = Sys_utils.cat fn in
   let buf = Buffer.create (String.length old_content) in
   let patch_list = List.sort compare_result patch_list in
   write_patches_to_buffer buf old_content patch_list;
@@ -137,7 +129,7 @@ let go conn args =
 
     let refactor_type = input_line stdin in
     let command = match refactor_type with
-    | "1" -> 
+    | "1" ->
       let class_name = input_prompt "Enter class name: " in
       let new_name = input_prompt "Enter a new name for this class: " in
       ServerRefactor.ClassRename (class_name, new_name)
@@ -152,7 +144,7 @@ let go conn args =
           input_prompt ("Enter a new name for this method: "^class_name^"::") in
       ServerRefactor.MethodRename (class_name, method_name, new_name)
     | _ -> raise Exit in
-    
+
     let patches = ServerCommand.rpc conn @@ ServerRpc.REFACTOR command in
     let file_map = List.fold_left patches
       ~f:map_patches_to_filename ~init:SMap.empty in

--- a/hphp/hack/src/hh_single_type_check.ml
+++ b/hphp/hack/src/hh_single_type_check.ml
@@ -414,5 +414,10 @@ let _ =
   if ! Sys.interactive
   then ()
   else
+    (* On windows, setting 'binary mode' avoids to output CRLF on
+       stdout.  The 'text mode' would not hurt the user in general, but
+       it breaks the testsuite where the output is compared to the
+       expected one (i.e. in given file without CRLF). *)
+    set_binary_mode_out stdout true;
     let options = parse_options () in
     main_hack options

--- a/hphp/hack/src/utils/sys_utils.ml
+++ b/hphp/hack/src/utils/sys_utils.ml
@@ -19,6 +19,13 @@ let open_in_no_fail fn =
     Printf.fprintf stderr "Could not open_in: '%s' (%s)\n" fn e;
     exit 3
 
+let open_in_bin_no_fail fn =
+  try open_in_bin fn
+  with e ->
+    let e = Printexc.to_string e in
+    Printf.fprintf stderr "Could not open_in: '%s' (%s)\n" fn e;
+    exit 3
+
 let close_in_no_fail fn ic =
   try close_in ic with e ->
     let e = Printexc.to_string e in
@@ -39,7 +46,7 @@ let close_out_no_fail fn oc =
     exit 3
 
 let cat filename =
-  let ic = open_in filename in
+  let ic = open_in_bin filename in
   let len = in_channel_length ic in
   let buf = Buffer.create len in
   Buffer.add_channel buf ic len;
@@ -48,7 +55,7 @@ let cat filename =
   content
 
 let cat_no_fail filename =
-  let ic = open_in_no_fail filename in
+  let ic = open_in_bin_no_fail filename in
   let len = in_channel_length ic in
   let buf = Buffer.create len in
   Buffer.add_channel buf ic len;
@@ -204,7 +211,7 @@ let lines_of_file filename =
 
 
 let read_file file =
-  let ic = open_in file  in
+  let ic = open_in_bin file  in
   let size = in_channel_length ic in
   let buf = String.create size in
   really_input ic buf 0 size;


### PR DESCRIPTION
Otherwise `in_channel_length` does not return the same number of bytes than really read with 'input_line'.

Or 'stdout' get garbled in the testsuite and can't be easily compared to the 'expected' output.