### PR TITLE
Don't include <sys/errno.h> under MSVC

### DIFF
--- a/hphp/util/synchronizable.cpp
+++ b/hphp/util/synchronizable.cpp
@@ -19,7 +19,9 @@
 #include "hphp/util/rank.h"
 #include "hphp/util/timer.h"
 
+#ifndef _MSC_VER
 #include <sys/errno.h>
+#endif
 
 namespace HPHP {
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Because it doesn't exist, and we don't need anything defined in it.