### PR TITLE
Fixup forward declaration mismatches not handled by #5693

### DIFF
--- a/hphp/util/code-cache.h
+++ b/hphp/util/code-cache.h
@@ -145,7 +145,7 @@ struct CodeCache::Selector {
     Args& profile(bool isProf) { m_profile = isProf; return *this; }
 
    private:
-    friend class Selector;
+    friend struct Selector;
 
     CodeCache& m_cache;
     bool m_hot;


### PR DESCRIPTION
This will fixup various places that the tool used for #5693 (D42015) wasn't able to determine the correct definition of.
This isn't dependent on #5693 (D42015), as this is only to fix things that that didn't touch.