### PR TITLE
Exclude util/light-process.cpp under MSVC

### DIFF
--- a/hphp/util/CMakeLists.txt
+++ b/hphp/util/CMakeLists.txt
@@ -36,6 +36,11 @@ add_custom_command(
 #  include_directories(${LIBNUMA_INCLUDE_DIRS})
 #endif()
 
+if(MSVC)
+  list(REMOVE_ITEM CXX_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/light-process.cpp")
+  list(REMOVE_ITEM HEADER_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/light-process.h")
+endif()
+
 add_library(hphp_util STATIC ${CXX_SOURCES} ${ASM_SOURCES} ${HEADER_SOURCES}
             "${CMAKE_CURRENT_SOURCE_DIR}/../hphp-repo-schema.h"
             "${CMAKE_CURRENT_SOURCE_DIR}/../hphp-build-info.cpp")

--- a/hphp/util/light-process.h
+++ b/hphp/util/light-process.h
@@ -17,6 +17,10 @@
 #ifndef incl_HPHP_LIGHT_PROCESS_H_
 #define incl_HPHP_LIGHT_PROCESS_H_
 
+#ifdef _MSC_VER
+# error LightProcess is not supported under MSVC!
+#endif
+
 #include <string>
 #include <vector>
 #include <cstdio>


### PR DESCRIPTION
LightProcess is heavily dependent upon fork, which is not available under Windows, so I've taken the route of simply not porting it to MSVC, and re-writing any required code that uses it, to not use it.
This simply removes the sources for them from the build under MSVC, and it shouldn't effect any other platforms.