### PR TITLE
Stub CALLEE_SAVED_BARRIER for MSVC

### DIFF
--- a/hphp/runtime/vm/jit/back-end-x64.cpp
+++ b/hphp/runtime/vm/jit/back-end-x64.cpp
@@ -76,6 +76,10 @@ struct BackEnd final : jit::BackEnd {
 #if defined(__CYGWIN__) || defined(__MINGW__)
   #define CALLEE_SAVED_BARRIER()                                    \
       asm volatile("" : : : "rbx", "rsi", "rdi", "r12", "r13", "r14", "r15");
+#elif defined(_MSC_VER)
+  // Unfortunately, we have no way to tell MSVC to do this, so we'll
+  // probably have to use a pair of assembly stubs to manage this.
+  #define CALLEE_SAVED_BARRIER() always_assert(false);
 #else
   #define CALLEE_SAVED_BARRIER()                                    \
       asm volatile("" : : : "rbx", "r12", "r13", "r14", "r15");


### PR DESCRIPTION
There isn't a way to force MSVC to save the registers, so this will likely have to be done with a pair of assembly stubs.
For now, just `always_assert(false);`.