### PR TITLE
Raise E_WARNING error if the constant is not defined.

### DIFF
--- a/hphp/runtime/ext/std/ext_std_misc.cpp
+++ b/hphp/runtime/ext/std/ext_std_misc.cpp
@@ -251,12 +251,12 @@ Variant HHVM_FUNCTION(constant, const String& name) {
         return cellAsCVarRef(cns);
       }
     }
-    raise_warning("Couldn't find constant %s", data);
   } else {
     auto const cns = Unit::loadCns(name.get());
     if (cns) return tvAsCVarRef(cns);
   }
 
+  raise_warning("constant(): Couldn't find constant %s", data);
   return init_null();
 }
 

--- a/hphp/test/quick/constants-SID.php.expectf
+++ b/hphp/test/quick/constants-SID.php.expectf
@@ -7,6 +7,8 @@ bool(true)
 NULL
 --SID--
 bool(false)
+
+Warning: constant(): Couldn't find constant SID in %s/test/quick/constants-SID.php on line 7
 NULL
 null: NULL
 NULL: NULL

--- a/hphp/test/slow/constant_function/5566.php
+++ b/hphp/test/slow/constant_function/5566.php
@@ -1,0 +1,4 @@
+<?php
+
+constant('TEST_CONSTANT_3');
+

--- a/hphp/test/slow/constant_function/5566.php.expectf
+++ b/hphp/test/slow/constant_function/5566.php.expectf
@@ -1,0 +1,2 @@
+
+Warning: constant(): Couldn't find constant TEST_CONSTANT_3 in %s/test/slow/constant_function/5566.php on line 3

--- a/hphp/test/slow/ext_misc/ext_misc.php.expect
+++ b/hphp/test/slow/ext_misc/ext_misc.php.expect
@@ -1,4 +1,0 @@
-bool(true)
-bool(true)
-bool(true)
-bool(true)

--- a/hphp/test/slow/ext_misc/ext_misc.php.expectf
+++ b/hphp/test/slow/ext_misc/ext_misc.php.expectf
@@ -1,0 +1,6 @@
+bool(true)
+bool(true)
+bool(true)
+
+Warning: constant(): Couldn't find constant a in %s/test/slow/ext_misc/ext_misc.php on line 16
+bool(true)

--- a/hphp/test/slow/namespace/dynamic_extra_slash_cns.php.expectf
+++ b/hphp/test/slow/namespace/dynamic_extra_slash_cns.php.expectf
@@ -1,1 +1,2 @@
+Warning: constant(): Couldn't find constant \\A\B in %s/test/slow/namespace/dynamic_extra_slash_cns.php on line 10
 NULL

--- a/hphp/test/slow/volatile/1233.php.expectf
+++ b/hphp/test/slow/volatile/1233.php.expectf
@@ -9,6 +9,8 @@ bool(false)
 bool(false)
 string(8) "constant"
 string(3) "foo"
+
+Warning: constant(): Couldn't find constant foo in %s/test/slow/volatile/1233.php on line 19
 NULL
 string(8) "constant"
 string(3) "bar"


### PR DESCRIPTION
Fix #5566.