### PR TITLE
Allow the unsigned constructor overload of Immed under MSVC

### DIFF
--- a/hphp/util/immed.h
+++ b/hphp/util/immed.h
@@ -60,7 +60,15 @@ inline bool magFits(uint64_t val, int s) {
  */
 struct Immed {
   /* implicit */ Immed(int i) : m_int(i) {}
+#ifdef _MSC_VER
+  // MSVC prefers not changing the sign of the value when
+  // resolving the overloads, which means that an unsigned
+  // argument, even of a size smaller than int, will error
+  // so we provide an unsigned overload to fix that.
+  /* implicit */ Immed(unsigned int i) : m_int((int)i) {}
+#else
   /* implicit */ Immed(unsigned i) = delete;
+#endif
   /* implicit */ Immed(long i) = delete;
   /* implicit */ Immed(unsigned long i) = delete;
   /* implicit */ Immed(long long i) = delete;


### PR DESCRIPTION
As explained in the comment, MSVC prefers not changing the sign of a value when resolving overloads, so an unsigned type, even if it losslessly fits in an `int`, will always resolve to the `unsigned` overload, which is normally defined as deleted.