### PR TITLE
[MSVC] Handle the pthread implementation we use under MSVC

### DIFF
--- a/hphp/runtime/base/thread-hooks.cpp
+++ b/hphp/runtime/base/thread-hooks.cpp
@@ -36,7 +36,7 @@ static Mutex threadMap_lock;
 
 PthreadInfo::PthreadInfo(start_routine_t start, void* arg) :
     start_routine(start), start_routine_arg(arg) {
-  pid = getpid();
+  pid = (pid_t)getpid();
 
 #ifndef _MSC_VER
   if (RuntimeOption::EvalLogThreadCreateBacktraces) {
@@ -98,7 +98,7 @@ void* start_routine_wrapper(void *arg) {
 #ifdef __linux__
   info.tid = syscall(SYS_gettid);
 #else
-  info.tid = getpid();
+  info.tid = (pid_t)getpid();
 #endif
 
   auto ret = info.start_routine(info.start_routine_arg);

--- a/hphp/runtime/debugger/cmd/cmd_interrupt.h
+++ b/hphp/runtime/debugger/cmd/cmd_interrupt.h
@@ -36,7 +36,11 @@ struct CmdInterrupt : DebuggerCommand {
       , m_program(program ? program : "")
       , m_site(site)
   {
+#ifdef _MSC_VER
+    m_threadId = (int64_t)pthread_getw32threadid_np(Process::GetThreadId());
+#else
     m_threadId = (int64_t)Process::GetThreadId();
+#endif
     if (error) m_errorMsg = error;
   }
 

--- a/hphp/runtime/debugger/cmd/cmd_thread.cpp
+++ b/hphp/runtime/debugger/cmd/cmd_thread.cpp
@@ -174,8 +174,15 @@ void CmdThread::debuggerInfo(InfoVec &info) {
   Add(info, "Host",       Process::GetHostName());
   Add(info, "Binary",     Process::GetAppName());
   Add(info, "Version",    HHVM_VERSION);
+#ifdef _MSC_VER
+  Add(info, "Process ID", FormatNumber("%lld",
+    (int64_t)Process::GetProcessId()));
+  Add(info, "Thread ID", FormatNumber("0x%llx",
+    (int64_t)pthread_getw32threadid_np(Process::GetThreadId())));
+#else
   Add(info, "Process ID", FormatNumber("%lld", Process::GetProcessId()));
   Add(info, "Thread ID",  FormatNumber("0x%llx", (int64_t)Process::GetThreadId()));
+#endif
 }
 
 bool CmdThread::onServer(DebuggerProxy &proxy) {

--- a/hphp/runtime/debugger/debugger.cpp
+++ b/hphp/runtime/debugger/debugger.cpp
@@ -344,7 +344,11 @@ bool Debugger::isThreadDebugging(int64_t tid) {
 // of debugging for request and other threads.
 void Debugger::registerThread() {
   TRACE(2, "Debugger::registerThread\n");
+#ifdef _MSC_VER
+  auto const tid = (int64_t)pthread_getw32threadid_np(Process::GetThreadId());
+#else
   auto const tid = (int64_t)Process::GetThreadId();
+#endif
   ThreadInfoMap::accessor acc;
   m_threadInfos.insert(acc, tid);
   acc->second = &TI();

--- a/hphp/runtime/ext/thread/ext_thread.cpp
+++ b/hphp/runtime/ext/thread/ext_thread.cpp
@@ -36,7 +36,11 @@ public:
 ///////////////////////////////////////////////////////////////////////////////
 
 int64_t HHVM_FUNCTION(hphp_get_thread_id) {
-  return  (unsigned long)Process::GetThreadId();
+#ifdef _MSC_VER
+  return (unsigned long)pthread_getw32threadid_np(Process::GetThreadId());
+#else
+  return (unsigned long)Process::GetThreadId();
+#endif
 }
 
 int64_t HHVM_FUNCTION(hphp_gettid) {

--- a/hphp/runtime/server/http-server.cpp
+++ b/hphp/runtime/server/http-server.cpp
@@ -366,7 +366,7 @@ void HttpServer::waitForServers() {
 
 static void exit_on_timeout(int sig) {
   signal(sig, SIG_DFL);
-  kill(getpid(), SIGKILL);
+  kill((pid_t)getpid(), SIGKILL);
   // we really shouldn't get here, but who knows.
   // abort so we catch it as a crash.
   abort();

--- a/hphp/runtime/server/replay-transport.cpp
+++ b/hphp/runtime/server/replay-transport.cpp
@@ -34,7 +34,12 @@ void ReplayTransport::recordInput(Transport* transport, const char *filename) {
   char buf[32];
   snprintf(buf, sizeof(buf), "%u", Process::GetProcessId());
   hdf["pid"] = std::string(buf);
+#ifdef _MSC_VER
+  snprintf(buf, sizeof(buf), "%" PRIx64,
+    (int64_t)pthread_getw32threadid_np(Process::GetThreadId()));
+#else
   snprintf(buf, sizeof(buf), "%" PRIx64, (int64_t)Process::GetThreadId());
+#endif
   hdf["tid"] = std::string(buf);
   snprintf(buf, sizeof(buf), "%u", Process::GetThreadPid());
   hdf["tpid"] = std::string(buf);

--- a/hphp/runtime/server/server-stats.cpp
+++ b/hphp/runtime/server/server-stats.cpp
@@ -613,7 +613,12 @@ void ServerStats::ReportStatus(std::string &output, Writer::Format format) {
     }
 
     w->beginObject("thread");
+#ifdef _MSC_VER
+    w->writeEntry("id",
+      (int64_t)pthread_getw32threadid_np(Process::GetThreadId()));
+#else
     w->writeEntry("id", (int64_t)ts.m_threadId);
+#endif
     w->writeEntry("tid", (int64_t)ts.m_threadPid);
     w->writeEntry("req", ts.m_requestCount);
     w->writeEntry("bytes", ts.m_writeBytes);

--- a/hphp/runtime/vm/jit/write-lease.cpp
+++ b/hphp/runtime/vm/jit/write-lease.cpp
@@ -45,7 +45,11 @@ bool Lease::mayLock(bool f) {
  * DEBUG-only, folks.
  */
 static inline pthread_t gremlinize_threadid(pthread_t tid) {
+#ifdef _MSC_VER
+  return pthread_t{(void*)(~((int64_t)pthread_getw32threadid_np(tid))), 0};
+#else
   return (pthread_t)(~((int64_t)tid));
+#endif
 }
 
 void Lease::gremlinLock() {

--- a/hphp/runtime/vm/treadmill.cpp
+++ b/hphp/runtime/vm/treadmill.cpp
@@ -186,7 +186,11 @@ void startRequest() {
     s_inflightRequests[threadIdx].startTime = correctTime(startTime);
     s_inflightRequests[threadIdx].pthreadId = Process::GetThreadId();
     FTRACE(1, "threadIdx {} pthreadId {} start @gen {}\n", threadIdx,
+#ifdef _MSC_VER
+           pthread_getw32threadid_np(s_inflightRequests[threadIdx].pthreadId),
+#else
            s_inflightRequests[threadIdx].pthreadId,
+#endif
            s_inflightRequests[threadIdx].startTime);
     if (s_oldestRequestInFlight.load(std::memory_order_relaxed) == 0) {
       s_oldestRequestInFlight = s_inflightRequests[threadIdx].startTime;

--- a/hphp/runtime/vm/treadmill.cpp
+++ b/hphp/runtime/vm/treadmill.cpp
@@ -185,13 +185,15 @@ void startRequest() {
     }
     s_inflightRequests[threadIdx].startTime = correctTime(startTime);
     s_inflightRequests[threadIdx].pthreadId = Process::GetThreadId();
-    FTRACE(1, "threadIdx {} pthreadId {} start @gen {}\n", threadIdx,
 #ifdef _MSC_VER
+    FTRACE(1, "threadIdx {} pthreadId {} start @gen {}\n", threadIdx,
            pthread_getw32threadid_np(s_inflightRequests[threadIdx].pthreadId),
-#else
-           s_inflightRequests[threadIdx].pthreadId,
-#endif
            s_inflightRequests[threadIdx].startTime);
+#else
+    FTRACE(1, "threadIdx {} pthreadId {} start @gen {}\n", threadIdx,
+           s_inflightRequests[threadIdx].pthreadId,
+           s_inflightRequests[threadIdx].startTime);
+#endif
     if (s_oldestRequestInFlight.load(std::memory_order_relaxed) == 0) {
       s_oldestRequestInFlight = s_inflightRequests[threadIdx].startTime;
     }

--- a/hphp/util/async-func.cpp
+++ b/hphp/util/async-func.cpp
@@ -20,6 +20,8 @@
 #include <sys/mman.h>
 #include <unistd.h>
 
+#include <folly/Portability.h>
+
 namespace HPHP {
 ///////////////////////////////////////////////////////////////////////////////
 
@@ -33,7 +35,7 @@ void* AsyncFuncImpl::s_finiFuncArg = nullptr;
 
 AsyncFuncImpl::AsyncFuncImpl(void *obj, PFN_THREAD_FUNC *func)
     : m_obj(obj), m_func(func),
-      m_threadStack(nullptr), m_threadId(0),
+      m_threadStack(nullptr), m_threadId(pthread_t_init),
       m_exception(nullptr), m_node(0),
       m_stopped(false), m_noInit(false) {
 }
@@ -104,7 +106,7 @@ bool AsyncFuncImpl::waitForEnd(int seconds /* = 0 */) {
 
   void *ret = nullptr;
   pthread_join(m_threadId, &ret);
-  m_threadId = 0;
+  m_threadId = pthread_t_init;
 
   if (m_threadStack != nullptr) {
     size_t guardsize;

--- a/hphp/util/async-func.cpp
+++ b/hphp/util/async-func.cpp
@@ -35,7 +35,7 @@ void* AsyncFuncImpl::s_finiFuncArg = nullptr;
 
 AsyncFuncImpl::AsyncFuncImpl(void *obj, PFN_THREAD_FUNC *func)
     : m_obj(obj), m_func(func),
-      m_threadStack(nullptr), m_threadId(pthread_t_init),
+      m_threadStack(nullptr), m_threadId(pthread_zero),
       m_exception(nullptr), m_node(0),
       m_stopped(false), m_noInit(false) {
 }
@@ -106,7 +106,7 @@ bool AsyncFuncImpl::waitForEnd(int seconds /* = 0 */) {
 
   void *ret = nullptr;
   pthread_join(m_threadId, &ret);
-  m_threadId = pthread_t_init;
+  m_threadId = pthread_zero;
 
   if (m_threadStack != nullptr) {
     size_t guardsize;

--- a/hphp/util/async-func.cpp
+++ b/hphp/util/async-func.cpp
@@ -35,7 +35,7 @@ void* AsyncFuncImpl::s_finiFuncArg = nullptr;
 
 AsyncFuncImpl::AsyncFuncImpl(void *obj, PFN_THREAD_FUNC *func)
     : m_obj(obj), m_func(func),
-      m_threadStack(nullptr), m_threadId(pthread_zero),
+      m_threadStack(nullptr), m_threadId({}),
       m_exception(nullptr), m_node(0),
       m_stopped(false), m_noInit(false) {
 }
@@ -106,7 +106,7 @@ bool AsyncFuncImpl::waitForEnd(int seconds /* = 0 */) {
 
   void *ret = nullptr;
   pthread_join(m_threadId, &ret);
-  m_threadId = pthread_zero;
+  m_threadId = {};
 
   if (m_threadStack != nullptr) {
     size_t guardsize;

--- a/hphp/util/logger.cpp
+++ b/hphp/util/logger.cpp
@@ -237,7 +237,7 @@ std::string Logger::GetHeader() {
   snprintf(header, sizeof(header), "[%s] [hphp] [%lld:%llx:%d:%06d%s] ",
            snow,
            (unsigned long long)s_pid,
-           (unsigned long long)Process::GetThreadId(),
+           (unsigned long long)Process::GetThreadIdForTrace(),
            threadData->request,
            (threadData->message == -1 ? 0 : threadData->message),
            ExtraHeader.c_str());

--- a/hphp/util/mutex.h
+++ b/hphp/util/mutex.h
@@ -221,7 +221,7 @@ class ReadWriteMutex {
 #ifdef MSVC_NO_STATIC_INCLASS_CONSTEXPR_INITIALIZATION
   static const pthread_t InvalidThread;
 #else
-  static constexpr pthread_t InvalidThread = pthread_zero;
+  static constexpr pthread_t InvalidThread = {};
 #endif
   pthread_t m_writeOwner;
   Rank m_rank;
@@ -309,8 +309,9 @@ private:
 };
 
 #if defined(DEBUG) && defined(MSVC_NO_STATIC_INCLASS_CONSTEXPR_INITIALIZATION)
-// Do this as COMDAT to avoid needing to create mutex.cpp just for this workaround.
-__declspec(selectany) const pthread_t ReadWriteMutex::InvalidThread = pthread_zero;
+// Do this as COMDAT to avoid needing to create mutex.cpp just
+// for this workaround.
+__declspec(selectany) const pthread_t ReadWriteMutex::InvalidThread = {};
 #endif
 
 /*

--- a/hphp/util/mutex.h
+++ b/hphp/util/mutex.h
@@ -221,7 +221,7 @@ class ReadWriteMutex {
 #ifdef MSVC_NO_STATIC_INCLASS_CONSTEXPR_INITIALIZATION
   static const pthread_t InvalidThread;
 #else
-  static constexpr pthread_t InvalidThread = pthread_t_init;
+  static constexpr pthread_t InvalidThread = pthread_zero;
 #endif
   pthread_t m_writeOwner;
   Rank m_rank;
@@ -310,7 +310,7 @@ private:
 
 #if defined(DEBUG) && defined(MSVC_NO_STATIC_INCLASS_CONSTEXPR_INITIALIZATION)
 // Do this as COMDAT to avoid needing to create mutex.cpp just for this workaround.
-__declspec(selectany) const pthread_t ReadWriteMutex::InvalidThread = pthread_t_init;
+__declspec(selectany) const pthread_t ReadWriteMutex::InvalidThread = pthread_zero;
 #endif
 
 /*

--- a/hphp/util/mutex.h
+++ b/hphp/util/mutex.h
@@ -33,6 +33,8 @@
 
 #include <tbb/concurrent_hash_map.h>
 
+#include <folly/Portability.h>
+
 #include "hphp/util/portability.h"
 #include "hphp/util/assertions.h"
 #include "hphp/util/rank.h"
@@ -216,7 +218,11 @@ class ReadWriteMutex {
  * implementation tends to do crazy things when a rwlock is double-wlocked,
  * so check and assert early in debug builds.
  */
-  static constexpr pthread_t InvalidThread = (pthread_t)0;
+#ifdef MSVC_NO_STATIC_INCLASS_CONSTEXPR_INITIALIZATION
+  static const pthread_t InvalidThread;
+#else
+  static constexpr pthread_t InvalidThread = pthread_t_init;
+#endif
   pthread_t m_writeOwner;
   Rank m_rank;
 #endif
@@ -301,6 +307,11 @@ private:
 
   pthread_rwlock_t m_rwlock;
 };
+
+#if defined(DEBUG) && defined(MSVC_NO_STATIC_INCLASS_CONSTEXPR_INITIALIZATION)
+// Do this as COMDAT to avoid needing to create mutex.cpp just for this workaround.
+__declspec(selectany) const pthread_t ReadWriteMutex::InvalidThread = pthread_t_init;
+#endif
 
 /*
  * A ranked wrapper around tbb::concurrent_hash_map.

--- a/hphp/util/process.cpp
+++ b/hphp/util/process.cpp
@@ -385,7 +385,7 @@ void Process::Daemonize(const char *stdoutFile /* = "/dev/null" */,
   pid_t pid, sid;
 
   /* already a daemon */
-  if (getppid() == 1) return;
+  if (getppid() == (pid_t)1) return;
 
 #ifdef _MSC_VER
   // We are Windows, fear us!
@@ -495,7 +495,7 @@ void Process::GetProcessId(const std::string &cmd, std::vector<pid_t> &pids,
       if (converted == ccmd && filename.find("/proc/") == 0) {
         long long pid = atoll(filename.c_str() + strlen("/proc/"));
         if (pid) {
-          pids.push_back(pid);
+          pids.push_back((pid_t)pid);
         }
       }
     }

--- a/hphp/util/process.h
+++ b/hphp/util/process.h
@@ -83,7 +83,7 @@ public:
    * Process identifier.
    */
   static pid_t GetProcessId() {
-    return getpid();
+    return (pid_t)getpid();
   }
 
   /**
@@ -130,6 +130,8 @@ public:
     // case we will need to revisit this.
 #ifdef __linux__
     return pthread_self();
+#elif defined(_MSC_VER)
+    return (uint64_t)pthread_getw32threadhandle_np(pthread_self());
 #else
     return (uint64_t)pthread_self();
 #endif
@@ -150,7 +152,7 @@ public:
 #elif defined(__CYGWIN__) || defined(__MINGW__)
     return (long)pthread_self();
 #elif defined(_MSC_VER)
-    return GetCurrentThreadId();
+    return (pid_t)GetCurrentThreadId();
 #else
     return syscall(SYS_gettid);
 #endif

--- a/hphp/util/ringbuffer.cpp
+++ b/hphp/util/ringbuffer.cpp
@@ -107,7 +107,11 @@ allocEntry(RingBufferType t) {
                                             std::memory_order_acq_rel));
   rb->m_seq = g_seqnum.fetch_add(1, std::memory_order_relaxed);
   rb->m_type = t;
+#ifdef _MSC_VER
+  rb->m_threadId = (uint32_t)((int64_t)pthread_getw32threadid_np(pthread_self()) & 0xFFFFFFFF);
+#else
   rb->m_threadId = (uint32_t)((int64_t)pthread_self() & 0xFFFFFFFF);
+#endif
   return rb;
 }
 

--- a/hphp/util/ssl-init.cpp
+++ b/hphp/util/ssl-init.cpp
@@ -25,7 +25,7 @@ namespace HPHP {
 static Mutex *s_locks = nullptr;
 
 static unsigned long callback_thread_id() {
-  return (unsigned long)Process::GetThreadId();
+  return (unsigned long)Process::GetThreadIdForTrace();
 }
 
 static void callback_locking(int mode, int type, const char *file, int line) {

--- a/hphp/util/trace.cpp
+++ b/hphp/util/trace.cpp
@@ -146,8 +146,13 @@ void vtrace(const char *fmt, va_list ap) {
     vtraceRingbuffer(fmt, ap);
   } else {
     ONTRACE(1, pthread_mutex_lock(&mtx));
+#ifdef _MSC_VER
+    ONTRACE(1, fprintf(out, "t%#08x: ",
+      int((int64_t)pthread_getw32threadid_np(pthread_self()) & 0xFFFFFFFF)));
+#else
     ONTRACE(1, fprintf(out, "t%#08x: ",
       int((int64_t)pthread_self() & 0xFFFFFFFF)));
+#endif
     vfprintf(out, fmt, ap);
     ONTRACE(1, pthread_mutex_unlock(&mtx));
     flush();


### PR DESCRIPTION
This is the changes needed to compile against the pthread implementation we user under MSVC. It includes both changes needed due to `pthread_t` being a struct, and `pid_t` being defined as a `void*`.

This is a combined form of 7 other PRs, #5956 (D44367), #5958 (D44379), #5961 (D44397), #5962 (D44403), #5963 (D44409), #5971 (D44457), and #5972 (D44463), as well as an additional set of changes for the core of the runtime.

This is dependent upon [folly#285](https://github.com/facebook/folly/pull/285) being merged upstream first.
This is also dependent upon an issue with how [folly#264](https://github.com/facebook/folly/pull/264) was merged being resolved first.