### PR TITLE
Link against dbghelp and dnsapi under MSVC

### DIFF
--- a/CMake/HPHPFindLibs.cmake
+++ b/CMake/HPHPFindLibs.cmake
@@ -590,4 +590,8 @@ macro(hphp_link target)
   if (LINUX)
     target_link_libraries(${target} -Wl,--wrap=pthread_create -Wl,--wrap=pthread_exit -Wl,--wrap=pthread_join)
   endif()
+
+  if (MSVC)
+    target_link_libraries(${target} dbghelp.lib dnsapi.lib)
+  endif()
 endmacro()


### PR DESCRIPTION
`dbghelp` is needed for symbol interaction and demangling names. `dnsapi` will be needed for the windows version of ext_std_network, which, although it isn't yet merged, will eventually be, and will need it.