### PR TITLE
Support MSVC in util/ringbuffer.cpp

### DIFF
--- a/hphp/util/ringbuffer.cpp
+++ b/hphp/util/ringbuffer.cpp
@@ -107,7 +107,11 @@ allocEntry(RingBufferType t) {
                                             std::memory_order_acq_rel));
   rb->m_seq = g_seqnum.fetch_add(1, std::memory_order_relaxed);
   rb->m_type = t;
+#ifdef _MSC_VER
+  rb->m_threadId = (uint32_t)((int64_t)pthread_getw32threadid_np(pthread_self()) & 0xFFFFFFFF);
+#else
   rb->m_threadId = (uint32_t)((int64_t)pthread_self() & 0xFFFFFFFF);
+#endif
   return rb;
 }
 


### PR DESCRIPTION
The pthread impl used on windows defines `pthread_t` as a struct, so we need to use something different for MSVC.