### PR TITLE
Use C++11 attributes rather than __attribute__

### DIFF
--- a/hphp/parser/hphp.ll
+++ b/hphp/parser/hphp.ll
@@ -1470,7 +1470,8 @@ namespace HPHP {
     yylex_destroy(m_yyscanner);
   }
 
-  static void suppress_unused_errors() __attribute__((unused));
+  [[gnu::unused]]
+  static void suppress_unused_errors();
   static void suppress_unused_errors() {
     yyinput(yyscan_t());
     yyunput(0,0,0);

--- a/hphp/runtime/base/builtin-functions.h
+++ b/hphp/runtime/base/builtin-functions.h
@@ -138,19 +138,19 @@ Object init_object(const String& s, const Array &params, ObjectData* o);
  *   - When level is 1, it's from system funcs that turn both into warnings
  *   - When level is 0, it's from user funcs that turn missing arg in warnings
  */
+[[gnu::cold]]
 void throw_wrong_argument_count_nr(const char *fn, int expected, int got,
                                    const char *expectDesc, int level = 0,
-                                   TypedValue *rv = nullptr)
-  __attribute__((__cold__));
+                                   TypedValue *rv = nullptr);
+[[gnu::cold]]
 void throw_missing_arguments_nr(const char *fn, int expected, int got,
-                                int level = 0, TypedValue *rv = nullptr)
-  __attribute__((__cold__));
+                                int level = 0, TypedValue *rv = nullptr);
+[[gnu::cold]]
 void throw_toomany_arguments_nr(const char *fn, int expected, int got,
-                                int level = 0, TypedValue *rv = nullptr)
-  __attribute__((__cold__));
+                                int level = 0, TypedValue *rv = nullptr);
+[[gnu::cold]]
 void throw_wrong_arguments_nr(const char *fn, int count, int cmin, int cmax,
-                              int level = 0, TypedValue *rv = nullptr)
-  __attribute__((__cold__));
+                              int level = 0, TypedValue *rv = nullptr);
 
 /**
  * Handler for exceptions thrown from user functions that we don't
@@ -168,8 +168,8 @@ void handle_destructor_exception(const char* situation = "Destructor");
 void throw_bad_type_exception(const char *fmt, ...) ATTRIBUTE_PRINTF(1,2);
 void throw_expected_array_exception(const char* fn = nullptr);
 void throw_expected_array_or_collection_exception(const char* fn = nullptr);
-void throw_invalid_argument(const char *fmt, ...) ATTRIBUTE_PRINTF(1,2)
-   __attribute__((__cold__));
+[[gnu::cold]]
+void throw_invalid_argument(const char *fmt, ...) ATTRIBUTE_PRINTF(1,2);
 
 /**
  * Unsetting ClassName::StaticProperty.

--- a/hphp/runtime/base/ini-parser/zend-ini.ll
+++ b/hphp/runtime/base/ini-parser/zend-ini.ll
@@ -398,8 +398,8 @@ DOUBLE_QUOTES_CHARS (("\\"{ANY_CHAR}|"$"[^{\"]|[^$\"\\])+|"$")
 
 %%
 
-static void __attribute__((__unused__))
-suppress_defined_but_not_used_warnings() {
+[[gnu::unused]]
+static void suppress_defined_but_not_used_warnings() {
   yyunput(0, 0);
   yy_top_state();
 }

--- a/hphp/runtime/base/ini-parser/zend-ini.yy.cpp
+++ b/hphp/runtime/base/ini-parser/zend-ini.yy.cpp
@@ -2575,9 +2575,8 @@ void yyfree (void * ptr )
 #line 395 "hphp/runtime/base/ini-parser/zend-ini.ll"
 
 
-
-static void __attribute__((__unused__))
-suppress_defined_but_not_used_warnings() {
+[[gnu::unused]]
+static void suppress_defined_but_not_used_warnings() {
   yyunput(0, 0);
   yy_top_state();
 }

--- a/hphp/runtime/base/program-functions.cpp
+++ b/hphp/runtime/base/program-functions.cpp
@@ -751,7 +751,7 @@ NEVER_INLINE void copyHashFuncs() {
 # define AT_END_OF_TEXT
 #endif
 
-NEVER_INLINE AT_END_OF_TEXT [[gnu::optimize("2")]]
+[[gnu::optimize("2")]] NEVER_INLINE AT_END_OF_TEXT
 static void hugifyText(char* from, char* to) {
 #if FACEBOOK && !defined FOLLY_SANITIZE_ADDRESS && defined MADV_HUGEPAGE
   if (from > to || (to - from) < sizeof(uint64_t)) {

--- a/hphp/runtime/base/program-functions.cpp
+++ b/hphp/runtime/base/program-functions.cpp
@@ -751,8 +751,8 @@ NEVER_INLINE void copyHashFuncs() {
 # define AT_END_OF_TEXT
 #endif
 
-static void NEVER_INLINE AT_END_OF_TEXT __attribute__((__optimize__("2")))
-hugifyText(char* from, char* to) {
+NEVER_INLINE AT_END_OF_TEXT [[gnu::optimize("2")]]
+static void hugifyText(char* from, char* to) {
 #if FACEBOOK && !defined FOLLY_SANITIZE_ADDRESS && defined MADV_HUGEPAGE
   if (from > to || (to - from) < sizeof(uint64_t)) {
     // This shouldn't happen if HHVM is behaving correctly (I think),

--- a/hphp/runtime/ext/hotprofiler/ext_hotprofiler.h
+++ b/hphp/runtime/ext/hotprofiler/ext_hotprofiler.h
@@ -158,14 +158,16 @@ struct Profiler {
   /**
    * Start a new frame with the specified symbol.
    */
-  virtual void beginFrame(const char *symbol) __attribute__ ((__noinline__)) ;
+  NEVER_INLINE
+  virtual void beginFrame(const char *symbol);
 
   /**
    * End top of the stack.
    */
+  NEVER_INLINE
   virtual void endFrame(const TypedValue *retval,
                         const char *symbol,
-                        bool endMain = false) __attribute__ ((__noinline__)) ;
+                        bool endMain = false);
 
   virtual void endAllFrames();
 

--- a/hphp/runtime/vm/debug/jit_symbol.cpp
+++ b/hphp/runtime/vm/debug/jit_symbol.cpp
@@ -21,4 +21,4 @@
  * and optimizes away the call. This prevents gdb from trapping updates to
  * the DWARF files emitted by HHVM */
 
-void __attribute__((__noinline__)) __jit_debug_register_code() { };
+NEVER_INLINE void __jit_debug_register_code() { };

--- a/hphp/tools/bootstrap/gen-ext-hhvm.cpp
+++ b/hphp/tools/bootstrap/gen-ext-hhvm.cpp
@@ -541,12 +541,13 @@ void emitCasts(const PhpFunc& func, std::ostream& out, const char* ind) {
  */
 void emitSlowPathHelper(const PhpFunc& func, const fbstring& prefix,
                         std::ostream& out) {
+  out << "NEVER_INLINE [[gnu::cold]]\n";
   out << "void " << prefix << func.getUniqueName()
       << "(TypedValue* rv, ActRec* ar, int32_t count";
   if (func.usesThis()) {
     out << ", c_" << func.className() << "* this_";
   }
-  out << ") __attribute__((__noinline__,cold));\n";
+  out << ");\n";
 
   out << "void " << prefix << func.getUniqueName()
       << "(TypedValue* rv, ActRec* ar, int32_t count";

--- a/hphp/tools/bootstrap/gen-ext-hhvm.cpp
+++ b/hphp/tools/bootstrap/gen-ext-hhvm.cpp
@@ -541,7 +541,7 @@ void emitCasts(const PhpFunc& func, std::ostream& out, const char* ind) {
  */
 void emitSlowPathHelper(const PhpFunc& func, const fbstring& prefix,
                         std::ostream& out) {
-  out << "NEVER_INLINE [[gnu::cold]]\n";
+  out << "[[gnu::cold]] NEVER_INLINE\n";
   out << "void " << prefix << func.getUniqueName()
       << "(TypedValue* rv, ActRec* ar, int32_t count";
   if (func.usesThis()) {


### PR DESCRIPTION
Because [GCC 4.8](https://gcc.gnu.org/gcc-4.8/cxx0x_status.html) supports them, as does MSVC, and they are much cleaner than the other syntax.
MSVC doesn't support the `[[gnu::]]` attributes, but that is just a warning, which we can disable.

This also adjusts a couple of uses of `__attribute__((__noinline__))` to `NEVER_INLINE`, to work correctly with MSVC.