### PR TITLE
Port util/chronolog.cpp to MSVC

### DIFF
--- a/hphp/util/cronolog.cpp
+++ b/hphp/util/cronolog.cpp
@@ -17,7 +17,9 @@
 
 #include <boost/filesystem/path.hpp>
 
+#ifndef _MSC_VER
 #include <pwd.h>
+#endif
 
 /* Default permissions for files and directories that are created */
 
@@ -78,6 +80,7 @@ static FILE *new_log_file(const char *fileTemplate, const char *linkname,
     return nullptr;
   }
 
+#ifndef _MSC_VER
   if (linkname) {
     struct stat stat_buf;
     struct stat stat_buf2;
@@ -101,6 +104,7 @@ static FILE *new_log_file(const char *fileTemplate, const char *linkname,
       create_link(filename.c_str(), linkname, linktype, prevlinkname);
     }
   }
+#endif
   return fdopen(log_fd, "a");
 }
 
@@ -137,7 +141,12 @@ FILE *Cronolog::getOutputFile() {
     /* If there is no log file open then open a new one. */
     if (m_file == nullptr) {
       const char *linkname = m_linkName.empty() ? nullptr : m_linkName.c_str();
-      m_file = new_log_file(m_template.c_str(), linkname, S_IFLNK,
+      m_file = new_log_file(m_template.c_str(),
+#ifdef _MSC_VER
+                            "", 0,
+#else
+                            linkname, S_IFLNK,
+#endif
                             m_prevLinkName, m_periodicity, m_periodMultiple,
                             m_periodDelay, m_fileName, sizeof(m_fileName),
                             time_now, &m_nextPeriod);
@@ -147,6 +156,9 @@ FILE *Cronolog::getOutputFile() {
 }
 
 void Cronolog::changeOwner(const string &username, const string &symlink) {
+#ifdef _MSC_VER
+  return;
+#else
   if (username.empty() || symlink.empty()) {
     return;
   }
@@ -180,6 +192,7 @@ void Cronolog::changeOwner(const string &username, const string &symlink) {
   if (success < 0) {
     fprintf(stderr, "Unable to chmod %s\n", symlink.c_str());
   }
+#endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This ignores setting the owner, and also doesn't bother with symlinks, because the former is a pain, and not really necessary, and the latter requires admin privledges on Windows.