### PR TITLE
Convert words to lowercase before formatting them

### DIFF
--- a/hphp/hack/src/format/format_hack.ml
+++ b/hphp/hack/src/format/format_hack.ml
@@ -2595,7 +2595,7 @@ and expr_atomic env =
      expr_atomic env
  | Tword ->
       let word = !(env.last_str) in
-      expr_atomic_word env last word
+      expr_atomic_word env last (String.lowercase word)
  | Tlb ->
      last_token env;
      right env array_body;

--- a/hphp/hack/test/format/case.php
+++ b/hphp/hack/test/format/case.php
@@ -1,0 +1,9 @@
+<?hh
+
+$foo = ArrAy(1 => 2);
+
+aRRaY(1 => 2);
+
+TuPLE(1, 5, 65);
+
+$tup = TUple(1, 5, 65);

--- a/hphp/hack/test/format/case.php.exp
+++ b/hphp/hack/test/format/case.php.exp
@@ -1,0 +1,9 @@
+<?hh
+
+$foo = array(1 => 2);
+
+array(1 => 2);
+
+tuple(1, 5, 65);
+
+$tup = tuple(1, 5, 65);


### PR DESCRIPTION
Since some people use `Array()`, it should be handled and converted into
the correct `array()`.

Fixes #6083

Test Plan: New hh_format test