### PR TITLE
Use __debugbreak for vixl's HostBreakpoint under MSVC

### DIFF
--- a/hphp/vixl/platform.h
+++ b/hphp/vixl/platform.h
@@ -29,12 +29,18 @@
 
 #include "hphp/util/assertions.h"
 
+#ifdef _M_X64
+#include <intrin.h> // for __debugbreak()
+#endif
+
 // Define platform specific functionalities.
 
 namespace vixl {
 inline void HostBreakpoint() {
 #if defined(__x86_64__)
   asm("int3");
+#elif defined(_M_X64)
+  __debugbreak();
 #elif defined(__AARCH64EL__)
   // TODO: Implement HostBreakpoint on a64.
   not_implemented();


### PR DESCRIPTION
Because inline assembly is evil, and intrinisics are king, at least, that's what MSVC likes to think.