### PR TITLE
Don't use elfwriter under MSVC

### DIFF
--- a/hphp/runtime/CMakeLists.txt
+++ b/hphp/runtime/CMakeLists.txt
@@ -7,6 +7,8 @@ list(APPEND HEADER_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/version.h")
 if(NOT LINUX)
   list(REMOVE_ITEM CXX_SOURCES
        ${CMAKE_CURRENT_SOURCE_DIR}/vm/debug/elfwriter.cpp)
+  list(REMOVE_ITEM HEADER_SOURCES
+       ${CMAKE_CURRENT_SOURCE_DIR}/vm/debug/elfwriter.h)
 endif()
 
 if(NOT ENABLE_FASTCGI)

--- a/hphp/runtime/vm/debug/dwarf.cpp
+++ b/hphp/runtime/vm/debug/dwarf.cpp
@@ -17,14 +17,17 @@
 
 #include <stdio.h>
 #include "debug.h"
-#if !defined(__APPLE__) && !defined(__FreeBSD__) && !defined(__CYGWIN__)
-#include "hphp/runtime/vm/debug/elfwriter.h"
-#endif
 #include "hphp/runtime/vm/debug/gdb-jit.h"
 
 #include "hphp/runtime/base/execution-context.h"
 #include "hphp/runtime/vm/jit/translator.h"
 #include "hphp/runtime/vm/jit/translator-inline.h"
+
+#if (!defined(__APPLE__) && !defined(__FreeBSD__) && \
+     !defined(__CYGWIN__) && !defined(_MSC_VER))
+#include "hphp/runtime/vm/debug/elfwriter.h"
+#define USE_ELF_WRITER 1
+#endif
 
 using namespace HPHP::jit;
 
@@ -35,7 +38,7 @@ int g_dwarfCallback(
   LIBDWARF_CALLBACK_NAME_TYPE name, int size, Dwarf_Unsigned type,
   Dwarf_Unsigned flags, Dwarf_Unsigned link, Dwarf_Unsigned info,
   Dwarf_Unsigned *sect_name_index, Dwarf_Ptr handle, int *error) {
-#if !defined(__APPLE__) && !defined(__FreeBSD__) && !defined(__CYGWIN__)
+#ifdef USE_ELF_WRITER
   ElfWriter *e = reinterpret_cast<ElfWriter *>(handle);
   return e->dwarfCallback(name, size, type, flags, link, info);
 #else
@@ -220,7 +223,7 @@ void DwarfInfo::compactChunks() {
     m_dwarfChunks[j] = nullptr;
   }
   m_dwarfChunks[i] = chunk;
-#if !defined(__APPLE__) && !defined(__FreeBSD__) && !defined(__CYGWIN__)
+#ifdef USE_ELF_WRITER
   // register compacted chunk with gdb
   ElfWriter e = ElfWriter(chunk);
 #endif
@@ -294,7 +297,7 @@ DwarfChunk* DwarfInfo::addTracelet(TCRange range,
     f->m_chunk = chunk;
   }
 
-#if !defined(__APPLE__) && !defined(__FreeBSD__) && !defined(__CYGWIN__)
+#ifdef USE_ELF_WRITER
   if (f->m_chunk->m_functions.size() >= RuntimeOption::EvalGdbSyncChunks) {
     ElfWriter e = ElfWriter(f->m_chunk);
   }
@@ -309,7 +312,7 @@ void DwarfInfo::syncChunks() {
   for (i = 0; i < m_dwarfChunks.size(); i++) {
     if (m_dwarfChunks[i] && !m_dwarfChunks[i]->isSynced()) {
       unregister_gdb_chunk(m_dwarfChunks[i]);
-#if !defined(__APPLE__) && !defined(__FreeBSD__) && !defined(__CYGWIN__)
+#ifdef USE_ELF_WRITER
       ElfWriter e = ElfWriter(m_dwarfChunks[i]);
 #endif
     }


### PR DESCRIPTION
Because it's already not being compiled.
This also switches it to define `USE_ELF_WRITER` at the top of the file, rather than the whole series of `!defined()` everywhere.