### PR TITLE
Only include shm headers if shm counters are enabled

### DIFF
--- a/hphp/util/shm-counter.cpp
+++ b/hphp/util/shm-counter.cpp
@@ -18,9 +18,12 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <errno.h>
+#include <new>
+
+#ifdef ENABLE_SHM_COUNTER
 #include <sys/ipc.h>
 #include <sys/shm.h>
-#include <new>
+#endif
 
 namespace HPHP {
 ///////////////////////////////////////////////////////////////////////////////
@@ -30,12 +33,12 @@ int ShmCounters::shmid;
 ShmCounters::logError_t ShmCounters::logError;
 ShmCounters *ShmCounters::s_shmCounters;
 
-#define LOG_ERROR(fmt, args...) \
+#define LOG_ERROR(fmt, ...) \
 do { \
   if (ShmCounters::logError) { \
-    ShmCounters::logError(fmt, ##args); \
+    ShmCounters::logError(fmt, ##__VA_ARGS__); \
   } else { \
-    fprintf(stderr, fmt, ##args); \
+    fprintf(stderr, fmt, ##__VA_ARGS__); \
   } \
 } while (false)
 


### PR DESCRIPTION
Because we don't have them under MSVC.
This also switches the LOG_ERROR preprocessor define to use a vararg syntax that MSVC supports.