### PR TITLE
Fix an assorted set of includes for MSVC

### DIFF
--- a/hphp/compiler/builtin_symbols.cpp
+++ b/hphp/compiler/builtin_symbols.cpp
@@ -33,7 +33,6 @@
 #include "hphp/runtime/base/execution-context.h"
 #include "hphp/runtime/vm/native.h"
 #include "hphp/util/logger.h"
-#include <dlfcn.h>
 #include <vector>
 
 using namespace HPHP;

--- a/hphp/compiler/compiler.cpp
+++ b/hphp/compiler/compiler.cpp
@@ -45,8 +45,10 @@
 #include "hphp/hhvm/process-init.h"
 
 #include <sys/types.h>
+#ifndef _MSC_VER
 #include <sys/wait.h>
 #include <dlfcn.h>
+#endif
 
 #include <boost/algorithm/string/replace.hpp>
 #include <boost/program_options/options_description.hpp>

--- a/hphp/compiler/expression/scalar_expression.cpp
+++ b/hphp/compiler/expression/scalar_expression.cpp
@@ -36,6 +36,7 @@
 #include <folly/Conv.h>
 
 #include <sstream>
+#include <cctype>
 #include <cmath>
 #include <limits.h>
 

--- a/hphp/runtime/base/ini-setting.cpp
+++ b/hphp/runtime/base/ini-setting.cpp
@@ -30,8 +30,11 @@
 #include "hphp/runtime/ext/extension-registry.h"
 
 #include "hphp/util/lock.h"
+#include "hphp/util/portability.h"
 
+#ifndef _MSC_VER
 #include <glob.h>
+#endif
 
 #define __STDC_LIMIT_MACROS
 #include <cstdint>

--- a/hphp/runtime/base/thread-hooks.cpp
+++ b/hphp/runtime/base/thread-hooks.cpp
@@ -15,13 +15,16 @@
 */
 #include "hphp/runtime/base/thread-hooks.h"
 #include <stdio.h>
-#include <dlfcn.h>
 #include <string.h>
+#ifndef _MSC_VER
 #include <execinfo.h>
+#include <dlfcn.h>
+#endif
 #include <unistd.h>
 
 #include "hphp/runtime/base/extended-logger.h"
 #include "hphp/util/assertions.h"
+#include "hphp/util/compatibility.h"
 #include "hphp/util/mutex.h"
 
 namespace HPHP {

--- a/hphp/runtime/ext/std/ext_std_misc.cpp
+++ b/hphp/runtime/ext/std/ext_std_misc.cpp
@@ -37,7 +37,9 @@
 #include "hphp/runtime/vm/type-profile.h"
 #include "hphp/system/constants.h"
 #include "hphp/util/logger.h"
+#ifndef _MSC_VER
 #include <sys/param.h> // MAXPATHLEN is here
+#endif
 #include "hphp/runtime/base/comparisons.h"
 
 namespace HPHP {

--- a/hphp/runtime/vm/debug/debug.cpp
+++ b/hphp/runtime/vm/debug/debug.cpp
@@ -27,7 +27,9 @@
 #include <string.h>
 #include <unistd.h>
 #include <errno.h>
+#ifndef _MSC_VER
 #include <cxxabi.h>
+#endif
 
 #ifdef HAVE_LIBBFD
 #include <bfd.h>


### PR DESCRIPTION
I really didn't want to type up descriptions for a PR for each of these changes, so it is a single PR isntead.
This basically just excludes certain includes under MSVC, adds includes that should have been there, or removes unneeded includes.