### PR TITLE
Don't try to link against CRYPT_LIB if it isn't found

### DIFF
--- a/CMake/HPHPFindLibs.cmake
+++ b/CMake/HPHPFindLibs.cmake
@@ -482,7 +482,9 @@ macro(hphp_link target)
 
   target_link_libraries(${target} ${LBER_LIBRARIES})
 
-  target_link_libraries(${target} ${CRYPT_LIB})
+  if (CRYPT_LIB)
+    target_link_libraries(${target} ${CRYPT_LIB})
+  endif()
 
   if (LINUX OR FREEBSD)
     target_link_libraries(${target} ${RT_LIB})


### PR DESCRIPTION
CRYPT_LIB is searched for optionally, and isn't needed, or available, on Windows, so don't try to link against it if it's not found.