### PR TITLE
Construct VregDbl and Vreg128 in an MSVC friendly way

### DIFF
--- a/hphp/runtime/vm/jit/vasm-reg.h
+++ b/hphp/runtime/vm/jit/vasm-reg.h
@@ -182,16 +182,16 @@ using Vreg8   = Vr<Reg8>;
 using VregSF  = Vr<RegSF>;
 
 struct VregDbl : Vr<RegXMM> {
-  explicit VregDbl(size_t rn) : Vr<RegXMM>{rn} {}
+  explicit VregDbl(size_t rn) : Vr<RegXMM>(rn) {}
   template<class... Args> /* implicit */ VregDbl(Args&&... args)
-    : Vr<RegXMM>{std::forward<Args>(args)...} {}
+    : Vr<RegXMM>(std::forward<Args>(args)...) {}
   static bool allowable(Vreg r) { return r.isVirt() || r.isSIMD(); }
 };
 
 struct Vreg128 : Vr<RegXMM> {
-  explicit Vreg128(size_t rn) : Vr<RegXMM>{rn} {}
+  explicit Vreg128(size_t rn) : Vr<RegXMM>(rn) {}
   template<class... Args> /* implicit */ Vreg128(Args&&... args)
-    : Vr<RegXMM>{std::forward<Args>(args)...}
+    : Vr<RegXMM>(std::forward<Args>(args)...)
   {}
 };
 


### PR DESCRIPTION
MSVC gives syntax errors if this is done with curly braces, but doesn't error, and compiles successfully if these are just normal parenthesis.