### PR TITLE
Fix util/ssl-init.cpp for platforms where pthread_t is a struct

### DIFF
--- a/hphp/util/ssl-init.cpp
+++ b/hphp/util/ssl-init.cpp
@@ -25,7 +25,7 @@ namespace HPHP {
 static Mutex *s_locks = nullptr;
 
 static unsigned long callback_thread_id() {
-  return (unsigned long)Process::GetThreadId();
+  return (unsigned long)Process::GetThreadIdForTrace();
 }
 
 static void callback_locking(int mode, int type, const char *file, int line) {


### PR DESCRIPTION
Such as MSVC. The value returned by the callback simply needs to be unique for each thread, which is exactly what `GetThreadIdForTrace` returns.