### PR TITLE
Don't use auto const when assigning a couple of bitsets

### DIFF
--- a/hphp/runtime/vm/jit/alias-analysis.cpp
+++ b/hphp/runtime/vm/jit/alias-analysis.cpp
@@ -85,7 +85,7 @@ ALocBits may_alias_part(const AliasAnalysis& aa,
                         AliasClass any,
                         ALocBits pessimistic) {
   if (proj) {
-    if (auto const meta = aa.find(*proj)) {
+    if (auto meta = aa.find(*proj)) {
       return ALocBits{meta->conflicts}.set(meta->index);
     }
     assertx(acls.maybe(any));
@@ -126,7 +126,7 @@ folly::Optional<ALocMeta> AliasAnalysis::find(AliasClass acls) const {
 }
 
 ALocBits AliasAnalysis::may_alias(AliasClass acls) const {
-  if (auto const meta = find(acls)) {
+  if (auto meta = find(acls)) {
     return ALocBits{meta->conflicts}.set(meta->index);
   }
 


### PR DESCRIPTION
In today's issue of MSVC regressions and oddities, I present to you the im-a-const construction dilema!

Basically, for some absurd reason, MSVC seems to think the type of the result of `ALocBits{meta->conflicts}` is a `const`.

The RC version actually handled this just fine; this issue wasn't present until the first actual release of VS 2015.
And yes, these really are the only two places this change is needed.