### PR TITLE
Pack ObjectData under MSVC

### DIFF
--- a/hphp/runtime/base/object-data.h
+++ b/hphp/runtime/base/object-data.h
@@ -58,6 +58,9 @@ struct TypedValue;
 void deepInitHelper(TypedValue* propVec, const TypedValueAux* propData,
                     size_t nProps);
 
+#ifdef _MSC_VER
+#pragma pack(push, 1)
+#endif
 struct ObjectData {
   enum Attribute : uint16_t {
     NoDestructor  = 0x0001, // __destruct()
@@ -439,6 +442,9 @@ private:
   int o_id; // Numeric identifier of this object (used for var_dump())
 #endif
 };
+#ifdef _MSC_VER
+#pragma pack(pop)
+#endif
 
 struct GlobalsArray;
 typedef GlobalsArray GlobalVariables;


### PR DESCRIPTION
Because otherwise it gets some extra padding that makes `FAST_COLLECTION_SIZE_OFFSET` no longer be correct.
This only applies the packing under MSVC.