### PR TITLE
Use the correct working directory when generating the build info.

### DIFF
--- a/hphp/util/CMakeLists.txt
+++ b/hphp/util/CMakeLists.txt
@@ -21,7 +21,7 @@ add_custom_command(
          "${CMAKE_CURRENT_SOURCE_DIR}/../hphp-build-info.cpp"
   COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/generate-buildinfo.sh"
   DEPENDS ${CXX_SOURCES}
-  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/
   COMMENT "Generating Repo Schema ID and Compiler ID"
   VERBATIM)
 


### PR DESCRIPTION
I have no idea how this has worked up 'til now, but it doesn't work on windows.
This sets the working directory for the script to the current source directory.