### PR TITLE
Enable the __host_start and __hot_end stubs under MSVC

### DIFF
--- a/hphp/util/code-cache.h
+++ b/hphp/util/code-cache.h
@@ -22,7 +22,7 @@
 
 namespace HPHP {
 
-#if defined(__APPLE__) || defined(__CYGWIN__)
+#if defined(__APPLE__) || defined(__CYGWIN__) || defined(_MSC_VER)
 extern const void* __hot_start;
 extern const void* __hot_end;
 #else


### PR DESCRIPTION
Apparently I forgot to add the change in the header in my other PR, #5770, which has already been merged.
This just adds the change to the header to enable the stubs fully.