### PR TITLE
Workaround a minor parser issue with MSVC

### DIFF
--- a/hphp/runtime/base/classname-is.h
+++ b/hphp/runtime/base/classname-is.h
@@ -34,7 +34,7 @@ struct InstantStatic {
 };
 
 template <class T, class TInit, TInit init()>
-T InstantStatic<T, TInit, init>::value { init() };
+T InstantStatic<T, TInit, init>::value(init());
 
 #define CLASSNAME_IS(str)                                               \
   static const char *GetClassName() { return str; }                     \


### PR DESCRIPTION
For some reason, this is one of the places that MSVC just doesn't quite manage to parse the curly brace initializers correctly.
This just switches it to a different form.