### PR TITLE
[MSVC] Adjust a couple of types to play nice with MSVC's bitfield layout

### DIFF
--- a/hphp/runtime/base/array-data.h
+++ b/hphp/runtime/base/array-data.h
@@ -50,7 +50,11 @@ struct ArrayData {
   // a few places in the code that depends on the order or the numeric
   // values. Also, all of the values need to be continuous from 0 to =
   // kNumKinds-1 since we use these values to index into a table.
+#ifdef HAVE_MSVC_BITFIELD_LAYOUT
+  enum ArrayKind : uintptr_t {
+#else
   enum ArrayKind : uint8_t {
+#endif
     kPackedKind = 0,  // PackedArray with keys in range [0..size)
     kStructKind = 1,  // StructArray with static string keys
     kMixedKind = 2,   // MixedArray arbitrary int or string keys, maybe holes

--- a/hphp/runtime/base/array-data.h
+++ b/hphp/runtime/base/array-data.h
@@ -50,11 +50,7 @@ struct ArrayData {
   // a few places in the code that depends on the order or the numeric
   // values. Also, all of the values need to be continuous from 0 to =
   // kNumKinds-1 since we use these values to index into a table.
-#ifdef HAVE_MSVC_BITFIELD_LAYOUT
   enum ArrayKind : uintptr_t {
-#else
-  enum ArrayKind : uint8_t {
-#endif
     kPackedKind = 0,  // PackedArray with keys in range [0..size)
     kStructKind = 1,  // StructArray with static string keys
     kMixedKind = 2,   // MixedArray arbitrary int or string keys, maybe holes

--- a/hphp/runtime/ext/hotprofiler/ext_hotprofiler.cpp
+++ b/hphp/runtime/ext/hotprofiler/ext_hotprofiler.cpp
@@ -802,13 +802,9 @@ class TraceProfiler : public Profiler {
     // from the memory field to use as a flag. We want to keep this
     // data structure small since we need a huge number of them during
     // a profiled run.
-    int64_t memory : 63; // Total memory, or memory allocated depending on flags
-#ifdef HAVE_MSVC_BITFIELD_LAYOUT
+    uint64_t memory : 63; // Total memory, or memory allocated depending on flags
     uint64_t is_func_exit : 1; // Is the entry for a function exit?
-#else
-    bool is_func_exit : 1; // Is the entry for a function exit?
-#endif
-    int64_t peak_memory : 63; // Peak memory, or memory freed depending on flags
+    uint64_t peak_memory : 63; // Peak memory, or memory freed depending on flags
     uint64_t unused : 1; // Unused, to keep memory and peak_memory the same size
 
     void clear() {

--- a/hphp/runtime/ext/hotprofiler/ext_hotprofiler.cpp
+++ b/hphp/runtime/ext/hotprofiler/ext_hotprofiler.cpp
@@ -802,9 +802,9 @@ class TraceProfiler : public Profiler {
     // from the memory field to use as a flag. We want to keep this
     // data structure small since we need a huge number of them during
     // a profiled run.
-    uint64_t memory : 63; // Total memory, or memory allocated depending on flags
+    uint64_t memory : 63;// Total memory, or memory allocated depending on flags
     uint64_t is_func_exit : 1; // Is the entry for a function exit?
-    uint64_t peak_memory : 63; // Peak memory, or memory freed depending on flags
+    uint64_t peak_memory : 63;// Peak memory, or memory freed depending on flags
     uint64_t unused : 1; // Unused, to keep memory and peak_memory the same size
 
     void clear() {

--- a/hphp/runtime/ext/hotprofiler/ext_hotprofiler.cpp
+++ b/hphp/runtime/ext/hotprofiler/ext_hotprofiler.cpp
@@ -803,7 +803,11 @@ class TraceProfiler : public Profiler {
     // data structure small since we need a huge number of them during
     // a profiled run.
     int64_t memory : 63; // Total memory, or memory allocated depending on flags
+#ifdef HAVE_MSVC_BITFIELD_LAYOUT
+    uint64_t is_func_exit : 1; // Is the entry for a function exit?
+#else
     bool is_func_exit : 1; // Is the entry for a function exit?
+#endif
     int64_t peak_memory : 63; // Peak memory, or memory freed depending on flags
     uint64_t unused : 1; // Unused, to keep memory and peak_memory the same size
 

--- a/hphp/runtime/ext/mbstring/ext_mbstring.cpp
+++ b/hphp/runtime/ext/mbstring/ext_mbstring.cpp
@@ -4159,8 +4159,13 @@ bool HHVM_FUNCTION(mb_send_mail,
   }
 
   struct {
+#ifdef HAVE_MSVC_BITFIELD_LAYOUT
+    unsigned int cnt_type : 1;
+    unsigned int cnt_trans_enc : 1;
+#else
     int cnt_type:1;
     int cnt_trans_enc:1;
+#endif
   } suppressed_hdrs = { 0, 0 };
 
   static const StaticString s_CONTENT_TYPE("CONTENT-TYPE");

--- a/hphp/runtime/ext/mbstring/ext_mbstring.cpp
+++ b/hphp/runtime/ext/mbstring/ext_mbstring.cpp
@@ -4159,13 +4159,8 @@ bool HHVM_FUNCTION(mb_send_mail,
   }
 
   struct {
-#ifdef HAVE_MSVC_BITFIELD_LAYOUT
-    unsigned int cnt_type : 1;
-    unsigned int cnt_trans_enc : 1;
-#else
-    int cnt_type:1;
-    int cnt_trans_enc:1;
-#endif
+    unsigned int cnt_type:1;
+    unsigned int cnt_trans_enc:1;
   } suppressed_hdrs = { 0, 0 };
 
   static const StaticString s_CONTENT_TYPE("CONTENT-TYPE");

--- a/hphp/runtime/vm/jit/type-specialization.h
+++ b/hphp/runtime/vm/jit/type-specialization.h
@@ -101,11 +101,7 @@ private:
   /*
    * Mask of specializations that a given ArraySpec represents.
    */
-#ifdef HAVE_MSVC_BITFIELD_LAYOUT
   enum SortOf : uintptr_t {
-#else
-  enum SortOf : uint8_t {
-#endif
     IsTop     = 0, // top
     IsBottom  = 1 << 0,
     HasKind   = 1 << 1,
@@ -198,11 +194,7 @@ private:
   /*
    * Sort tag.
    */
-#ifdef HAVE_MSVC_BITFIELD_LAYOUT
   enum SortOf : uintptr_t {
-#else
-  enum SortOf : uint8_t {
-#endif
     IsTop,
     IsBottom,
     IsSub,

--- a/hphp/runtime/vm/jit/type-specialization.h
+++ b/hphp/runtime/vm/jit/type-specialization.h
@@ -101,7 +101,11 @@ private:
   /*
    * Mask of specializations that a given ArraySpec represents.
    */
+#ifdef HAVE_MSVC_BITFIELD_LAYOUT
+  enum SortOf : uintptr_t {
+#else
   enum SortOf : uint8_t {
+#endif
     IsTop     = 0, // top
     IsBottom  = 1 << 0,
     HasKind   = 1 << 1,
@@ -194,7 +198,16 @@ private:
   /*
    * Sort tag.
    */
-  enum SortOf : uint8_t { IsTop, IsBottom, IsSub, IsExact, };
+#ifdef HAVE_MSVC_BITFIELD_LAYOUT
+  enum SortOf : uintptr_t {
+#else
+  enum SortOf : uint8_t {
+#endif
+    IsTop,
+    IsBottom,
+    IsSub,
+    IsExact,
+  };
 
   /*
    * Data members.

--- a/hphp/runtime/vm/jit/type.h
+++ b/hphp/runtime/vm/jit/type.h
@@ -725,7 +725,11 @@ private:
     struct {
       bits_t m_bits : 58;
       bits_t m_ptrKind : 5;
+#ifdef HAVE_MSVC_BITFIELD_LAYOUT
+      bits_t m_hasConstVal : 1;
+#else
       bool m_hasConstVal : 1;
+#endif
     };
     uint64_t m_rawInt;
   };

--- a/hphp/runtime/vm/jit/type.h
+++ b/hphp/runtime/vm/jit/type.h
@@ -725,11 +725,7 @@ private:
     struct {
       bits_t m_bits : 58;
       bits_t m_ptrKind : 5;
-#ifdef HAVE_MSVC_BITFIELD_LAYOUT
       bits_t m_hasConstVal : 1;
-#else
-      bool m_hasConstVal : 1;
-#endif
     };
     uint64_t m_rawInt;
   };

--- a/hphp/runtime/vm/srckey.h
+++ b/hphp/runtime/vm/srckey.h
@@ -155,13 +155,8 @@ private:
     struct {
       FuncId m_funcID;
       uint32_t m_offset : 30;
-#ifdef HAVE_MSVC_BITFIELD_LAYOUT
       uint32_t m_prologue : 1;
       uint32_t m_resumed : 1;
-#else
-      bool m_prologue : 1;
-      bool m_resumed : 1;
-#endif
     };
   };
 };

--- a/hphp/runtime/vm/srckey.h
+++ b/hphp/runtime/vm/srckey.h
@@ -155,8 +155,13 @@ private:
     struct {
       FuncId m_funcID;
       uint32_t m_offset : 30;
+#ifdef HAVE_MSVC_BITFIELD_LAYOUT
+      uint32_t m_prologue : 1;
+      uint32_t m_resumed : 1;
+#else
       bool m_prologue : 1;
       bool m_resumed : 1;
+#endif
     };
   };
 };

--- a/hphp/util/portability.h
+++ b/hphp/util/portability.h
@@ -184,4 +184,14 @@
 
 //////////////////////////////////////////////////////////////////////
 
+#ifdef _MSC_VER
+// This is used to make it easy to locate all places where changes
+// were required due to the way MSVC lays out bitfields.
+//
+// Basically, the issue is that MSVC will only put two fields in
+// the same byte if the type of both fields is the same size,
+// otherwise it starts a new byte.
+# define HAVE_MSVC_BITFIELD_LAYOUT 1
+#endif
+
 #endif

--- a/hphp/util/portability.h
+++ b/hphp/util/portability.h
@@ -184,14 +184,4 @@
 
 //////////////////////////////////////////////////////////////////////
 
-#ifdef _MSC_VER
-// This is used to make it easy to locate all places where changes
-// were required due to the way MSVC lays out bitfields.
-//
-// Basically, the issue is that MSVC will only put two fields in
-// the same byte if the type of both fields is the same size,
-// otherwise it starts a new byte.
-# define HAVE_MSVC_BITFIELD_LAYOUT 1
-#endif
-
 #endif


### PR DESCRIPTION
As described in the define this adds, the issue here is that MSVC will only put two bitfields in the same byte if their types are the same size.
This is done in such a way as to only effect the MSVC build.