### PR TITLE
Enable the dlfn compatibility layer for MSVC

### DIFF
--- a/hphp/util/compatibility.cpp
+++ b/hphp/util/compatibility.cpp
@@ -140,9 +140,8 @@ int fadvise_dontneed(int fd, off_t len) {
 #endif
 }
 
-#if defined(__CYGWIN__)
+#if defined(__CYGWIN__) || defined(_MSC_VER)
 #include <windows.h>
-#include <libintl.h>
 
 // since we only support win 7+
 // capturestackbacktrace is always available in kernel
@@ -160,14 +159,13 @@ int backtrace (void **buffer, int size) {
 
 int dladdr(const void *addr, Dl_info *info) {
   MEMORY_BASIC_INFORMATION mem_info;
-  HMODULE module;
   char moduleName[MAX_PATH];
 
   if(!VirtualQuery(addr, &mem_info, sizeof(mem_info))) {
     return 0;
   }
 
-  if(!GetModuleFileNameA(module, moduleName, sizeof(moduleName))) {
+  if(!GetModuleFileNameA(nullptr, moduleName, sizeof(moduleName))) {
     return 0;
   }
 
@@ -180,10 +178,14 @@ int dladdr(const void *addr, Dl_info *info) {
   return 1;
 }
 
+#ifdef __CYGWIN__
+#include <libintl.h>
 // libbfd on cygwin is broken, stub dgettext to make linker unstupid
 char * libintl_dgettext(const char *domainname, const char *msgid) {
   return dgettext(domainname, msgid);
 }
+#endif
+
 #endif
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/hphp/util/compatibility.h
+++ b/hphp/util/compatibility.h
@@ -49,7 +49,7 @@ int64_t gettime_diff_us(const timespec &start, const timespec &end);
  */
 int fadvise_dontneed(int fd, off_t len);
 
-#ifdef __CYGWIN__
+#if defined(__CYGWIN__) || defined(_MSC_VER)
 
 typedef struct {
   const char *dli_fname;


### PR DESCRIPTION
The layer was created for Cygwin, but work for MSVC as well.
This also passes nullptr rather than an unitialized local for `GetModuleFileName`, which works correctly.