### PR TITLE
[MSVC] Stub out the unwind mechanics under MSVC

### DIFF
--- a/hphp/runtime/vm/jit/code-gen-x64.cpp
+++ b/hphp/runtime/vm/jit/code-gen-x64.cpp
@@ -19,8 +19,10 @@
 #include <cstring>
 #include <iostream>
 #include <limits>
-#include <unwind.h>
 #include <vector>
+#ifndef _MSC_VER
+#include <unwind.h>
+#endif
 
 #include <folly/ScopeGuard.h>
 #include <folly/Format.h>

--- a/hphp/runtime/vm/jit/mc-generator.cpp
+++ b/hphp/runtime/vm/jit/mc-generator.cpp
@@ -24,7 +24,9 @@
 #include <stdio.h>
 #include <sys/mman.h>
 #include <unistd.h>
+#ifndef _MSC_VER
 #include <unwind.h>
+#endif
 
 #include <algorithm>
 #include <exception>

--- a/hphp/runtime/vm/jit/unwind-x64.cpp
+++ b/hphp/runtime/vm/jit/unwind-x64.cpp
@@ -183,7 +183,6 @@ tc_unwind_personality(int version,
                       uint64_t exceptionClass,
                       _Unwind_Exception* exceptionObj,
                       _Unwind_Context* context) {
-  using namespace abi;
   // Exceptions thrown by g++-generated code will have the class "GNUCC++"
   // packed into a 64-bit int. libc++ has the class "CLNGC++". For now we
   // shouldn't be seeing exceptions from any other runtimes but this may
@@ -211,7 +210,7 @@ tc_unwind_personality(int version,
   if (Trace::moduleEnabled(TRACEMOD, 1)) {
     DEBUG_ONLY auto const* unwindType =
       (actions & _UA_SEARCH_PHASE) ? "search" : "cleanup";
-#ifdef HAVE_CXXABI_H
+#ifndef _MSC_VER
     int status;
     auto* exnType = abi::__cxa_demangle(ti.name(), nullptr, nullptr, &status);
     SCOPE_EXIT { free(exnType); };

--- a/hphp/runtime/vm/jit/unwind-x64.h
+++ b/hphp/runtime/vm/jit/unwind-x64.h
@@ -20,7 +20,6 @@
 #include <cstdlib>
 #include <sstream>
 #include <string>
-#include <unwind.h>
 #include <memory>
 #include <exception>
 #include <typeinfo>
@@ -31,6 +30,36 @@
 #include "hphp/runtime/vm/tread-hash-map.h"
 #include "hphp/util/asm-x64.h"
 #include "hphp/util/assertions.h"
+
+#ifndef _MSC_VER
+#include <unwind.h>
+#else
+// Stubs! Don't you just love them?
+// In this case, the stubs are just
+// here to allow the code to compile.
+// Attempting to use the stubs will
+// likely just result in a segfault.
+
+struct _Unwind_Exception {
+  uint64_t exception_class;
+};
+
+#define _URC_CONTINUE_UNWIND 0
+#define _URC_INSTALL_CONTEXT 0
+#define _URC_HANDLER_FOUND 0
+typedef int _Unwind_Reason_Code;
+
+#define _UA_HANDLER_FRAME 0
+#define _UA_CLEANUP_PHASE 0
+#define _UA_SEARCH_PHASE 0
+typedef int _Unwind_Action;
+
+typedef void _Unwind_Context;
+
+inline uintptr_t _Unwind_GetGR(_Unwind_Context*, int) { return 0; }
+inline uintptr_t _Unwind_GetIP(_Unwind_Context*) { return 0; }
+inline void _Unwind_SetIP(_Unwind_Context*, uint64_t) { }
+#endif
 
 namespace HPHP {
 struct ActRec;

--- a/hphp/runtime/vm/jit/unwind-x64.h
+++ b/hphp/runtime/vm/jit/unwind-x64.h
@@ -56,9 +56,16 @@ typedef int _Unwind_Action;
 
 typedef void _Unwind_Context;
 
-inline uintptr_t _Unwind_GetGR(_Unwind_Context*, int) { return 0; }
-inline uintptr_t _Unwind_GetIP(_Unwind_Context*) { return 0; }
-inline void _Unwind_SetIP(_Unwind_Context*, uint64_t) { }
+inline uintptr_t _Unwind_GetGR(_Unwind_Context*, int) {
+  always_assert(false);
+  return 0;
+}
+inline uintptr_t _Unwind_GetIP(_Unwind_Context*) {
+  always_assert(false);
+  return 0;
+}
+inline void _Unwind_Resume() { always_assert(false); }
+inline void _Unwind_SetIP(_Unwind_Context*, uint64_t) { always_assert(false); }
 #endif
 
 namespace HPHP {


### PR DESCRIPTION
MSVC's exception handling code is significantly different from GCC's, meaning none of this code is actually going to work correctly for MSVC, so just stub it out for now so that we can compile.