### PR TITLE
Exclude afdt-util from the build under MSVC

### DIFF
--- a/hphp/util/CMakeLists.txt
+++ b/hphp/util/CMakeLists.txt
@@ -36,6 +36,11 @@ add_custom_command(
 #  include_directories(${LIBNUMA_INCLUDE_DIRS})
 #endif()
 
+if(MSVC)
+  list(REMOVE_ITEM CXX_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/afdt-util.cpp")
+  list(REMOVE_ITEM HEADER_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/afdt-util.h")
+endif()
+
 add_library(hphp_util STATIC ${CXX_SOURCES} ${ASM_SOURCES} ${HEADER_SOURCES}
             "${CMAKE_CURRENT_SOURCE_DIR}/../hphp-repo-schema.h"
             "${CMAKE_CURRENT_SOURCE_DIR}/../hphp-build-info.cpp")

--- a/hphp/util/afdt-util.h
+++ b/hphp/util/afdt-util.h
@@ -17,6 +17,10 @@
 #ifndef incl_HPHP_AFDT_UTIL_H_
 #define incl_HPHP_AFDT_UTIL_H_
 
+#ifdef _MSC_VER
+# error AFDT is not currently supported for MSVC!
+#endif
+
 #include <sys/socket.h>
 #include <vector>
 #include <string>


### PR DESCRIPTION
Because we don't have libafdt under MSVC.
This also adds an error to the header that will trigger if the file is included under MSVC.

This will conflict with #5944 (D44289), due to needing to add the removal at the same spot.