### PR TITLE
Support util/process under MSVC

### DIFF
--- a/hphp/util/process.cpp
+++ b/hphp/util/process.cpp
@@ -385,7 +385,7 @@ void Process::Daemonize(const char *stdoutFile /* = "/dev/null" */,
   pid_t pid, sid;
 
   /* already a daemon */
-  if (getppid() == 1) return;
+  if (getppid() == (pid_t)1) return;
 
 #ifdef _MSC_VER
   // We are Windows, fear us!
@@ -495,7 +495,7 @@ void Process::GetProcessId(const std::string &cmd, std::vector<pid_t> &pids,
       if (converted == ccmd && filename.find("/proc/") == 0) {
         long long pid = atoll(filename.c_str() + strlen("/proc/"));
         if (pid) {
-          pids.push_back(pid);
+          pids.push_back((pid_t)pid);
         }
       }
     }

--- a/hphp/util/process.h
+++ b/hphp/util/process.h
@@ -83,7 +83,7 @@ public:
    * Process identifier.
    */
   static pid_t GetProcessId() {
-    return getpid();
+    return (pid_t)getpid();
   }
 
   /**
@@ -130,6 +130,8 @@ public:
     // case we will need to revisit this.
 #ifdef __linux__
     return pthread_self();
+#elif defined(_MSC_VER)
+    return (uint64_t)pthread_getw32threadhandle_np(pthread_self());
 #else
     return (uint64_t)pthread_self();
 #endif
@@ -150,7 +152,7 @@ public:
 #elif defined(__CYGWIN__) || defined(__MINGW__)
     return (long)pthread_self();
 #elif defined(_MSC_VER)
-    return GetCurrentThreadId();
+    return (pid_t)GetCurrentThreadId();
 #else
     return syscall(SYS_gettid);
 #endif


### PR DESCRIPTION
While this was ported by me before, it was using a pthread library that turned out to be very broken.
This includes the fixes needed to get the header compiling on MSVC with a functional pthread library (where `pthread_t` is a struct).