### PR TITLE
Don't include <sys/errno.h> in synchronizable-multi.cpp under MSVC

### DIFF
--- a/hphp/util/synchronizable-multi.cpp
+++ b/hphp/util/synchronizable-multi.cpp
@@ -19,7 +19,9 @@
 #include "hphp/util/lock.h"
 #include "hphp/util/timer.h"
 
+#ifndef _MSC_VER
 #include <sys/errno.h>
+#endif
 
 namespace HPHP {
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Because it doesn't exist, and what we use has already been included elsewhere.