### PR TITLE
Minimalistic `hh_shared.c` for MinGW64.

### DIFF
--- a/hphp/hack/src/heap/hh_shared.c
+++ b/hphp/hack/src/heap/hh_shared.c
@@ -76,12 +76,19 @@
  */
 /*****************************************************************************/
 
-
+#include <caml/mlvalues.h>
+#include <caml/unixsupport.h>
 #include <caml/memory.h>
 #include <caml/alloc.h>
 #include <caml/fail.h>
 
-#ifndef _WIN32
+#ifdef _WIN32
+
+#include <windows.h>
+#include <assert.h>
+
+#else
+
 /* define CAML_NAME_SPACE to ensure all the caml imports are prefixed with
  * 'caml_' */
 #define CAML_NAME_SPACE
@@ -98,12 +105,25 @@
 #include <sys/stat.h>
 #include <sys/syscall.h>
 #include <sys/types.h>
+#include <unistd.h>
+
+#endif
+
 #ifndef NO_LZ4
 #include <lz4.h>
 #include <lz4hc.h>
 #endif
 
-#include <unistd.h>
+
+#ifdef _WIN32
+static int win32_getpagesize(void)
+{
+  SYSTEM_INFO siSysInfo;
+  GetSystemInfo(&siSysInfo);
+  return siSysInfo.dwPageSize;
+}
+#define getpagesize win32_getpagesize
+#endif
 
 /*****************************************************************************/
 /* Config settings (essentially constants, so they don't need to live in shared
@@ -148,10 +168,10 @@ static size_t heap_size;
 
 /* Fix the location of our shared memory so we can save and restore the
  * hashtable easily */
-#define SHARED_MEM_INIT 0x500000000000
+#define SHARED_MEM_INIT 0x500000000000ll
 
 /* As a sanity check when loading from a file */
-static uint64_t MAGIC_CONSTANT = 0xfacefacefaceb000;
+static uint64 MAGIC_CONSTANT = 0xfacefacefaceb000ll;
 
 /* The VCS identifier (typically a git hash) of the build */
 extern const char* const BuildInfo_kRevision;
@@ -162,7 +182,7 @@ extern const char* const BuildInfo_kRevision;
 
 /* Cells of the Hashtable */
 typedef struct {
-  unsigned long hash;
+  uint64 hash;
   char* addr;
 } helt_t;
 
@@ -179,8 +199,8 @@ static value* global_storage;
  * The highest 2 bits are unused.
  * The next 31 bits encode the key the lower 31 bits the value.
  */
-static uint64_t* deptbl;
-static uint64_t* deptbl_bindings;
+static uint64* deptbl;
+static uint64* deptbl_bindings;
 
 /* The hashtable containing the shared values. */
 static helt_t* hashtbl;
@@ -217,7 +237,7 @@ value hh_heap_size() {
 
 value hh_hash_used_slots() {
   CAMLparam0();
-  uint64_t count = 0;
+  uint64 count = 0;
   uintptr_t i = 0;
   for (i = 0; i < HASHTBL_SIZE; ++i) {
     if (hashtbl[i].addr != NULL) {
@@ -237,8 +257,19 @@ value hh_hash_slots() {
  * the globals that live in shared memory.
  */
 /*****************************************************************************/
+
 static void init_shared_globals(char* mem) {
-  int page_size = getpagesize();
+  size_t page_size = getpagesize();
+
+#ifdef _WIN32
+  if (!VirtualAlloc(mem,
+                    global_size_b + page_size +
+                      2 * DEP_SIZE_B + HASHTBL_SIZE_B,
+                    MEM_COMMIT, PAGE_READWRITE)) {
+    win32_maperr(GetLastError());
+    uerror("VirtualAlloc2", Nothing);
+  }
+#endif
 
   /* Global storage initialization:
    * We store this at the start of the shared memory section as it never
@@ -272,10 +303,10 @@ static void init_shared_globals(char* mem) {
   /* END OF THE SMALL OBJECTS PAGE */
 
   /* Dependencies */
-  deptbl = (uint64_t*)mem;
+  deptbl = (uint64*)mem;
   mem += DEP_SIZE_B;
 
-  deptbl_bindings = (uint64_t*)mem;
+  deptbl_bindings = (uint64*)mem;
   mem += DEP_SIZE_B;
 
   /* Hashtable */
@@ -318,17 +349,20 @@ static void set_priorities() {
   );
   #endif
 
+  #ifndef _WIN32
   // Don't slam the CPU either, though this has much less tendency to make the
   // system totally unresponsive so we don't need to lower all the way.
   int dummy = nice(10);
   (void)dummy; // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=25509
+  #endif
+
 }
 
 /*****************************************************************************/
 /* Must be called by the master BEFORE forking the workers! */
 /*****************************************************************************/
 
-void hh_shared_init(
+value hh_shared_init(
   value global_size_val,
   value heap_size_val
 ) {
@@ -338,23 +372,54 @@ void hh_shared_init(
   global_size_b = Long_val(global_size_val);
   heap_size = Long_val(heap_size_val);
 
+  char* shared_mem;
+
+  size_t page_size = getpagesize();
+
+  /* The total size of the shared memory.  Most of it is going to remain
+   * virtual. */
+  size_t shared_mem_size =
+    global_size_b + 2 * DEP_SIZE_B + HASHTBL_SIZE_B +
+    heap_size + page_size;
+
+#ifdef _WIN32
+  HANDLE handle = CreateFileMapping(
+    INVALID_HANDLE_VALUE,
+    NULL,
+    PAGE_READWRITE | SEC_RESERVE,
+    shared_mem_size >> 32, shared_mem_size & ((1ll << 32) - 1),
+    NULL);
+  if (handle == NULL) {
+    win32_maperr(GetLastError());
+    uerror("CreateFileMapping", Nothing);
+  }
+  if (!SetHandleInformation(handle, HANDLE_FLAG_INHERIT, HANDLE_FLAG_INHERIT)) {
+    win32_maperr(GetLastError());
+    uerror("SetHandleInformation", Nothing);
+  }
+  shared_mem = MapViewOfFileEx(
+    handle,
+    FILE_MAP_ALL_ACCESS,
+    0, 0,
+    0,
+    (char *)SHARED_MEM_INIT);
+  if (shared_mem != (char *)SHARED_MEM_INIT) {
+    shared_mem = NULL;
+    win32_maperr(GetLastError());
+    uerror("MapViewOfFileEx", Nothing);
+  }
+
+#else /* _WIN32 */
+
   /* MAP_NORESERVE is because we want a lot more virtual memory than what
    * we are actually going to use.
    */
   int flags = MAP_SHARED | MAP_ANON | MAP_NORESERVE | MAP_FIXED;
   int prot  = PROT_READ  | PROT_WRITE;
 
-  int page_size = getpagesize();
-
-  /* The total size of the shared memory.  Most of it is going to remain
-   * virtual. */
-  size_t shared_mem_size = global_size_b + 2 * DEP_SIZE_B + HASHTBL_SIZE_B +
-      heap_size;
-
-  char* shared_mem =
-    (char*)mmap((void*)SHARED_MEM_INIT, page_size + shared_mem_size, prot,
+  shared_mem =
+    (char*)mmap((void*)SHARED_MEM_INIT,  shared_mem_size, prot,
                 flags, 0, 0);
-
   if(shared_mem == MAP_FAILED) {
     printf("Error initializing: %s\n", strerror(errno));
     exit(2);
@@ -365,20 +430,22 @@ void hh_shared_init(
   // a core file. Moreover, it can be HUGE, and the extensive work done dumping
   // it once for each CPU can mean that the user will reboot their machine
   // before the much more useful stack gets dumped!
-  madvise(shared_mem, page_size + shared_mem_size, MADV_DONTDUMP);
+  madvise(shared_mem, shared_mem_size, MADV_DONTDUMP);
 #endif
 
   // Keeping the pids around to make asserts.
   master_pid = getpid();
   my_pid = master_pid;
 
-  char* bottom = shared_mem;
+#endif /* _WIN32 */
 
+  char* bottom = shared_mem;
   init_shared_globals(shared_mem);
 
   // Checking that we did the maths correctly.
-  assert(*heap + heap_size == bottom + shared_mem_size + page_size);
+  assert(*heap + heap_size == bottom + shared_mem_size);
 
+#ifndef _WIN32
   // Uninstall ocaml's segfault handler. It's supposed to throw an exception on
   // stack overflow, but we don't actually handle that exception, so what
   // happens in practice is we terminate at toplevel with an unhandled exception
@@ -388,10 +455,11 @@ void hh_shared_init(
   sigemptyset(&sigact.sa_mask);
   sigact.sa_flags = 0;
   sigaction(SIGSEGV, &sigact, NULL);
+#endif
 
   set_priorities();
 
-  CAMLreturn0;
+  CAMLreturn(Val_unit);
 }
 
 #ifdef NO_LZ4
@@ -505,7 +573,7 @@ void hh_load(value in_filename) {
     caml_failwith("Failed to open file");
   }
 
-  uint64_t magic = 0;
+  uint64 magic = 0;
   read_all(fileno(fp), (void*)&magic, sizeof magic);
   assert(magic == MAGIC_CONSTANT);
 
@@ -567,7 +635,9 @@ void hh_load(value in_filename) {
 
 /* Must be called by every worker before any operation is performed */
 void hh_worker_init() {
+#ifndef _WIN32
   my_pid = getpid();
+#endif
 }
 
 /*****************************************************************************/
@@ -653,14 +723,14 @@ void hh_shared_clear() {
  */
 /*****************************************************************************/
 
-static int htable_add(uint64_t* table, unsigned long hash, uint64_t value) {
+static int htable_add(uint64* table, unsigned long hash, uint64 value) {
   unsigned long slot = hash & (DEP_SIZE - 1);
 
   while(1) {
     /* It considerably speeds things up to do a normal load before trying using
      * an atomic operation.
      */
-    uint64_t slot_val = table[slot];
+    uint64 slot_val = table[slot];
 
     // The binding exists, done!
     if(slot_val == value)
@@ -683,8 +753,8 @@ static int htable_add(uint64_t* table, unsigned long hash, uint64_t value) {
 }
 
 void hh_add_dep(value ocaml_dep) {
-  unsigned long dep  = Long_val(ocaml_dep);
-  unsigned long hash = (dep >> 31) * (dep & ((1l << 31) - 1));
+  uint64 dep  = Long_val(ocaml_dep);
+  unsigned long hash = (dep >> 31) * (dep & ((1ul << 31) - 1));
 
   if(!htable_add(deptbl_bindings, hash, hash)) {
     return;
@@ -695,7 +765,7 @@ void hh_add_dep(value ocaml_dep) {
 
 value hh_dep_used_slots() {
   CAMLparam0();
-  uint64_t count = 0;
+  uint64 count = 0;
   uintptr_t slot = 0;
   for (slot = 0; slot < DEP_SIZE; ++slot) {
     if (deptbl[slot]) {
@@ -726,7 +796,7 @@ value hh_get_dep(value dep) {
     }
     if(deptbl[slot] >> 31 == hash) {
       cell = caml_alloc_tuple(2);
-      Field(cell, 0) = Val_long(deptbl[slot] & ((1l << 31) - 1));
+      Field(cell, 0) = Val_long(deptbl[slot] & ((1ul << 31) - 1));
       Field(cell, 1) = result;
       result = cell;
     }
@@ -766,6 +836,10 @@ void hh_call_after_init() {
  */
 /*****************************************************************************/
 void hh_collect() {
+#ifdef _WIN32
+  // TODO GRGR
+  return;
+#else
   int flags       = MAP_PRIVATE | MAP_ANON | MAP_NORESERVE;
   int prot        = PROT_READ | PROT_WRITE;
   char* dest;
@@ -811,6 +885,7 @@ void hh_collect() {
     printf("Error while collecting: %s\n", strerror(errno));
     exit(2);
   }
+#endif
 }
 
 /*****************************************************************************/
@@ -825,6 +900,12 @@ void hh_collect() {
 static char* hh_alloc(size_t size) {
   size_t slot_size  = ALIGNED(size + sizeof(size_t));
   char* chunk       = __sync_fetch_and_add(heap, slot_size);
+#ifdef _WIN32
+  if (!VirtualAlloc(chunk, slot_size, MEM_COMMIT, PAGE_READWRITE)) {
+    win32_maperr(GetLastError());
+    uerror("VirtualAlloc1", Nothing);
+  }
+#endif
   *((size_t*)chunk) = size;
   return (chunk + sizeof(size_t));
 }
@@ -1002,81 +1083,3 @@ void hh_remove(value key) {
   assert(hashtbl[slot].hash == get_hash(key));
   hashtbl[slot].addr = NULL;
 }
-
-#else // _WIN32
-// CAGO: some of theses functions will be the same as in linux version
-
-void hh_add(value key, value data) {}
-void hh_add_dep(value ocaml_dep) {}
-void hh_call_after_init() {}
-void hh_collect() {}
-void hh_move(value key1, value key2) {}
-void hh_remove(value key) {}
-void hh_save(value out_filename) {}
-void hh_shared_clear() {}
-void hh_shared_init(value global_size_val, value heap_size_val) {}
-void hh_load(value in_filename) {}
-void hh_shared_store(value data) {}
-void hh_worker_init() {}
-
-value hh_counter_next() {
-  CAMLparam0();
-  caml_failwith("'hh_counter_next` is not implemented in `hh_shared.c`.");
-  CAMLreturn(Val_unit);
-}
-
-value hh_dep_slots() {
-  CAMLparam0();
-  caml_failwith("'hh_dep_slots` is not implemented in `hh_shared.c`.");
-  CAMLreturn(Val_unit);
-}
-
-value hh_dep_used_slots() {
-  CAMLparam0();
-  caml_failwith("'hh_dep_used_slots` is not implemented in `hh_shared.c`.");
-  CAMLreturn(Val_unit);
-}
-
-value hh_get(value key) {
-  CAMLparam1(key);
-  caml_failwith("'hh_get` is not implemented in `hh_shared.c`.");
-  CAMLreturn(Val_unit);
-}
-
-value hh_get_dep(value dep) {
-  CAMLparam1(dep);
-  caml_failwith("'hh_get_dep` is not implemented in `hh_shared.c`.");
-  CAMLreturn(Val_unit);
-}
-
-value hh_hash_slots() {
-  CAMLparam0();
-  caml_failwith("'hh_hash_slots` is not implemented in `hh_shared.c`.");
-  CAMLreturn(Val_unit);
-}
-
-value hh_hash_used_slots() {
-  CAMLparam0();
-  caml_failwith("'hh_hash_used_slots` is not implemented in `hh_shared.c`.");
-  CAMLreturn(Val_unit);
-}
-
-value hh_heap_size() {
-  CAMLparam0();
-  caml_failwith("'hh_heap_size` is not implemented in `hh_shared.c`.");
-  CAMLreturn(Val_unit);
-}
-
-value hh_mem(value key) {
-  CAMLparam1(key);
-  caml_failwith("'hh_mem` is not implemented in `hh_shared.c`.");
-  CAMLreturn(Val_unit);
-}
-
-value hh_shared_load() {
-  CAMLparam0();
-  caml_failwith("'hh_shared_load` is not implemented in `hh_shared.c`.");
-  CAMLreturn(Val_unit);
-}
-
-#endif

--- a/hphp/hack/src/heap/hh_shared.c
+++ b/hphp/hack/src/heap/hh_shared.c
@@ -383,6 +383,24 @@ value hh_shared_init(
     heap_size + page_size;
 
 #ifdef _WIN32
+  /*
+
+     We create an anonymous memory file, whose `handle` might be
+     inheriten by slave processes.
+
+     This memory file is tagged "reserved" but not "commited". Meaning
+     that the memory space will be reserved in the virtual memory
+     table but the pages will not be bound to any physical memory
+     yet. Further call to 'VirtualAlloc' will allow to "commit" page,
+     meaning they will be bound to physical memory.
+
+     This is behaviour should reflect the 'MAP_NORESERVE' flag of
+     'mmap' on Unix. But, on Unix, the "commit" is implicit.
+
+     Commiting the whole shared heap at once would require the same
+     amount of free space in memory (or in swap file).
+
+  */
   HANDLE handle = CreateFileMapping(
     INVALID_HANDLE_VALUE,
     NULL,

--- a/hphp/hack/src/heap/hh_shared.c
+++ b/hphp/hack/src/heap/hh_shared.c
@@ -344,9 +344,12 @@ static void set_priorities() {
   );
   #endif
 
-  #ifndef _WIN32
   // Don't slam the CPU either, though this has much less tendency to make the
   // system totally unresponsive so we don't need to lower all the way.
+  #ifdef _WIN32
+  SetPriorityClass(GetCurrentProcess(), BELOW_NORMAL_PRIORITY_CLASS);
+  // One might also try: PROCESS_MODE_BACKGROUND_BEGIN
+  #else
   int dummy = nice(10);
   (void)dummy; // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=25509
   #endif

--- a/hphp/hack/src/heap/hh_shared.c
+++ b/hphp/hack/src/heap/hh_shared.c
@@ -82,16 +82,14 @@
 #include <caml/alloc.h>
 #include <caml/fail.h>
 
+#include <assert.h>
+
 #ifdef _WIN32
-
 #include <windows.h>
-
 #else
-
 /* define CAML_NAME_SPACE to ensure all the caml imports are prefixed with
  * 'caml_' */
 #define CAML_NAME_SPACE
-#include <assert.h>
 #include <fcntl.h>
 #include <pthread.h>
 #include <signal.h>
@@ -105,14 +103,12 @@
 #include <sys/syscall.h>
 #include <sys/types.h>
 #include <unistd.h>
-
 #endif
 
 #ifndef NO_LZ4
 #include <lz4.h>
 #include <lz4hc.h>
 #endif
-
 
 #ifdef _WIN32
 static int win32_getpagesize(void)

--- a/hphp/hack/src/heap/hh_shared.c
+++ b/hphp/hack/src/heap/hh_shared.c
@@ -85,7 +85,6 @@
 #ifdef _WIN32
 
 #include <windows.h>
-#include <assert.h>
 
 #else
 

--- a/hphp/hack/src/heap/hh_shared.c
+++ b/hphp/hack/src/heap/hh_shared.c
@@ -381,18 +381,18 @@ value hh_shared_init(
   /*
 
      We create an anonymous memory file, whose `handle` might be
-     inheriten by slave processes.
+     inherited by slave processes.
 
-     This memory file is tagged "reserved" but not "commited". Meaning
-     that the memory space will be reserved in the virtual memory
-     table but the pages will not be bound to any physical memory
-     yet. Further call to 'VirtualAlloc' will allow to "commit" page,
+     This memory file is tagged "reserved" but not "committed". This
+     means that the memory space will be reserved in the virtual
+     memory table but the pages will not be bound to any physical
+     memory yet. Further calls to 'VirtualAlloc' will "commit" pages,
      meaning they will be bound to physical memory.
 
-     This is behaviour should reflect the 'MAP_NORESERVE' flag of
+     This is behavior that should reflect the 'MAP_NORESERVE' flag of
      'mmap' on Unix. But, on Unix, the "commit" is implicit.
 
-     Commiting the whole shared heap at once would require the same
+     Committing the whole shared heap at once would require the same
      amount of free space in memory (or in swap file).
 
   */


### PR DESCRIPTION
- Replaced 'uint64_t' with 'uint64' (as exported by 'caml/mlvalues.h')
- Implemented shared memory allocation
- Disabled (temporary) garbage collection on Windows