### PR TITLE
Allow setting LIBPTHREAD_LIBRARIES to a multi-config friendly value

### DIFF
--- a/CMake/HPHPFindLibs.cmake
+++ b/CMake/HPHPFindLibs.cmake
@@ -470,7 +470,7 @@ macro(hphp_link target)
     target_link_libraries(${target} ${KERBEROS_LIB})
   endif()
 
-  if (${LIBPTHREAD_LIBRARIES})
+  if (LIBPTHREAD_LIBRARIES)
     target_link_libraries(${target} ${LIBPTHREAD_LIBRARIES})
   endif()
 


### PR DESCRIPTION
Without this, if you've set `LIBPTHREAD_LIBRARIES` to a multi-config friendly value, such as this except from my CMake cache:
```
LIBPTHREAD_LIBRARIES:FILEPATH=optimized;F:/Libraries/libpthread/lib/libpthreadMT.lib;debug;F:/Libraries/libpthread/lib/libpthreadMTd.lib
```
CMake will error when it tries to do this, because it is incorrectly trying to substitute the value of this variable in the condition of the if statement.
This simply changes it to not substitute the entire value.