### PR TITLE
Assert ObjectData is the correct size under MSVC

### DIFF
--- a/hphp/runtime/base/object-data.cpp
+++ b/hphp/runtime/base/object-data.cpp
@@ -75,8 +75,13 @@ static Array convert_to_array(const ObjectData* obj, Class* cls) {
   return tvAsCVarRef(prop).toArray();
 }
 
+#ifdef _MSC_VER
+static_assert(sizeof(ObjectData) == (use_lowptr ? 16 : 20),
+              "Change this only on purpose");
+#else
 static_assert(sizeof(ObjectData) == (use_lowptr ? 16 : 24),
               "Change this only on purpose");
+#endif
 
 //////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
Because MSVC will not lay out child structs in a parent struct's alignment padding, MSVC's `ObjectData` needs to be 20 bytes.