### PR TITLE
Fix bug on casting double to uint_64

### DIFF
--- a/hphp/runtime/base/type-conversions.h
+++ b/hphp/runtime/base/type-conversions.h
@@ -71,7 +71,7 @@ inline int64_t toInt64(double  v) {
   // Intel, you get 0x800..00, a.k.a. the minimum int64_t. We mimic that on all
   // platforms, though this makes us sad.
   return (v >= 0
-          ? (v > std::numeric_limits<uint64_t>::max() ? 0u : (uint64_t)v)
+          ? (v < std::numeric_limits<uint64_t>::max() ? (uint64_t)v : 0u)
           : (v < 0 ? (int64_t)v : std::numeric_limits<int64_t>::min()));
 }
 inline int64_t toInt64(const char* v) = delete;


### PR DESCRIPTION
When 'v' is equal to 'std::numeric_limits<uint64_t>::max()', it should not be
casted to uint64_t, because there will be an overflow.
For x86_64 machines, the cast above results in overflow, but the result is
'0', i. e., the expected result.
Others platforms may not behave the same way, as tested on PPC64, that returns
'-1' for the same cast.
Looking for make HHVM behave the same way in both platforms, this change
returns '0' if the number going to be casted ('v') is equal to
'std::numeric_limits<uint64_t>::max()'. There is no behavior change for x86_64
platform.
See discussion: https://github.com/facebook/hhvm/issues/5932.
PS: tested on php5 v5.6.9-1 on PPC64 and that result is also supposed to be ‘0’,
not ‘-1’.