### PR TITLE
Implement fnmatch, glob, rand_r, and strptime for MSVC

### DIFF
--- a/hphp/util/CMakeLists.txt
+++ b/hphp/util/CMakeLists.txt
@@ -10,6 +10,15 @@ list(APPEND ASM_SOURCES ${asmfiles})
 # sgolemon(2014-02-19)
 HHVM_REMOVE_MATCHES_FROM_LISTS(CXX_SOURCES MATCHES "/test/" "channeled-json-")
 
+if (NOT MSVC)
+  list(REMOVE_ITEM CXX_SOURCES
+    ${CMAKE_CURRENT_SOURCE_DIR}/portability/fnmatch.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/portability/glob.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/portability/rand_r.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/portability/strptime.cpp
+  )
+endif()
+
 add_custom_command(
   OUTPUT "${CMAKE_CURRENT_SOURCE_DIR}/../hphp-repo-schema.h"
          "${CMAKE_CURRENT_SOURCE_DIR}/../hphp-build-info.cpp"

--- a/hphp/util/portability.h
+++ b/hphp/util/portability.h
@@ -170,4 +170,11 @@
 
 //////////////////////////////////////////////////////////////////////
 
+#ifdef _MSC_VER
+# include "hphp/util/portability/fnmatch.h"
+# include "hphp/util/portability/glob.h"
+# include "hphp/util/portability/rand_r.h"
+# include "hphp/util/portability/strptime.h"
+#endif
+
 #endif

--- a/hphp/util/portability/fnmatch.cpp
+++ b/hphp/util/portability/fnmatch.cpp
@@ -1,0 +1,185 @@
+// Borrowed from PHP
+/*
+* Copyright (c) 1989, 1993, 1994
+*	The Regents of the University of California.  All rights reserved.
+*
+* This code is derived from software contributed to Berkeley by
+* Guido van Rossum.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions
+* are met:
+* 1. Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+* 2. Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in the
+*    documentation and/or other materials provided with the distribution.
+* 3. All advertising materials mentioning features or use of this software
+*    must display the following acknowledgement:
+*	This product includes software developed by the University of
+*	California, Berkeley and its contributors.
+* 4. Neither the name of the University nor the names of its contributors
+*    may be used to endorse or promote products derived from this software
+*    without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+* ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+* FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+* DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+* OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+* HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+* LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+* OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+* SUCH DAMAGE.
+*
+* From FreeBSD fnmatch.c 1.11
+* $Id$
+*/
+#include "hphp/util/portability/fnmatch.h"
+
+#include <ctype.h>
+#include <string.h>
+
+#define EOS '\0'
+
+static const char* rangematch(const char *pattern, char test, int flags)
+{
+  int negate, ok;
+  char c, c2;
+
+  /*
+  * A bracket expression starting with an unquoted circumflex
+  * character produces unspecified results (IEEE 1003.2-1992,
+  * 3.13.2).  This implementation treats it like '!', for
+  * consistency with the regular expression syntax.
+  * J.T. Conklin (conklin@ngai.kaleida.com)
+  */
+  if ((negate = (*pattern == '!' || *pattern == '^')))
+    ++pattern;
+
+  if (flags & FNM_CASEFOLD)
+    test = tolower((unsigned char)test);
+
+  for (ok = 0; (c = *pattern++) != ']';) {
+    if (c == '\\' && !(flags & FNM_NOESCAPE))
+      c = *pattern++;
+    if (c == EOS)
+      return nullptr;
+
+    if (flags & FNM_CASEFOLD)
+      c = tolower((unsigned char)c);
+
+    if (*pattern == '-'
+      && (c2 = *(pattern + 1)) != EOS && c2 != ']') {
+      pattern += 2;
+      if (c2 == '\\' && !(flags & FNM_NOESCAPE))
+        c2 = *pattern++;
+      if (c2 == EOS)
+        return nullptr;
+
+      if (flags & FNM_CASEFOLD)
+        c2 = tolower((unsigned char)c2);
+
+      if ((unsigned char)c <= (unsigned char)test &&
+        (unsigned char)test <= (unsigned char)c2)
+        ok = 1;
+    }
+    else if (c == test)
+      ok = 1;
+  }
+  return (ok == negate ? nullptr : pattern);
+}
+
+extern "C" int fnmatch(const char *pattern, const char *string, int flags)
+{
+  const char *stringstart;
+  char c, test;
+
+  for (stringstart = string;;)
+    switch (c = *pattern++) {
+    case EOS:
+      if ((flags & FNM_LEADING_DIR) && *string == '/')
+        return (0);
+      return (*string == EOS ? 0 : FNM_NOMATCH);
+    case '?':
+      if (*string == EOS)
+        return (FNM_NOMATCH);
+      if (*string == '/' && (flags & FNM_PATHNAME))
+        return (FNM_NOMATCH);
+      if (*string == '.' && (flags & FNM_PERIOD) &&
+        (string == stringstart ||
+          ((flags & FNM_PATHNAME) && *(string - 1) == '/')))
+        return (FNM_NOMATCH);
+      ++string;
+      break;
+    case '*':
+      c = *pattern;
+      /* Collapse multiple stars. */
+      while (c == '*')
+        c = *++pattern;
+
+      if (*string == '.' && (flags & FNM_PERIOD) &&
+        (string == stringstart ||
+          ((flags & FNM_PATHNAME) && *(string - 1) == '/')))
+        return (FNM_NOMATCH);
+
+      /* Optimize for pattern with * at end or before /. */
+      if (c == EOS)
+        if (flags & FNM_PATHNAME)
+        return ((flags & FNM_LEADING_DIR) ||
+          strchr(string, '/') == nullptr ?
+          0 : FNM_NOMATCH);
+        else
+          return (0);
+      else if (c == '/' && flags & FNM_PATHNAME) {
+        if ((string = strchr(string, '/')) == nullptr)
+          return (FNM_NOMATCH);
+        break;
+      }
+
+      /* General case, use recursion. */
+      while ((test = *string) != EOS) {
+        if (!fnmatch(pattern, string, flags & ~FNM_PERIOD))
+          return (0);
+        if (test == '/' && flags & FNM_PATHNAME)
+          break;
+        ++string;
+      }
+      return (FNM_NOMATCH);
+    case '[':
+      if (*string == EOS)
+        return (FNM_NOMATCH);
+      if (*string == '/' && flags & FNM_PATHNAME)
+        return (FNM_NOMATCH);
+      if ((pattern = rangematch(pattern, *string, flags)) == nullptr)
+        return (FNM_NOMATCH);
+      ++string;
+      break;
+    case '\\':
+      if (!(flags & FNM_NOESCAPE)) {
+        if ((c = *pattern++) == EOS) {
+          c = '\\';
+          --pattern;
+        }
+      }
+      /* FALLTHROUGH */
+    default:
+      if (c == *string)
+        ;
+      else if ((flags & FNM_CASEFOLD) &&
+        (tolower((unsigned char)c) ==
+          tolower((unsigned char)*string)))
+        ;
+      else if ((flags & FNM_PREFIX_DIRS) && *string == EOS &&
+        (c == '/' && string != stringstart ||
+          string == stringstart + 1 && *stringstart == '/'))
+        return (0);
+      else
+        return (FNM_NOMATCH);
+      string++;
+      break;
+    }
+  /* NOTREACHED */
+}

--- a/hphp/util/portability/fnmatch.h
+++ b/hphp/util/portability/fnmatch.h
@@ -1,0 +1,51 @@
+// Borrowed from PHP
+/*
+* Copyright (c) 1989, 1993
+*	The Regents of the University of California.  All rights reserved.
+*
+* This code is derived from software contributed to Berkeley by
+* Guido van Rossum.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions
+* are met:
+* 1. Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+* 2. Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in the
+*    documentation and/or other materials provided with the distribution.
+* 3. All advertising materials mentioning features or use of this software
+*    must display the following acknowledgement:
+*	This product includes software developed by the University of
+*	California, Berkeley and its contributors.
+* 4. Neither the name of the University nor the names of its contributors
+*    may be used to endorse or promote products derived from this software
+*    without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+* ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+* FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+* DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+* OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+* HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+* LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+* OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+* SUCH DAMAGE.
+*/
+#ifndef incl_HPHP_UTIL_PORTABILITY_FNMATCH_H_
+#define incl_HPHP_UTIL_PORTABILITY_FNMATCH_H_
+
+#define	FNM_NOMATCH	1	/* Match failed. */
+
+#define	FNM_NOESCAPE	0x01	/* Disable backslash escaping. */
+#define	FNM_PATHNAME	0x02	/* Slash must be matched by slash. */
+#define	FNM_PERIOD	0x04	/* Period must be matched by period. */
+#define	FNM_LEADING_DIR	0x08	/* Ignore /<tail> after Imatch. */
+#define	FNM_CASEFOLD	0x10	/* Case insensitive search. */
+#define FNM_PREFIX_DIRS	0x20	/* Directory prefixes of pattern match too. */
+
+extern "C" int fnmatch(const char *pattern, const char *string, int flags);
+
+#endif

--- a/hphp/util/portability/glob.cpp
+++ b/hphp/util/portability/glob.cpp
@@ -1,0 +1,688 @@
+// Borrowed from PHP
+/*
+* Copyright (c) 1989, 1993
+*	The Regents of the University of California.  All rights reserved.
+*
+* This code is derived from software contributed to Berkeley by
+* Guido van Rossum.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions
+* are met:
+* 1. Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+* 2. Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in the
+*    documentation and/or other materials provided with the distribution.
+* 3. All advertising materials mentioning features or use of this software
+*    must display the following acknowledgement:
+*	This product includes software developed by the University of
+*	California, Berkeley and its contributors.
+* 4. Neither the name of the University nor the names of its contributors
+*    may be used to endorse or promote products derived from this software
+*    without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+* ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+* FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+* DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+* OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+* HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+* LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+* OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+* SUCH DAMAGE.
+*/
+#include "hphp/util/portability/glob.h"
+
+#include <ctype.h>
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+
+#include <folly/CPortability.h>
+
+#define ARG_MAX 14500
+
+#define	DOLLAR		'$'
+#define	DOT		'.'
+#define	EOS		'\0'
+#define	LBRACKET	'['
+#define	NOT		'!'
+#define	QUESTION	'?'
+#define	QUOTE		'\\'
+#define	RANGE		'-'
+#define	RBRACKET	']'
+#define	SEP		DEFAULT_SLASH
+#define	STAR		'*'
+#define	TILDE		'~'
+#define	UNDERSCORE	'_'
+#define	LBRACE		'{'
+#define	RBRACE		'}'
+#define	SLASH		'/'
+#define	COMMA		','
+
+#define	M_QUOTE		0x8000
+#define	M_PROTECT	0x4000
+#define	M_MASK		0xffff
+#define	M_ASCII		0x00ff
+typedef char Char;
+#define MAXPATHLEN MAX_PATH
+
+
+#define	CHAR(c)		((Char)((c)&M_ASCII))
+#define	META(c)		((Char)((c)|M_QUOTE))
+#define	M_ALL		META('*')
+#define	M_END		META(']')
+#define	M_NOT		META('!')
+#define	M_ONE		META('?')
+#define	M_RNG		META('-')
+#define	M_SET		META('[')
+#define	ismeta(c)	(((c)&M_QUOTE) != 0)
+
+static int	 compare(const void *, const void *);
+static int	 g_Ctoc(const Char *, char *, u_int);
+static int	 glob0(const Char *, glob_t *);
+static int	 glob1(Char *, Char *, glob_t *, size_t *);
+static int	 glob2(Char *, Char *, Char *, Char *, Char *, Char *,
+  glob_t *, size_t *);
+static int	 glob3(Char *, Char *, Char *, Char *, Char *, Char *,
+  Char *, Char *, glob_t *, size_t *);
+static int	 globextend(const Char *, glob_t *, size_t *);
+static const Char *globtilde(const Char *, Char *, size_t, glob_t *);
+static int	 globexp1(const Char *, glob_t *);
+static int	 globexp2(const Char *, const Char *, glob_t *, int *);
+static int	 match(Char *, Char *, Char *);
+
+/*
+* Expand recursively a glob {} pattern. When there is no more expansion
+* invoke the standard globbing routine to glob the rest of the magic
+* characters
+*/
+static int
+globexp1(const Char* pattern, glob_t* pglob)
+{
+  const Char* ptr = pattern;
+  int rv;
+
+  /* Protect a single {}, for find(1), like csh */
+  if (pattern[0] == LBRACE && pattern[1] == RBRACE && pattern[2] == EOS)
+    return glob0(pattern, pglob);
+
+  while ((ptr = (const Char *)strchr((Char *)ptr, LBRACE)) != nullptr)
+    if (!globexp2(ptr, pattern, pglob, &rv))
+    return rv;
+
+  return glob0(pattern, pglob);
+}
+
+
+/*
+* Recursive brace globbing helper. Tries to expand a single brace.
+* If it succeeds then it invokes globexp1 with the new pattern.
+* If it fails then it tries to glob the rest of the pattern and returns.
+*/
+static int
+globexp2(const Char* ptr, const Char* pattern, glob_t* pglob, int* rv)
+{
+  int     i;
+  Char   *lm, *ls;
+  const Char *pe, *pm, *pl;
+  Char    patbuf[MAXPATHLEN];
+
+  /* copy part up to the brace */
+  for (lm = patbuf, pm = pattern; pm != ptr; *lm++ = *pm++)
+    ;
+  *lm = EOS;
+  ls = lm;
+
+  /* Find the balanced brace */
+  for (i = 0, pe = ++ptr; *pe; pe++)
+    if (*pe == LBRACKET) {
+      /* Ignore everything between [] */
+      for (pm = pe++; *pe != RBRACKET && *pe != EOS; pe++)
+        ;
+      if (*pe == EOS) {
+        /*
+        * We could not find a matching RBRACKET.
+        * Ignore and just look for RBRACE
+        */
+        pe = pm;
+      }
+    }
+    else if (*pe == LBRACE)
+      i++;
+    else if (*pe == RBRACE) {
+      if (i == 0)
+        break;
+      i--;
+    }
+
+    /* Non matching braces; just glob the pattern */
+    if (i != 0 || *pe == EOS) {
+      *rv = glob0(patbuf, pglob);
+      return 0;
+    }
+
+    for (i = 0, pl = pm = ptr; pm <= pe; pm++) {
+      const Char *pb;
+
+      switch (*pm) {
+      case LBRACKET:
+        /* Ignore everything between [] */
+        for (pb = pm++; *pm != RBRACKET && *pm != EOS; pm++)
+          ;
+        if (*pm == EOS) {
+          /*
+          * We could not find a matching RBRACKET.
+          * Ignore and just look for RBRACE
+          */
+          pm = pb;
+        }
+        break;
+
+      case LBRACE:
+        i++;
+        break;
+
+      case RBRACE:
+        if (i) {
+          i--;
+          break;
+        }
+        /* FALLTHROUGH */
+      case COMMA:
+        if (i && *pm == COMMA)
+          break;
+        else {
+          /* Append the current string */
+          for (lm = ls; (pl < pm); *lm++ = *pl++)
+            ;
+
+          /*
+          * Append the rest of the pattern after the
+          * closing brace
+          */
+          for (pl = pe + 1; (*lm++ = *pl++) != EOS; )
+            ;
+
+          /* Expand the current pattern */
+          *rv = globexp1(patbuf, pglob);
+
+          /* move after the comma, to the next string */
+          pl = pm + 1;
+        }
+        break;
+
+      default:
+        break;
+      }
+    }
+    *rv = 0;
+    return 0;
+}
+
+
+
+/*
+* expand tilde from the passwd file.
+*/
+static const Char *
+globtilde(const Char* pattern, Char* patbuf, size_t patbuf_len, glob_t* pglob)
+{
+  char *h;
+  const Char *p;
+  Char *b, *eb;
+
+  if (*pattern != TILDE || !(pglob->gl_flags & GLOB_TILDE))
+    return pattern;
+
+  /* Copy up to the end of the string or / */
+  eb = &patbuf[patbuf_len - 1];
+  for (p = pattern + 1, h = (char *)patbuf;
+  h < (char *)eb && *p && *p != SLASH; *h++ = (char)*p++)
+    ;
+
+  *h = EOS;
+
+
+  if (((char *)patbuf)[0] == EOS) {
+    /*
+    * handle a plain ~ or ~/ by expanding $HOME
+    * first and then trying the password file
+    */
+    if ((h = getenv("HOME")) == nullptr) {
+      return pattern;
+    }
+  }
+  else {
+    /*
+    * Expand a ~user
+    */
+    return pattern;
+  }
+
+  /* Copy the home directory */
+  for (b = patbuf; b < eb && *h; *b++ = *h++)
+    ;
+
+  /* Append the rest of the pattern */
+  while (b < eb && (*b++ = *p++) != EOS)
+    ;
+  *b = EOS;
+
+  return patbuf;
+}
+
+
+/*
+* The main glob() routine: compiles the pattern (optionally processing
+* quotes), calls glob1() to do the real pattern matching, and finally
+* sorts the list (unless unsorted operation is requested).  Returns 0
+* if things went well, nonzero if errors occurred.  It is not an error
+* to find no matches.
+*/
+static int
+glob0(const Char* pattern, glob_t* pglob)
+{
+  const Char *qpatnext;
+  int c, err, oldpathc;
+  Char *bufnext, patbuf[MAXPATHLEN];
+  size_t limit = 0;
+
+  qpatnext = globtilde(pattern, patbuf, MAXPATHLEN, pglob);
+  oldpathc = pglob->gl_pathc;
+  bufnext = patbuf;
+
+  /* We don't need to check for buffer overflow any more. */
+  while ((c = *qpatnext++) != EOS) {
+    switch (c) {
+    case LBRACKET:
+      c = *qpatnext;
+      if (c == NOT)
+        ++qpatnext;
+      if (*qpatnext == EOS ||
+        strchr((Char *)qpatnext + 1, RBRACKET) == nullptr) {
+        *bufnext++ = LBRACKET;
+        if (c == NOT)
+          --qpatnext;
+        break;
+      }
+      *bufnext++ = M_SET;
+      if (c == NOT)
+        *bufnext++ = M_NOT;
+      c = *qpatnext++;
+      do {
+        *bufnext++ = CHAR(c);
+        if (*qpatnext == RANGE &&
+          (c = qpatnext[1]) != RBRACKET) {
+          *bufnext++ = M_RNG;
+          *bufnext++ = CHAR(c);
+          qpatnext += 2;
+        }
+      } while ((c = *qpatnext++) != RBRACKET);
+      pglob->gl_flags |= GLOB_MAGCHAR;
+      *bufnext++ = M_END;
+      break;
+    case QUESTION:
+      pglob->gl_flags |= GLOB_MAGCHAR;
+      *bufnext++ = M_ONE;
+      break;
+    case STAR:
+      pglob->gl_flags |= GLOB_MAGCHAR;
+      /* collapse adjacent stars to one,
+      * to avoid exponential behavior
+      */
+      if (bufnext == patbuf || bufnext[-1] != M_ALL)
+        *bufnext++ = M_ALL;
+      break;
+    default:
+      *bufnext++ = CHAR(c);
+      break;
+    }
+  }
+  *bufnext = EOS;
+
+  if ((err = glob1(patbuf, patbuf + MAXPATHLEN - 1, pglob, &limit)) != 0)
+    return(err);
+
+  /*
+  * If there was no match we are going to append the pattern
+  * if GLOB_NOCHECK was specified or if GLOB_NOMAGIC was specified
+  * and the pattern did not contain any magic characters
+  * GLOB_NOMAGIC is there just for compatibility with csh.
+  */
+  if (pglob->gl_pathc == oldpathc) {
+    if ((pglob->gl_flags & GLOB_NOCHECK) ||
+      ((pglob->gl_flags & GLOB_NOMAGIC) &&
+        !(pglob->gl_flags & GLOB_MAGCHAR)))
+      return(globextend(pattern, pglob, &limit));
+    else
+      return(GLOB_NOMATCH);
+  }
+  if (!(pglob->gl_flags & GLOB_NOSORT))
+    qsort(pglob->gl_pathv + pglob->gl_offs + oldpathc,
+      pglob->gl_pathc - oldpathc, sizeof(char *), compare);
+  return(0);
+}
+
+static int
+compare(const void *p, const void *q)
+{
+  return(strcmp(*(char **)p, *(char **)q));
+}
+
+static int
+glob1(Char* pattern, Char* pattern_last, glob_t* pglob, size_t* limitp)
+{
+  Char pathbuf[MAXPATHLEN];
+
+  /* A nullptr pathname is invalid -- POSIX 1003.1 sect. 2.4. */
+  if (*pattern == EOS)
+    return(0);
+  return(glob2(pathbuf, pathbuf + MAXPATHLEN - 1,
+    pathbuf, pathbuf + MAXPATHLEN - 1,
+    pattern, pattern_last, pglob, limitp));
+}
+
+/*
+* The functions glob2 and glob3 are mutually recursive; there is one level
+* of recursion for each segment in the pattern that contains one or more
+* meta characters.
+*/
+static int
+glob2(Char* pathbuf, Char* pathbuf_last, Char* pathend, Char* pathend_last, Char* pattern,
+  Char* pattern_last, glob_t* pglob, size_t* limitp)
+{
+  struct stat sb;
+  Char *p, *q;
+  int anymeta;
+
+  /*
+  * Loop over pattern segments until end of pattern or until
+  * segment with meta character found.
+  */
+  for (anymeta = 0;;) {
+    if (*pattern == EOS) {		/* End of pattern? */
+      *pathend = EOS;
+      ++pglob->gl_matchc;
+      return(globextend(pathbuf, pglob, limitp));
+    }
+
+    /* Find end of next segment, copy tentatively to pathend. */
+    q = pathend;
+    p = pattern;
+    while (*p != EOS && *p != '/' && *p != '\\') {
+      if (ismeta(*p))
+        anymeta = 1;
+      if (q + 1 > pathend_last)
+        return (1);
+      *q++ = *p++;
+    }
+
+    if (!anymeta) {		/* No expansion, do next segment. */
+      pathend = q;
+      pattern = p;
+      while (*pattern == '/' || *pattern == '\\') {
+        if (pathend + 1 > pathend_last)
+          return (1);
+        *pathend++ = *pattern++;
+      }
+    }
+    else
+      /* Need expansion, recurse. */
+      return(glob3(pathbuf, pathbuf_last, pathend,
+        pathend_last, pattern, pattern_last,
+        p, pattern_last, pglob, limitp));
+  }
+  /* NOTREACHED */
+}
+
+static int
+glob3(Char* pathbuf, Char* pathbuf_last, Char* pathend, Char* pathend_last, Char* pattern, Char* pattern_last,
+  Char* restpattern, Char* restpattern_last, glob_t* pglob, size_t* limitp)
+{
+  register struct dirent *dp;
+  DIR *dirp;
+  int err;
+  char buf[MAXPATHLEN];
+
+  if (pathend > pathend_last)
+    return (1);
+  *pathend = EOS;
+  errno = 0;
+
+  if ((dirp = opendir(pathbuf)) == nullptr) {
+    return(0);
+  }
+
+  err = 0;
+
+  /* Search directory for matching names. */
+  while ((dp = (*readdir)(dirp))) {
+    register u_char *sc;
+    register Char *dc;
+
+    /* Initial DOT must be matched literally. */
+    if (dp->d_name[0] == DOT && *pattern != DOT)
+      continue;
+    dc = pathend;
+    sc = (u_char *)dp->d_name;
+    while (dc < pathend_last && (*dc++ = *sc++) != EOS)
+      ;
+    if (dc >= pathend_last) {
+      *dc = EOS;
+      err = 1;
+      break;
+    }
+
+    if (!match(pathend, pattern, restpattern)) {
+      *pathend = EOS;
+      continue;
+    }
+    err = glob2(pathbuf, pathbuf_last, --dc, pathend_last,
+      restpattern, restpattern_last, pglob, limitp);
+    if (err)
+      break;
+  }
+
+  closedir(dirp);
+  return(err);
+}
+
+
+/*
+* Extend the gl_pathv member of a glob_t structure to accommodate a new item,
+* add the new item, and update gl_pathc.
+*
+* This assumes the BSD realloc, which only copies the block when its size
+* crosses a power-of-two boundary; for v7 realloc, this would cause quadratic
+* behavior.
+*
+* Return 0 if new item added, error code if memory couldn't be allocated.
+*
+* Invariant of the glob_t structure:
+*	Either gl_pathc is zero and gl_pathv is nullptr; or gl_pathc > 0 and
+*	gl_pathv points to (gl_offs + gl_pathc + 1) items.
+*/
+static int
+globextend(const Char* path, glob_t* pglob, size_t* limitp)
+{
+  register char **pathv;
+  register int i;
+  u_int newsize, len;
+  char *copy;
+  const Char *p;
+
+  newsize = sizeof(*pathv) * (2 + pglob->gl_pathc + pglob->gl_offs);
+  pathv = (char**)(pglob->gl_pathv ? realloc((char *)pglob->gl_pathv, newsize) :
+    malloc(newsize));
+  if (pathv == nullptr) {
+    if (pglob->gl_pathv) {
+      free(pglob->gl_pathv);
+      pglob->gl_pathv = nullptr;
+    }
+    return(GLOB_NOSPACE);
+  }
+
+  if (pglob->gl_pathv == nullptr && pglob->gl_offs > 0) {
+    /* first time around -- clear initial gl_offs items */
+    pathv += pglob->gl_offs;
+    for (i = pglob->gl_offs; --i >= 0; )
+      *--pathv = nullptr;
+  }
+  pglob->gl_pathv = pathv;
+
+  for (p = path; *p++;)
+    ;
+  len = (u_int)(p - path);
+  *limitp += len;
+  if ((copy = (char*)malloc(len)) != nullptr) {
+    if (g_Ctoc(path, copy, len)) {
+      free(copy);
+      return(GLOB_NOSPACE);
+    }
+    pathv[pglob->gl_offs + pglob->gl_pathc++] = copy;
+  }
+  pathv[pglob->gl_offs + pglob->gl_pathc] = nullptr;
+
+  if ((pglob->gl_flags & GLOB_LIMIT) &&
+    newsize + *limitp >= ARG_MAX) {
+    errno = 0;
+    return(GLOB_NOSPACE);
+  }
+
+  return(copy == nullptr ? GLOB_NOSPACE : 0);
+}
+
+
+/*
+* pattern matching function for filenames.  Each occurrence of the *
+* pattern causes a recursion level.
+*/
+static int
+match(register Char* name, register Char* pat, register Char* patend)
+{
+  int ok, negate_range;
+  Char c, k;
+
+  while (pat < patend) {
+    c = *pat++;
+    switch (c & M_MASK) {
+    case M_ALL:
+      if (pat == patend)
+        return(1);
+      do
+        if (match(name, pat, patend))
+        return(1);
+      while (*name++ != EOS)
+        ;
+      return(0);
+    case M_ONE:
+      if (*name++ == EOS)
+        return(0);
+      break;
+    case M_SET:
+      ok = 0;
+      if ((k = *name++) == EOS)
+        return(0);
+      if ((negate_range = ((*pat & M_MASK) == M_NOT)) != EOS)
+        ++pat;
+      while (((c = *pat++) & M_MASK) != M_END)
+        if ((*pat & M_MASK) == M_RNG) {
+          if (c <= k && k <= pat[1])
+            ok = 1;
+          pat += 2;
+        }
+        else if (c == k)
+          ok = 1;
+      if (ok == negate_range)
+        return(0);
+      break;
+    default:
+      if (*name++ != c)
+        return(0);
+      break;
+    }
+  }
+  return(*name == EOS);
+}
+
+/* Free allocated data belonging to a glob_t structure. */
+
+static int
+g_Ctoc(register const Char* str, char* buf, u_int len)
+{
+
+  while (len--) {
+    if ((*buf++ = (char)*str++) == EOS)
+      return (0);
+  }
+  return (1);
+}
+
+extern "C" int
+glob(const char* pattern, int flags, int(*errfunc)(const char *, int), glob_t* pglob)
+{
+  const u_char *patnext;
+  int c;
+  Char *bufnext, *bufend, patbuf[MAXPATHLEN];
+  /* Force skipping escape sequences on windows
+  * due to the ambiguity with path backslashes
+  */
+  flags |= GLOB_NOESCAPE;
+
+  patnext = (u_char *)pattern;
+  if (!(flags & GLOB_APPEND)) {
+    pglob->gl_pathc = 0;
+    pglob->gl_pathv = nullptr;
+    if (!(flags & GLOB_DOOFFS))
+      pglob->gl_offs = 0;
+  }
+  pglob->gl_flags = flags & ~GLOB_MAGCHAR;
+  pglob->gl_errfunc = errfunc;
+  pglob->gl_matchc = 0;
+
+  bufnext = patbuf;
+  bufend = bufnext + MAXPATHLEN - 1;
+  if (flags & GLOB_NOESCAPE)
+    while (bufnext < bufend && (c = *patnext++) != EOS)
+    *bufnext++ = c;
+  else {
+    /* Protect the quoted characters. */
+    while (bufnext < bufend && (c = *patnext++) != EOS)
+      if (c == QUOTE) {
+        if ((c = *patnext++) == EOS) {
+          c = QUOTE;
+          --patnext;
+        }
+        *bufnext++ = c | M_PROTECT;
+      }
+      else
+        *bufnext++ = c;
+  }
+  *bufnext = EOS;
+
+  if (flags & GLOB_BRACE)
+    return globexp1(patbuf, pglob);
+  else
+    return glob0(patbuf, pglob);
+}
+
+extern "C" void globfree(glob_t* pglob)
+{
+  register int i;
+  register char **pp;
+
+  if (pglob->gl_pathv != nullptr) {
+    pp = pglob->gl_pathv + pglob->gl_offs;
+    for (i = pglob->gl_pathc; i--; ++pp)
+      if (*pp)
+      free(*pp);
+    free(pglob->gl_pathv);
+    pglob->gl_pathv = nullptr;
+  }
+}

--- a/hphp/util/portability/glob.h
+++ b/hphp/util/portability/glob.h
@@ -1,0 +1,76 @@
+// Borrowed from PHP
+/*
+* Copyright (c) 1989, 1993
+*	The Regents of the University of California.  All rights reserved.
+*
+* This code is derived from software contributed to Berkeley by
+* Guido van Rossum.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions
+* are met:
+* 1. Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+* 2. Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in the
+*    documentation and/or other materials provided with the distribution.
+* 3. All advertising materials mentioning features or use of this software
+*    must display the following acknowledgement:
+*	This product includes software developed by the University of
+*	California, Berkeley and its contributors.
+* 4. Neither the name of the University nor the names of its contributors
+*    may be used to endorse or promote products derived from this software
+*    without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+* ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+* FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+* DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+* OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+* HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+* LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+* OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+* SUCH DAMAGE.
+*/
+#ifndef incl_HPHP_UTIL_PORTABILITY_GLOB_H_
+#define incl_HPHP_UTIL_PORTABILITY_GLOB_H_
+
+typedef struct {
+  int gl_pathc;		/* Count of total paths so far. */
+  int gl_matchc;		/* Count of paths matching pattern. */
+  int gl_offs;		/* Reserved at beginning of gl_pathv. */
+  int gl_flags;		/* Copy of flags parameter to glob. */
+  char **gl_pathv;	/* List of paths matching pattern. */
+                        /* Copy of errfunc parameter to glob. */
+  int(*gl_errfunc)(const char *, int);
+} glob_t;
+
+/* Flags */
+#define	GLOB_APPEND	0x0001	/* Append to output from previous call. */
+#define	GLOB_DOOFFS	0x0002	/* Use gl_offs. */
+#define	GLOB_ERR	0x0004	/* Return on error. */
+#define	GLOB_MARK	0x0008	/* Append / to matching directories. */
+#define	GLOB_NOCHECK	0x0010	/* Return pattern itself if nothing matches. */
+#define	GLOB_NOSORT	0x0020	/* Don't sort. */
+
+#define	GLOB_BRACE	0x0080	/* Expand braces ala csh. */
+#define	GLOB_MAGCHAR	0x0100	/* Pattern had globbing characters. */
+#define	GLOB_NOMAGIC	0x0200	/* GLOB_NOCHECK without magic chars (csh). */
+#define	GLOB_QUOTE	0x0400	/* Quote special chars with \. */
+#define	GLOB_TILDE	0x0800	/* Expand tilde names from the passwd file. */
+#define	GLOB_NOESCAPE	0x1000	/* Disable backslash escaping. */
+#define GLOB_LIMIT	0x2000	/* Limit pattern match output to ARG_MAX */
+
+/* Error values returned by glob(3) */
+#define	GLOB_NOSPACE	(-1)	/* Malloc call failed. */
+#define	GLOB_ABORTED	(-2)	/* Unignored error. */
+#define	GLOB_NOMATCH	(-3)	/* No match and GLOB_NOCHECK not set. */
+#define	GLOB_NOSYS	(-4)	/* Function not supported. */
+#define GLOB_ABEND	GLOB_ABORTED
+
+extern "C" int glob(const char*, int, int(*)(const char*, int), glob_t*);
+extern "C" void globfree(glob_t*);
+
+#endif

--- a/hphp/util/portability/rand_r.cpp
+++ b/hphp/util/portability/rand_r.cpp
@@ -1,0 +1,48 @@
+// Borrowed from PHP
+/*-
+* Copyright (c) 1990, 1993
+*	The Regents of the University of California.  All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions
+* are met:
+* 1. Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+* 2. Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in the
+*    documentation and/or other materials provided with the distribution.
+* 3. All advertising materials mentioning features or use of this software
+*    must display the following acknowledgement:
+*	This product includes software developed by the University of
+*	California, Berkeley and its contributors.
+* 4. Neither the name of the University nor the names of its contributors
+*    may be used to endorse or promote products derived from this software
+*    without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+* ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+* FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+* DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+* OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+* HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+* LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+* OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+* SUCH DAMAGE.
+*
+* Posix rand_r function added May 1999 by Wes Peters <wes@softweyr.com>.
+*/
+#include "hphp/util/portability/rand_r.h"
+
+#include <stdlib.h>
+#include <sys/types.h>
+
+#include <folly/CPortability.h>
+
+extern "C" int rand_r(unsigned int *ctx)
+{
+  u_long val = (u_long)*ctx;
+  *ctx = (int)((val = val * 1103515245 + 12345) % ((u_long)RAND_MAX + 1));
+  return (int)*ctx;
+}

--- a/hphp/util/portability/rand_r.h
+++ b/hphp/util/portability/rand_r.h
@@ -1,0 +1,41 @@
+// Borrowed from PHP
+/*-
+* Copyright (c) 1990, 1993
+*	The Regents of the University of California.  All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions
+* are met:
+* 1. Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+* 2. Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in the
+*    documentation and/or other materials provided with the distribution.
+* 3. All advertising materials mentioning features or use of this software
+*    must display the following acknowledgement:
+*	This product includes software developed by the University of
+*	California, Berkeley and its contributors.
+* 4. Neither the name of the University nor the names of its contributors
+*    may be used to endorse or promote products derived from this software
+*    without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+* ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+* FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+* DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+* OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+* HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+* LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+* OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+* SUCH DAMAGE.
+*
+* Posix rand_r function added May 1999 by Wes Peters <wes@softweyr.com>.
+*/
+#ifndef incl_HPHP_UTIL_PORTABILITY_RAND_R_H_
+#define incl_HPHP_UTIL_PORTABILITY_RAND_R_H_
+
+extern "C" int rand_r(unsigned int *ctx);
+
+#endif

--- a/hphp/util/portability/strptime.cpp
+++ b/hphp/util/portability/strptime.cpp
@@ -1,0 +1,573 @@
+// This file has been modified to extract it from it's original source,
+// and has been adjusted to fit in HHVM instead.
+// Locale-based date-time formatting has also been stripped due to
+// not wanting to deal with porting to MSVC.
+
+/*	$NetBSD: strptime.c,v 1.39 2015/04/06 14:38:22 ginsbach Exp $	*/
+
+/*-
+ * Copyright (c) 1997, 1998, 2005, 2008 The NetBSD Foundation, Inc.
+ * All rights reserved.
+ *
+ * This code was contributed to The NetBSD Foundation by Klaus Klein.
+ * Heavily optimised by David Laight
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE NETBSD FOUNDATION, INC. AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <ctype.h>
+#include <stdint.h>
+#include <string.h>
+#include <time.h>
+
+#include "hphp/util/locale-portability.h"
+#include <folly/CPortability.h>
+
+extern "C" {
+
+typedef unsigned char u_char;
+
+#define _TIME_LOCALE(loc) \
+    ((_TimeLocale *)((loc)->part_impl[(size_t)LC_TIME]))
+
+/*
+ * We do not implement alternate representations. However, we always
+ * check whether a given modifier is allowed for a certain conversion.
+ */
+#define ALT_E			0x01
+#define ALT_O			0x02
+#define	LEGAL_ALT(x)		{ if (alt_format & ~(x)) return NULL; }
+
+static char gmt[] = { "GMT" };
+static char utc[] = { "UTC" };
+/* RFC-822/RFC-2822 */
+static const char * const nast[5] = {
+       "EST",    "CST",    "MST",    "PST",    "\0\0\0"
+};
+static const char * const nadt[5] = {
+       "EDT",    "CDT",    "MDT",    "PDT",    "\0\0\0"
+};
+static char const day_name[][10] = {
+  "Sunday", "Monday", "Tuesday", "Wednesday",
+  "Thursday", "Friday", "Saturday"
+};
+static char const ab_day_name[][4] = {
+  "Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"
+};
+static char const mon_name[][10] = {
+  "January", "February", "March", "April", "May", "June",
+  "July", "August", "September", "October", "November", "December"
+};
+static char const ab_mon_name[][4] = {
+  "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+  "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"
+};
+
+static char const am_pm_name[][3] = { "AM", "PM" };
+
+static const u_char *conv_num(const unsigned char *, int *, uint32_t, uint32_t);
+static const u_char *find_string(const u_char *, int *, const char * const *,
+  const char * const *, int);
+
+char* strptime_l(const char* buf, const char* fmt, struct tm* tm, locale_t loc);
+
+char *
+strptime(const char *buf, const char *fmt, struct tm *tm)
+{
+  return strptime_l(buf, fmt, tm, _current_locale());
+}
+
+char *
+strptime_l(const char *buf, const char *fmt, struct tm *tm, locale_t loc)
+{
+  unsigned char c;
+  const unsigned char *bp, *ep;
+  int alt_format, i, split_year = 0, neg = 0, offs;
+  const char *new_fmt;
+
+  bp = (const u_char *)buf;
+
+  while (bp != NULL && (c = *fmt++) != '\0') {
+    /* Clear `alternate' modifier prior to new conversion. */
+    alt_format = 0;
+    i = 0;
+
+    /* Eat up white-space. */
+    if (isspace(c)) {
+      while (isspace(*bp))
+        bp++;
+      continue;
+    }
+
+    if (c != '%')
+      goto literal;
+
+
+  again:
+    switch (c = *fmt++) {
+      case '%':	/* "%%" is converted to "%". */
+        literal :
+          if (c != *bp++)
+          return NULL;
+        LEGAL_ALT(0);
+        continue;
+
+        /*
+         * "Alternative" modifiers. Just set the appropriate flag
+         * and start over again.
+         */
+      case 'E':	/* "%E?" alternative conversion modifier. */
+        LEGAL_ALT(0);
+        alt_format |= ALT_E;
+        goto again;
+
+      case 'O':	/* "%O?" alternative conversion modifier. */
+        LEGAL_ALT(0);
+        alt_format |= ALT_O;
+        goto again;
+
+        /*
+         * "Complex" conversion rules, implemented through recursion.
+         */
+      case 'c':	/* Date and time, using the locale's format. */
+        new_fmt = "%a %b %e %H:%M:%S %Y";
+        goto recurse;
+
+      case 'D':	/* The date as "%m/%d/%y". */
+        new_fmt = "%m/%d/%y";
+        LEGAL_ALT(0);
+        goto recurse;
+
+      case 'F':	/* The date as "%Y-%m-%d". */
+        new_fmt = "%Y-%m-%d";
+        LEGAL_ALT(0);
+        goto recurse;
+
+      case 'R':	/* The time as "%H:%M". */
+        new_fmt = "%H:%M";
+        LEGAL_ALT(0);
+        goto recurse;
+
+      case 'r':	/* The time in 12-hour clock representation. */
+        new_fmt = "%I:%M:%S %p";
+        LEGAL_ALT(0);
+        goto recurse;
+
+      case 'T':	/* The time as "%H:%M:%S". */
+        new_fmt = "%H:%M:%S";
+        LEGAL_ALT(0);
+        goto recurse;
+
+      case 'X':	/* The time, using the locale's format. */
+        new_fmt = "%H:%M:%S";
+        goto recurse;
+
+      case 'x':	/* The date, using the locale's format. */
+        new_fmt = "%m/%d/%y";
+      recurse:
+        bp = (const u_char *)strptime((const char *)bp,
+          new_fmt, tm);
+        LEGAL_ALT(ALT_E);
+        continue;
+
+        /*
+         * "Elementary" conversion rules.
+         */
+      case 'A':	/* The day of week, using the locale's form. */
+      case 'a':
+        bp = find_string(bp, &tm->tm_wday,
+          (char**)day_name, (char**)ab_day_name, 7);
+        LEGAL_ALT(0);
+        continue;
+
+      case 'B':	/* The month, using the locale's form. */
+      case 'b':
+      case 'h':
+        bp = find_string(bp, &tm->tm_mon,
+          (char**)mon_name, (char**)ab_mon_name,
+          12);
+        LEGAL_ALT(0);
+        continue;
+
+      case 'C':	/* The century number. */
+        i = 20;
+        bp = conv_num(bp, &i, 0, 99);
+        
+        i = i * 100 - TM_YEAR_BASE;
+        if (split_year)
+          i += tm->tm_year % 100;
+        split_year = 1;
+        tm->tm_year = i;
+        LEGAL_ALT(ALT_E);
+        continue;
+
+      case 'd':	/* The day of month. */
+      case 'e':
+        bp = conv_num(bp, &tm->tm_mday, 1, 31);
+        LEGAL_ALT(ALT_O);
+        continue;
+
+      case 'k':	/* The hour (24-hour clock representation). */
+        LEGAL_ALT(0);
+        /* FALLTHROUGH */
+      case 'H':
+        bp = conv_num(bp, &tm->tm_hour, 0, 23);
+        LEGAL_ALT(ALT_O);
+        continue;
+
+      case 'l':	/* The hour (12-hour clock representation). */
+        LEGAL_ALT(0);
+        /* FALLTHROUGH */
+      case 'I':
+        bp = conv_num(bp, &tm->tm_hour, 1, 12);
+        if (tm->tm_hour == 12)
+          tm->tm_hour = 0;
+        LEGAL_ALT(ALT_O);
+        continue;
+
+      case 'j':	/* The day of year. */
+        i = 1;
+        bp = conv_num(bp, &i, 1, 366);
+        tm->tm_yday = i - 1;
+        LEGAL_ALT(0);
+        continue;
+
+      case 'M':	/* The minute. */
+        bp = conv_num(bp, &tm->tm_min, 0, 59);
+        LEGAL_ALT(ALT_O);
+        continue;
+
+      case 'm':	/* The month. */
+        i = 1;
+        bp = conv_num(bp, &i, 1, 12);
+        tm->tm_mon = i - 1;
+        LEGAL_ALT(ALT_O);
+        continue;
+
+      case 'p':	/* The locale's equivalent of AM/PM. */
+        bp = find_string(bp, &i, (char**)am_pm_name,
+          NULL, 2);
+        if (tm->tm_hour > 11)
+          return NULL;
+        tm->tm_hour += i * 12;
+        LEGAL_ALT(0);
+        continue;
+
+      case 'S':	/* The seconds. */
+        bp = conv_num(bp, &tm->tm_sec, 0, 61);
+        LEGAL_ALT(ALT_O);
+        continue;
+
+    #ifndef TIME_MAX
+    #define TIME_MAX	INT64_MAX
+    #endif
+      case 's':	/* seconds since the epoch */
+      {
+        time_t sse = 0;
+        uint64_t rulim = TIME_MAX;
+
+        if (*bp < '0' || *bp > '9') {
+          bp = NULL;
+          continue;
+        }
+
+        do {
+          sse *= 10;
+          sse += *bp++ - '0';
+          rulim /= 10;
+        } while ((sse * 10 <= TIME_MAX) &&
+          rulim && *bp >= '0' && *bp <= '9');
+
+        if (sse < 0 || (uint64_t)sse > TIME_MAX) {
+          bp = NULL;
+          continue;
+        }
+
+        if (localtime_r(&sse, tm) == NULL)
+          bp = NULL;
+      }
+      continue;
+
+      case 'U':	/* The week of year, beginning on sunday. */
+      case 'W':	/* The week of year, beginning on monday. */
+              /*
+               * XXX This is bogus, as we can not assume any valid
+               * information present in the tm structure at this
+               * point to calculate a real value, so just check the
+               * range for now.
+               */
+        bp = conv_num(bp, &i, 0, 53);
+        LEGAL_ALT(ALT_O);
+        continue;
+
+      case 'w':	/* The day of week, beginning on sunday. */
+        bp = conv_num(bp, &tm->tm_wday, 0, 6);
+        LEGAL_ALT(ALT_O);
+        continue;
+
+      case 'u':	/* The day of week, monday = 1. */
+        bp = conv_num(bp, &i, 1, 7);
+        tm->tm_wday = i % 7;
+        LEGAL_ALT(ALT_O);
+        continue;
+
+      case 'g':	/* The year corresponding to the ISO week
+                       * number but without the century.
+                       */
+        bp = conv_num(bp, &i, 0, 99);
+        continue;
+
+      case 'G':	/* The year corresponding to the ISO week
+                       * number with century.
+                       */
+        do
+          bp++;
+        while (isdigit(*bp));
+        continue;
+
+      case 'V':	/* The ISO 8601:1988 week number as decimal */
+        bp = conv_num(bp, &i, 0, 53);
+        continue;
+
+      case 'Y':	/* The year. */
+        i = TM_YEAR_BASE;	/* just for data sanity... */
+        bp = conv_num(bp, &i, 0, 9999);
+        tm->tm_year = i - TM_YEAR_BASE;
+        LEGAL_ALT(ALT_E);
+        continue;
+
+      case 'y':	/* The year within 100 years of the epoch. */
+              /* LEGAL_ALT(ALT_E | ALT_O); */
+        bp = conv_num(bp, &i, 0, 99);
+
+        if (split_year)
+          /* preserve century */
+          i += (tm->tm_year / 100) * 100;
+        else {
+          split_year = 1;
+          if (i <= 68)
+            i = i + 2000 - TM_YEAR_BASE;
+          else
+            i = i + 1900 - TM_YEAR_BASE;
+        }
+        tm->tm_year = i;
+        continue;
+
+      case 'z':
+        /*
+         * We recognize all ISO 8601 formats:
+         * Z	= Zulu time/UTC
+         * [+-]hhmm
+         * [+-]hh:mm
+         * [+-]hh
+         * We recognize all RFC-822/RFC-2822 formats:
+         * UT|GMT
+         *          North American : UTC offsets
+         * E[DS]T = Eastern : -4 | -5
+         * C[DS]T = Central : -5 | -6
+         * M[DS]T = Mountain: -6 | -7
+         * P[DS]T = Pacific : -7 | -8
+         *          Military
+         * [A-IL-M] = -1 ... -9 (J not used)
+         * [N-Y]  = +1 ... +12
+         */
+        while (isspace(*bp))
+          bp++;
+
+        switch (*bp++) {
+        case 'G':
+          if (*bp++ != 'M')
+            return NULL;
+          /*FALLTHROUGH*/
+        case 'U':
+          if (*bp++ != 'T')
+            return NULL;
+          /*FALLTHROUGH*/
+        case 'Z':
+          tm->tm_isdst = 0;
+    #ifdef TM_GMTOFF
+          tm->TM_GMTOFF = 0;
+    #endif
+    #ifdef TM_ZONE
+          tm->TM_ZONE = utc;
+    #endif
+          continue;
+        case '+':
+          neg = 0;
+          break;
+        case '-':
+          neg = 1;
+          break;
+        default:
+          --bp;
+          ep = find_string(bp, &i, nast, NULL, 4);
+          if (ep != NULL) {
+    #ifdef TM_GMTOFF
+            tm->TM_GMTOFF = -5 - i;
+    #endif
+    #ifdef TM_ZONE
+            tm->TM_ZONE = __UNCONST(nast[i]);
+    #endif
+            bp = ep;
+            continue;
+          }
+          ep = find_string(bp, &i, nadt, NULL, 4);
+          if (ep != NULL) {
+            tm->tm_isdst = 1;
+    #ifdef TM_GMTOFF
+            tm->TM_GMTOFF = -4 - i;
+    #endif
+    #ifdef TM_ZONE
+            tm->TM_ZONE = __UNCONST(nadt[i]);
+    #endif
+            bp = ep;
+            continue;
+          }
+
+          if ((*bp >= 'A' && *bp <= 'I') ||
+            (*bp >= 'L' && *bp <= 'Y')) {
+    #ifdef TM_GMTOFF
+            /* Argh! No 'J'! */
+            if (*bp >= 'A' && *bp <= 'I')
+              tm->TM_GMTOFF =
+              ('A' - 1) - (int)*bp;
+            else if (*bp >= 'L' && *bp <= 'M')
+              tm->TM_GMTOFF = 'A' - (int)*bp;
+            else if (*bp >= 'N' && *bp <= 'Y')
+              tm->TM_GMTOFF = (int)*bp - 'M';
+    #endif
+    #ifdef TM_ZONE
+            tm->TM_ZONE = NULL; /* XXX */
+    #endif
+            bp++;
+            continue;
+          }
+          return NULL;
+        }
+        offs = 0;
+        for (i = 0; i < 4; ) {
+          if (isdigit(*bp)) {
+            offs = offs * 10 + (*bp++ - '0');
+            i++;
+            continue;
+          }
+          if (i == 2 && *bp == ':') {
+            bp++;
+            continue;
+          }
+          break;
+        }
+        switch (i) {
+        case 2:
+          offs *= 100;
+          break;
+        case 4:
+          i = offs % 100;
+          if (i >= 60)
+            return NULL;
+          /* Convert minutes into decimal */
+          offs = (offs / 100) * 100 + (i * 50) / 30;
+          break;
+        default:
+          return NULL;
+        }
+        if (neg)
+          offs = -offs;
+        tm->tm_isdst = 0;	/* XXX */
+    #ifdef TM_GMTOFF
+        tm->TM_GMTOFF = offs;
+    #endif
+    #ifdef TM_ZONE
+        tm->TM_ZONE = NULL;	/* XXX */
+    #endif
+        continue;
+
+        /*
+         * Miscellaneous conversions.
+         */
+      case 'n':	/* Any kind of white-space. */
+      case 't':
+        while (isspace(*bp))
+          bp++;
+        LEGAL_ALT(0);
+        continue;
+
+
+      default:	/* Unknown/unsupported conversion. */
+        return NULL;
+    }
+  }
+
+  return (char*)bp;
+}
+
+
+static const u_char *
+conv_num(const unsigned char *buf, int *dest, uint32_t llim, uint32_t ulim)
+{
+  uint32_t result = 0;
+  unsigned char ch;
+
+  /* The limit also determines the number of valid digits. */
+  uint32_t rulim = ulim;
+
+  ch = *buf;
+  if (ch < '0' || ch > '9')
+    return NULL;
+
+  do {
+    result *= 10;
+    result += ch - '0';
+    rulim /= 10;
+    ch = *++buf;
+  } while ((result * 10 <= ulim) && rulim && ch >= '0' && ch <= '9');
+
+  if (result < llim || result > ulim)
+    return NULL;
+
+  *dest = result;
+  return buf;
+}
+
+static const u_char *
+find_string(const u_char *bp, int *tgt, const char * const *n1,
+  const char * const *n2, int c)
+{
+  int i;
+  size_t len;
+
+  /* check full name - then abbreviated ones */
+  for (; n1 != NULL; n1 = n2, n2 = NULL) {
+    for (i = 0; i < c; i++, n1++) {
+      len = strlen(*n1);
+      if (strncasecmp(*n1, (const char *)bp, len) == 0) {
+        *tgt = i;
+        return bp + len;
+      }
+    }
+  }
+
+  /* Nothing matched */
+  return NULL;
+}
+
+};

--- a/hphp/util/portability/strptime.h
+++ b/hphp/util/portability/strptime.h
@@ -1,0 +1,26 @@
+/*
+   +----------------------------------------------------------------------+
+   | HipHop for PHP                                                       |
+   +----------------------------------------------------------------------+
+   | Copyright (c) 2010-2014 Facebook, Inc. (http://www.facebook.com)     |
+   +----------------------------------------------------------------------+
+   | This source file is subject to version 3.01 of the PHP license,      |
+   | that is bundled with this package in the file LICENSE, and is        |
+   | available through the world-wide-web at the following url:           |
+   | http://www.php.net/license/3_01.txt                                  |
+   | If you did not receive a copy of the PHP license and are unable to   |
+   | obtain it through the world-wide-web, please send a note to          |
+   | license@php.net so we can mail you a copy immediately.               |
+   +----------------------------------------------------------------------+
+*/
+#ifndef incl_HPHP_UTIL_PORTABILITY_STRPTIME_H_
+#define incl_HPHP_UTIL_PORTABILITY_STRPTIME_H_
+
+// These are implemented by strptime.cpp
+#include "hphp/util/locale-portability.h"
+extern "C" {
+  char* strptime_l(const char* buf, const char* fmt, struct tm* tm, locale_t loc);
+  char* strptime(const char* buf, const char* fmt, struct tm* tm);
+}
+
+#endif


### PR DESCRIPTION
This supersedes #5638 (D41601) and #5634 (D41577).
This puts them all in `utils/portability`.