### PR TITLE
Define GOOGLE_GLOG_DLL_DECL under MSVC

### DIFF
--- a/CMake/HPHPFindLibs.cmake
+++ b/CMake/HPHPFindLibs.cmake
@@ -42,7 +42,7 @@ endif()
 
 # google-glog
 find_package(Glog REQUIRED)
-if (${CMAKE_CXX_COMPILER_ID} STREQUAL "MSVC")
+if (LIBGLOG_STATIC)
   add_definitions("-DGOOGLE_GLOG_DLL_DECL=")
 endif()
 include_directories(${LIBGLOG_INCLUDE_DIR})

--- a/CMake/HPHPFindLibs.cmake
+++ b/CMake/HPHPFindLibs.cmake
@@ -42,6 +42,9 @@ endif()
 
 # google-glog
 find_package(Glog REQUIRED)
+if (${CMAKE_CXX_COMPILER_ID} STREQUAL "MSVC")
+  add_definitions("-DGOOGLE_GLOG_DLL_DECL=")
+endif()
 include_directories(${LIBGLOG_INCLUDE_DIR})
 
 # inotify checks


### PR DESCRIPTION
Because we're linking against the static library. Without this, anything using glog will fail to link because it will reference the functions as `dllimport`.