### PR TITLE
Remove usage of SIGUSR1 and SIGALRM on Windows.

### DIFF
--- a/hphp/hack/src/Makefile
+++ b/hphp/hack/src/Makefile
@@ -67,6 +67,7 @@ NATIVE_OBJECT_FILES=\
   utils/get_build_id.o\
   utils/nproc.o\
   utils/realpath.o\
+  utils/handle_stubs.o\
   $(INOTIFY)/$(notdir $(INOTIFY))_stubs.o
 
 OCAML_LIBRARIES=\

--- a/hphp/hack/src/build.ocp
+++ b/hphp/hack/src/build.ocp
@@ -101,7 +101,7 @@ begin library "hh-utils-common"
     "utils/get_build_id.c"
     "utils/nproc.c"
     "utils/realpath.c"
-    "utils/hh_json.ml"
+    "utils/handle_stubs.c"
     "utils/ident.ml"
     "utils/utils.ml"
     "utils/sys_utils.ml"
@@ -112,6 +112,7 @@ begin library "hh-utils-common"
     "utils/lint.ml"
     "utils/config_file.ml"
     "utils/tail.ml"
+    "utils/handle.ml"
   ]
 end
 

--- a/hphp/hack/src/client/clientStart.ml
+++ b/hphp/hack/src/client/clientStart.ml
@@ -11,10 +11,13 @@
 module CCS = ClientConnectSimple
 
 let get_hhserver () =
-  let server_next_to_client = (Filename.dirname Sys.argv.(0)) ^ "/hh_server" in
+  let exe_name =
+    if Sys.win32 then "hh_server.exe" else "hh_server" in
+  let server_next_to_client =
+    Path.(to_string @@ concat (dirname executable_name) exe_name) in
   if Sys.file_exists server_next_to_client
   then server_next_to_client
-  else "hh_server"
+  else exe_name
 
 type env = {
   root: Path.t;
@@ -23,40 +26,42 @@ type env = {
 }
 
 let start_server env =
-  let hh_server = Printf.sprintf "%s -d %s %s --waiting-client %d"
-    (Filename.quote (get_hhserver ()))
-    (Filename.quote (Path.to_string env.root))
-    (if env.no_load then "--no-load" else "")
-    (Unix.getpid ())
-  in
-  Printf.eprintf "Server launched with the following command:\n\t%s\n%!"
-    hh_server;
 
-  (* Start up the hh_server, and wait on SIGUSR1, which is sent to us at various
-   * stages of the start up process. See if we're in the state we want to be in;
-   * if not, go to sleep again. *)
-  let old_mask = Unix.sigprocmask Unix.SIG_BLOCK [Sys.sigusr1] in
-  (* Have to actually handle and discard the signal -- if it's ignored, it won't
-   * break the sigsuspend. *)
-  let old_handle = Sys.signal Sys.sigusr1 (Sys.Signal_handle (fun _ -> ())) in
+  (* Create a pipe for synchronization with the server: we will wait
+     until the server finishes its initialisation phase. *)
+  let in_fd, out_fd = Unix.pipe () in
+  let ic = Unix.in_channel_of_descr in_fd in
+
+  let hh_server = get_hhserver () in
+  let hh_server_args =
+    Array.concat [
+      [|hh_server; "-d"; Path.to_string env.root|];
+      if env.no_load then [| "--no-load" |] else [||];
+      [| "--waiting-client"; string_of_int (Handle.get_handle out_fd) |]
+    ] in
+  Printf.eprintf "Server launched with the following command:\n\t%s\n%!"
+    (String.concat " "
+       (Array.to_list (Array.map Filename.quote hh_server_args)));
 
   let rec wait_loop () =
-    Unix.sigsuspend old_mask;
-    (* NB: SIGUSR1 is now blocked again. *)
-    if env.wait && not (Lock.check (ServerFiles.init_file env.root)) then
-      wait_loop ()
-    else
-      ()
-  in
+    let msg = input_line ic in
+    if env.wait && msg <> "ready" then wait_loop () in
 
-  (match Unix.system hh_server with
-    | Unix.WEXITED 0 -> ()
-    | _ -> Printf.fprintf stderr "Could not start hh_server!\n"; exit 77);
-  wait_loop ();
+  try
+    let server_pid =
+      Unix.(create_process hh_server hh_server_args stdin stdout stderr) in
 
-  let _ = Sys.signal Sys.sigusr1 old_handle in
-  let _ = Unix.sigprocmask Unix.SIG_SETMASK old_mask in
-  ()
+    match Unix.waitpid [] server_pid with
+    | _, Unix.WEXITED 0 ->
+        wait_loop ();
+        close_in ic
+    | _ ->
+        Printf.fprintf stderr "Could not start hh_server!\n";
+        exit 77
+  with _ ->
+    Printf.fprintf stderr "Could not start hh_server!\n";
+    exit 77
+
 
 let should_start env =
   let root_s = Path.to_string env.root in

--- a/hphp/hack/src/hh_client.ml
+++ b/hphp/hack/src/hh_client.ml
@@ -43,8 +43,7 @@ let () =
    * detect and handle better than a signal). Ignore SIGUSR1 since we sometimes
    * use that for the server to tell us when it's done initializing, but if we
    * aren't explicitly listening we don't care. *)
-  Sys.set_signal Sys.sigpipe Sys.Signal_ignore;
-  Sys.set_signal Sys.sigusr1 Sys.Signal_ignore;
+  if not Sys.win32 then Sys.set_signal Sys.sigpipe Sys.Signal_ignore;
   let command = ClientArgs.parse_args () in
   let log_cmd = ClientLogCommandUtils.log_command_of_command command in
   HackEventLogger.client_startup log_cmd;

--- a/hphp/hack/src/server/serverArgs.ml
+++ b/hphp/hack/src/server/serverArgs.ml
@@ -21,7 +21,7 @@ type options = {
   convert          : Path.t option;
   no_load          : bool;
   save_filename    : string option;
-  waiting_client   : int option;
+  waiting_client   : out_channel option;
 }
 
 (*****************************************************************************)
@@ -45,8 +45,8 @@ module Messages = struct
   let convert       = " adds type annotations automatically"
   let save          = " save server state to file"
   let no_load       = " don't load from a saved state"
-  let waiting_client= " kill pid with SIGUSR1 when server has begun starting"^
-                      " and again when it's done starting"
+  let waiting_client= " send message to fd/handle when server has begun \
+                      \ starting and again when it's done starting"
 end
 
 (*****************************************************************************)
@@ -78,7 +78,8 @@ let parse_options () =
   let waiting_client= ref None in
   let cdir          = fun s -> convert_dir := Some s in
   let set_save      = fun s -> save := Some s in
-  let set_wait      = fun pid -> waiting_client := Some pid in
+  let set_wait      = fun fd ->
+    waiting_client := Some (Handle.to_out_channel fd) in
   let options =
     ["--debug"         , Arg.Set debug         , Messages.debug;
      "--ai"            , Arg.Set ai_mode       , Messages.ai;

--- a/hphp/hack/src/server/serverArgs.mli
+++ b/hphp/hack/src/server/serverArgs.mli
@@ -21,7 +21,7 @@ type options = {
   convert          : Path.t option;
   no_load          : bool;
   save_filename    : string option;
-  waiting_client   : int option;
+  waiting_client   : out_channel option;
 }
 
 val parse_options: unit -> options
@@ -39,4 +39,4 @@ val should_detach       : options -> bool
 val convert             : options -> Path.t option
 val no_load             : options -> bool
 val save_filename       : options -> string option
-val waiting_client      : options -> int option
+val waiting_client      : options -> out_channel option

--- a/hphp/hack/src/server/serverMain.ml
+++ b/hphp/hack/src/server/serverMain.ml
@@ -34,22 +34,26 @@ end = struct
   let release_init_lock root =
     ignore(Lock.release (ServerFiles.init_file root))
 
+  let wakeup_client ?(close = false) options msg =
+    match ServerArgs.waiting_client options with
+    | None -> ()
+    | Some oc ->
+        output_string oc (msg ^ "\n");
+        if close then close_out oc else flush oc
+
   (* This code is only executed when the options --check is NOT present *)
   let go options init_fun =
     let root = ServerArgs.root options in
-    let send_signal () = match ServerArgs.waiting_client options with
-      | None -> ()
-      | Some pid -> (try Unix.kill pid Sys.sigusr1 with _ -> ()) in
     let t = Unix.gettimeofday () in
     Hh_logger.log "Initializing Server (This might take some time)";
     grab_init_lock root;
-    send_signal ();
+    wakeup_client options "starting";
     (* note: we only run periodical tasks on the root, not extras *)
     ServerPeriodical.init root;
     let env = init_fun () in
     release_init_lock root;
     Hh_logger.log "Server is READY";
-    send_signal ();
+    wakeup_client ~close:true options "ready";
     let t' = Unix.gettimeofday () in
     Hh_logger.log "Took %f seconds to initialize." (t' -. t);
     env
@@ -103,9 +107,9 @@ module Program : SERVER_PROGRAM =
       (* Force hhi files to be extracted and their location saved before workers
        * fork, so everyone can know about the same hhi path. *)
       ignore (Hhi.get_hhi_root());
-      ignore (
-          Sys.signal Sys.sigusr1 (Sys.Signal_handle Typing.debug_print_last_pos)
-        )
+      if not Sys.win32 then
+        ignore @@
+        Sys.signal Sys.sigusr1 (Sys.Signal_handle Typing.debug_print_last_pos)
 
     let make_next_files dir =
       let php_next_files = Find.make_next_files FindUtils.is_php dir in
@@ -420,7 +424,7 @@ let main options config =
   (* this is to transform SIGPIPE in an exception. A SIGPIPE can happen when
    * someone C-c the client.
    *)
-  Sys.set_signal Sys.sigpipe Sys.Signal_ignore;
+  if not Sys.win32 then Sys.set_signal Sys.sigpipe Sys.Signal_ignore;
   PidLog.init (ServerFiles.pids_file root);
   PidLog.log ~reason:"main" (Unix.getpid());
   let watch_paths = root :: Program.get_watch_paths options in

--- a/hphp/hack/src/typing/typing_suggest_service.ml
+++ b/hphp/hack/src/typing/typing_suggest_service.ml
@@ -33,6 +33,9 @@ let timeout secs f =
   end;
   Sys.set_signal Sys.sigalrm old_handler
 
+let timeout secs f =
+  if Sys.win32 then f () (* TODO *) else timeout secs f
+
 module TypingSuggestFastStore = GlobalStorage.Make(struct
   type t = FileInfo.fast
 end)

--- a/hphp/hack/src/utils/handle.ml
+++ b/hphp/hack/src/utils/handle.ml
@@ -1,0 +1,28 @@
+(**
+ * Copyright (c) 2015, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the "hack" directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ *)
+
+(* On Win32, unwrap the handle from the 'abstract block' representing
+   the file descriptor otherwise it can't be marshalled or passed as
+   an integer command-line argument. *)
+
+type handle = int
+external raw_get_handle :
+  Unix.file_descr -> handle = "caml_hh_worker_get_handle" "noalloc"
+external raw_wrap_handle :
+  handle -> Unix.file_descr = "caml_hh_worker_create_handle"
+
+let () = assert (Sys.win32 || Obj.is_int (Obj.repr Unix.stdin))
+let get_handle =
+  if Sys.win32 then raw_get_handle else Obj.magic
+let wrap_handle =
+  if Sys.win32 then raw_wrap_handle else Obj.magic
+
+let to_in_channel h = wrap_handle h |> Unix.in_channel_of_descr
+let to_out_channel h = wrap_handle h |> Unix.out_channel_of_descr

--- a/hphp/hack/src/utils/handle_stubs.c
+++ b/hphp/hack/src/utils/handle_stubs.c
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) 2015, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the "hack" directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#include <caml/mlvalues.h>
+#include <caml/unixsupport.h>
+
+#ifdef __WIN32__
+
+value caml_hh_worker_get_handle(value x) {
+    HANDLE h = Handle_val(x);
+    return Val_long(h);
+}
+
+value caml_hh_worker_create_handle(value x) {
+    HANDLE h1 = (HANDLE)Long_val(x);
+    return win_alloc_handle(h1);
+}
+
+#else
+
+value caml_hh_worker_get_handle(value x) {
+    return x;
+}
+
+value caml_hh_worker_create_handle(value x) {
+    return x;
+}
+
+#endif

--- a/hphp/hack/src/utils/sys_utils.ml
+++ b/hphp/hack/src/utils/sys_utils.ml
@@ -131,12 +131,18 @@ let with_timeout timeout ~on_timeout ~do_ =
   let old_timeout = ref 0 in
   Utils.with_context
     ~enter:(fun () ->
-      old_handler := Sys.signal Sys.sigalrm (Sys.Signal_handle on_timeout);
-      old_timeout := Unix.alarm timeout)
+        old_handler := Sys.signal Sys.sigalrm (Sys.Signal_handle on_timeout);
+        old_timeout := Unix.alarm timeout)
     ~exit:(fun () ->
-      ignore (Unix.alarm !old_timeout);
-      Sys.set_signal Sys.sigalrm !old_handler)
+        ignore (Unix.alarm !old_timeout);
+        Sys.set_signal Sys.sigalrm !old_handler)
     ~do_
+
+let with_timeout timeout ~on_timeout ~do_ =
+  if Sys.win32 then
+    do_ () (* TODO *)
+  else
+    with_timeout timeout ~on_timeout ~do_
 
 let read_stdin_to_string () =
   let buf = Buffer.create 4096 in


### PR DESCRIPTION
We can't use on SIGALRM or SIGUSR1 on Windows. Then:
- for the client to wait until the end of server's initialization, we
  use a pipe instead.
- all timeout are temporary disabled on Windows (WIP).
