### PR TITLE
Include process directly in stack-trace.cpp rather than through light-process

### DIFF
--- a/hphp/util/stack-trace.cpp
+++ b/hphp/util/stack-trace.cpp
@@ -35,7 +35,7 @@
 #include "hphp/util/process.h"
 #include "hphp/util/lock.h"
 #include "hphp/util/logger.h"
-#include "hphp/util/light-process.h"
+#include "hphp/util/process.h"
 #include "hphp/util/compatibility.h"
 #include "hphp/util/hash.h"
 


### PR DESCRIPTION
Because light-process isn't supported under MSVC.