### PR TITLE
Use alignas rather than __attribute__((__aligned__()))

### DIFF
--- a/hphp/runtime/base/array-iterator.h
+++ b/hphp/runtime/base/array-iterator.h
@@ -614,7 +614,7 @@ class CufIter {
   StringData* m_name;
 };
 
-struct Iter {
+struct alignas(16) Iter {
   const ArrayIter&   arr() const { return m_u.aiter; }
   const MArrayIter& marr() const { return m_u.maiter; }
   const CufIter&     cuf() const { return m_u.cufiter; }
@@ -635,7 +635,7 @@ private:
     MArrayIter maiter;
     CufIter cufiter;
   } m_u;
-} __attribute__ ((__aligned__(16)));
+};
 
 //////////////////////////////////////////////////////////////////////
 

--- a/hphp/runtime/base/memory-manager.h
+++ b/hphp/runtime/base/memory-manager.h
@@ -351,8 +351,7 @@ struct Allocator {
   SMALL_SIZE(105,     31,       29,      2, no,               1) \
   SMALL_SIZE(106,     31,       29,      3, no,               1) \
 
-__attribute__((__aligned__(64)))
-constexpr uint8_t kSmallSize2Index[] = {
+alignas(64) constexpr uint8_t kSmallSize2Index[] = {
 #define S2I_4(i)  i,
 #define S2I_5(i)  S2I_4(i) S2I_4(i)
 #define S2I_6(i)  S2I_5(i) S2I_5(i)
@@ -373,8 +372,7 @@ constexpr uint8_t kSmallSize2Index[] = {
 #undef SMALL_SIZE
 };
 
-__attribute__((__aligned__(64)))
-constexpr uint32_t kSmallIndex2Size[] = {
+alignas(64) constexpr uint32_t kSmallIndex2Size[] = {
 #define SMALL_SIZE(index, lg_grp, lg_delta, ndelta, lg_delta_lookup, ncontig) \
   ((uint32_t{1}<<lg_grp) + (uint32_t{ndelta}<<lg_delta)),
   SMALL_SIZES

--- a/hphp/runtime/ext/json/JSON_parser.cpp
+++ b/hphp/runtime/ext/json/JSON_parser.cpp
@@ -168,7 +168,7 @@ namespace HPHP {
     This table maps the 128 ASCII characters into the 32 character classes.
     The remaining Unicode characters should be mapped to S_ETC.
 */
-static const int8_t ascii_class[128] __attribute__((__aligned__(64))) = {
+alignas(64) static const int8_t ascii_class[128] = {
     S_ERR, S_ERR, S_ERR, S_ERR, S_ERR, S_ERR, S_ERR, S_ERR,
     S_ERR, S_WSP, S_WSP, S_ERR, S_ERR, S_WSP, S_ERR, S_ERR,
     S_ERR, S_ERR, S_ERR, S_ERR, S_ERR, S_ERR, S_ERR, S_ERR,
@@ -191,7 +191,7 @@ static const int8_t ascii_class[128] __attribute__((__aligned__(64))) = {
 };
 
 /*<fb>*/
-static const int8_t loose_ascii_class[128] __attribute__((__aligned__(64))) = {
+alignas(64) static const int8_t loose_ascii_class[128] = {
   S_ERR, S_ERR, S_ERR, S_ERR, S_ERR, S_ERR, S_ERR, S_ERR,
   S_ERR, S_WSP, S_WSP, S_ERR, S_ERR, S_WSP, S_ERR, S_ERR,
   S_ERR, S_ERR, S_ERR, S_ERR, S_ERR, S_ERR, S_ERR, S_ERR,
@@ -222,7 +222,7 @@ static const int8_t loose_ascii_class[128] __attribute__((__aligned__(64))) = {
     0 and 29. An action is a negative number between -1 and -9. A JSON text is
     accepted if the end of the text is in state 9 and mode is MODE_DONE.
 */
-static const int8_t state_transition_table[30][32] __attribute__((__aligned__(64))) = {
+alignas(64) static const int8_t state_transition_table[30][32] = {
 /* 0*/ { 0, 0,-8,-1,-6,-1,-1,-1, 3,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1},
 /* 1*/ { 1, 1,-1,-9,-1,-1,-1,-1, 3,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1},
 /* 2*/ { 2, 2,-8,-1,-6,-5,-1,-1, 3,-1,-1,-1,20,-1,21,22,-1,-1,-1,-1,-1,13,-1,17,-1,-1,10,-1,-1,-1,-1},
@@ -259,7 +259,7 @@ static const int8_t state_transition_table[30][32] __attribute__((__aligned__(64
 /*
   Alternate "loose" transition table to support unquoted keys.
 */
-static const int8_t loose_state_transition_table[31][32] __attribute__((__aligned__(64))) = {
+alignas(64) static const int8_t loose_state_transition_table[31][32] = {
 /* 0*/ { 0, 0,-8,-1,-6,-1,-1,-1, 3,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1},
 /* 1*/ { 1, 1,-1,-9,-1,-1,-1,-1, 3,-1,-1,-1,-1,-1,30,30,30,30,30,30,30,30,30,30,30,30,30,30,30,30,30},
 /* 2*/ { 2, 2,-8,-1,-6,-5,-1,-1, 3,-1,-1,-1,20,-1,21,22,-1,-1,-1,-1,-1,13,-1,17,-1,-1,10,-1,-1,-1,-1},

--- a/hphp/runtime/vm/jit/mc-generator.cpp
+++ b/hphp/runtime/vm/jit/mc-generator.cpp
@@ -128,7 +128,7 @@ static const char* const kPerfCounterNames[] = {
 // alignment, which causes it to emit an inlined version of memcpy which does
 // not assume 16-byte alignment. (Perversely, it also tickles the ld bug
 // differently such that it actually gets 16-byte alignment :\)
-__attribute__((__aligned__(8)))
+alignas(8)
 #endif
 __thread int64_t s_perfCounters[tpc_num_counters];
 

--- a/hphp/runtime/vm/resumable.h
+++ b/hphp/runtime/vm/resumable.h
@@ -59,7 +59,7 @@ namespace HPHP {
  *                        | Parent object           |
  *                        +-------------------------+ high address
  */
-struct Resumable {
+struct alignas(16) Resumable {
   // This function is used only by AFWH, temporary till AFWH is converted to HNI
   static Resumable* FromObj(ObjectData* obj) {
     return reinterpret_cast<Resumable*>(obj) - 1;
@@ -179,7 +179,7 @@ private:
     };
     uint64_t m_offsetAndSize;
   };
-} __attribute__((__aligned__(16)));
+};
 
 static_assert(Resumable::arOff() == 0,
               "ActRec must be in the beginning of Resumable");


### PR DESCRIPTION
Not only is it far shorter, it's standards compliant as well!

MSVC supports this, and [GCC 4.8](https://gcc.gnu.org/gcc-4.8/cxx0x_status.html) supports it as well, so use it.