### PR TITLE
Implements `hh_server --daemon` on Windows.

### DIFF
--- a/hphp/hack/src/client/clientStart.ml
+++ b/hphp/hack/src/client/clientStart.ml
@@ -30,6 +30,7 @@ let start_server env =
   (* Create a pipe for synchronization with the server: we will wait
      until the server finishes its initialisation phase. *)
   let in_fd, out_fd = Unix.pipe () in
+  Unix.set_close_on_exec in_fd;
   let ic = Unix.in_channel_of_descr in_fd in
 
   let hh_server = get_hhserver () in
@@ -50,6 +51,7 @@ let start_server env =
   try
     let server_pid =
       Unix.(create_process hh_server hh_server_args stdin stdout stderr) in
+    Unix.close out_fd;
 
     match Unix.waitpid [] server_pid with
     | _, Unix.WEXITED 0 ->

--- a/hphp/hack/src/dfind/dfindLib.ml
+++ b/hphp/hack/src/dfind/dfindLib.ml
@@ -12,7 +12,7 @@ open Utils
 
 type t = (SSet.t, unit) Daemon.handle
 
-let init roots = Daemon.fork (DfindServer.run_daemon roots)
+let init roots = Daemon.spawn DfindServer.entry_point roots
 
 let pid handle = handle.Daemon.pid
 

--- a/hphp/hack/src/dfind/dfindServer.ml
+++ b/hphp/hack/src/dfind/dfindServer.ml
@@ -72,3 +72,6 @@ let run_daemon roots (ic, oc) =
     let timeout = -1.0 in
     Fsnotify.select env.fsnotify ~read_fdl ~timeout fsnotify_callback
   done
+
+let entry_point =
+  Daemon.register_entry_point "dfind" run_daemon

--- a/hphp/hack/src/dfind/dfindServer.mli
+++ b/hphp/hack/src/dfind/dfindServer.mli
@@ -11,3 +11,4 @@
 open Utils
 
 val run_daemon: Path.t list -> (unit, SSet.t) Daemon.channel_pair -> unit
+val entry_point: (Path.t list, unit, SSet.t) Daemon.entry

--- a/hphp/hack/src/server/serverArgs.ml
+++ b/hphp/hack/src/server/serverArgs.ml
@@ -21,7 +21,7 @@ type options = {
   convert          : Path.t option;
   no_load          : bool;
   save_filename    : string option;
-  waiting_client   : out_channel option;
+  waiting_client   : Handle.handle option;
 }
 
 (*****************************************************************************)
@@ -79,8 +79,7 @@ let parse_options () =
   let cdir          = fun s -> convert_dir := Some s in
   let set_ai        = fun s -> ai_mode := Some s in
   let set_save      = fun s -> save := Some s in
-  let set_wait      = fun fd ->
-    waiting_client := Some (Handle.to_out_channel fd) in
+  let set_wait      = fun fd -> waiting_client := Some fd in
   let options =
     ["--debug"         , Arg.Set debug         , Messages.debug;
      "--ai"            , Arg.String set_ai     , Messages.ai;

--- a/hphp/hack/src/server/serverArgs.mli
+++ b/hphp/hack/src/server/serverArgs.mli
@@ -21,7 +21,7 @@ type options = {
   convert          : Path.t option;
   no_load          : bool;
   save_filename    : string option;
-  waiting_client   : out_channel option;
+  waiting_client   : Handle.handle option;
 }
 
 val parse_options: unit -> options
@@ -39,4 +39,4 @@ val should_detach       : options -> bool
 val convert             : options -> Path.t option
 val no_load             : options -> bool
 val save_filename       : options -> string option
-val waiting_client      : options -> out_channel option
+val waiting_client      : options -> Handle.handle option

--- a/hphp/hack/src/server/serverFiles.ml
+++ b/hphp/hack/src/server/serverFiles.ml
@@ -32,7 +32,7 @@ let make_link_of_timestamped linkname =
     year (tm.tm_mon + 1) tm.tm_mday tm.tm_hour tm.tm_min tm.tm_sec in
   let filename = Filename.concat dir (spf "%s-%s.%s" base time_str ext) in
   Sys_utils.unlink_no_fail linkname;
-  Unix.symlink filename linkname;
+  Sys_utils.symlink filename linkname;
   filename
 
 let init_file root = path_of_root root "init"

--- a/hphp/hack/src/utils/daemon.ml
+++ b/hphp/hack/src/utils/daemon.ml
@@ -18,10 +18,12 @@ type ('in_, 'out) handle = {
   pid : int;
 }
 
-let to_channel : 'a out_channel -> ?flush:bool -> 'a -> unit =
-fun oc ?flush:(should_flush=true) v ->
-  Marshal.to_channel oc v [];
-  if should_flush then flush oc
+let to_channel :
+  'a out_channel -> ?flags:Marshal.extern_flags list -> ?flush:bool ->
+  'a -> unit =
+  fun oc ?(flags = []) ?flush:(should_flush=true) v ->
+    Marshal.to_channel oc v flags;
+    if should_flush then flush oc
 
 let from_channel : 'a in_channel -> 'a = fun ic ->
   Marshal.from_channel ic
@@ -33,6 +35,82 @@ let descr_of_in_channel : 'a in_channel -> Unix.file_descr =
 
 let descr_of_out_channel : 'a out_channel -> Unix.file_descr =
   Unix.descr_of_out_channel
+
+(** *)
+
+module Entry : sig
+
+  (* All the 'untyped' operations---that are required for the
+     entry-points hashtable and the parameters stored in env
+     variable---are hidden in this sub-module, behind a 'type-safe'
+     interface. *)
+
+  type ('param, 'input, 'output) t
+  val register:
+    string -> ('param -> ('input, 'output) channel_pair -> unit) ->
+    ('param, 'input, 'output) t
+  val find:
+    ('param, 'input, 'output) t ->
+    'param ->
+    ('input, 'output) channel_pair -> unit
+  val set_context:
+    ('param, 'input, 'output) t -> 'param ->
+    Unix.file_descr * Unix.file_descr ->
+    unit
+  val get_context:
+    unit ->
+    (('param, 'input, 'output) t * 'param * ('input, 'output) channel_pair)
+
+end = struct
+
+  type ('param, 'input, 'output) t = string
+
+  (* Store functions as 'Obj.t' *)
+  let entry_points : (string, Obj.t) Hashtbl.t = Hashtbl.create 23
+  let register name f =
+    if Hashtbl.mem entry_points name then
+      Printf.ksprintf failwith
+        "Daemon.register_entry_point: duplicate entry point %S."
+        name;
+    Hashtbl.add entry_points name (Obj.repr f);
+    name
+  let find name =
+    try Obj.obj (Hashtbl.find entry_points name)
+    with Not_found ->
+      Printf.ksprintf failwith
+        "Unknown entry point %S" name
+
+  let set_context entry param (ic, oc) =
+    let data =
+      (Handle.get_handle ic,
+       Handle.get_handle oc,
+       param) in
+    let data_str = String.escaped (Marshal.to_string data []) in
+    Unix.putenv "HH_SERVER_DAEMON" entry;
+    Unix.putenv "HH_SERVER_DAEMON_PARAM" data_str
+  let get_context () =
+    let entry = Unix.getenv "HH_SERVER_DAEMON" in
+    let (ic, oc, param) =
+      try
+        let raw = Sys.getenv "HH_SERVER_DAEMON_PARAM" in
+        Marshal.from_string (Scanf.unescaped raw) 0
+      with _ -> failwith "Can't find daemon parameters." in
+    (entry, param,
+     (Unix.in_channel_of_descr (Handle.wrap_handle ic),
+      Unix.out_channel_of_descr (Handle.wrap_handle oc)))
+
+end
+
+type ('param, 'input, 'output) entry = ('param, 'input, 'output) Entry.t
+
+let exec entry param ic oc =
+  let f = Entry.find entry in
+  try f param (ic, oc); exit 0
+  with _ -> exit 1
+
+let register_entry_point = Entry.register
+
+let null_path = Path.to_string Path.null_path
 
 let make_pipe () =
   let descr_in, descr_out = Unix.pipe () in
@@ -54,10 +132,10 @@ let fork ?log_file (f : ('a, 'b) channel_pair -> unit) :
       close_out parent_out;
       Sys_utils.with_umask 0o111 begin fun () ->
         let fd =
-          Unix.openfile "/dev/null" [Unix.O_RDONLY; Unix.O_CREAT] 0o777 in
+          Unix.openfile null_path [Unix.O_RDONLY; Unix.O_CREAT] 0o777 in
         Unix.dup2 fd Unix.stdin;
         Unix.close fd;
-        let fn = Option.value_map log_file ~default:"/dev/null" ~f:
+        let fn = Option.value_map log_file ~default:null_path ~f:
           begin fun fn ->
             Sys_utils.mkdir_no_fail (Filename.dirname fn);
             fn
@@ -74,8 +152,56 @@ let fork ?log_file (f : ('a, 'b) channel_pair -> unit) :
       close_out child_out;
       { channels = parent_in, parent_out; pid }
 
+let spawn
+    (type param) (type input) (type output)
+    ?reason ?log_file
+    (entry: (param, input, output) entry)
+    (param: param) : (output, input) handle =
+  let parent_in, child_out = Unix.pipe () in
+  let child_in, parent_out = Unix.pipe () in
+  (* Close descriptors on exec so they are not leaked. *)
+  Unix.set_close_on_exec parent_in;
+  Unix.set_close_on_exec parent_out;
+  Entry.set_context entry param (child_in, child_out);
+  let null_fd =
+    Unix.openfile null_path [Unix.O_RDONLY; Unix.O_CREAT] 0o777 in
+  let out_path =
+    Option.value_map log_file
+      ~default:null_path
+      ~f:(fun fn ->
+          Sys_utils.mkdir_no_fail (Filename.dirname fn);
+          fn)  in
+  let out_fd =
+    Unix.openfile out_path [Unix.O_WRONLY; Unix.O_CREAT; Unix.O_TRUNC] 0o666 in
+  let pid =
+    Unix.create_process
+      Sys.executable_name [|Sys.executable_name|]
+      null_fd out_fd out_fd in
+  Option.iter reason ~f:(fun reason -> PidLog.log ~reason pid);
+  Unix.close child_in;
+  Unix.close child_out;
+  Unix.close out_fd;
+  Unix.close null_fd;
+  { channels = Unix.in_channel_of_descr parent_in,
+               Unix.out_channel_of_descr parent_out;
+    pid }
+
 (* for testing code *)
 let devnull () =
   let ic = open_in "/dev/null" in
   let oc = open_out "/dev/null" in
   {channels = ic, oc; pid = 0}
+
+let check_entry_point () =
+  try
+    let entry, param, (ic, oc) = Entry.get_context () in
+    exec entry param ic oc
+  with Not_found -> ()
+
+let close { channels = (ic, oc); _ } =
+  close_in ic;
+  close_out oc
+
+let kill h =
+  close h;
+  Unix.kill h.pid Sys.sigkill

--- a/hphp/hack/src/utils/daemon.mli
+++ b/hphp/hack/src/utils/daemon.mli
@@ -8,25 +8,75 @@
  *
  *)
 
-(* Type-safe versions of the channels in Pervasives. *)
+(** Type-safe versions of the channels in Pervasives. *)
+
 type 'a in_channel
 type 'a out_channel
 type ('in_, 'out) channel_pair = 'in_ in_channel * 'out out_channel
+
+val to_channel :
+  'a out_channel -> ?flags:Marshal.extern_flags list -> ?flush:bool ->
+  'a -> unit
+val from_channel : 'a in_channel -> 'a
+val flush : 'a out_channel -> unit
+
+(* This breaks the type safety, but is necessary in order to allow select() *)
+val descr_of_in_channel : 'a in_channel -> Unix.file_descr
+val descr_of_out_channel : 'a out_channel -> Unix.file_descr
+
+(** Spawning new process *)
+
+(* In the absence of 'fork' on Windows, its usage must be restricted
+   to Unix specifics parts.
+
+   This module provides a mechanism to "spawn" new instance of the
+   current program, but with a custom entry point (e.g. Slaves,
+   DfindServer, ...). Then, alternate entry points should not depend
+   on global references that may not have been (re)initialised in the
+   new process.
+
+   All required data must be passed through the typed channels.
+   associated to the spawned process.
+
+ *)
+
+(* Alternate entry points *)
+type ('param, 'input, 'output) entry
+
+(* Alternate entry points must be registered at toplevel, i.e.
+   every call to `Daemon.register_entry_point` must have been
+   evaluated when `Daemon.check_entry_point` is called at the
+   beginning of `ServerMain.start`. *)
+val register_entry_point :
+  string -> ('param -> ('input, 'output) channel_pair -> unit) ->
+  ('param, 'input, 'output) entry
+
+(* Handler upon spawn and forked process. *)
 type ('in_, 'out) handle = {
   channels : ('in_, 'out) channel_pair;
   pid : int;
 }
 
-val to_channel : 'a out_channel -> ?flush:bool -> 'a -> unit
-val from_channel : 'a in_channel -> 'a
-val flush : 'a out_channel -> unit
-(* This breaks the type safety, but is necessary in order to allow select() *)
-val descr_of_in_channel : 'a in_channel -> Unix.file_descr
-val descr_of_out_channel : 'a out_channel -> Unix.file_descr
-
 (* Fork and run a function that communicates via the typed channels *)
-val fork : ?log_file:string -> (('a, 'b) channel_pair -> unit) ->
-  ('b, 'a) handle
+val fork : ?log_file:string -> (('input, 'output) channel_pair -> unit) ->
+  ('output, 'input) handle
 
 (* for unit tests *)
 val devnull : unit -> ('a, 'b) handle
+
+(* Spawn a new instance of the current process, and execute the
+   alternate entry point. *)
+val spawn :
+  ?reason:string -> ?log_file:string ->
+  ('param, 'input, 'output) entry -> 'param -> ('output, 'input) handle
+
+(* Close the typed channels associated to a 'spawned' child. *)
+val close : ('a, 'b) handle -> unit
+
+(* Kill a 'spawned' child and close the associated typed channels. *)
+val kill : ('a, 'b) handle -> unit
+
+(* Main function, that execute a alternate entry point.
+   It should be called only once. Just before the main entry point.
+   This function does not return when a custom entry point is selected. *)
+val check_entry_point : unit -> unit

--- a/hphp/hack/src/utils/fork.ml
+++ b/hphp/hack/src/utils/fork.ml
@@ -26,6 +26,12 @@ let fork () =
 let fork_and_log ?reason () =
   let result = fork() in
   (match result with
-  | -1 | 0 -> ()
-  | pid -> PidLog.log ?reason pid);
+   | -1  -> ()
+   | 0   -> PidLog.close ();
+   | pid -> PidLog.log ?reason pid);
   result
+
+let fork_and_may_log ?reason () =
+  match reason with
+  | None -> fork ()
+  | Some _ -> fork_and_log ?reason ()

--- a/hphp/hack/src/utils/pidLog.ml
+++ b/hphp/hack/src/utils/pidLog.ml
@@ -15,7 +15,9 @@ let log_oc = ref None
 let init pids_file =
   assert (!log_oc = None);
   Sys_utils.with_umask 0o111 begin fun () ->
-    log_oc := Some (open_out pids_file)
+    let oc = open_out pids_file in
+    log_oc := Some oc;
+    Unix.(set_close_on_exec (descr_of_out_channel oc))
   end
 
 let log ?reason pid =
@@ -46,3 +48,7 @@ let get_pids pids_file =
     List.rev !results
   with Sys_error _ ->
     raise FailedToGetPids
+
+let close () =
+  Option.iter !log_oc ~f:close_out;
+  log_oc := None

--- a/hphp/hack/src/utils/sys_utils.ml
+++ b/hphp/hack/src/utils/sys_utils.ml
@@ -290,3 +290,15 @@ let is_test_mode () =
     ignore @@ Sys.getenv "HH_TEST_MODE";
     true
   with _ -> false
+
+let symlink =
+  (* Dummy implementation of `symlink` on Windows: we create a text
+     file containing the targeted-file's path. Symlink are available
+     on Windows since Vista, but until Seven (included), one should
+     have administratrive rights in order to create symlink. *)
+  let win32_symlink source dest = write_file ~file:dest source in
+  if Sys.win32 then win32_symlink else Unix.symlink
+
+let setsid =
+  (* Not implemented on Windows. Let's just return the pid *)
+  if Sys.win32 then Unix.getpid else Unix.setsid


### PR DESCRIPTION
In the absence of 'fork' on Windows, we added multiple entry points to `hh_server`.

All the platform-specific code is grouped in the module `Daemon`. This module export a function 'create_entry_point' to explicitely name alternate entry point. And a function `spawn` that allows to create an new instance of the current exectutable, that will execute a given alternate 'entry point'.

The function `spawn` replace the `Daemon.fork` function. Still, on Unix it is based on `Fork.fork` while on Windows, it is based on `Unix.create_process`.

This patch also introduces a function `Daemon.set_close_on_spawn`. It helps in managing file descriptors that should not leaks on `spawn`ed processes.