### PR TITLE
Include array-data-defs in repo-auth-type

### DIFF
--- a/hphp/runtime/base/repo-auth-type.cpp
+++ b/hphp/runtime/base/repo-auth-type.cpp
@@ -19,6 +19,7 @@
 
 #include <folly/Hash.h>
 
+#include "hphp/runtime/base/array-data-defs.h"
 #include "hphp/runtime/base/repo-auth-type-array.h"
 #include "hphp/runtime/base/object-data.h"
 #include "hphp/runtime/base/tv-helpers.h"


### PR DESCRIPTION
Because sometimes MSVC actually follows the standards.

This particular issue is caused by the `/Zc:inline` option for MSVC. This eliminates unreferenced inline definitions in the object files. `repo-auth-type` references one of the functions that is only ever defined inline in `array-data-defs`, and, if MSVC hadn't prevented it from being emitted due to it not being referenced, it would be present in multiple object files, however, as it isn't referenced anywhere else, it doesn't get emitted, so, come link-time, it can't find the symbol.
The solution is simple: Give repo-auth-type the inline definitions of the required functions.