### PR TITLE
HHI embedding on Windows.

### DIFF
--- a/hphp/hack/.gitignore
+++ b/hphp/hack/.gitignore
@@ -14,3 +14,4 @@ src/parsing/parser.mli
 *.opt
 _obuild/
 .ocp/
+hhi/**/INDEX

--- a/hphp/hack/make.bat
+++ b/hphp/hack/make.bat
@@ -21,7 +21,8 @@ REM 2/ generate get_build_id.gen.c
 REM 3/ start build hack with ocp-build
 :build
 if not exist "_obuild/" ocp-build init
-ocaml.exe unix.cma ./src/scripts/gen_build_id.ml ./src/utils/get_build_id.gen.c
+ocaml.exe unix.cma ./scripts/gen_build_id.ml ./src/utils/get_build_id.gen.c
+ocaml.exe unix.cma ./scripts/gen_index.ml hhi.rc hhi
 ocp-build
 md bin 2>NUL
 copy _obuild\hh_server\hh_server.asm.exe bin\hh_server.exe

--- a/hphp/hack/scripts/gen_build_id.ml
+++ b/hphp/hack/scripts/gen_build_id.ml
@@ -1,0 +1,22 @@
+(**
+ * Copyright (c) 2015, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the "hack" directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ *)
+
+#use "scripts/utils.ml"
+
+let () =
+  let out_file = Sys.argv.(1) in
+  let rev = read_process_output "git" [|"git"; "rev-parse"; "HEAD"|] in
+  let content =
+    Printf.sprintf "const char* const BuildInfo_kRevision = %S;\n" rev in
+  let do_dump =
+    not (Sys.file_exists out_file) || string_of_file out_file <> content in
+  if do_dump then
+    with_out_channel out_file @@ fun oc ->
+    output_string oc content

--- a/hphp/hack/scripts/gen_index.ml
+++ b/hphp/hack/scripts/gen_index.ml
@@ -1,0 +1,54 @@
+(**
+ * Copyright (c) 2015, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the "hack" directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ *)
+
+#use "scripts/utils.ml"
+
+let get_idx =
+  let idx = ref 100 in
+  fun () -> incr idx; !idx
+
+let rec iter rc dir =
+  let files = Sys.readdir dir in
+  let index_file = Filename.concat dir "INDEX" in
+  let index = open_out index_file in
+  Array.iter
+    (fun name ->
+        let idx = get_idx () in
+        let file = Filename.concat dir name in
+        if Sys.is_directory file then begin
+          Printf.fprintf index "%d dir %s\n" idx name;
+          let file, digest = iter rc file in
+          Printf.fprintf rc "%d 256 %s // %s\n" idx
+            file (Digest.to_hex digest)
+       end else if name <> "INDEX" then begin
+         let digest = Digest.file file in
+         Printf.fprintf index "%d file %s\n" idx name;
+         Printf.fprintf rc "%d 257 %s // %s\n"
+           idx file (Digest.to_hex digest);
+        end)
+       files;
+  close_out index;
+  index_file, Digest.file index_file
+
+let () =
+  let out_file = Sys.argv.(1) in
+  let dir = Sys.argv.(2) in
+  let temp_file = Filename.temp_file "hhi" ".rc" in
+  let rc = open_out temp_file in
+  let file, digest = iter rc dir in
+  Printf.fprintf rc "100 256 %s // %s\n" file (Digest.to_hex digest);
+  close_out rc;
+  let do_copy =
+    not (Sys.file_exists out_file) ||
+    string_of_file out_file <> string_of_file temp_file in
+  if do_copy then begin
+        if (Sys.file_exists out_file) then Sys.remove out_file;
+        Sys.rename temp_file out_file
+  end

--- a/hphp/hack/scripts/utils.ml
+++ b/hphp/hack/scripts/utils.ml
@@ -53,18 +53,3 @@ let string_of_file filename =
     end in
   iter ic b s;
   Buffer.contents b
-
-let () =
-  let out_file = Sys.argv.(1) in
-  let rev =
-    try read_process_output "git" [|"git"; "rev-parse"; "HEAD"|]
-    with Failure _ ->
-      read_process_output "hg" [|"hg"; "id"; "-i"|]
-  in
-  let content =
-    Printf.sprintf "const char* const BuildInfo_kRevision = %S;\n" rev in
-  let do_dump =
-    not (Sys.file_exists out_file) || string_of_file out_file <> content in
-  if do_dump then
-    with_out_channel out_file @@ fun oc ->
-    output_string oc content

--- a/hphp/hack/src/Makefile
+++ b/hphp/hack/src/Makefile
@@ -63,6 +63,7 @@ MODULES=\
 NATIVE_OBJECT_FILES=\
   heap/hh_shared.o\
   hhi/hhi_elf.o\
+  hhi/hhi_win32res_stubs.o\
   utils/files.o\
   utils/get_build_id.gen.o\
   utils/get_build_id.o\
@@ -74,7 +75,8 @@ NATIVE_OBJECT_FILES=\
 
 OCAML_LIBRARIES=\
   str\
-  unix
+  unix\
+  bigarray
 
 NATIVE_LIBRARIES=\
   pthread\
@@ -146,8 +148,8 @@ build-hack-stubs:
 	if [ "$$REV" != "$$(cat utils/get_build_id.gen.c)" ]; then echo "$$REV" > utils/get_build_id.gen.c; fi
 
 build-hack-stubs-with-ocp:
-	ocaml unix.cma $(ROOT)/scripts/gen_build_id.ml \
-                       $(ROOT)/utils/get_build_id.gen.c
+	cd $(ROOT)/.. && \
+        ocaml unix.cma scripts/gen_build_id.ml src/utils/get_build_id.gen.c
 
 build-hhi-archive:
 	mkdir -p ../bin

--- a/hphp/hack/src/_tags
+++ b/hphp/hack/src/_tags
@@ -12,3 +12,4 @@
 <third-party/avl/*.ml*>: warn(-27)
 <third-party/core/*.ml*>: warn(-32)
 <utils/*.ml*>: warn(-3-27)
+<hhi/hhi_win32res.ml>: warn(-3)

--- a/hphp/hack/src/build.ocp
+++ b/hphp/hack/src/build.ocp
@@ -324,11 +324,40 @@ begin library "hh-socket"
 end
 
 begin library "hh-hhi"
-  requires += [ "hh-globals" "hh-utils" ]
+  requires += [ "hh-globals" "hh-utils" "bigarray" ]
   files = [
     "hhi/hhi_elf.c"
+    "hhi/hhi_win32res_stubs.c"
+    "hhi/hhi_win32res.ml"
     "hhi/hhi.ml"
   ]
+  if (os_type = "Win32") then {
+    (* Embed resources *)
+    hhi_source = "../hhi.rc"
+    hhi_target = "%{hh-hhi_FULL_DST_DIR}%/hhi_res.o"
+    cclib = [ hhi_target ]
+    build_rules = [
+      hhi_target (
+        sources = [ hhi_source ]
+        commands = [
+          { "windres"
+            "--preprocessor=x86_64-w64-mingw32-gcc.exe"
+            "--preprocessor-arg=-E"
+            "--preprocessor-arg=-xc-header"
+            hhi_source hhi_target }
+        ]
+        build_target = true
+      )
+    ]
+  } else if (system = "macosx" && os_type = "Unix") then {
+    cclib = [
+      "-sectcreate" "-__text" "hhi"
+      "%{ROOTPROJECT_FULL_SRC_DIR}%/bin/hhi.tar.gz"
+      "-framework" "CoreServices"
+      "-framework" "CoreFoundation"
+    ]
+  }
+
 end
 
 begin library "hh-server-base"

--- a/hphp/hack/src/hhi/hhi.ml
+++ b/hphp/hack/src/hhi/hhi.ml
@@ -46,10 +46,22 @@ let extract_external () =
     Path.concat (Path.dirname Path.executable_name) "/../hhi.tar.gz" in
   if Path.file_exists path then Some (extract (Path.cat path)) else None
 
+let extract_win32_res () =
+  match Hhi_win32res.read_index () with
+  | None -> None
+  | Some idx ->
+    let tmpdir = Path.make (Tmp.temp_dir GlobalConfig.tmp_dir "hhi") in
+    Hhi_win32res.dump_files tmpdir idx;
+    touch_root tmpdir;
+    Some tmpdir
+
 let get_hhi_root_impl () =
-  match extract_embedded () with
-  | Some path -> Some path
-  | None -> extract_external ()
+  if Sys.win32 then
+    extract_win32_res ()
+  else
+    match extract_embedded () with
+    | Some path -> Some path
+    | None -> extract_external ()
 
 (* We want this to be idempotent so that later code can check if a given file
  * came from the hhi unarchive directory or not, to provide better error

--- a/hphp/hack/src/hhi/hhi_win32res.ml
+++ b/hphp/hack/src/hhi/hhi_win32res.ml
@@ -1,0 +1,82 @@
+(**
+ * Copyright (c) 2015, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the "hack" directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ *)
+
+type cstring =
+  (int, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t
+
+external load :
+  int -> int -> cstring option =
+  "caml_hh_win32res_load_resource"
+
+external unsafe_blit :
+  cstring -> int -> string -> int -> int -> unit =
+  "caml_hh_win32res_blit_to_string"
+
+let to_string b =
+  let len = Bigarray.Array1.dim b in
+  let s = String.create len in
+  unsafe_blit b 0 s 0 len;
+  s
+
+type item =
+  | Dir of string * index
+  | File of string * int
+and index = item list
+
+let rec read_index_raw data =
+  let data = to_string data in
+  let lines = Str.split (Str.regexp "\n") data in
+  List.map
+    (fun line ->
+      Scanf.sscanf line "%d %s %s"
+        (fun id kind name ->
+           match kind with
+           | "file" -> File (name, id)
+           | "dir" -> Dir (name, read_index_exn id)
+           | kind -> Printf.ksprintf failwith "Unexpected kind %s." kind))
+    lines
+and read_index_exn node =
+  match read_index_opt node with
+  | None ->
+      Printf.ksprintf failwith "Win32res: can't read index #%d." node
+  | Some idx -> idx
+and read_index_opt node =
+  match load node 256 with
+  | None -> None
+  | Some data -> Some (read_index_raw data)
+
+let dump_file file id =
+  let src =
+    match load id 257 with
+    | None ->
+        Printf.ksprintf failwith "Win32res: can't read file #%d." id
+    | Some data -> data in
+  let len = Bigarray.Array1.dim src in
+  let fd = Unix.(openfile file [O_RDWR;O_CREAT;O_TRUNC] 0o644) in
+  let dst =
+    Bigarray.Array1.map_file fd
+      Bigarray.int8_unsigned Bigarray.c_layout true len in
+  Bigarray.Array1.blit src dst;
+  Unix.close fd
+
+let rec dump_item root = function
+  | Dir (name, idx) ->
+      let root = Filename.concat root name in
+      Unix.mkdir root 0o755;
+      List.iter (dump_item root) idx
+  | File (name, id) ->
+      let file = Filename.concat root name in
+      dump_file file id
+
+
+let read_index () = read_index_opt 100
+let dump_files root idx =
+  let root = Path.to_string root in
+  List.iter (dump_item root) idx

--- a/hphp/hack/src/hhi/hhi_win32res.mli
+++ b/hphp/hack/src/hhi/hhi_win32res.mli
@@ -1,0 +1,14 @@
+(**
+ * Copyright (c) 2015, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the "hack" directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ *)
+
+type index
+
+val read_index: unit -> index option
+val dump_files: Path.t -> index -> unit

--- a/hphp/hack/src/hhi/hhi_win32res_stubs.c
+++ b/hphp/hack/src/hhi/hhi_win32res_stubs.c
@@ -1,0 +1,77 @@
+/**
+ * Copyright (c) 2015, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the "hack" directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#include <caml/mlvalues.h>
+#include <caml/unixsupport.h>
+#include <caml/bigarray.h>
+#include <caml/memory.h>
+#include <caml/alloc.h>
+
+#ifdef _WIN32
+#include <windows.h>
+#else
+#include <string.h>
+#endif
+
+#define UNUSED(x) (void)(x)
+
+value caml_hh_win32res_blit_to_string(value val_buf1, value val_ofs1,
+                                      value val_buf2, value val_ofs2,
+                                      value val_len)
+{
+  memcpy(String_val(val_buf2) + Long_val(val_ofs2),
+         (char*)Caml_ba_data_val(val_buf1) + Long_val(val_ofs1),
+         Long_val(val_len));
+  return Val_unit;
+}
+
+#ifdef _WIN32
+
+value caml_hh_win32res_load_resource(value name, value type)
+{
+  CAMLparam2(name, type);
+  CAMLlocal2(ba, ba_opt);
+  intnat dim[1];
+  HGLOBAL rcData;
+  HRSRC rc;
+  rc = FindResource(
+         NULL,
+         MAKEINTRESOURCE(Long_val(name)),
+         MAKEINTRESOURCE(Long_val(type)));
+  if (!rc) {
+    win32_maperr(GetLastError());
+    CAMLreturn(Val_long(0)); // None
+  }
+  rcData = LoadResource(NULL, rc);
+  if (!rcData) {
+    win32_maperr(GetLastError());
+    uerror("LoadResource", Nothing);
+  }
+  dim[0] = SizeofResource(NULL, rc);
+  ba = caml_ba_alloc(
+         CAML_BA_UINT8 /* CAML_BA_CHAR */ | CAML_BA_C_LAYOUT,
+         1,
+         LockResource(rcData),
+         dim);
+  ba_opt = caml_alloc_small(1, 0);
+  Field(ba_opt, 0) = ba;
+  CAMLreturn(ba_opt);
+}
+
+#else
+
+value caml_hh_win32res_load_resource(value name, value type)
+{
+  UNUSED(name);
+  UNUSED(type);
+  return Val_long(0); // None
+}
+
+#endif


### PR DESCRIPTION
This remove, on Windows, the dependency over the external command `tar`. Instead, we build our own INDEX and embeded every .hhi files in the binary as Windows resources.

A small OCaml script builds all the required INDEX and the Windows-resources description file (i.e. `hphp/hack/hhi.rc`).