### PR TITLE
Add support for udg scheme (unix with datagram protocol)

### DIFF
--- a/hphp/runtime/ext/sockets/ext_sockets.cpp
+++ b/hphp/runtime/ext/sockets/ext_sockets.cpp
@@ -339,7 +339,9 @@ static req::ptr<Socket> create_new_socket(
 
   if (scheme == "udp" || scheme == "udg") {
     type = SOCK_DGRAM;
-  } else if (scheme == "unix") {
+  }
+
+  if (scheme == "unix" || scheme == "udg") {
     domain = AF_UNIX;
   }
 
@@ -424,7 +426,9 @@ static Variant new_socket_connect(const HostURL &hosturl, double timeout,
 
   if (scheme == "udp" || scheme == "udg") {
     type = SOCK_DGRAM;
-  } else if (scheme == "unix") {
+  }
+
+  if (scheme == "unix" || scheme == "udg") {
     domain = AF_UNIX;
   }
 

--- a/hphp/test/slow/ext_socket/udg_sock.php
+++ b/hphp/test/slow/ext_socket/udg_sock.php
@@ -1,0 +1,24 @@
+<?php
+
+$socket = '/tmp/socktest'.rand();
+$data = 'Data to be sent';
+
+// Create the server side
+$server = socket_create(AF_UNIX, SOCK_DGRAM, 0);
+var_dump($server);
+$ret = socket_set_nonblock($server);
+var_dump($ret);
+$ret = socket_bind($server, $socket , 0);
+var_dump($ret);
+
+// Create the client and send/receive the data
+$client = stream_socket_client("udg://$socket");
+var_dump($client);
+
+fwrite($client, $data);
+
+$readed = socket_read($server, 100);
+var_dump($readed);
+
+socket_close($server);
+unlink($socket);

--- a/hphp/test/slow/ext_socket/udg_sock.php.expect
+++ b/hphp/test/slow/ext_socket/udg_sock.php.expect
@@ -1,0 +1,5 @@
+resource(4) of type (stream)
+bool(true)
+bool(true)
+resource(5) of type (stream)
+string(15) "Data to be sent"

--- a/hphp/util/network.cpp
+++ b/hphp/util/network.cpp
@@ -193,7 +193,7 @@ HostURL::HostURL(const std::string &hosturl, int port) :
       m_hosturl += hosturl.substr(extraPos);
     }
     m_ipv6 = true;
-  } else if (m_scheme == "unix") {
+  } else if (m_scheme == "unix" || m_scheme == "udg") {
     // unix socket
     m_host = hosturl.substr(spos);
     m_hosturl += m_host;


### PR DESCRIPTION
The support for udg transport is almost complete at the lower levels, but some changes were needed to get it properly working:
 - Add the udg scheme to the host parsing
 - Change socket creation to set the AF_UNIX domain when using this transport