### PR TITLE
Don't force ext_zend_compat to be enabled with the heap scanning

### DIFF
--- a/hphp/runtime/base/heap-scan.h
+++ b/hphp/runtime/base/heap-scan.h
@@ -36,7 +36,9 @@
 #include "hphp/runtime/ext/extension-registry.h"
 #include "hphp/runtime/base/request-event-handler.h"
 #include "hphp/runtime/server/server-note.h"
+#ifdef ENABLE_ZEND_COMPAT
 #include "hphp/runtime/ext_zend_compat/php-src/TSRM/TSRM.h"
+#endif
 #include "hphp/runtime/ext/asio/ext_sleep-wait-handle.h"
 #include "hphp/runtime/ext/asio/asio-external-thread-event-queue.h"
 #include "hphp/runtime/ext/asio/ext_reschedule-wait-handle.h"
@@ -176,8 +178,10 @@ template<class F> void RequestEventHandler::scan(F& mark) const {
 }
 
 template<class F> void scan_ezc_resources(F& mark) {
+#ifdef ENABLE_ZEND_COMPAT
   ExtMarker<F> bridge(mark);
   ts_scan_resources(bridge);
+#endif
 }
 
 template<class F> void Exception::scan(F& mark) const {


### PR DESCRIPTION
It is possible to disable ext_zend_compat, and I haven't ported it to MSVC yet, and it will be a while before I get around to doing so.
This just disables the include and the body of the resource scanning stub for zend compat.