### PR TITLE
Support generating systemlib.php on Windows

### DIFF
--- a/hphp/runtime/ext_hhvm/make_systemlib.sh
+++ b/hphp/runtime/ext_hhvm/make_systemlib.sh
@@ -1,12 +1,8 @@
 #!/bin/sh
 
-cd $FBCODE_DIR
-
 # fbconfig passes a couple --foo arguments.
 shift;
 shift;
-
-SYSTEMLIB=$INSTALL_DIR/systemlib.php
 
 lib=""
 if [ "$1" = "--lib" ] ; then
@@ -20,6 +16,11 @@ fi
 prefix=""
 if [ "$1" = "--rel" ] ; then
   prefix=$INSTALL_DIR/
+  shift
+fi
+
+if [ "$SYSTEMLIB" = "" ] ; then
+  SYSTEMLIB=$1/systemlib.php
   shift
 fi
 
@@ -40,8 +41,6 @@ for ii in $@; do
 
   BN=`basename $i`
   BNPHP=`basename $BN .php`
-  BNNSPHP=`basename $BN .ns.php`
-  BNHHAS=`basename $BN .hhas`
   if [ "$BNPHP.php" = "$BN" ]; then
     # First, .php files are included with their open tags stripped
     if head -1 $i | grep -qv '^<?\(php\|hh\)'; then
@@ -49,6 +48,7 @@ for ii in $@; do
       exit 1
     fi
     echo "" >> ${SYSTEMLIB}
+    BNNSPHP=`basename $BN .ns.php`
     if [ ! "$BNNSPHP.ns.php" = "$BN" ]; then
       echo "namespace {" >> ${SYSTEMLIB}
     fi
@@ -57,6 +57,7 @@ for ii in $@; do
       echo "}" >> ${SYSTEMLIB}
     fi
   else
+    BNHHAS=`basename $BN .hhas`
     if [ ! "$BNHHAS.hhas" = "$BN" ]; then
       echo "File $i is neither PHP nor HHAS source" >&2
       exit 1

--- a/hphp/system/CMakeLists.txt
+++ b/hphp/system/CMakeLists.txt
@@ -54,12 +54,12 @@ endforeach()
 add_custom_command(
   OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/systemlib.php
   DEPENDS "php.txt" ${SYSTEMLIB_SRCS}
-  COMMAND "INSTALL_DIR=${CMAKE_CURRENT_BINARY_DIR}"
-          "FBCODE_DIR=${CMAKE_CURRENT_SOURCE_DIR}/../.."
-          "${CMAKE_CURRENT_SOURCE_DIR}/../runtime/ext_hhvm/make_systemlib.sh"
+  COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/../runtime/ext_hhvm/make_systemlib.sh"
           "--install_dir=${CMAKE_CURRENT_BINARY_DIR}"
           "--fbcode_dir=${CMAKE_CURRENT_SOURCE_DIR}/.."
+          "${CMAKE_CURRENT_BINARY_DIR}"
           "${SYSTEMLIB_SRCS_STR}"
+  WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/../.."
   COMMENT "Generating systemlib.php")
 
 add_custom_target(


### PR DESCRIPTION
We can't set environment variables when invoking a bash scrip ton windows, so get around it by passing them as arguments instead.
This also includes a minor optimization to speed up generating the systemlib on windows, because process creation is painfully slow. Even with this, it can still take 10-15 seconds to generate it due to the number of calls to basename.

This will require changes to the internal build system.