### PR TITLE
Don't include dlfcn in util/stack-trace.h under MSVC

### DIFF
--- a/hphp/util/stack-trace.h
+++ b/hphp/util/stack-trace.h
@@ -24,7 +24,9 @@
 #include "hphp/util/portability.h"
 #include "hphp/util/compatibility.h"
 
+#ifndef _MSC_VER
 #include <dlfcn.h>
+#endif
 
 namespace HPHP {
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Because it doesn't exist, and its functionality is supplemented by `util/compatibility.h` once #5948 (D44325) is merged.
While technically this is dependent upon #5948 (D44325), it would only break MSVC, so shouldn't really be considered a dependency of this PR.