### PR TITLE
Fix util/trace.cpp's pthread interaction under MSVC

### DIFF
--- a/hphp/util/trace.cpp
+++ b/hphp/util/trace.cpp
@@ -146,8 +146,13 @@ void vtrace(const char *fmt, va_list ap) {
     vtraceRingbuffer(fmt, ap);
   } else {
     ONTRACE(1, pthread_mutex_lock(&mtx));
+#ifdef _MSC_VER
+    ONTRACE(1, fprintf(out, "t%#08x: ",
+      int((int64_t)pthread_getw32threadid_np(pthread_self()) & 0xFFFFFFFF)));
+#else
     ONTRACE(1, fprintf(out, "t%#08x: ",
       int((int64_t)pthread_self() & 0xFFFFFFFF)));
+#endif
     vfprintf(out, fmt, ap);
     ONTRACE(1, pthread_mutex_unlock(&mtx));
     flush();


### PR DESCRIPTION
Because `pthread_t` is a struct under MSVC.