### PR TITLE
Don't handle SIGQUIT and SIGBUS in the crash reporter under MSVC

### DIFF
--- a/hphp/runtime/base/crash-reporter.cpp
+++ b/hphp/runtime/base/crash-reporter.cpp
@@ -129,11 +129,13 @@ static void bt_handler(int sig) {
 }
 
 void install_crash_reporter() {
+#ifndef _MSC_VER
   signal(SIGQUIT, bt_handler);
+  signal(SIGBUS,  bt_handler);
+#endif
   signal(SIGILL,  bt_handler);
   signal(SIGFPE,  bt_handler);
   signal(SIGSEGV, bt_handler);
-  signal(SIGBUS,  bt_handler);
   signal(SIGABRT, bt_handler);
 
   register_assert_fail_logger(&StackTraceNoHeap::AddExtraLogging);


### PR DESCRIPTION
Because we don't have either of these.