### PR TITLE
Support the timezone bias calculation in ext_openssl under MSVC

### DIFF
--- a/hphp/runtime/ext/openssl/ext_openssl.cpp
+++ b/hphp/runtime/ext/openssl/ext_openssl.cpp
@@ -2417,6 +2417,10 @@ static time_t asn1_time_to_time_t(ASN1_UTCTIME *timestr) {
   long gmadjust = 0;
 #if HAVE_TM_GMTOFF
   gmadjust = thetime.tm_gmtoff;
+#elif defined(_MSC_VER)
+  TIME_ZONE_INFORMATION inf;
+  GetTimeZoneInformation(&inf);
+  gmadjust = thetime.tm_isdst ? inf.DaylightBias : inf.StandardBias;
 #else
   /**
    * If correcting for daylight savings time, we set the adjustment to


### PR DESCRIPTION
Because `timezone` is actually a struct under MSVC, and doesn't even come close to doing what the code was trying to achieve. (and it also wouldn't compile)