### PR TITLE
Add a define to indicate MBFL is built as a static library

### DIFF
--- a/CMake/HPHPSetup.cmake
+++ b/CMake/HPHPSetup.cmake
@@ -274,6 +274,7 @@ endif()
 
 include_directories("${TP_DIR}/timelib")
 include_directories("${TP_DIR}/libafdt/src")
+add_definitions("-DMBFL_STATIC")
 include_directories("${TP_DIR}/libmbfl")
 include_directories("${TP_DIR}/libmbfl/mbfl")
 include_directories("${TP_DIR}/libmbfl/filters")


### PR DESCRIPTION
As explained in [hhvm-third-party#80](https://github.com/hhvm/hhvm-third-party/pull/80), mbfl tries to export its symbols even though we are building it as a static library, so tell it we are building a static library.