### PR TITLE
Fix all-scan-header dependency

### DIFF
--- a/hphp/system/CMakeLists.txt
+++ b/hphp/system/CMakeLists.txt
@@ -25,6 +25,10 @@ if (ENABLE_ASYNC_MYSQL)
   add_dependencies(hphp_system webscalesqlclient)
 endif ()
 
+# Similar to the case in hphp_parser, class_map.cpp eventually depends on
+# all-scan-decl.h
+add_dependencies(hphp_system all-scan-header)
+
 auto_sources(files "*.h" "${CMAKE_CURRENT_SOURCE_DIR}")
 # constants.h doesn't exist until build time,
 # so we need to manually inject it here


### PR DESCRIPTION
Similar to 9eefc6fa5337612530d9a34d4d552ff483fef63c, ```class_map.cpp``` indirectly includes ```all-scan-decl.h```. On Arch Linux commit 0340a47636198caa37bb787b512d0a21eb046f53 cause the following error:
```
[ 38%] Building CXX object hphp/system/CMakeFiles/hphp_system.dir/class_map.cpp.o
In file included from /home/yen/tmp/hhvm/hphp/system/class_map.cpp:15:
In file included from /home/yen/tmp/hhvm/hphp/runtime/base/externals.h:28:
In file included from /home/yen/tmp/hhvm/hphp/runtime/base/type-variant.h:22:
In file included from /home/yen/tmp/hhvm/hphp/runtime/base/tv-helpers.h:22:
/home/yen/tmp/hhvm/hphp/runtime/base/resource-data.h:22:10: fatal error: 'hphp/scan-methods/all-scan-decl.h' file not
      found
#include "hphp/scan-methods/all-scan-decl.h"
         ^
1 error generated.
hphp/system/CMakeFiles/hphp_system.dir/build.make:69: recipe for target 'hphp/system/CMakeFiles/hphp_system.dir/class_map.cpp.o' failed
make[2]: *** [hphp/system/CMakeFiles/hphp_system.dir/class_map.cpp.o] Error 1
CMakeFiles/Makefile2:1938: recipe for target 'hphp/system/CMakeFiles/hphp_system.dir/all' failed
make[1]: *** [hphp/system/CMakeFiles/hphp_system.dir/all] Error 2
Makefile:127: recipe for target 'all' failed
make: *** [all] Error 2
```

Tested with cmake 3.3.0 and ```make -j1```