### PR TITLE
Include <cctype> for std::tolower in the parser

### DIFF
--- a/hphp/parser/hphp.ll
+++ b/hphp/parser/hphp.ll
@@ -2,6 +2,7 @@
 #include "hphp/parser/scanner.h"
 #include "hphp/system/systemlib.h"
 #include <cassert>
+#include <cctype>
 
 #ifdef __clang__
 #pragma clang diagnostic ignored "-Wnull-conversion"


### PR DESCRIPTION
Because it was previously being included only because of the internals of a standard library, and it doesn't get included under MSVC unless we do so explicitly.