### PR TITLE
Don't use a template for ExecutionContext destruction

### DIFF
--- a/hphp/runtime/base/execution-context.cpp
+++ b/hphp/runtime/base/execution-context.cpp
@@ -95,6 +95,10 @@ ExecutionContext::ExecutionContext()
     RuntimeOption::SerializationSizeLimit;
 }
 
+// See header for why this is required.
+#ifndef _MSC_VER
+template<>
+#endif
 void ThreadLocalNoCheck<ExecutionContext>::destroy() {
   if (!isNull()) {
     getNoCheck()->sweep();

--- a/hphp/runtime/base/execution-context.cpp
+++ b/hphp/runtime/base/execution-context.cpp
@@ -95,7 +95,7 @@ ExecutionContext::ExecutionContext()
     RuntimeOption::SerializationSizeLimit;
 }
 
-template<> void ThreadLocalNoCheck<ExecutionContext>::destroy() {
+void ThreadLocalNoCheck<ExecutionContext>::destroy() {
   if (!isNull()) {
     getNoCheck()->sweep();
     setNull();

--- a/hphp/runtime/base/execution-context.h
+++ b/hphp/runtime/base/execution-context.h
@@ -602,6 +602,11 @@ public:
 
 ///////////////////////////////////////////////////////////////////////////////
 
+// MSVC doesn't instantiate this, causing an undefined symbol at link time
+// if the template<> is present, but other compilers require it.
+#ifndef _MSC_VER
+template<>
+#endif
 void ThreadLocalNoCheck<ExecutionContext>::destroy();
 
 extern DECLARE_THREAD_LOCAL_NO_CHECK(ExecutionContext, g_context);

--- a/hphp/runtime/base/execution-context.h
+++ b/hphp/runtime/base/execution-context.h
@@ -602,7 +602,7 @@ public:
 
 ///////////////////////////////////////////////////////////////////////////////
 
-template<> void ThreadLocalNoCheck<ExecutionContext>::destroy();
+void ThreadLocalNoCheck<ExecutionContext>::destroy();
 
 extern DECLARE_THREAD_LOCAL_NO_CHECK(ExecutionContext, g_context);
 


### PR DESCRIPTION
MSVC ends up not instantiating the template, and thus failing to link if this is templated like this.