### PR TITLE
Port ext_string to MSVC

### DIFF
--- a/hphp/runtime/ext/string/ext_string.h
+++ b/hphp/runtime/ext/string/ext_string.h
@@ -23,7 +23,9 @@
 #include "hphp/runtime/base/zend-string.h"
 #include "hphp/runtime/base/zend-printf.h"
 #include "hphp/util/bstring.h"
+#ifndef _MSC_VER
 #include <langinfo.h>
+#endif
 
 namespace HPHP {
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
`qsort_r` is `qsort_s` under MSVC, and the context pointer is the first argument to the callback rather than the last.
I didn't want to deal with porting the multi-dimentional C99 stack allocated array to use alloca, so I just disabled that for now.
We don't have `nl_langinfo` under MSVC, so raise a warning when it's called.