### PR TITLE
Use alloca in ext_hash

### DIFF
--- a/hphp/runtime/ext/hash/ext_hash.cpp
+++ b/hphp/runtime/ext/hash/ext_hash.cpp
@@ -155,7 +155,8 @@ struct HashContext : SweepableResourceData {
     /* Just in case the algo has internally allocated resources */
     if (context) {
       assert(ops->digest_size >= 0);
-      unsigned char dummy[ops->digest_size];
+      unsigned char* dummy = (unsigned char*)alloca(
+        sizeof(unsigned char) * ops->digest_size);
       ops->hash_final(dummy, context);
       free(context);
     }


### PR DESCRIPTION
Rather than a C99 stack allocated array, which MSVC doesn't support.