### PR TITLE
Remove a set of defines for windows in chronoutils.h

### DIFF
--- a/hphp/util/cronoutils.h
+++ b/hphp/util/cronoutils.h
@@ -105,16 +105,6 @@
 # endif
 #endif
 
-#ifdef _WIN32
-#define mode_t int
-
-#define open  _open
-#define close _close
-#define read  _read
-#define write _write
-#define mkdir _mkdir
-#endif
-
 /* Some operating systems don't declare getopt() */
 
 #ifdef NEED_GETOPT_DEFS


### PR DESCRIPTION
I don't know where this originally came from, but, while it might have worked in whatever project it was used in at the time, defining things like this just breaks things. (it even has the `mode_t` define wrong, `mode_t` is supposed to be a typedef to `short`)
This removes the offending block of code.