### PR TITLE
Explicitly use folly::make_unique

### DIFF
--- a/hphp/runtime/server/warmup-request-handler.cpp
+++ b/hphp/runtime/server/warmup-request-handler.cpp
@@ -51,7 +51,7 @@ void WarmupRequestHandler::logToAccessLog(Transport *transport) {
 }
 
 std::unique_ptr<RequestHandler> WarmupRequestHandlerFactory::createHandler() {
-  return make_unique<WarmupRequestHandler>(m_timeout, shared_from_this());
+  return folly::make_unique<WarmupRequestHandler>(m_timeout, shared_from_this());
 }
 
 void WarmupRequestHandlerFactory::bumpReqCount() {


### PR DESCRIPTION
Because MSVC implements `make_unique`, which is also present in this scope, and it then proceeds to get confused about which implementation we are trying to reference.