### PR TITLE
Fix a couple of typename uses that MSVC complains about

### DIFF
--- a/hphp/runtime/vm/jit/minstr-helpers.h
+++ b/hphp/runtime/vm/jit/minstr-helpers.h
@@ -584,7 +584,7 @@ arraySetImpl(ArrayData* a, key_type<keyType> key, Cell value, RefData* ref) {
   m(arraySetIR,  KeyType::Int,   false,      true)           \
 
 #define X(nm, keyType, checkForInt, setRef)                  \
-typename ShuffleReturn<setRef>::return_type                  \
+ShuffleReturn<setRef>::return_type                           \
 inline nm(ArrayData* a, key_type<keyType> key, Cell value, RefData* ref) { \
   return arraySetImpl<keyType, checkForInt, setRef>(a, key, value, ref);\
 }

--- a/hphp/runtime/vm/jit/typecheck-hoisting.cpp
+++ b/hphp/runtime/vm/jit/typecheck-hoisting.cpp
@@ -81,7 +81,7 @@ T* UnionFind<T>::find(T* tmp) const {
 
 template <typename T>
 typename UnionFind<T>::Node* UnionFind<T>::traverseToRoot(
-  UnionFind<T>::Node& start
+  typename UnionFind<T>::Node& start
 ) {
   auto current = &start;
   while (current->parent) {


### PR DESCRIPTION
GCC is very forgiving about the placement of `typename` on types, MSVC is not.
This adds a `typename` where it is needed, and removes one where it isn't.