### PR TITLE
`hh_server` use PF_INET instead of PF_UNIX on Windows.

### DIFF
--- a/hphp/hack/src/client/clientConnectSimple.ml
+++ b/hphp/hack/src/client/clientConnectSimple.ml
@@ -30,7 +30,14 @@ let wait_on_server_restart ic =
 
 let establish_connection root =
   let sock_name = Socket.get_path (GlobalConfig.socket_file root) in
-  let sockaddr = Unix.ADDR_UNIX sock_name in
+  let sockaddr =
+    if Sys.win32 then
+      let ic = open_in_bin sock_name in
+      let port = input_binary_int ic in
+      close_in ic;
+      Unix.(ADDR_INET (inet_addr_loopback, port))
+    else
+      Unix.ADDR_UNIX sock_name in
   Result.Ok (Unix.open_connection sockaddr)
 
 let get_cstate (ic, oc) =


### PR DESCRIPTION
As PF_UNIX are not available on Windows, we have to use PF_INET. To keep the change minimal, we store the port number into the Unix socket file and we listen only on 127.0.0.1.

Note: this feature is implicit in OCPWin but not in vanilla OCaml.