### PR TITLE
Support vm/jit/frame-state under MSVC

### DIFF
--- a/hphp/runtime/vm/jit/frame-state.cpp
+++ b/hphp/runtime/vm/jit/frame-state.cpp
@@ -708,10 +708,10 @@ void FrameStateMgr::syncPrediction(SlotState<Stack>& slot) {
   auto it = map.find(canonValue);
   if (it == map.end()) {
     ITRACE(4, "No prediction in map; slot has {}\n", prediction);
-    if (prediction < slot.default_type) map.emplace(canonValue, prediction);
+    if (prediction < slot.default_type()) map.emplace(canonValue, prediction);
     return;
   }
-  if (prediction == slot.default_type) {
+  if (prediction == slot.default_type()) {
     ITRACE(4, "No prediction in slot; map has {}\n", it->second);
     prediction = it->second;
     return;

--- a/hphp/runtime/vm/jit/frame-state.h
+++ b/hphp/runtime/vm/jit/frame-state.h
@@ -106,7 +106,9 @@ private:
  */
 template<bool Stack>
 struct SlotState {
-  static constexpr Type default_type = Stack ? TStkElem : TGen;
+  static constexpr Type default_type() {
+    return Stack ? TStkElem : TGen;
+  }
 
   /*
    * The current value of the or stack slot.
@@ -121,7 +123,7 @@ struct SlotState {
    * incoming edges.  However, whenever we have a value, the type of
    * the SSATmp must match this `type' field.
    */
-  Type type{default_type};
+  Type type{default_type()};
 
   /*
    * Prediction for the type of a local or stack slot, if it's boxed or if
@@ -130,7 +132,7 @@ struct SlotState {
    * Invariants:
    *   always a subtype of `type'
    */
-  Type predictedType{default_type};
+  Type predictedType{default_type()};
 
   /*
    * The sources of the currently known type. They may be values. If the value
@@ -145,8 +147,6 @@ struct SlotState {
    */
   bool maybeChanged{false};
 };
-
-template<bool Stack> constexpr Type SlotState<Stack>::default_type;
 
 using LocalState = SlotState<false>;
 using StackState = SlotState<true>;


### PR DESCRIPTION
MSVC doesn't currently support in-class initialization for static constexpr values, so, as the use of it is very limited, I just converted it to a function.