### PR TITLE
Use srand and rand in ext_std_math.cpp under MSVC

### DIFF
--- a/hphp/runtime/ext/std/ext_std_math.cpp
+++ b/hphp/runtime/ext/std/ext_std_math.cpp
@@ -398,7 +398,9 @@ int64_t HHVM_FUNCTION(getrandmax) { return RAND_MAX;}
 
 ///////////////////////////////////////////////////////////////////////////////
 
-#ifdef __APPLE__
+// Note that MSVC's rand is actually thread-safe to begin with
+// so no changes are actually needed to make it so.
+#if defined(__APPLE__) || defined(_MSC_VER)
 static bool s_rand_is_seeded = false;
 #else
 struct RandomBuf {
@@ -413,7 +415,7 @@ static __thread RandomBuf s_state;
 #endif
 
 static void randinit(uint32_t seed) {
-#ifdef __APPLE__
+#if defined(__APPLE__) || defined(_MSC_VER)
   s_rand_is_seeded = true;
   srandom(seed);
 #else
@@ -441,7 +443,7 @@ void HHVM_FUNCTION(srand, const Variant& seed /* = null_variant */) {
 int64_t HHVM_FUNCTION(rand,
                       int64_t min /* = 0 */,
                       const Variant& max /* = null_variant */) {
-#ifdef __APPLE__
+#if defined(__APPLE__) || defined(_MSC_VER)
   if (!s_rand_is_seeded) {
 #else
   if (s_state.state != RandomBuf::RequestInit) {
@@ -450,7 +452,7 @@ int64_t HHVM_FUNCTION(rand,
   }
 
   int64_t number;
-#ifdef __APPLE__
+#if defined(__APPLE__) || defined(_MSC_VER)
   number = random();
 #else
   int32_t numberIn;
@@ -500,7 +502,7 @@ const StaticString s_PHP_ROUND_HALF_ODD("PHP_ROUND_HALF_ODD");
   Native::registerConstant<KindOfDouble>(makeStaticString("M_"#nm), k_M_##nm)  \
 
 void StandardExtension::requestInit() {
-#ifndef __APPLE__
+#if !defined(__APPLE__) && !defined(_MSC_VER)
   if (s_state.state == RandomBuf::RequestInit) {
     s_state.state = RandomBuf::ThreadInit;
   }

--- a/hphp/runtime/ext/std/ext_std_math.cpp
+++ b/hphp/runtime/ext/std/ext_std_math.cpp
@@ -400,8 +400,10 @@ int64_t HHVM_FUNCTION(getrandmax) { return RAND_MAX;}
 
 // Note that MSVC's rand is actually thread-safe to begin with
 // so no changes are actually needed to make it so.
-#if defined(__APPLE__) || defined(_MSC_VER)
+#ifdef __APPLE__
 static bool s_rand_is_seeded = false;
+#elif defined(_MSC_VER)
+static __thread bool s_rand_is_seeded = false;
 #else
 struct RandomBuf {
   random_data data;
@@ -415,9 +417,12 @@ static __thread RandomBuf s_state;
 #endif
 
 static void randinit(uint32_t seed) {
-#if defined(__APPLE__) || defined(_MSC_VER)
+#ifdef __APPLE__
   s_rand_is_seeded = true;
   srandom(seed);
+#elif defined(_MSC_VER)
+  s_rand_is_seeded = true;
+  srand(seed);
 #else
   if (s_state.state == RandomBuf::Uninit) {
     initstate_r(seed, s_state.buf, sizeof s_state.buf, &s_state.data);
@@ -452,8 +457,10 @@ int64_t HHVM_FUNCTION(rand,
   }
 
   int64_t number;
-#if defined(__APPLE__) || defined(_MSC_VER)
+#ifdef __APPLE__
   number = random();
+#elif defined(_MSC_VER)
+  number = rand();
 #else
   int32_t numberIn;
   random_r(&s_state.data, &numberIn);


### PR DESCRIPTION
This simply means using the codepath already present for OSX.
MSVC's implementation is actually thread-safe to begin with, so the other code path isn't needed at all.