### PR TITLE
Support ext_xenon under MSVC

### DIFF
--- a/hphp/runtime/ext/xenon/ext_xenon.cpp
+++ b/hphp/runtime/ext/xenon/ext_xenon.cpp
@@ -151,7 +151,7 @@ Xenon& Xenon::getInstance() noexcept {
 }
 
 Xenon::Xenon() noexcept : m_stopping(false) {
-#ifndef __APPLE__
+#if !defined(__APPLE__) && !defined(_MSC_VER)
   m_timerid = 0;
 #endif
 }
@@ -162,7 +162,7 @@ Xenon::Xenon() noexcept : m_stopping(false) {
 // We need to create a semaphore and a thread.
 // If all of those happen, then we need a timer attached to a signal handler.
 void Xenon::start(uint64_t msec) {
-#ifndef __APPLE__
+#if !defined(__APPLE__) && !defined(_MSC_VER)
   TRACE(1, "XenonForceAlwaysOn %d\n", RuntimeOption::XenonForceAlwaysOn);
   if (!RuntimeOption::XenonForceAlwaysOn
       && m_timerid == 0
@@ -201,7 +201,7 @@ void Xenon::start(uint64_t msec) {
 
 // If Xenon owns a pthread, tell it to stop, also clean up anything from start.
 void Xenon::stop() {
-#ifndef __APPLE__
+#if !defined(__APPLE__) && !defined(_MSC_VER)
   if (m_timerid) {
     m_stopping = true;
     sem_post(&m_timerTriggered);

--- a/hphp/runtime/ext/xenon/ext_xenon.h
+++ b/hphp/runtime/ext/xenon/ext_xenon.h
@@ -102,7 +102,7 @@ class Xenon final {
     bool      m_stopping;
   private:
     sem_t     m_timerTriggered;
-#ifndef __APPLE__
+#if !defined(__APPLE__) && !defined(_MSC_VER)
     pthread_t m_triggerThread;
     timer_t   m_timerid;
 #endif


### PR DESCRIPTION
Because, like OSX, we don't have `timer_t`.