### PR TITLE
Don't assert that the native stack is aligned under MSVC

### DIFF
--- a/hphp/runtime/vm/vm-regs.h
+++ b/hphp/runtime/vm/vm-regs.h
@@ -109,7 +109,9 @@ inline ActRec*& vmJitCalledFrame() {
 }
 
 inline void assert_native_stack_aligned() {
+#ifndef _MSC_VER
   assert(reinterpret_cast<uintptr_t>(__builtin_frame_address(0)) % 16 == 0);
+#endif
 }
 
 inline void interp_set_regs(ActRec* ar, Cell* sp, Offset pcOff) {


### PR DESCRIPTION
While it is a worthwhile check, we can't implement `__builtin_frame_adress` under MSVC without an external asm stub, so just disable the assert for now instead.