### PR TITLE
[WIP] Port PHP7 CSPRNG functions random_int() and random_bytes()

### DIFF
--- a/hphp/runtime/ext/random/config.cmake
+++ b/hphp/runtime/ext/random/config.cmake
@@ -1,0 +1,2 @@
+HHVM_EXTENSION(random ext_random.cpp)
+HHVM_SYSTEMLIB(random ext_random.php)

--- a/hphp/runtime/ext/random/ext_random.cpp
+++ b/hphp/runtime/ext/random/ext_random.cpp
@@ -74,8 +74,7 @@ Variant HHVM_FUNCTION(random_int, int64_t min, int64_t max) {
   }
 
   // Special case where no modulus is required
-  // @TODO Replace literal with HHVM equivalent of ZEND_ULONG_MAX
-	if (umax == 0xffffffffffffffff) {
+	if (umax == std::numeric_limits<uint64_t>::max()) {
     return result;
 	}
 
@@ -84,8 +83,8 @@ Variant HHVM_FUNCTION(random_int, int64_t min, int64_t max) {
 
   // Powers of two are not biased
 	if ((umax & (umax - 1)) != 0) {
-		// Ceiling under which 0xffffffffffffffff % max == 0
-		int64_t limit = 0xffffffffffffffff - (0xffffffffffffffff % umax) - 1;
+		// Ceiling under which std::numeric_limits<uint64_t>::max() % max == 0
+		int64_t limit = std::numeric_limits<uint64_t>::max() - (std::numeric_limits<uint64_t>::max() % umax) - 1;
 
 		// Discard numbers over the limit to avoid modulo bias
 		while (result > limit) {

--- a/hphp/runtime/ext/random/ext_random.cpp
+++ b/hphp/runtime/ext/random/ext_random.cpp
@@ -19,36 +19,16 @@
 #include "hphp/runtime/base/execution-context.h"
 #include "hphp/runtime/vm/runtime.h"
 
-#include <fstream>
+#include <folly/Random.h>
 
 namespace HPHP {
 ///////////////////////////////////////////////////////////////////////////////
 
-// @TODO Make this a shared class in runtime/base/ dir?
 // @TODO Throw exceptions instead of raising warnings
 static bool getRandomBytes(void *bytes, size_t length) {
-  // @TODO Check for sources of random at compile time
-  // @TODO Add file pointer caching of some sort?
-  std::ifstream randomSource ("/dev/urandom", std::ios::binary);
-  if (!randomSource.is_open()) {
-    raise_warning(
-      "Cannot open source device"
-    );
-    return false;
-  }
 
-  randomSource.seekg(0, randomSource.beg);
-  randomSource.read((char*)bytes, length);
-
-  if (!randomSource) {
-    raise_warning(
-      "Could not gather sufficient random data"
-    );
-    randomSource.close();
-		return false;
-	}
-
-  randomSource.close();
+  // @TODO Need better error handling
+  folly::Random::secureRandom(bytes, length);
 
   return true;
 }

--- a/hphp/runtime/ext/random/ext_random.cpp
+++ b/hphp/runtime/ext/random/ext_random.cpp
@@ -1,0 +1,134 @@
+/*
+   +----------------------------------------------------------------------+
+   | HipHop for PHP                                                       |
+   +----------------------------------------------------------------------+
+   | Copyright (c) 2010-2015 Facebook, Inc. (http://www.facebook.com)     |
+   | Copyright (c) 1997-2010 The PHP Group                                |
+   +----------------------------------------------------------------------+
+   | This source file is subject to version 3.01 of the PHP license,      |
+   | that is bundled with this package in the file LICENSE, and is        |
+   | available through the world-wide-web at the following url:           |
+   | http://www.php.net/license/3_01.txt                                  |
+   | If you did not receive a copy of the PHP license and are unable to   |
+   | obtain it through the world-wide-web, please send a note to          |
+   | license@php.net so we can mail you a copy immediately.               |
+   +----------------------------------------------------------------------+
+*/
+
+#include "hphp/runtime/ext/extension.h"
+#include "hphp/runtime/base/execution-context.h"
+#include "hphp/runtime/vm/runtime.h"
+
+#include <fstream>
+
+namespace HPHP {
+///////////////////////////////////////////////////////////////////////////////
+
+// @TODO Make this a shared class in runtime/base/ dir?
+// @TODO Throw exceptions instead of raising warnings
+static bool getRandomBytes(void *bytes, size_t length) {
+  // @TODO Check for sources of random at compile time
+  // @TODO Add file pointer caching of some sort?
+  std::ifstream randomSource ("/dev/urandom", std::ios::binary);
+  if (!randomSource.is_open()) {
+    raise_warning(
+      "Cannot open source device"
+    );
+    return false;
+  }
+
+  randomSource.seekg(0, randomSource.beg);
+  randomSource.read((char*)bytes, length);
+
+  if (!randomSource) {
+    raise_warning(
+      "Could not gather sufficient random data"
+    );
+    randomSource.close();
+		return false;
+	}
+
+  randomSource.close();
+
+  return true;
+}
+
+Variant HHVM_FUNCTION(random_bytes, int64_t length) {
+  if (length < 1) {
+    raise_warning(
+      "Length must be greater than 0"
+    );
+		return false;
+	}
+
+  char *bytes = (char*)calloc(length, 1);
+
+  if (bytes == NULL) {
+    raise_warning(
+      "Cannot allocate memory"
+    );
+		return false;
+  }
+
+  if (!getRandomBytes(bytes, length)) {
+    free(bytes);
+    return false;
+  }
+
+  return String(bytes, length, AttachString);
+}
+
+Variant HHVM_FUNCTION(random_int, int64_t min, int64_t max) {
+  if (min >= max) {
+    raise_warning(
+      "Minimum value must be less than the maximum value"
+    );
+		return false;
+	}
+
+
+	uint64_t umax = max - min;
+  uint64_t result;
+  if(!getRandomBytes(&result, sizeof(result))) {
+    return false;
+  }
+
+  // Special case where no modulus is required
+  // @TODO Replace literal with HHVM equivalent of ZEND_ULONG_MAX
+	if (umax == 0xffffffffffffffff) {
+    return result;
+	}
+
+	// Increment the max so the range is inclusive of max
+	umax++;
+
+  // Powers of two are not biased
+	if ((umax & (umax - 1)) != 0) {
+		// Ceiling under which 0xffffffffffffffff % max == 0
+		int64_t limit = 0xffffffffffffffff - (0xffffffffffffffff % umax) - 1;
+
+		// Discard numbers over the limit to avoid modulo bias
+		while (result > limit) {
+      if(!getRandomBytes(&result, sizeof(result))) {
+        return false;
+      }
+		}
+	}
+
+  return (int64_t) ((result % umax) + min);
+}
+
+class RandomExtension final : public Extension {
+public:
+  RandomExtension() : Extension("random") {}
+  void moduleInit() override {
+    HHVM_FE(random_bytes);
+    HHVM_FE(random_int);
+    loadSystemlib();
+  }
+} s_random_extension;
+
+HHVM_GET_MODULE(random);
+
+///////////////////////////////////////////////////////////////////////////////
+}

--- a/hphp/runtime/ext/random/ext_random.php
+++ b/hphp/runtime/ext/random/ext_random.php
@@ -6,12 +6,13 @@
  *
  * @param int $length - The length of the random string in bytes.
  *
- * @return mixed - The crypto-secure random bytes in binary format, or FALSE
- *                 on failure.
+ * @return string - The crypto-secure random bytes in binary format.
+ *
+ * @throws Exception - If generating sufficiently random data fails.
  *
  */
 <<__Native>>
-function random_bytes(int $length): mixed;
+function random_bytes(int $length): string;
 
 /**
  * Generates cryptographic random integers that are suitable for use where
@@ -20,8 +21,11 @@ function random_bytes(int $length): mixed;
  * @param int $min - The lowest value to be returned down to PHP_INT_MIN.
  * @param int $max - The highest value to be returned up to PHP_INT_MAX.
  *
- * @return mixed - The crypto-secure random integer, or FALSE on failure.
+ * @return int - The crypto-secure random integer.
+ *
+ * @throws Exception - If generating sufficiently random data fails.
+ * @throws Error - If $min > $max.
  *
  */
 <<__Native>>
-function random_int(int $min, int $max): mixed;
+function random_int(int $min, int $max): int;

--- a/hphp/runtime/ext/random/ext_random.php
+++ b/hphp/runtime/ext/random/ext_random.php
@@ -1,0 +1,27 @@
+<?hh
+
+/**
+ * Generates cryptographically secure pseudo-random bytes that are suitable for
+ *   use in cryptography when generating salts, keys and initialization vectors.
+ *
+ * @param int $length - The length of the random string in bytes.
+ *
+ * @return mixed - The crypto-secure random bytes in binary format, or FALSE
+ *                 on failure.
+ *
+ */
+<<__Native>>
+function random_bytes(int $length): mixed;
+
+/**
+ * Generates cryptographic random integers that are suitable for use where
+ *   unbiased results are critical (e.g. shuffling a Poker deck).
+ *
+ * @param int $min - The lowest value to be returned down to PHP_INT_MIN.
+ * @param int $max - The highest value to be returned up to PHP_INT_MAX.
+ *
+ * @return mixed - The crypto-secure random integer, or FALSE on failure.
+ *
+ */
+<<__Native>>
+function random_int(int $min, int $max): mixed;


### PR DESCRIPTION
Hello! This PR is a port of the [CSPRNG functions](http://php.net/csprng) `random_*()` which were [added in PHP7](https://wiki.php.net/rfc/easy_userland_csprng).

This PR is very much a work in progress and I'll need a lot of help from you smarter kids to get this implemented properly. But it works well on my machine thanks to some one-on-one help from @jmikola.

The things that I know need to be addressed:

1. The PHP version [checks for sources of random at compile time](https://github.com/php/php-src/blob/97f159d70288ae94f9a05a370121bcbea760ed9a/Zend/Zend.m4#L406-L412). Not sure how to do this in HHVM.
2. PHP [supports Windows with `arc4random_buf()`](https://github.com/php/php-src/blob/cbcacbb2dad4c97ba5653f42729f7956193d9112/ext/standard/random.c#L86). Not sure if we want to support this as well as HHVM gets more Windows friendly... is that a thing?
3. There is [an open PR](https://github.com/php/php-src/pull/1397) to change the behavior of handling the cases when a reliable source of random cannot be found. It would be better to throw an exception to halt execution since the functions are used in cryptographic contexts (see PR for details). This PR models the existing implementation but I'd rather it model the more secure PR.
4. There is [another open PR](https://github.com/php/php-src/pull/1398) that changes the behavior of the argument validation.
5. The PHP version [caches the file descriptor](https://github.com/php/php-src/blob/cbcacbb2dad4c97ba5653f42729f7956193d9112/ext/standard/random.c#L33-L50). Not sure how to do that in HHVM. (But I'm using `fstream` to read from `/dev/urandom`. Not sure if we just want to use `open()` instead.)
6. The code references `0xffffffffffffffff` since I don't know the HHVM equivalent of `ZEND_ULONG_MAX`
7. The random bytes logic is contained in the `getRandomBytes()` function but it could potentially be moved to a more global scope to serve other parts of the codebase that need crypto-secure bytes.
8. I've written this as an extension called `random` so that I could quickly iterate changes with `hphpize`. But ultimately this would be integrated into the [standard lib like the PHP version](https://github.com/php/php-src/blob/master/ext/standard/random.c). I've put a [skeleton version up for HHVM](https://github.com/php/php-src/blob/cbcacbb2dad4c97ba5653f42729f7956193d9112/ext/standard/random.c#L33-L50) just as an example.

I think that's it off the top of my head. :)