### PR TITLE
Use 64-bit shifts in surprise-flags

### DIFF
--- a/hphp/runtime/base/surprise-flags.h
+++ b/hphp/runtime/base/surprise-flags.h
@@ -28,26 +28,26 @@ namespace HPHP {
  * in the rds header, so they must be above 2^48.
  */
 enum SurpriseFlag : size_t {
-  MemExceededFlag      = 1ul << 48,
-  TimedOutFlag         = 1ul << 49,
-  SignaledFlag         = 1ul << 50,
-  EventHookFlag        = 1ul << 51,
-  PendingExceptionFlag = 1ul << 52,
-  InterceptFlag        = 1ul << 53,
-  XenonSignalFlag      = 1ul << 54,
-  AsyncEventHookFlag   = 1ul << 55,
+  MemExceededFlag      = 1ull << 48,
+  TimedOutFlag         = 1ull << 49,
+  SignaledFlag         = 1ull << 50,
+  EventHookFlag        = 1ull << 51,
+  PendingExceptionFlag = 1ull << 52,
+  InterceptFlag        = 1ull << 53,
+  XenonSignalFlag      = 1ull << 54,
+  AsyncEventHookFlag   = 1ull << 55,
 
   /* Set by the debugger to break out of loops in translated code. */
-  DebuggerSignalFlag   = 1ul << 56,
+  DebuggerSignalFlag   = 1ull << 56,
 
   /* Set by the debugger hook handler to force function entry/exit events. */
-  DebuggerHookFlag     = 1ul << 57,
+  DebuggerHookFlag     = 1ull << 57,
 
-  CPUTimedOutFlag      = 1ul << 58,
-  IntervalTimerFlag    = 1ul << 59,
+  CPUTimedOutFlag      = 1ull << 58,
+  IntervalTimerFlag    = 1ull << 59,
 
   /* Set if a GC should be run at the next safe point. */
-  PendingGCFlag        = 1ul << 60,
+  PendingGCFlag        = 1ull << 60,
 
   /*
    * Flags that shouldn't be cleared by fetchAndClearSurpriseFlags, because

--- a/hphp/runtime/base/surprise-flags.h
+++ b/hphp/runtime/base/surprise-flags.h
@@ -89,12 +89,12 @@ inline bool checkSurpriseFlags() {
 }
 
 inline void setSurpriseFlag(SurpriseFlag flag) {
-  assertx(flag >= 1ul << 48);
+  assertx(flag >= 1ull << 48);
   stackLimitAndSurprise().fetch_or(flag);
 }
 
 inline bool getSurpriseFlag(SurpriseFlag flag) {
-  assertx(flag >= 1ul << 48);
+  assertx(flag >= 1ull << 48);
   return stackLimitAndSurprise().load() & flag;
 }
 


### PR DESCRIPTION
Because otherwise MSVC does these as 32-bit shifts, which means every single one of the flags would evaluate to 0.