### PR TITLE
Don't declare function prototypes in the bodies of functions

### DIFF
--- a/hphp/hhvm/process-init.cpp
+++ b/hphp/hhvm/process-init.cpp
@@ -53,6 +53,7 @@ SYSTEMLIB_CLASSES(SYSTEM_CLASS_STRING)
 #undef pinitSentinel
 #undef STRINGIZE_CLASS_NAME
 
+void tweak_variant_dtors();
 void ProcessInit() {
   // Create the global mcg object
   jit::mcg = new jit::MCGenerator();
@@ -174,7 +175,6 @@ void ProcessInit() {
   RuntimeOption::EvalAllowHhas = ah;
   Option::WholeProgram = wp;
 
-  void tweak_variant_dtors();
   tweak_variant_dtors();
 
   folly::SingletonVault::singleton()->registrationComplete();

--- a/hphp/runtime/base/runtime-option.cpp
+++ b/hphp/runtime/base/runtime-option.cpp
@@ -715,6 +715,7 @@ void RuntimeOption::ReadSatelliteInfo(
   Config::Iterate(ss_callback, ini, hdf, "Satellites");
 }
 
+extern void initialize_apc();
 void RuntimeOption::Load(
   IniSetting::Map& ini, Hdf& config,
   const std::vector<std::string>& iniClis /* = std::vector<std::string>() */,
@@ -1758,7 +1759,6 @@ void RuntimeOption::Load(
 
 
   ExtensionRegistry::moduleLoad(ini, config);
-  extern void initialize_apc();
   initialize_apc();
 }
 


### PR DESCRIPTION
Becuse MSVC expects these functions to be `extern _cdecl` functions in the root namespace. GCC and Clang expect them to be in the current namespace.
This just moves the declarations outside of the body of the function.