### PR TITLE
Return void from throwNotNotifiedException

### DIFF
--- a/hphp/runtime/ext/asio/ext_condition-wait-handle.cpp
+++ b/hphp/runtime/ext/asio/ext_condition-wait-handle.cpp
@@ -35,7 +35,7 @@ namespace {
   }
 
   NEVER_INLINE ATTRIBUTE_NORETURN
-  Object throwNotNotifiedException() {
+  void throwNotNotifiedException() {
     SystemLib::throwInvalidArgumentExceptionObject(
       "ConditionWaitHandle not notified by its child");
   }


### PR DESCRIPTION
Because, as MSVC rightly warns:
```
hphp\runtime\ext\asio\ext_condition-wait-handle.cpp(38): warning C4646: function declared with __declspec(noreturn) has non-void return type
```