### PR TITLE
Avoid usage of 'Sys.command' and 'Unix.system'

### DIFF
--- a/hphp/hack/src/find/find.mli
+++ b/hphp/hack/src/find/find.mli
@@ -8,8 +8,19 @@
  *
  *)
 
-val make_next_files: ?name: string ->
-  (string -> bool) -> ?others: Path.t list -> Path.t ->
+val make_next_files:
+  ?name: string ->
+  ?filter:(string -> bool) -> ?others: Path.t list -> Path.t ->
   (unit -> string list)
 
-val find_with_name: Path.t list -> string -> string list
+val find:
+  ?max_depth:int -> ?filter:(string -> bool) -> ?file_only:bool ->
+  Path.t list -> string list
+
+val find_with_name:
+  ?max_depth:int -> ?file_only:bool ->
+  Path.t list -> string -> string list
+
+val iter_files:
+  ?max_depth:int -> ?filter:(string -> bool) -> ?file_only:bool ->
+  Path.t list -> (string -> unit) -> unit

--- a/hphp/hack/src/hh_format.ml
+++ b/hphp/hack/src/hh_format.ml
@@ -116,7 +116,7 @@ let debug_directory dir =
   let path = Path.make dir in
   let next = compose
     (List.map ~f:Path.make)
-    (Find.make_next_files FindUtils.is_php path) in
+    (Find.make_next_files ~filter:FindUtils.is_php path) in
   let workers = Worker.make GlobalConfig.nbr_procs GlobalConfig.gc_control in
   MultiWorker.call
     (Some workers)
@@ -218,7 +218,7 @@ let directory modes dir =
   let path = Path.make dir in
   let next = compose
     (List.map ~f:Path.make)
-    (Find.make_next_files FindUtils.is_php path) in
+    (Find.make_next_files ~filter:FindUtils.is_php path) in
   let workers = Worker.make GlobalConfig.nbr_procs GlobalConfig.gc_control in
   let messages =
     MultiWorker.call

--- a/hphp/hack/src/hh_match.ml
+++ b/hphp/hack/src/hh_match.ml
@@ -166,7 +166,7 @@ let directory dir fn =
   let path = Path.make dir in
   let next = Utils.compose
     (List.map ~f:Path.make)
-    (Find.make_next_files FindUtils.is_php path) in
+    (Find.make_next_files ~filter:FindUtils.is_php path) in
   let workers = Worker.make GlobalConfig.nbr_procs GlobalConfig.gc_control in
   (* Information for the patcher to figure out what transformations to do *)
   let fileschanged =

--- a/hphp/hack/src/hhi/hhi.ml
+++ b/hphp/hack/src/hhi/hhi.ml
@@ -15,8 +15,8 @@ external get_embedded_hhi_data : string -> string option =
 let root = ref None
 
 let touch_root r =
-  let r = Filename.quote (Path.to_string r) in
-  ignore (Unix.system ("find " ^ r ^ " -name '*.hhi' -exec touch '{}' ';'"))
+  let filter file = Filename.check_suffix file ".hhi" in
+  Find.iter_files ~filter [ r ] (Sys_utils.try_touch ~follow_symlinks:true)
 
 let touch () =
   match !root with

--- a/hphp/hack/src/server/serverEnvBuild.ml
+++ b/hphp/hack/src/server/serverEnvBuild.ml
@@ -50,7 +50,7 @@ let make_genv options config local_config =
       let wait_until_ready () = () in
       indexer, notifier, wait_until_ready
     | None ->
-      let indexer filter = Find.make_next_files ~name:"root" filter root in
+      let indexer filter = Find.make_next_files ~name:"root" ~filter root in
       let log_link = ServerFiles.dfind_log root in
       let log_file = ServerFiles.make_link_of_timestamped log_link in
       let dfind =

--- a/hphp/hack/src/server/serverInit.ml
+++ b/hphp/hack/src/server/serverInit.ml
@@ -55,7 +55,8 @@ let make_next_files genv : Relative_path.t MultiWorker.nextlist =
   let hhi_root = Hhi.get_hhi_root () in
   let next_files_hhi = compose
     (List.map ~f:(Relative_path.(create Hhi)))
-    (Find.make_next_files ~name:"hhi" FindUtils.is_php hhi_root) in
+    (Find.make_next_files
+       ~name:"hhi" ~filter:FindUtils.is_php hhi_root) in
   fun () ->
     match next_files_hhi () with
     | [] -> next_files_root ()


### PR DESCRIPTION
This also removes a dependency on the external 'find' command.