### PR TITLE
Remove some verbose logs from filesystem extension

### DIFF
--- a/hphp/runtime/ext/std/ext_std_file.cpp
+++ b/hphp/runtime/ext/std/ext_std_file.cpp
@@ -967,7 +967,7 @@ bool HHVM_FUNCTION(is_writable,
   if (filename.empty()) {
     return false;
   }
-  return accessSyscall(filename, W_OK) == 0;
+  return accessSyscall(filename, W_OK);
 }
 
 bool HHVM_FUNCTION(is_writeable,
@@ -982,7 +982,7 @@ bool HHVM_FUNCTION(is_readable,
   if (filename.empty()) {
     return false;
   }
-  return accessSyscall(filename, R_OK, true) == 0;
+  return accessSyscall(filename, R_OK, true);
 }
 
 bool HHVM_FUNCTION(is_executable,
@@ -991,7 +991,7 @@ bool HHVM_FUNCTION(is_executable,
   if (filename.empty()) {
     return false;
   }
-  return accessSyscall(filename, X_OK) == 0;
+  return accessSyscall(filename, X_OK);
 }
 
 static VFileType lookupVirtualFile(const String& filename) {
@@ -1028,9 +1028,9 @@ bool HHVM_FUNCTION(is_file,
 
   struct stat sb;
   if (statSyscall(filename, &sb, true)) {
-    return false;
-  } else {
     return (sb.st_mode & S_IFMT) == S_IFREG;
+  } else {
+    return false;
   }
 }
 
@@ -1047,9 +1047,9 @@ bool HHVM_FUNCTION(is_dir,
 
   struct stat sb;
   if (statSyscall(filename, &sb, false)) {
-    return false;
-  } else {
     return (sb.st_mode & S_IFMT) == S_IFDIR;
+  } else {
+    return false;
   }
 }
 
@@ -1058,9 +1058,9 @@ bool HHVM_FUNCTION(is_link,
   CHECK_PATH_FALSE(filename, 1);
   struct stat sb;
   if (lstatSyscall(filename, &sb)) {
-    return false;
-  } else {
     return (sb.st_mode & S_IFMT) == S_IFLNK;
+  } else {
+    return false;
   }
 }
 
@@ -1540,7 +1540,7 @@ bool HHVM_FUNCTION(unlink,
   CHECK_PATH_FALSE(filename, 1);
   Stream::Wrapper* w = Stream::getWrapperFromURI(filename);
   if (!w) return false;
-  return w->unlink(filename) == 0;
+  return w->unlink(filename);
 }
 
 bool HHVM_FUNCTION(link,
@@ -1748,7 +1748,7 @@ bool HHVM_FUNCTION(mkdir,
   Stream::Wrapper* w = Stream::getWrapperFromURI(pathname);
   if (!w) return false;
   int options = recursive ? k_STREAM_MKDIR_RECURSIVE : 0;
-  return w->mkdir(pathname, mode, options) == 0;
+  return w->mkdir(pathname, mode, options);
 }
 
 bool HHVM_FUNCTION(rmdir,
@@ -1757,7 +1757,7 @@ bool HHVM_FUNCTION(rmdir,
   Stream::Wrapper* w = Stream::getWrapperFromURI(dirname);
   if (!w) return false;
   int options = 0;
-  return w->rmdir(dirname, options) == 0;
+  return w->rmdir(dirname, options);
 }
 
 String HHVM_FUNCTION(dirname,

--- a/hphp/runtime/ext/std/ext_std_file.cpp
+++ b/hphp/runtime/ext/std/ext_std_file.cpp
@@ -982,28 +982,6 @@ bool HHVM_FUNCTION(is_writable,
   }
   CHECK_SYSTEM_SILENT(accessSyscall(filename, W_OK));
   return true;
-  /*
-  int mask = S_IWOTH;
-  if (sb.st_uid == getuid()) {
-    mask = S_IWUSR;
-  } else if (sb.st_gid == getgid()) {
-    mask = S_IWGRP;
-  } else {
-    int groups = getgroups(0, NULL);
-    if (groups > 0) {
-      gid_t *gids = (gid_t *)malloc(groups * sizeof(gid_t));
-      int n = getgroups(groups, gids);
-      for (int i = 0; i < n; i++) {
-        if (sb.st_gid == gids[i]) {
-          mask = S_IWGRP;
-          break;
-        }
-      }
-      free(gids);
-    }
-  }
-  return sb.st_mode & mask;
-  */
 }
 
 bool HHVM_FUNCTION(is_writeable,
@@ -1020,28 +998,6 @@ bool HHVM_FUNCTION(is_readable,
   }
   CHECK_SYSTEM_SILENT(accessSyscall(filename, R_OK, true));
   return true;
-  /*
-  int mask = S_IROTH;
-  if (sb.st_uid == getuid()) {
-    mask = S_IRUSR;
-  } else if (sb.st_gid == getgid()) {
-    mask = S_IRGRP;
-  } else {
-    int groups = getgroups(0, NULL);
-    if (groups > 0) {
-      gid_t *gids = (gid_t *)malloc(groups * sizeof(gid_t));
-      int n = getgroups(groups, gids);
-      for (int i = 0; i < n; i++) {
-        if (sb.st_gid == gids[i]) {
-          mask = S_IRGRP;
-          break;
-        }
-      }
-      free(gids);
-    }
-  }
-  return sb.st_mode & mask;
-  */
 }
 
 bool HHVM_FUNCTION(is_executable,
@@ -1052,28 +1008,6 @@ bool HHVM_FUNCTION(is_executable,
   }
   CHECK_SYSTEM_SILENT(accessSyscall(filename, X_OK));
   return true;
-  /*
-  int mask = S_IXOTH;
-  if (sb.st_uid == getuid()) {
-    mask = S_IXUSR;
-  } else if (sb.st_gid == getgid()) {
-    mask = S_IXGRP;
-  } else {
-    int groups = getgroups(0, NULL);
-    if (groups > 0) {
-      gid_t *gids = (gid_t *)malloc(groups * sizeof(gid_t));
-      int n = getgroups(groups, gids);
-      for (int i = 0; i < n; i++) {
-        if (sb.st_gid == gids[i]) {
-          mask = S_IXGRP;
-          break;
-        }
-      }
-      free(gids);
-    }
-  }
-  return (sb.st_mode & mask) && (sb.st_mode & S_IFMT) != S_IFDIR;
-  */
 }
 
 static VFileType lookupVirtualFile(const String& filename) {

--- a/hphp/runtime/ext/std/ext_std_file.cpp
+++ b/hphp/runtime/ext/std/ext_std_file.cpp
@@ -110,10 +110,11 @@
     std::string msg = folly::errnoStr(errno).c_str();     \
     auto const ee = ExtendedException(msg);               \
     auto fileAndLine = ee.getFileAndLine();               \
-    std::string prefix = __FUNCTION__;                    \
-    prefix += ": ";                                       \
-    Logger::Log(Logger::LogVerbose, prefix.data(), ee,    \
-        fileAndLine.first.c_str(), fileAndLine.second);   \
+    std::ostringstream os;                                \
+    os <<__FUNCTION__ <<": " <<msg                        \
+      <<" in " <<fileAndLine.first.c_str()                \
+      <<" on line " <<fileAndLine.second;                 \
+    Logger::Verbose(os.str());                            \
     return false;                                         \
   }                                                       \
 

--- a/hphp/runtime/ext/std/ext_std_file.cpp
+++ b/hphp/runtime/ext/std/ext_std_file.cpp
@@ -967,7 +967,7 @@ bool HHVM_FUNCTION(is_writable,
   if (filename.empty()) {
     return false;
   }
-  return accessSyscall(filename, W_OK);
+  return accessSyscall(filename, W_OK) == 0;
 }
 
 bool HHVM_FUNCTION(is_writeable,
@@ -982,7 +982,7 @@ bool HHVM_FUNCTION(is_readable,
   if (filename.empty()) {
     return false;
   }
-  return accessSyscall(filename, R_OK, true);
+  return accessSyscall(filename, R_OK, true) == 0;
 }
 
 bool HHVM_FUNCTION(is_executable,
@@ -991,7 +991,7 @@ bool HHVM_FUNCTION(is_executable,
   if (filename.empty()) {
     return false;
   }
-  return accessSyscall(filename, X_OK);
+  return accessSyscall(filename, X_OK) == 0;
 }
 
 static VFileType lookupVirtualFile(const String& filename) {
@@ -1028,9 +1028,9 @@ bool HHVM_FUNCTION(is_file,
 
   struct stat sb;
   if (statSyscall(filename, &sb, true)) {
-    return (sb.st_mode & S_IFMT) == S_IFREG;
-  } else {
     return false;
+  } else {
+    return (sb.st_mode & S_IFMT) == S_IFREG;
   }
 }
 
@@ -1047,9 +1047,9 @@ bool HHVM_FUNCTION(is_dir,
 
   struct stat sb;
   if (statSyscall(filename, &sb, false)) {
-    return (sb.st_mode & S_IFMT) == S_IFDIR;
-  } else {
     return false;
+  } else {
+    return (sb.st_mode & S_IFMT) == S_IFDIR;
   }
 }
 
@@ -1058,9 +1058,9 @@ bool HHVM_FUNCTION(is_link,
   CHECK_PATH_FALSE(filename, 1);
   struct stat sb;
   if (lstatSyscall(filename, &sb)) {
-    return (sb.st_mode & S_IFMT) == S_IFLNK;
-  } else {
     return false;
+  } else {
+    return (sb.st_mode & S_IFMT) == S_IFLNK;
   }
 }
 
@@ -1540,7 +1540,7 @@ bool HHVM_FUNCTION(unlink,
   CHECK_PATH_FALSE(filename, 1);
   Stream::Wrapper* w = Stream::getWrapperFromURI(filename);
   if (!w) return false;
-  return w->unlink(filename);
+  return w->unlink(filename) == 0;
 }
 
 bool HHVM_FUNCTION(link,
@@ -1748,7 +1748,7 @@ bool HHVM_FUNCTION(mkdir,
   Stream::Wrapper* w = Stream::getWrapperFromURI(pathname);
   if (!w) return false;
   int options = recursive ? k_STREAM_MKDIR_RECURSIVE : 0;
-  return w->mkdir(pathname, mode, options);
+  return w->mkdir(pathname, mode, options) == 0;
 }
 
 bool HHVM_FUNCTION(rmdir,
@@ -1757,7 +1757,7 @@ bool HHVM_FUNCTION(rmdir,
   Stream::Wrapper* w = Stream::getWrapperFromURI(dirname);
   if (!w) return false;
   int options = 0;
-  return w->rmdir(dirname, options);
+  return w->rmdir(dirname, options) == 0;
 }
 
 String HHVM_FUNCTION(dirname,

--- a/hphp/runtime/ext/std/ext_std_file.cpp
+++ b/hphp/runtime/ext/std/ext_std_file.cpp
@@ -107,8 +107,13 @@
 
 #define CHECK_SYSTEM_SILENT(exp)                          \
   if ((exp) != 0) {                                       \
-    Logger::Verbose("%s/%d: %s", __FUNCTION__, __LINE__,  \
-                    folly::errnoStr(errno).c_str());      \
+    std::string msg = folly::errnoStr(errno).c_str();     \
+    auto const ee = ExtendedException(msg);               \
+    auto fileAndLine = ee.getFileAndLine();               \
+    std::string prefix = __FUNCTION__;                    \
+    prefix += ": ";                                       \
+    Logger::Log(Logger::LogVerbose, prefix.data(), ee,    \
+        fileAndLine.first.c_str(), fileAndLine.second);   \
     return false;                                         \
   }                                                       \
 

--- a/hphp/runtime/ext/std/ext_std_file.cpp
+++ b/hphp/runtime/ext/std/ext_std_file.cpp
@@ -105,13 +105,6 @@
     return false;                                         \
   }                                                       \
 
-#define CHECK_SYSTEM_SILENT(exp)                          \
-  if ((exp) != 0) {                                       \
-    Logger::Verbose("%s/%d: %s", __FUNCTION__, __LINE__,  \
-                    folly::errnoStr(errno).c_str());      \
-    return false;                                         \
-  }                                                       \
-
 // libxml/xpathInternals.h defines CHECK_ERROR,
 // we need to undef it first
 #ifdef CHECK_ERROR
@@ -974,30 +967,7 @@ bool HHVM_FUNCTION(is_writable,
   if (filename.empty()) {
     return false;
   }
-  CHECK_SYSTEM_SILENT(accessSyscall(filename, W_OK));
-  return true;
-  /*
-  int mask = S_IWOTH;
-  if (sb.st_uid == getuid()) {
-    mask = S_IWUSR;
-  } else if (sb.st_gid == getgid()) {
-    mask = S_IWGRP;
-  } else {
-    int groups = getgroups(0, NULL);
-    if (groups > 0) {
-      gid_t *gids = (gid_t *)malloc(groups * sizeof(gid_t));
-      int n = getgroups(groups, gids);
-      for (int i = 0; i < n; i++) {
-        if (sb.st_gid == gids[i]) {
-          mask = S_IWGRP;
-          break;
-        }
-      }
-      free(gids);
-    }
-  }
-  return sb.st_mode & mask;
-  */
+  return accessSyscall(filename, W_OK);
 }
 
 bool HHVM_FUNCTION(is_writeable,
@@ -1012,30 +982,7 @@ bool HHVM_FUNCTION(is_readable,
   if (filename.empty()) {
     return false;
   }
-  CHECK_SYSTEM_SILENT(accessSyscall(filename, R_OK, true));
-  return true;
-  /*
-  int mask = S_IROTH;
-  if (sb.st_uid == getuid()) {
-    mask = S_IRUSR;
-  } else if (sb.st_gid == getgid()) {
-    mask = S_IRGRP;
-  } else {
-    int groups = getgroups(0, NULL);
-    if (groups > 0) {
-      gid_t *gids = (gid_t *)malloc(groups * sizeof(gid_t));
-      int n = getgroups(groups, gids);
-      for (int i = 0; i < n; i++) {
-        if (sb.st_gid == gids[i]) {
-          mask = S_IRGRP;
-          break;
-        }
-      }
-      free(gids);
-    }
-  }
-  return sb.st_mode & mask;
-  */
+  return accessSyscall(filename, R_OK, true);
 }
 
 bool HHVM_FUNCTION(is_executable,
@@ -1044,30 +991,7 @@ bool HHVM_FUNCTION(is_executable,
   if (filename.empty()) {
     return false;
   }
-  CHECK_SYSTEM_SILENT(accessSyscall(filename, X_OK));
-  return true;
-  /*
-  int mask = S_IXOTH;
-  if (sb.st_uid == getuid()) {
-    mask = S_IXUSR;
-  } else if (sb.st_gid == getgid()) {
-    mask = S_IXGRP;
-  } else {
-    int groups = getgroups(0, NULL);
-    if (groups > 0) {
-      gid_t *gids = (gid_t *)malloc(groups * sizeof(gid_t));
-      int n = getgroups(groups, gids);
-      for (int i = 0; i < n; i++) {
-        if (sb.st_gid == gids[i]) {
-          mask = S_IXGRP;
-          break;
-        }
-      }
-      free(gids);
-    }
-  }
-  return (sb.st_mode & mask) && (sb.st_mode & S_IFMT) != S_IFDIR;
-  */
+  return accessSyscall(filename, X_OK);
 }
 
 static VFileType lookupVirtualFile(const String& filename) {
@@ -1103,8 +1027,11 @@ bool HHVM_FUNCTION(is_file,
   }
 
   struct stat sb;
-  CHECK_SYSTEM_SILENT(statSyscall(filename, &sb, true));
-  return (sb.st_mode & S_IFMT) == S_IFREG;
+  if (statSyscall(filename, &sb, true)) {
+    return (sb.st_mode & S_IFMT) == S_IFREG;
+  } else {
+    return false;
+  }
 }
 
 bool HHVM_FUNCTION(is_dir,
@@ -1119,16 +1046,22 @@ bool HHVM_FUNCTION(is_dir,
   }
 
   struct stat sb;
-  CHECK_SYSTEM_SILENT(statSyscall(filename, &sb, false));
-  return (sb.st_mode & S_IFMT) == S_IFDIR;
+  if (statSyscall(filename, &sb, false)) {
+    return (sb.st_mode & S_IFMT) == S_IFDIR;
+  } else {
+    return false;
+  }
 }
 
 bool HHVM_FUNCTION(is_link,
                    const String& filename) {
   CHECK_PATH_FALSE(filename, 1);
   struct stat sb;
-  CHECK_SYSTEM_SILENT(lstatSyscall(filename, &sb));
-  return (sb.st_mode & S_IFMT) == S_IFLNK;
+  if (lstatSyscall(filename, &sb)) {
+    return (sb.st_mode & S_IFMT) == S_IFLNK;
+  } else {
+    return false;
+  }
 }
 
 bool HHVM_FUNCTION(is_uploaded_file,
@@ -1607,8 +1540,7 @@ bool HHVM_FUNCTION(unlink,
   CHECK_PATH_FALSE(filename, 1);
   Stream::Wrapper* w = Stream::getWrapperFromURI(filename);
   if (!w) return false;
-  CHECK_SYSTEM_SILENT(w->unlink(filename));
-  return true;
+  return w->unlink(filename);
 }
 
 bool HHVM_FUNCTION(link,
@@ -1816,8 +1748,7 @@ bool HHVM_FUNCTION(mkdir,
   Stream::Wrapper* w = Stream::getWrapperFromURI(pathname);
   if (!w) return false;
   int options = recursive ? k_STREAM_MKDIR_RECURSIVE : 0;
-  CHECK_SYSTEM_SILENT(w->mkdir(pathname, mode, options));
-  return true;
+  return w->mkdir(pathname, mode, options);
 }
 
 bool HHVM_FUNCTION(rmdir,
@@ -1826,8 +1757,7 @@ bool HHVM_FUNCTION(rmdir,
   Stream::Wrapper* w = Stream::getWrapperFromURI(dirname);
   if (!w) return false;
   int options = 0;
-  CHECK_SYSTEM_SILENT(w->rmdir(dirname, options));
-  return true;
+  return w->rmdir(dirname, options);
 }
 
 String HHVM_FUNCTION(dirname,

--- a/hphp/runtime/ext/std/ext_std_file.cpp
+++ b/hphp/runtime/ext/std/ext_std_file.cpp
@@ -111,9 +111,9 @@
     auto const ee = ExtendedException(msg);               \
     auto fileAndLine = ee.getFileAndLine();               \
     std::ostringstream os;                                \
-    os <<__FUNCTION__ <<": " <<msg                        \
-      <<" in " <<fileAndLine.first.c_str()                \
-      <<" on line " <<fileAndLine.second;                 \
+    os << __FUNCTION__ << ": " << msg                     \
+      << " in " << fileAndLine.first.c_str()              \
+      << " on line " << fileAndLine.second;               \
     Logger::Verbose(os.str());                            \
     return false;                                         \
   }                                                       \


### PR DESCRIPTION
Remove some verbose logs from filesystem extension
A couple of functions are throwing some ugly errors (e.g. when the file
does not exist). This is a small incompatibility with PHP, as those functions
are not supposed to log those kind of errors, so I removed them.
I also removed some commented code which has been dead for a long time.

No test added/modified (seems that this extension is barely covered with tests).

I would like this pull request to be on behalf my employer (Tuenti). We already sign the corporate CLA for that.