### PR TITLE
[MSVC] Handle a few places where MSVC chokes on the atomic loads

### DIFF
--- a/hphp/runtime/base/preg.cpp
+++ b/hphp/runtime/base/preg.cpp
@@ -193,11 +193,7 @@ public:
   }
 
   ~PCRECache() {
-#ifdef MSVC_NO_NONVOID_ATOMIC_IF
     if (m_kind == CacheKind::Static && m_staticCache.load()) {
-#else
-    if (m_kind == CacheKind::Static && m_staticCache) {
-#endif
       DestroyStatic(m_staticCache);
     }
   }
@@ -280,11 +276,7 @@ void PCRECache::DestroyStatic(StaticCache* cache) {
 void PCRECache::reinit(CacheKind kind) {
   switch (m_kind) {
     case CacheKind::Static:
-#ifdef MSVC_NO_NONVOID_ATOMIC_IF
       if (m_staticCache.load()) {
-#else
-      if (m_staticCache) {
-#endif
         DestroyStatic(m_staticCache);
         m_staticCache = nullptr;
       }
@@ -320,11 +312,7 @@ bool PCRECache::find(Accessor& accessor,
   switch (m_kind) {
     case CacheKind::Static:
       {
-#ifdef MSVC_NO_NONVOID_ATOMIC_IF
         assert(m_staticCache.load());
-#else
-        assert(m_staticCache);
-#endif
         StaticCache::iterator it;
         auto cache = m_staticCache.load(std::memory_order_acquire);
         if ((it = cache->find(regex.get())) != cache->end()) {
@@ -375,11 +363,7 @@ void PCRECache::insert(
   switch (m_kind) {
     case CacheKind::Static:
       {
-#ifdef MSVC_NO_NONVOID_ATOMIC_IF
         assert(m_staticCache.load());
-#else
-        assert(m_staticCache);
-#endif
         // Clear the cache if we haven't refreshed it in a while
         if (time(nullptr) > m_expire) {
           clearStatic();

--- a/hphp/runtime/base/preg.cpp
+++ b/hphp/runtime/base/preg.cpp
@@ -193,7 +193,11 @@ public:
   }
 
   ~PCRECache() {
+#ifdef MSVC_NO_NONVOID_ATOMIC_IF
+    if (m_kind == CacheKind::Static && m_staticCache.load()) {
+#else
     if (m_kind == CacheKind::Static && m_staticCache) {
+#endif
       DestroyStatic(m_staticCache);
     }
   }
@@ -276,7 +280,11 @@ void PCRECache::DestroyStatic(StaticCache* cache) {
 void PCRECache::reinit(CacheKind kind) {
   switch (m_kind) {
     case CacheKind::Static:
+#ifdef MSVC_NO_NONVOID_ATOMIC_IF
+      if (m_staticCache.load()) {
+#else
       if (m_staticCache) {
+#endif
         DestroyStatic(m_staticCache);
         m_staticCache = nullptr;
       }
@@ -312,7 +320,11 @@ bool PCRECache::find(Accessor& accessor,
   switch (m_kind) {
     case CacheKind::Static:
       {
+#ifdef MSVC_NO_NONVOID_ATOMIC_IF
+        assert(m_staticCache.load());
+#else
         assert(m_staticCache);
+#endif
         StaticCache::iterator it;
         auto cache = m_staticCache.load(std::memory_order_acquire);
         if ((it = cache->find(regex.get())) != cache->end()) {
@@ -363,7 +375,11 @@ void PCRECache::insert(
   switch (m_kind) {
     case CacheKind::Static:
       {
+#ifdef MSVC_NO_NONVOID_ATOMIC_IF
+        assert(m_staticCache.load());
+#else
         assert(m_staticCache);
+#endif
         // Clear the cache if we haven't refreshed it in a while
         if (time(nullptr) > m_expire) {
           clearStatic();

--- a/hphp/runtime/vm/tread-hash-map.h
+++ b/hphp/runtime/vm/tread-hash-map.h
@@ -209,7 +209,11 @@ private:
     auto newTable = allocTable(old->capac * 2);
     for (auto i = 0; i < old->capac; ++i) {
       value_type* ent = old->entries + i;
+#ifdef MSVC_NO_NONVOID_ATOMIC_IF
+      if (ent->first.load()) {
+#else
       if (ent->first) {
+#endif
         insertImpl(newTable, ent->first, ent->second);
       }
     }

--- a/hphp/runtime/vm/tread-hash-map.h
+++ b/hphp/runtime/vm/tread-hash-map.h
@@ -209,11 +209,7 @@ private:
     auto newTable = allocTable(old->capac * 2);
     for (auto i = 0; i < old->capac; ++i) {
       value_type* ent = old->entries + i;
-#ifdef MSVC_NO_NONVOID_ATOMIC_IF
       if (ent->first.load()) {
-#else
-      if (ent->first) {
-#endif
         insertImpl(newTable, ent->first, ent->second);
       }
     }

--- a/hphp/util/atomic-vector.h
+++ b/hphp/util/atomic-vector.h
@@ -131,7 +131,11 @@ Value AtomicVector<Value>::exchange(size_t i, const Value& val) {
     return oldVal;
   }
 
+#ifdef MSVC_NO_NONVOID_ATOMIC_IF
+  assert(m_next.load());
+#else
   assert(m_next);
+#endif
   return m_next.load(std::memory_order_acquire)->exchange(i - m_size, val);
 }
 
@@ -149,7 +153,11 @@ bool AtomicVector<Value>::compare_exchange(size_t i,
     return oldVal;
   }
 
+#ifdef MSVC_NO_NONVOID_ATOMIC_IF
+  assert(m_next.load());
+#else
   assert(m_next);
+#endif
   return m_next.load(std::memory_order_acquire)->
                      compare_exchange(i - m_size, expect,  val);
 }
@@ -163,7 +171,11 @@ Value AtomicVector<Value>::get(size_t i) const {
     return val;
   }
 
+#ifdef MSVC_NO_NONVOID_ATOMIC_IF
+  assert(m_next.load());
+#else
   assert(m_next);
+#endif
   return m_next.load(std::memory_order_acquire)->get(i - m_size);
 }
 

--- a/hphp/util/atomic-vector.h
+++ b/hphp/util/atomic-vector.h
@@ -131,11 +131,7 @@ Value AtomicVector<Value>::exchange(size_t i, const Value& val) {
     return oldVal;
   }
 
-#ifdef MSVC_NO_NONVOID_ATOMIC_IF
   assert(m_next.load());
-#else
-  assert(m_next);
-#endif
   return m_next.load(std::memory_order_acquire)->exchange(i - m_size, val);
 }
 
@@ -153,11 +149,7 @@ bool AtomicVector<Value>::compare_exchange(size_t i,
     return oldVal;
   }
 
-#ifdef MSVC_NO_NONVOID_ATOMIC_IF
   assert(m_next.load());
-#else
-  assert(m_next);
-#endif
   return m_next.load(std::memory_order_acquire)->
                      compare_exchange(i - m_size, expect,  val);
 }
@@ -171,11 +163,7 @@ Value AtomicVector<Value>::get(size_t i) const {
     return val;
   }
 
-#ifdef MSVC_NO_NONVOID_ATOMIC_IF
   assert(m_next.load());
-#else
-  assert(m_next);
-#endif
   return m_next.load(std::memory_order_acquire)->get(i - m_size);
 }
 


### PR DESCRIPTION
Basically the issue here is that MSVC doesn't like it when you use an `std::atomic` with a type other than `void*` as a condition to an `if` statement, so this works around it by just loading the value explicitly.

~~This is dependent upon an issue with how [folly#264](https://github.com/facebook/folly/pull/264) was merged being resolved first.~~
~~Depends on [folly#305](https://github.com/facebook/folly/pull/305) being merged upstream first.~~