### PR TITLE
Stub out what little we use in LibDwarf under MSVC

### DIFF
--- a/hphp/runtime/vm/debug/dwarf.h
+++ b/hphp/runtime/vm/debug/dwarf.h
@@ -21,8 +21,30 @@
 #include <folly/Optional.h>
 
 #include "hphp/runtime/vm/jit/translator.h"
+#ifndef _MSC_VER
 #include <libdwarf.h>
 #include <dwarf.h>
+#else
+// We don't have libdwarf, so stub it out.
+typedef void* Dwarf_Ptr;
+typedef uint32_t Dwarf_Unsigned;
+
+#define DW_EH_PE_absptr 0
+
+#define DW_CFA_def_cfa 0
+#define DW_CFA_offset 0
+#define DW_CFA_offset_extended_sf 0
+#define DW_CFA_same_value 0
+#define DW_CFA_set_loc 0
+#define DW_CFA_val_expression 0
+
+#define DW_OP_breg7 0
+#define DW_OP_const4s 0
+#define DW_OP_deref_size 0
+#define DW_OP_dup 0
+#define DW_OP_mul 0
+#define DW_OP_plus 0
+#endif
 #include <vector>
 
 namespace HPHP {


### PR DESCRIPTION
Because we don't have any use for libdwarf under MSVC, we can just stub out the constants and typdefs HHVM uses, of which there aren't many.