### PR TITLE
Support util/mutex.h under MSVC

### DIFF
--- a/hphp/util/mutex.h
+++ b/hphp/util/mutex.h
@@ -33,6 +33,8 @@
 
 #include <tbb/concurrent_hash_map.h>
 
+#include <folly/Portability.h>
+
 #include "hphp/util/portability.h"
 #include "hphp/util/assertions.h"
 #include "hphp/util/rank.h"
@@ -216,7 +218,11 @@ class ReadWriteMutex {
  * implementation tends to do crazy things when a rwlock is double-wlocked,
  * so check and assert early in debug builds.
  */
-  static constexpr pthread_t InvalidThread = (pthread_t)0;
+#ifdef MSVC_NO_STATIC_INCLASS_CONSTEXPR_INITIALIZATION
+  static const pthread_t InvalidThread;
+#else
+  static constexpr pthread_t InvalidThread = pthread_t_init;
+#endif
   pthread_t m_writeOwner;
   Rank m_rank;
 #endif
@@ -301,6 +307,11 @@ private:
 
   pthread_rwlock_t m_rwlock;
 };
+
+#if defined(DEBUG) && defined(MSVC_NO_STATIC_INCLASS_CONSTEXPR_INITIALIZATION)
+// Do this as COMDAT to avoid needing to create mutex.cpp just for this workaround.
+__declspec(selectany) const pthread_t ReadWriteMutex::InvalidThread = pthread_t_init;
+#endif
 
 /*
  * A ranked wrapper around tbb::concurrent_hash_map.


### PR DESCRIPTION
This adds a workaround for a limitation of MSVC, and also uses pthread_t_init rather than casting 0 to a pthread_t.

This is dependent upon an issue with how [folly#264](https://github.com/facebook/folly/pull/264) was merged being resolved first.
This is also dependent upon [folly#285](https://github.com/facebook/folly/pull/285) being merged upstream first as well.