### PR TITLE
Include <cctype> in boostrap/idl.h

### DIFF
--- a/hphp/tools/bootstrap/idl.h
+++ b/hphp/tools/bootstrap/idl.h
@@ -17,6 +17,8 @@
 #ifndef HPHP_IDL_H
 #define HPHP_IDL_H
 
+#include <cctype>
+
 #include <folly/Conv.h>
 #include <folly/DynamicConverter.h>
 #include <folly/FBString.h>


### PR DESCRIPTION
Because it's what defines `std::tolower`.
This header compiles without this on platforms other than MSVC, because something else in the include chain has included it. This is not the case for MSVC, and it needs to be explicitly included.