### PR TITLE
Explicitly convert  Variant to a String in a couple of places

### DIFF
--- a/hphp/runtime/debugger/debugger_client.cpp
+++ b/hphp/runtime/debugger/debugger_client.cpp
@@ -1558,7 +1558,7 @@ void DebuggerClient::tutorial(const char *text) {
   sb.append(BOX_VL); sb.append(hr); sb.append(BOX_VR); sb.append("\n");
   for (ArrayIter iter(lines); iter; ++iter) {
     sb.append(BOX_V); sb.append(' ');
-    sb.append(StringUtil::Pad(iter.second(), LineWidth - 4));
+    sb.append(StringUtil::Pad(iter.second().toString(), LineWidth - 4));
     sb.append(' '); sb.append(BOX_V); sb.append("\n");
   }
   sb.append(BOX_LL); sb.append(hr); sb.append(BOX_LR); sb.append("\n");

--- a/hphp/runtime/ext/std/ext_std_file.cpp
+++ b/hphp/runtime/ext/std/ext_std_file.cpp
@@ -1845,7 +1845,7 @@ bool HHVM_FUNCTION(chdir,
                    const String& directory) {
   CHECK_PATH_FALSE(directory, 1);
   if (HHVM_FN(is_dir)(directory)) {
-    g_context->setCwd(HHVM_FN(realpath)(directory));
+    g_context->setCwd(HHVM_FN(realpath)(directory).toString());
     return true;
   }
   raise_warning("No such file or directory (errno 2)");

--- a/hphp/runtime/ext/url/ext_url.cpp
+++ b/hphp/runtime/ext/url/ext_url.cpp
@@ -85,7 +85,7 @@ Variant HHVM_FUNCTION(get_headers, const String& url, int format /* = 0 */) {
 
   Array assoc;
   for (ArrayIter iter(ret); iter; ++iter) {
-    Array tokens = HHVM_FN(explode)(": ", iter.second(), 2).toArray();
+    Array tokens = HHVM_FN(explode)(": ", iter.second().toString(), 2).toArray();
     if (tokens.size() == 2) {
       assoc.set(tokens[0], tokens[1]);
     } else {

--- a/hphp/runtime/server/source-root-info.cpp
+++ b/hphp/runtime/server/source-root-info.cpp
@@ -67,7 +67,7 @@ SourceRootInfo::SourceRootInfo(Transport* transport)
     createFromCommonRoot(sandboxName);
   } else {
     Array pair = StringUtil::Explode(
-      matches.toArray().rvalAt(1), "-", 2).toArray();
+      matches.toArray().rvalAt(1).toString(), "-", 2).toArray();
     m_user = pair.rvalAt(0).toString();
     bool defaultSb = pair.size() == 1;
     if (defaultSb) {


### PR DESCRIPTION
I have no idea why this was working under GCC, but MSVC generated the error correctly here, as the implicit conversion operator from `Variant` to `String` is defined as deleted.