### PR TITLE
Use GetThreadIdForTrace in the logger

### DIFF
--- a/hphp/util/logger.cpp
+++ b/hphp/util/logger.cpp
@@ -237,7 +237,7 @@ std::string Logger::GetHeader() {
   snprintf(header, sizeof(header), "[%s] [hphp] [%lld:%llx:%d:%06d%s] ",
            snow,
            (unsigned long long)s_pid,
-           (unsigned long long)Process::GetThreadId(),
+           (unsigned long long)Process::GetThreadIdForTrace(),
            threadData->request,
            (threadData->message == -1 ? 0 : threadData->message),
            ExtraHeader.c_str());


### PR DESCRIPTION
Because, under MSVC, pthread_t is a struct, and doesn't convert to an unsigned long long.