### PR TITLE
Explicitly specify bits_t as the base of TypedBits

### DIFF
--- a/hphp/runtime/vm/jit/type.h
+++ b/hphp/runtime/vm/jit/type.h
@@ -322,7 +322,7 @@ private:
   static constexpr size_t kPtrBoxShift  = kBoxShift + kPtrShift;
 
 public:
-  enum TypedBits {
+  enum TypedBits : bits_t {
 #define IRT(name, bits)       k##name = (bits),
 #define IRTP(name, ptr, bits) k##name = (bits),
     IR_TYPES


### PR DESCRIPTION
Because MSVC determines the base type of an enum from the first value, not from the largest value.