### PR TITLE
Inclue the file path in "Internal error" messages

### DIFF
--- a/hphp/hack/src/hh_format.ml
+++ b/hphp/hack/src/hh_format.ml
@@ -193,7 +193,7 @@ let format_in_place modes (filepath : Path.t) =
       close_out oc;
       None
   | Format_hack.Internal_error ->
-      Some "Internal error\n"
+      Some (Printf.sprintf "Internal error in %s\n" (Path.to_string filepath))
   | Format_hack.Parsing_error errorl ->
       Some (Errors.to_string (Errors.to_absolute (List.hd_exn errorl)))
   | Format_hack.Disabled_mode ->
@@ -235,10 +235,11 @@ let format_string modes file from to_ content =
   | Format_hack.Success content ->
       output_string stdout content
   | Format_hack.Internal_error ->
-      Printf.fprintf stderr "Internal error\n%!";
+      Printf.eprintf "Internal error in %s\n%!"
+        (Path.to_string file);
       exit 2
   | Format_hack.Parsing_error error ->
-      Printf.fprintf stderr "Parsing error\n%s\n%!"
+      Printf.eprintf "Parsing error\n%s\n%!"
         (Errors.to_string (Errors.to_absolute (List.hd_exn error)));
       exit 2
   | Format_hack.Disabled_mode ->
@@ -288,10 +289,10 @@ let () =
       let file_and_modified_lines = Format_diff.parse_diff prefix diff in
       Format_diff.apply modes apply_mode ~diff:file_and_modified_lines
   | _ when diff ->
-      Printf.fprintf stderr "--diff mode expects no files\n";
+      Printf.eprintf "--diff mode expects no files\n";
       exit 2
   | [] when apply_mode <> Format_mode.Print ->
-      Printf.fprintf stderr "Cannot modify stdin in-place\n";
+      Printf.eprintf "Cannot modify stdin in-place\n";
       exit 2
   | [] -> format_stdin modes from to_
   | [dir] when Sys.is_directory dir ->


### PR DESCRIPTION
Since "Internal error" being thrown doesn't halt execution when running
on multiple files, it would be a lot of work to change the exit code.
Instead, just say what file the error is in.

Also switched `Printf.fprintf stderr` to `Printf.eprintf` in `hh_format.ml`.

Fixes #6082

Test Plan: Run this change on the test in D45141 before merging that
fix. No new test, cause "Internal error" should get fixed rather than be
expected.