### PR TITLE
Disable linking against afdt under MSVC

### DIFF
--- a/CMake/HPHPFindLibs.cmake
+++ b/CMake/HPHPFindLibs.cmake
@@ -548,7 +548,9 @@ macro(hphp_link target)
     target_link_libraries(${target} mcrouter)
   endif()
 
-  target_link_libraries(${target} afdt)
+  if (NOT MSVC)
+    target_link_libraries(${target} afdt)
+  endif()
   target_link_libraries(${target} mbfl)
 
   if (EDITLINE_LIBRARIES)


### PR DESCRIPTION
Because this would be a nightmare to port, and is only needed for the takeover agent, which I'll disable under MSVC in a future PR.