### PR TITLE
Use uLong where appropriate in ext_zlib rather than size_t

### DIFF
--- a/hphp/runtime/ext/zlib/ext_zlib.cpp
+++ b/hphp/runtime/ext/zlib/ext_zlib.cpp
@@ -404,7 +404,7 @@ typedef struct nzlib_format_s {
 } nzlib_format_t;
 
 Variant HHVM_FUNCTION(nzcompress, const String& uncompressed) {
-  size_t len = compressBound(uncompressed.size());
+  uLong len = compressBound(uncompressed.size());
   String str(sizeof(nzlib_format_t) + len, ReserveString);
   nzlib_format_t* format = (nzlib_format_t*)str.mutableData();
 
@@ -430,7 +430,7 @@ Variant HHVM_FUNCTION(nzuncompress, const String& compressed) {
     return false;
   }
 
-  size_t len = ntohl(format->uncompressed_sz);
+  uLong len = ntohl(format->uncompressed_sz);
   if (len == 0) {
     return empty_string_variant();
   }


### PR DESCRIPTION
Because MSVC doesn't like it when you try to pass a `size_t*` to a function expecting an `unsigned long*`.