### PR TITLE
Explicitly cast kNumActRecCells to int32 when constructing AStack

### DIFF
--- a/hphp/runtime/vm/jit/memory-effects.cpp
+++ b/hphp/runtime/vm/jit/memory-effects.cpp
@@ -823,7 +823,7 @@ MemEffects memory_effects_impl(const IRInstruction& inst) {
           // ActRec, but AliasClass needs an offset to the highest cell it will
           // store.
           spOffset.offset + int32_t{kNumActRecCells} - 1,
-          kNumActRecCells
+          (int32_t)kNumActRecCells
         },
         AStack {
           inst.src(0),
@@ -1316,7 +1316,7 @@ MemEffects memory_effects_impl(const IRInstruction& inst) {
         // store.
         inst.extra<DbgTrashFrame>()->offset.offset +
           int32_t{kNumActRecCells} - 1,
-        kNumActRecCells
+        (int32_t)kNumActRecCells
       }
     };
   case DbgTrashMem:

--- a/hphp/runtime/vm/jit/memory-effects.cpp
+++ b/hphp/runtime/vm/jit/memory-effects.cpp
@@ -823,7 +823,7 @@ MemEffects memory_effects_impl(const IRInstruction& inst) {
           // ActRec, but AliasClass needs an offset to the highest cell it will
           // store.
           spOffset.offset + int32_t{kNumActRecCells} - 1,
-          static_cast<int32_t>(kNumActRecCells)
+          int32_t{kNumActRecCells}
         },
         AStack {
           inst.src(0),
@@ -1316,7 +1316,7 @@ MemEffects memory_effects_impl(const IRInstruction& inst) {
         // store.
         inst.extra<DbgTrashFrame>()->offset.offset +
           int32_t{kNumActRecCells} - 1,
-        static_cast<int32_t>(kNumActRecCells)
+        int32_t{kNumActRecCells}
       }
     };
   case DbgTrashMem:

--- a/hphp/runtime/vm/jit/memory-effects.cpp
+++ b/hphp/runtime/vm/jit/memory-effects.cpp
@@ -823,7 +823,7 @@ MemEffects memory_effects_impl(const IRInstruction& inst) {
           // ActRec, but AliasClass needs an offset to the highest cell it will
           // store.
           spOffset.offset + int32_t{kNumActRecCells} - 1,
-          (int32_t)kNumActRecCells
+          static_cast<int32_t>(kNumActRecCells)
         },
         AStack {
           inst.src(0),
@@ -1316,7 +1316,7 @@ MemEffects memory_effects_impl(const IRInstruction& inst) {
         // store.
         inst.extra<DbgTrashFrame>()->offset.offset +
           int32_t{kNumActRecCells} - 1,
-        (int32_t)kNumActRecCells
+        static_cast<int32_t>(kNumActRecCells)
       }
     };
   case DbgTrashMem:


### PR DESCRIPTION
Because `kNumActRecCells` is defined as a `size_t`, and, although the actual value would fit in an `int32_t`, MSVC attempts to resolve the overload based on the `size_t` type, and fails.