### PR TITLE
[MSVC] Use the folly event portability header where needed

### DIFF
--- a/hphp/runtime/base/libevent-http-client.cpp
+++ b/hphp/runtime/base/libevent-http-client.cpp
@@ -18,6 +18,7 @@
 #include <vector>
 
 #include <folly/Conv.h>
+#include <folly/EventPortability.h>
 
 #include "hphp/runtime/server/server-stats.h"
 #include "hphp/runtime/base/runtime-option.h"


### PR DESCRIPTION
In order to workaround the fact that the Windows version of libevent expects `HANDLE`'s and HHVM works with file descriptors, I created a portability header in folly for it.
This just includes the header in the only place (currently) in HHVM where it is needed. (it's needed in multiple places in Folly and Proxygen)

This requires [folly#301](https://github.com/facebook/folly/pull/301) to be merged upstream first.