### PR TITLE
Define PCRE_STATIC when using the bundled PCRE

### DIFF
--- a/CMake/HPHPSetup.cmake
+++ b/CMake/HPHPSetup.cmake
@@ -266,6 +266,7 @@ endif()
 
 if (NOT PCRE_LIBRARY)
   include_directories("${TP_DIR}/pcre")
+  add_definitions("-DPCRE_STATIC=1")
 endif()
 
 if (NOT FASTLZ_LIBRARY)


### PR DESCRIPTION
Because the bundled one is built as a static library.