### PR TITLE
Port util/kernel-version.cpp to MSVC

### DIFF
--- a/hphp/util/kernel-version.cpp
+++ b/hphp/util/kernel-version.cpp
@@ -17,10 +17,16 @@
 #include "hphp/util/assertions.h"
 #include "hphp/util/portability.h"
 
-#include <unistd.h>
-#include <sys/utsname.h>
 #include <stdio.h>
 #include <iostream>
+
+#ifdef _MSC_VER
+#include <Windows.h>
+#else
+#include <unistd.h>
+#include <sys/utsname.h>
+#endif
+
 namespace HPHP {
 
 void KernelVersion::parse(const char* s) {
@@ -45,10 +51,20 @@ void KernelVersion::parse(const char* s) {
 }
 
 KernelVersion::KernelVersion() {
+#ifdef _MSC_VER
+  OSVERSIONINFO verInf;
+  verInf.dwOSVersionInfoSize = sizeof(OSVERSIONINFO);
+  GetVersionEx(&verInf);
+  m_major = verInf.dwMajorVersion;
+  m_minor = verInf.dwMinorVersion;
+  m_build = verInf.dwBuildNumber;
+  m_release = verInf.dwPlatformId;
+#else
   struct utsname uts;
   DEBUG_ONLY int err = uname(&uts);
   assert(err == 0);
   parse(uts.release);
+#endif
 }
 
 KernelVersion::KernelVersion(const char* s) {


### PR DESCRIPTION
Because implementing utsname was too much of a pain for only a couple of spots to use it.