### PR TITLE
Use a temporary placeholder as the frame pointer under MSVC

### DIFF
--- a/hphp/util/portability.h
+++ b/hphp/util/portability.h
@@ -125,6 +125,10 @@
 #  define DECLARE_FRAME_POINTER(fp) register ActRec* fp asm("rbp");
 # endif
 
+#elif defined(_M_X64)
+
+# define DECLARE_FRAME_POINTER(fp) register ActRec* fp = nullptr;
+
 #elif defined(__AARCH64EL__)
 
 # if defined(__clang__)

--- a/hphp/util/portability.h
+++ b/hphp/util/portability.h
@@ -127,7 +127,11 @@
 
 #elif defined(_M_X64)
 
-# define DECLARE_FRAME_POINTER(fp) register ActRec* fp = nullptr;
+// TODO: FIXME! Without this implemented properly, the JIT
+// will fail "pretty spectacularly".
+# define DECLARE_FRAME_POINTER(fp) \
+  always_assert(false);            \
+  register ActRec* fp = nullptr;
 
 #elif defined(__AARCH64EL__)
 


### PR DESCRIPTION
There is no way to get the frame pointer from C/C++ under 64-bit MSVC, and this is only used in the JIT, so stub this out to a nullptr variable for now, so that we can compile.