### PR TITLE
Experimental: Double-inc

### DIFF
--- a/hphp/runtime/base/countable.h
+++ b/hphp/runtime/base/countable.h
@@ -115,7 +115,7 @@ inline bool isStatic(RefCount count) {
 
 inline void incRefCount(RefCount& count) {
   assert(check_refcount(count));
-  if (isRefCounted(count)) { ++count; }
+  if (isRefCounted(count)) { count += 2; }
 }
 
 inline RefCount decRefCount(RefCount& count) {

--- a/hphp/runtime/base/countable.h
+++ b/hphp/runtime/base/countable.h
@@ -158,7 +158,7 @@ inline bool isStatic(RefCount count) { return false; }
 
 inline void incRefCount(RefCount& count) {
   assert(check_refcount_ns(count));
-  ++count;
+  count += 2;
 }
 
 inline RefCount decRefCount(RefCount& count) {

--- a/hphp/runtime/vm/jit/code-gen-helpers-x64.cpp
+++ b/hphp/runtime/vm/jit/code-gen-helpers-x64.cpp
@@ -97,7 +97,7 @@ void emitIncRef(Vout& v, Vreg base) {
   }
   // emit incref
   auto const sf = v.makeReg();
-  v << inclm{base[FAST_REFCOUNT_OFFSET], sf};
+  v << addqim{2, base[FAST_REFCOUNT_OFFSET], sf};
   emitAssertFlagsNonNegative(v, sf);
 }
 


### PR DESCRIPTION
Experimental (not for merging in). Simulates a 1-bit refcount using increment-by-two for refcounts, without other refactoring.