### PR TITLE
Adding DNS cache feature (disabled by default)

### DIFF
--- a/hphp/doc/options.compiled
+++ b/hphp/doc/options.compiled
@@ -314,12 +314,6 @@ These are experimental LFU settings.
 
     }
 
-    # DNS cache
-    DnsCache {
-      Enable = false
-      TTL = 600   # in seconds
-    }
-
     # Light process has very little forking cost, because they are pre-forked
     # Recommend to turn it on for faster shell command execution.
     LightProcessFilePrefix = ./lightprocess

--- a/hphp/runtime/ext/sockets/ext_sockets.cpp
+++ b/hphp/runtime/ext/sockets/ext_sockets.cpp
@@ -174,7 +174,7 @@ static bool php_set_inet_addr(struct sockaddr_in *sin,
     sin->sin_addr.s_addr = tmp.s_addr;
   } else {
     const HostEnt *result = cached_gethostbyname(address);
-    if (result == NULL) {
+    if (result == nullptr) {
       /* Note: < -10000 indicates a host lookup error */
       SOCKET_ERROR(sock, "Host lookup failed", errno);
       return false;
@@ -529,7 +529,7 @@ Variant HHVM_FUNCTION(socket_create_listen,
                       int port,
                       int backlog /* = 128 */) {
   const HostEnt *result = cached_gethostbyname("0.0.0.0");
-  if (result == NULL) {
+  if (result == nullptr) {
     return false;
   }
 

--- a/hphp/runtime/ext/sockets/ext_sockets.cpp
+++ b/hphp/runtime/ext/sockets/ext_sockets.cpp
@@ -173,19 +173,18 @@ static bool php_set_inet_addr(struct sockaddr_in *sin,
   if (inet_aton(address, &tmp)) {
     sin->sin_addr.s_addr = tmp.s_addr;
   } else {
-    HostEnt result;
-    if (!safe_gethostbyname(address, result)) {
+    const HostEnt *result = cached_gethostbyname(address);
+    if (result == NULL) {
       /* Note: < -10000 indicates a host lookup error */
-      SOCKET_ERROR(sock, "Host lookup failed", (-10000 - result.herr));
+      SOCKET_ERROR(sock, "Host lookup failed", errno);
       return false;
     }
-    if (result.hostbuf.h_addrtype != AF_INET) {
+    if (result->hostbuf.h_addrtype != AF_INET) {
       raise_warning("Host lookup failed: Non AF_INET domain "
                       "returned on AF_INET socket");
       return false;
     }
-    memcpy(&(sin->sin_addr.s_addr), result.hostbuf.h_addr_list[0],
-           result.hostbuf.h_length);
+    result->get_current_address(&(sin->sin_addr));
   }
 
   return true;
@@ -529,15 +528,15 @@ Variant HHVM_FUNCTION(socket_create,
 Variant HHVM_FUNCTION(socket_create_listen,
                       int port,
                       int backlog /* = 128 */) {
-  HostEnt result;
-  if (!safe_gethostbyname("0.0.0.0", result)) {
+  const HostEnt *result = cached_gethostbyname("0.0.0.0");
+  if (result == NULL) {
     return false;
   }
 
   struct sockaddr_in la;
-  memcpy((char *) &la.sin_addr, result.hostbuf.h_addr,
-         result.hostbuf.h_length);
-  la.sin_family = result.hostbuf.h_addrtype;
+  memcpy((char *) &la.sin_addr, result->hostbuf.h_addr,
+         result->hostbuf.h_length);
+  la.sin_family = result->hostbuf.h_addrtype;
   la.sin_port = htons((unsigned short)port);
 
   auto sock = req::make<Socket>(

--- a/hphp/runtime/ext/std/ext_std_network.cpp
+++ b/hphp/runtime/ext/std/ext_std_network.cpp
@@ -168,7 +168,7 @@ String HHVM_FUNCTION(gethostbyname, const String& hostname) {
 
 
   const HostEnt *result = cached_gethostbyname(hostname.data());
-  if (result == NULL) {
+  if (result == nullptr) {
     return hostname;
   }
   struct in_addr in;
@@ -185,7 +185,7 @@ Variant HHVM_FUNCTION(gethostbynamel, const String& hostname) {
   IOStatusHelper io("gethostbynamel", hostname.data());
 
   const HostEnt *result = cached_gethostbyname(hostname.data());
-  if (result == NULL) {
+  if (result == nullptr) {
     return false;
   }
 

--- a/hphp/util/network.cpp
+++ b/hphp/util/network.cpp
@@ -234,13 +234,15 @@ public:
   HostEntCache hostEntCache;
 
   NetworkData() :lastCleanup(0) {
-    IniSetting::Bind(IniSetting::CORE, IniSetting::PHP_INI_ALL, "hhvm.server.dns_cache.enable", "false", &s_dns_cache_enable);
-    IniSetting::Bind(IniSetting::CORE, IniSetting::PHP_INI_ALL, "hhvm.server.dns_cache.ttl", "60", &s_dns_cache_ttl);
+    IniSetting::Bind(IniSetting::CORE, IniSetting::PHP_INI_ALL,
+        "hhvm.server.dns_cache.enable", "false", &s_dns_cache_enable);
+    IniSetting::Bind(IniSetting::CORE, IniSetting::PHP_INI_ALL,
+        "hhvm.server.dns_cache.ttl", "60", &s_dns_cache_ttl);
   }
 
   void cleanupCache() {
     // If DNS cache is deactivated, we just always clean the hash table
-    time_t now = time(NULL);
+    time_t now = time(nullptr);
 
     if (!s_dns_cache_enable || (now > lastCleanup + s_dns_cache_ttl)) {
       hostEntCache.clear();
@@ -267,7 +269,7 @@ const HostEnt *cached_gethostbyname(const char *address) {
   HostEnt *result = new HostEnt;
   if (!safe_gethostbyname(address, *result)) {
     delete result;
-    return NULL;
+    return nullptr;
   }
 
   s_networkData->hostEntCache[address] = *result;

--- a/hphp/util/network.cpp
+++ b/hphp/util/network.cpp
@@ -26,6 +26,8 @@
 
 #include "hphp/util/lock.h"
 #include "hphp/util/process.h"
+#include "hphp/runtime/base/ini-setting.h"
+
 
 namespace HPHP {
 ///////////////////////////////////////////////////////////////////////////////
@@ -72,6 +74,13 @@ bool safe_gethostbyname(const char *address, HostEnt &result) {
     hstbuflen *= 2;
     result.tmphstbuf = (char*)realloc(result.tmphstbuf, hstbuflen);
   }
+
+  result.index = 0;
+  result.n_addrs = 0;
+  for(char** addr = result.hostbuf.h_addr_list; *addr; addr++) {
+    result.n_addrs++;
+  }
+
   return !res && hp;
 #endif
 }
@@ -217,6 +226,52 @@ HostURL::HostURL(const std::string &hosturl, int port) :
     m_ipv6 = false;
   }
   m_valid = true;
+}
+
+typedef hphp_hash_map<std::string, HostEnt> HostEntCache;
+class NetworkData {
+public:
+  HostEntCache hostEntCache;
+
+  NetworkData() :lastCleanup(0) {
+    IniSetting::Bind(IniSetting::CORE, IniSetting::PHP_INI_ALL, "hhvm.server.dns_cache.enable", "false", &s_dns_cache_enable);
+    IniSetting::Bind(IniSetting::CORE, IniSetting::PHP_INI_ALL, "hhvm.server.dns_cache.ttl", "60", &s_dns_cache_ttl);
+  }
+
+  void cleanupCache() {
+    // If DNS cache is deactivated, we just always clean the hash table
+    time_t now = time(NULL);
+
+    if (!s_dns_cache_enable || (now > lastCleanup + s_dns_cache_ttl)) {
+      hostEntCache.clear();
+      lastCleanup = now;
+    }
+  }
+private:
+  time_t lastCleanup;
+  bool s_dns_cache_enable;
+  int s_dns_cache_ttl;
+};
+
+static IMPLEMENT_THREAD_LOCAL(NetworkData, s_networkData);
+
+const HostEnt *cached_gethostbyname(const char *address) {
+  s_networkData->cleanupCache();
+
+  HostEntCache::iterator cached = s_networkData->hostEntCache.find(address);
+  if (cached != s_networkData->hostEntCache.end()) {
+    cached->second.rotate_index();
+    return &cached->second;
+  }
+
+  HostEnt *result = new HostEnt;
+  if (!safe_gethostbyname(address, *result)) {
+    delete result;
+    return NULL;
+  }
+
+  s_networkData->hostEntCache[address] = *result;
+  return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/hphp/util/network.h
+++ b/hphp/util/network.h
@@ -33,12 +33,22 @@ namespace HPHP {
 
 class HostEnt {
 public:
-  HostEnt() : tmphstbuf(nullptr) {}
+  HostEnt() : tmphstbuf(nullptr), index(0), n_addrs(0) {}
   ~HostEnt() { if (tmphstbuf) free(tmphstbuf);}
+
+  void rotate_index() {
+    if (++index >= n_addrs) index = 0;
+  }
+
+  void get_current_address(struct in_addr *in) const {
+     memcpy(&(in->s_addr), hostbuf.h_addr_list[index], hostbuf.h_length);
+  }
 
   struct hostent hostbuf;
   char *tmphstbuf;
   int herr;
+  // Index to rotate through all available adresses
+  int index, n_addrs;
 };
 
 // Extract out the scheme, host and port from a URL
@@ -71,6 +81,7 @@ private:
 };
 
 bool safe_gethostbyname(const char *address, HostEnt &result);
+const HostEnt *cached_gethostbyname(const char *address);
 
 ///////////////////////////////////////////////////////////////////////////////
 /**


### PR DESCRIPTION
This fix #5927

The change is a little intrusive, but it leads to cleaner code.
The calls to safe_gethostbyname are now changed to cached_gethostbyname.
The cache is implemented with a thread-local map and this map is accessed every
time a DNS resolution is issued.
If the cache is deactivated, the map is cleared before each DNS resolution
(effectively negating the cache).

If the cache is enabled, the entries are considered stale after TTL seconds and
the next DNS resolution triggers a reload.

Related config entries (already on the documentation):
  * hhvm.server.dns_cache.enable (default: false)
  * hhvm.server.dns_cache.ttl (default: 60)