### PR TITLE
Use <sched.h> under MSVC for ext_hotprofiler

### DIFF
--- a/hphp/runtime/ext/hotprofiler/ext_hotprofiler.h
+++ b/hphp/runtime/ext/hotprofiler/ext_hotprofiler.h
@@ -44,7 +44,7 @@
         thread_policy_set(mach_thread_self(), THREAD_AFFINITY_POLICY, \
                           (int *)mask, THREAD_AFFINITY_POLICY_COUNT)
 
-#elif (defined(__CYGWIN__) || defined(__MINGW__)
+#elif defined(__CYGWIN__) || defined(__MINGW__)
 #include <windows.h>
 typedef DWORD_PTR cpu_set_t;
 

--- a/hphp/runtime/ext/hotprofiler/ext_hotprofiler.h
+++ b/hphp/runtime/ext/hotprofiler/ext_hotprofiler.h
@@ -44,7 +44,7 @@
         thread_policy_set(mach_thread_self(), THREAD_AFFINITY_POLICY, \
                           (int *)mask, THREAD_AFFINITY_POLICY_COUNT)
 
-#elif (defined(__CYGWIN__) || defined(__MINGW__) || defined(_MSC_VER))
+#elif (defined(__CYGWIN__) || defined(__MINGW__)
 #include <windows.h>
 typedef DWORD_PTR cpu_set_t;
 


### PR DESCRIPTION
Because, unlike Cygwin and MinGW, we have a proper pthread implementation.