### PR TITLE
Make ext_process optional

### DIFF
--- a/hphp/runtime/base/thread-info.cpp
+++ b/hphp/runtime/base/thread-info.cpp
@@ -28,7 +28,9 @@
 #include "hphp/runtime/base/code-coverage.h"
 #include "hphp/runtime/base/rds.h"
 #include "hphp/runtime/base/surprise-flags.h"
+#ifdef ENABLE_EXTENSION_PROCESS
 #include "hphp/runtime/ext/process/ext_process.h"
+#endif
 
 namespace HPHP {
 ///////////////////////////////////////////////////////////////////////////////
@@ -210,9 +212,12 @@ size_t check_request_surprise() {
   if (do_GC) {
     MM().collect();
   }
+
+#ifdef ENABLE_EXTENSION_PROCESS
   if (do_signaled) {
     HHVM_FN(pcntl_signal_dispatch)();
   }
+#endif
 
   if (pendingException) {
     pendingException->throwException();

--- a/hphp/runtime/ext/process/config.cmake
+++ b/hphp/runtime/ext/process/config.cmake
@@ -1,4 +1,4 @@
-HHVM_DEFINE_EXTENSION("process" REQUIRED
+HHVM_DEFINE_EXTENSION("process"
   SOURCES
     ext_process.cpp
   HEADERS


### PR DESCRIPTION
ext_process, or, to give it it's correct name, ext_pcntl, is not going to be supported on Windows, and even PHP itself doesn't attempt to support it on Windows. This means that it needs to be possible to disable it on Windows, however, it requires a hook in the core runtime.
This disables the hook if ext_process isn't enabled. This also removes the `REQUIRED` flag in the config for the extension.

Requires #8572.