### PR TITLE
Disable uses of tm_gmtoff and tm_zone under MSVC

### DIFF
--- a/hphp/runtime/base/datetime.cpp
+++ b/hphp/runtime/base/datetime.cpp
@@ -510,6 +510,7 @@ void DateTime::sub(const req::ptr<DateInterval>& interval) {
 // conversions
 
 void DateTime::toTm(struct tm &ta) const {
+  // TODO: Fixme under MSVC!
   ta.tm_sec  = second();
   ta.tm_min  = minute();
   ta.tm_hour = hour();
@@ -520,14 +521,18 @@ void DateTime::toTm(struct tm &ta) const {
   ta.tm_yday = doy();
   if (utc()) {
     ta.tm_isdst = 0;
+#ifndef _MSC_VER
     ta.tm_gmtoff = 0;
     ta.tm_zone = "GMT";
+#endif
   } else {
     timelib_time_offset *offset =
       timelib_get_time_zone_info(m_time->sse, m_time->tz_info);
     ta.tm_isdst = offset->is_dst;
+#ifndef _MSC_VER
     ta.tm_gmtoff = offset->offset;
     ta.tm_zone = offset->abbr;
+#endif
     timelib_time_offset_dtor(offset);
   }
 }
@@ -719,6 +724,7 @@ String DateTime::rfcFormat(const String& format) const {
 }
 
 String DateTime::stdcFormat(const String& format) const {
+  // TODO: Fixme under MSVC!
   struct tm ta;
   timelib_time_offset *offset = nullptr;
   ta.tm_sec  = second();
@@ -731,13 +737,17 @@ String DateTime::stdcFormat(const String& format) const {
   ta.tm_yday = doy();
   if (utc()) {
     ta.tm_isdst = 0;
+#ifndef _MSC_VER
     ta.tm_gmtoff = 0;
     ta.tm_zone = "GMT";
+#endif
   } else {
     offset = timelib_get_time_zone_info(m_time->sse, m_time->tz_info);
     ta.tm_isdst = offset->is_dst;
+#ifndef _MSC_VER
     ta.tm_gmtoff = offset->offset;
     ta.tm_zone = offset->abbr;
+#endif
   }
 
   if ((ta.tm_sec < 0 || ta.tm_sec > 60) ||

--- a/hphp/runtime/base/timezone.cpp
+++ b/hphp/runtime/base/timezone.cpp
@@ -44,10 +44,13 @@ public:
     struct tm tmbuf;
     struct tm *ta = localtime_r(&the_time, &tmbuf);
     const char *tzid = nullptr;
+#ifndef _MSC_VER
+    // TODO: Fixme under MSVC!
     if (ta) {
       tzid = timelib_timezone_id_from_abbr(ta->tm_zone, ta->tm_gmtoff,
                                            ta->tm_isdst);
     }
+#endif
     if (!tzid) {
       tzid = "UTC";
     }
@@ -61,9 +64,13 @@ public:
   "misspelled the timezone identifier. "
 
     string_printf(m_warning, DATE_TZ_ERRMSG
-                  "We selected '%s' for '%s/%.1f/%s' instead",
-                  tzid, ta ? ta->tm_zone : "Unknown",
+                  "We selected '%s' for '%s/%.1f/%s' instead", tzid,
+#ifdef _MSC_VER
+                  "Unknown", 0,
+#else
+                  ta ? ta->tm_zone : "Unknown",
                   ta ? (float) (ta->tm_gmtoff / 3600) : 0,
+#endif
                   ta ? (ta->tm_isdst ? "DST" : "no DST") : "Unknown");
   }
 };


### PR DESCRIPTION
We don't have these fields in `tm`, so a different way to handle these locations is going to be needed.
This just disables them for the moment to make it possible to compile under MSVC.