### PR TITLE
Implement deleteMultiByKey and deleteMulti functions.

### DIFF
--- a/hphp/hack/hhi/stdlib/builtins_memcached.hhi
+++ b/hphp/hack/hhi/stdlib/builtins_memcached.hhi
@@ -78,6 +78,9 @@ class Memcached {
   public function decrement($key, $offset = 1) { }
   public function delete($key, $time = 0) { }
   public function deleteByKey($server_key, $key, $time = 0) { }
+  public function deleteMulti(array $keys, int $time = 0): mixed { }
+  public function deleteMultiByKey(string $server_key, array $keys,
+                                   int $time = 0): mixed { }
   public function fetch() { }
   public function fetchAll() { }
   public function flush($delay = 0) { }

--- a/hphp/runtime/ext/memcached/ext_memcached.cpp
+++ b/hphp/runtime/ext/memcached/ext_memcached.cpp
@@ -853,7 +853,7 @@ bool HHVM_METHOD(Memcached, deletebykey, const String& server_key,
 
 Variant HHVM_METHOD(Memcached, deletemultibykey, const String& server_key,
                                          const Array& keys,
-                                         int time /*= 0*/) {
+                                         int64_t time /*= 0*/) {
   auto data = Native::data<MemcachedData>(this_);
   data->m_impl->rescode = q_Memcached$$RES_SUCCESS;
 

--- a/hphp/runtime/ext/memcached/ext_memcached.php
+++ b/hphp/runtime/ext/memcached/ext_memcached.php
@@ -248,6 +248,37 @@ class Memcached {
   }
 
   /**
+   * Add an item under a new key on a specific server
+   *
+   * @param string $server_key - The key identifying the server to store the value on
+   * or retrieve it from. Instead of hashing on the actual key for the item, we
+   * hash on the server key when deciding which memcached server to talk to.
+   * This allows related items to be grouped together on a single server for
+   * efficiency with multi operations..
+   * @param array $keys - The keys to be deleted.
+   * @param int $time - The amount of time the server will wait to delete
+   *   the items.
+   *
+   * @return array
+   */
+  <<__Native>>
+  public function deleteMultiByKey(string $server_key, array $keys,
+                                   int $time = 0): mixed;
+
+  /**
+   * Add an item under a new key on a specific server
+   *
+   * @param array $keys - The keys to be deleted.
+   * @param int $time - The amount of time the server will wait to delete
+   *   the items.
+   *
+   * @return array
+   */
+  public function deleteMulti(array $keys, int $time = 0): mixed {
+    return $this->deleteMultiByKey('', $keys, $time);
+  }
+
+  /**
    * Delete an item from a specific server
    *
    * @param string $server_key -

--- a/hphp/test/quick/builtin_extension_Memcached.php.expectf
+++ b/hphp/test/quick/builtin_extension_Memcached.php.expectf
@@ -5,7 +5,7 @@ object(Memcached)#1 (0) {
 Warning: Attempted to serialize unserializable builtin class Memcached in %s/builtin_extensions.inc on line 8
 string(2) "N;"
 NULL
-array(46) {
+array(48) {
   [0]=>
   string(11) "__construct"
   [1]=>
@@ -31,72 +31,76 @@ array(46) {
   [11]=>
   string(6) "delete"
   [12]=>
-  string(11) "deleteByKey"
+  string(16) "deleteMultiByKey"
   [13]=>
-  string(5) "fetch"
+  string(11) "deleteMulti"
   [14]=>
-  string(8) "fetchAll"
+  string(11) "deleteByKey"
   [15]=>
-  string(5) "flush"
+  string(5) "fetch"
   [16]=>
-  string(3) "get"
+  string(8) "fetchAll"
   [17]=>
-  string(10) "getAllKeys"
+  string(5) "flush"
   [18]=>
-  string(8) "getByKey"
+  string(3) "get"
   [19]=>
-  string(10) "getDelayed"
+  string(10) "getAllKeys"
   [20]=>
-  string(15) "getDelayedByKey"
+  string(8) "getByKey"
   [21]=>
-  string(8) "getMulti"
+  string(10) "getDelayed"
   [22]=>
-  string(13) "getMultiByKey"
+  string(15) "getDelayedByKey"
   [23]=>
-  string(9) "getOption"
+  string(8) "getMulti"
   [24]=>
-  string(13) "getResultCode"
+  string(13) "getMultiByKey"
   [25]=>
-  string(16) "getResultMessage"
+  string(9) "getOption"
   [26]=>
-  string(14) "getServerByKey"
+  string(13) "getResultCode"
   [27]=>
-  string(13) "getServerList"
+  string(16) "getResultMessage"
   [28]=>
-  string(15) "resetServerList"
+  string(14) "getServerByKey"
   [29]=>
-  string(8) "getStats"
+  string(13) "getServerList"
   [30]=>
-  string(10) "getVersion"
+  string(15) "resetServerList"
   [31]=>
-  string(9) "increment"
+  string(8) "getStats"
   [32]=>
-  string(14) "incrementByKey"
+  string(10) "getVersion"
   [33]=>
-  string(12) "isPersistent"
+  string(9) "increment"
   [34]=>
-  string(10) "isPristine"
+  string(14) "incrementByKey"
   [35]=>
-  string(7) "prepend"
+  string(12) "isPersistent"
   [36]=>
-  string(12) "prependByKey"
+  string(10) "isPristine"
   [37]=>
-  string(4) "quit"
+  string(7) "prepend"
   [38]=>
-  string(7) "replace"
+  string(12) "prependByKey"
   [39]=>
-  string(12) "replaceByKey"
+  string(4) "quit"
   [40]=>
-  string(3) "set"
+  string(7) "replace"
   [41]=>
-  string(8) "setByKey"
+  string(12) "replaceByKey"
   [42]=>
-  string(8) "setMulti"
+  string(3) "set"
   [43]=>
-  string(13) "setMultiByKey"
+  string(8) "setByKey"
   [44]=>
-  string(9) "setOption"
+  string(8) "setMulti"
   [45]=>
+  string(13) "setMultiByKey"
+  [46]=>
+  string(9) "setOption"
+  [47]=>
   string(10) "setOptions"
 }
 ================
@@ -109,7 +113,7 @@ object(A_Memcached)#2 (1) {
 Warning: Attempted to serialize unserializable builtin class A_Memcached in %s/builtin_extensions.inc on line 26
 string(2) "N;"
 NULL
-array(46) {
+array(48) {
   [0]=>
   string(11) "__construct"
   [1]=>
@@ -135,71 +139,75 @@ array(46) {
   [11]=>
   string(6) "delete"
   [12]=>
-  string(11) "deleteByKey"
+  string(16) "deleteMultiByKey"
   [13]=>
-  string(5) "fetch"
+  string(11) "deleteMulti"
   [14]=>
-  string(8) "fetchAll"
+  string(11) "deleteByKey"
   [15]=>
-  string(5) "flush"
+  string(5) "fetch"
   [16]=>
-  string(3) "get"
+  string(8) "fetchAll"
   [17]=>
-  string(10) "getAllKeys"
+  string(5) "flush"
   [18]=>
-  string(8) "getByKey"
+  string(3) "get"
   [19]=>
-  string(10) "getDelayed"
+  string(10) "getAllKeys"
   [20]=>
-  string(15) "getDelayedByKey"
+  string(8) "getByKey"
   [21]=>
-  string(8) "getMulti"
+  string(10) "getDelayed"
   [22]=>
-  string(13) "getMultiByKey"
+  string(15) "getDelayedByKey"
   [23]=>
-  string(9) "getOption"
+  string(8) "getMulti"
   [24]=>
-  string(13) "getResultCode"
+  string(13) "getMultiByKey"
   [25]=>
-  string(16) "getResultMessage"
+  string(9) "getOption"
   [26]=>
-  string(14) "getServerByKey"
+  string(13) "getResultCode"
   [27]=>
-  string(13) "getServerList"
+  string(16) "getResultMessage"
   [28]=>
-  string(15) "resetServerList"
+  string(14) "getServerByKey"
   [29]=>
-  string(8) "getStats"
+  string(13) "getServerList"
   [30]=>
-  string(10) "getVersion"
+  string(15) "resetServerList"
   [31]=>
-  string(9) "increment"
+  string(8) "getStats"
   [32]=>
-  string(14) "incrementByKey"
+  string(10) "getVersion"
   [33]=>
-  string(12) "isPersistent"
+  string(9) "increment"
   [34]=>
-  string(10) "isPristine"
+  string(14) "incrementByKey"
   [35]=>
-  string(7) "prepend"
+  string(12) "isPersistent"
   [36]=>
-  string(12) "prependByKey"
+  string(10) "isPristine"
   [37]=>
-  string(4) "quit"
+  string(7) "prepend"
   [38]=>
-  string(7) "replace"
+  string(12) "prependByKey"
   [39]=>
-  string(12) "replaceByKey"
+  string(4) "quit"
   [40]=>
-  string(3) "set"
+  string(7) "replace"
   [41]=>
-  string(8) "setByKey"
+  string(12) "replaceByKey"
   [42]=>
-  string(8) "setMulti"
+  string(3) "set"
   [43]=>
-  string(13) "setMultiByKey"
+  string(8) "setByKey"
   [44]=>
-  string(9) "setOption"
+  string(8) "setMulti"
   [45]=>
+  string(13) "setMultiByKey"
+  [46]=>
+  string(9) "setOption"
+  [47]=>
   string(10) "setOptions"
 }

--- a/hphp/test/slow/ext_memcached/deletemulti.php
+++ b/hphp/test/slow/ext_memcached/deletemulti.php
@@ -20,7 +20,7 @@ $data = array(
     'bar' => 'bar-data',
     'baz' => 'baz-data',
     'lol' => 'lol-data',
-    'kek' => 'kek-data',
+    'kek' => 'kek-data'
 );
 
 $keys = array_keys($data);

--- a/hphp/test/slow/ext_memcached/deletemulti.php
+++ b/hphp/test/slow/ext_memcached/deletemulti.php
@@ -5,22 +5,22 @@ $m->addServer('localhost', '11211');
 
 function has_all_keys($keys, $array, $check_true = false)
 {
-	foreach ($keys as $key) {
-		if (!isset($array[$key]))
-			return false;
-		
-		if ($check_true && $array[$key] !== true)
-			return false;
-	}
-	return true;
+    foreach ($keys as $key) {
+        if (!isset($array[$key]))
+            return false;
+
+        if ($check_true && $array[$key] !== true)
+            return false;
+    }
+    return true;
 }
 
 $data = array(
-	'foo' => 'foo-data',
-	'bar' => 'bar-data',
-	'baz' => 'baz-data',
-	'lol' => 'lol-data',
-	'kek' => 'kek-data',
+    'foo' => 'foo-data',
+    'bar' => 'bar-data',
+    'baz' => 'baz-data',
+    'lol' => 'lol-data',
+    'kek' => 'kek-data',
 );
 
 $keys = array_keys($data);
@@ -63,4 +63,3 @@ foreach ($retval as $key => $value) {
         echo "$key NOT FOUND\n";
     }
 }
-

--- a/hphp/test/slow/ext_memcached/deletemulti.php
+++ b/hphp/test/slow/ext_memcached/deletemulti.php
@@ -1,0 +1,66 @@
+<?php
+
+$m = new Memcached();
+$m->addServer('localhost', '11211');
+
+function has_all_keys($keys, $array, $check_true = false)
+{
+	foreach ($keys as $key) {
+		if (!isset($array[$key]))
+			return false;
+		
+		if ($check_true && $array[$key] !== true)
+			return false;
+	}
+	return true;
+}
+
+$data = array(
+	'foo' => 'foo-data',
+	'bar' => 'bar-data',
+	'baz' => 'baz-data',
+	'lol' => 'lol-data',
+	'kek' => 'kek-data',
+);
+
+$keys = array_keys($data);
+
+$null = null;
+$m->setMulti($data, 3600);
+
+/* Check that all keys were stored */
+var_dump(has_all_keys($keys, $m->getMulti($keys)));
+
+/* Check that all keys get deleted */
+$deleted = $m->deleteMulti($keys);
+
+var_dump(has_all_keys($keys, $deleted, true));
+
+/* Try to get the deleted keys, should give empty array */
+var_dump($m->getMulti($keys));
+
+/* ---- same tests for byKey variants ---- */
+$m->setMultiByKey("hi", $data, 3600);
+
+var_dump(has_all_keys($keys, $m->getMultiByKey('hi', $keys)));
+
+/* Check that all keys get deleted */
+$deleted = $m->deleteMultiByKey('hi', $keys);
+var_dump(has_all_keys($keys, $deleted, true));
+
+/* Try to get the deleted keys, should give empty array */
+var_dump($m->getMultiByKey('hi', $keys));
+
+/* Test deleting non-existent keys */
+$keys = array();
+$keys[] = "nothere";
+$keys[] = "nothere2";
+
+$retval = $m->deleteMulti($keys);
+
+foreach ($retval as $key => $value) {
+    if ($value === Memcached::RES_NOTFOUND) {
+        echo "$key NOT FOUND\n";
+    }
+}
+

--- a/hphp/test/slow/ext_memcached/deletemulti.php.expect
+++ b/hphp/test/slow/ext_memcached/deletemulti.php.expect
@@ -1,0 +1,10 @@
+bool(true)
+bool(true)
+array(0) {
+}
+bool(true)
+bool(true)
+array(0) {
+}
+nothere NOT FOUND
+nothere2 NOT FOUND

--- a/hphp/test/slow/ext_memcached/deletemulti.php.skipif
+++ b/hphp/test/slow/ext_memcached/deletemulti.php.skipif
@@ -1,0 +1,9 @@
+<?php
+
+$memc = new Memcached();
+$memc->addServer('localhost', '11211');
+$version = $memc->getVersion();
+if (!$version) {
+  echo "SKIP No Memcached running";
+}
+

--- a/hphp/test/slow/ext_memcached/deletemultitypes.php
+++ b/hphp/test/slow/ext_memcached/deletemultitypes.php
@@ -3,7 +3,6 @@
 $m = new Memcached();
 $m->addServer('localhost', '11211');
 
-
 function dump_types($v, $k) {
 	echo gettype($v) . "\n";
 }

--- a/hphp/test/slow/ext_memcached/deletemultitypes.php
+++ b/hphp/test/slow/ext_memcached/deletemultitypes.php
@@ -1,0 +1,15 @@
+<?php
+
+$m = new Memcached();
+$m->addServer('localhost', '11211');
+
+
+function dump_types($v, $k) {
+	echo gettype($v) . "\n";
+}
+
+$keys = array(100, 'str');
+array_walk($keys, 'dump_types');
+
+$deleted = $m->deleteMulti($keys);
+array_walk($keys, 'dump_types');

--- a/hphp/test/slow/ext_memcached/deletemultitypes.php
+++ b/hphp/test/slow/ext_memcached/deletemultitypes.php
@@ -4,7 +4,7 @@ $m = new Memcached();
 $m->addServer('localhost', '11211');
 
 function dump_types($v, $k) {
-	echo gettype($v) . "\n";
+    echo gettype($v) . "\n";
 }
 
 $keys = array(100, 'str');

--- a/hphp/test/slow/ext_memcached/deletemultitypes.php.expect
+++ b/hphp/test/slow/ext_memcached/deletemultitypes.php.expect
@@ -1,0 +1,4 @@
+integer
+string
+integer
+string

--- a/hphp/test/slow/ext_memcached/deletemultitypes.php.skipif
+++ b/hphp/test/slow/ext_memcached/deletemultitypes.php.skipif
@@ -1,0 +1,9 @@
+<?php
+
+$memc = new Memcached();
+$memc->addServer('localhost', '11211');
+$version = $memc->getVersion();
+if (!$version) {
+  echo "SKIP No Memcached running";
+}
+

--- a/hphp/test/slow/ext_memcached/getmulti.php
+++ b/hphp/test/slow/ext_memcached/getmulti.php
@@ -4,14 +4,14 @@ $m = new Memcached();
 $m->addServer('localhost', '11211');
 
 class Foo {
-	function __toString() {
-		return 'a-foo';
-	}
+    function __toString() {
+        return 'a-foo';
+    }
 }
 
 $data = array();
 for ($i = 0; $i < 1000; $i++) {
-	$data['key' . $i] = 'value' . $i;
+    $data['key' . $i] = 'value' . $i;
 }
 $data['a-foo'] = 'a-last';
 var_dump($m->setMulti($data));
@@ -23,15 +23,15 @@ $v = $m->getMulti($keys);
 var_dump(is_array($v));
 var_dump($m->getResultCode() == Memcached::RES_SUCCESS);
 if (is_array($v)) {
-	foreach ($v as $key => $value) {
-		if (!isset($data[$key]) or $value !== $data[$key]) {
-			echo "mismatch \$data['$key'] = \n";
-			var_dump($data[$key]);
-			var_dump($value);
-		}
-	}
+    foreach ($v as $key => $value) {
+        if (!isset($data[$key]) or $value !== $data[$key]) {
+            echo "mismatch \$data['$key'] = \n";
+            var_dump($data[$key]);
+            var_dump($value);
+        }
+    }
 } else {
-	echo "Result not an array\n";
+    echo "Result not an array\n";
 }
 
 var_dump(is_object($keys['last']));

--- a/hphp/test/slow/ext_memcached/getmulti.php
+++ b/hphp/test/slow/ext_memcached/getmulti.php
@@ -1,0 +1,37 @@
+<?php
+
+$m = new Memcached();
+$m->addServer('localhost', '11211');
+
+class Foo {
+	function __toString() {
+		return 'a-foo';
+	}
+}
+
+$data = array();
+for ($i = 0; $i < 1000; $i++) {
+	$data['key' . $i] = 'value' . $i;
+}
+$data['a-foo'] = 'a-last';
+var_dump($m->setMulti($data));
+
+$keys = array_keys($data);
+$keys['last'] = new Foo();
+
+$v = $m->getMulti($keys);
+var_dump(is_array($v));
+var_dump($m->getResultCode() == Memcached::RES_SUCCESS);
+if (is_array($v)) {
+	foreach ($v as $key => $value) {
+		if (!isset($data[$key]) or $value !== $data[$key]) {
+			echo "mismatch \$data['$key'] = \n";
+			var_dump($data[$key]);
+			var_dump($value);
+		}
+	}
+} else {
+	echo "Result not an array\n";
+}
+
+var_dump(is_object($keys['last']));

--- a/hphp/test/slow/ext_memcached/getmulti.php.expect
+++ b/hphp/test/slow/ext_memcached/getmulti.php.expect
@@ -1,0 +1,4 @@
+bool(true)
+bool(true)
+bool(true)
+bool(true)

--- a/hphp/test/slow/ext_memcached/getmulti.php.skipif
+++ b/hphp/test/slow/ext_memcached/getmulti.php.skipif
@@ -1,0 +1,9 @@
+<?php
+
+$memc = new Memcached();
+$memc->addServer('localhost', '11211');
+$version = $memc->getVersion();
+if (!$version) {
+  echo "SKIP No Memcached running";
+}
+


### PR DESCRIPTION
Implement deleteMultiByKey and deleteMulti functions and getMulti must return an empty array instead of false if no key was found.

getMulti must return an array, memcached's documentation is incorrect on php.net :
https://github.com/php-memcached-dev/php-memcached/blob/def716a80f1be732b5dad1c13d3023248db64881/php_memcached.c#L1762

deleteMulti and deleteMultiByKey must return an array, memcached's documentation is incorrect on php.net :
https://github.com/php-memcached-dev/php-memcached/blob/def716a80f1be732b5dad1c13d3023248db64881/php_memcached.c#L691

Fix for #5261.