### PR TITLE
Force the 64-bit hosted toolchain under MSVC

### DIFF
--- a/CMake/VisualStudioToolset.cmake
+++ b/CMake/VisualStudioToolset.cmake
@@ -1,0 +1,19 @@
+# Due to HHVM's size, we need to use the native 64-bit toolchain to get a decent link time,
+# and, in fact, it's also needed to be able to link at all in debug mode, due to the size of
+# the hphp_runtime_static static library. However, Visual Studio defaults to using the 32-bit
+# hosted cross compiler targetting 64-bit. Unfortunately, CMake doesn't provide us a way to
+# do this, so we have to resort to a hack-around in order to make this possible. Because the
+# toolset value is put into the project file unescaped, we can use it to add the PreferredToolArchitecture
+# value that we need, as long as we make sure to properly close and re-open the current tags.
+#
+# To add support for newer MSVC versions, simply adjust the actual toolset value at the start
+# and end of the string.
+#
+# Unfortunately, we can't rely on the MSVC and MSVC14 variables to check if we need to enable
+# this, due to the fact they are set when the C/CXX languages are enabled, however, this value
+# needs to be set before the languages are enabled in order to have any effect, so we set it
+# based directly off of the name of the generator, which is set before configuration even begins.
+
+if ("${CMAKE_GENERATOR}" STREQUAL "Visual Studio 14 2015 Win64")
+    set(CMAKE_GENERATOR_TOOLSET "v140</PlatformToolset><PreferredToolArchitecture>x64</PreferredToolArchitecture><PlatformToolset>v140")
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,9 @@
 CMAKE_MINIMUM_REQUIRED(VERSION 2.8.7 FATAL_ERROR)
 
+# This needs to be done before any languages are enabled or
+# projects are created.
+INCLUDE("${CMAKE_CURRENT_SOURCE_DIR}/CMake/VisualStudioToolset.cmake")
+
 # includes
 SET(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/CMake" ${CMAKE_MODULE_PATH})
 include_directories(${CMAKE_CURRENT_BINARY_DIR})


### PR DESCRIPTION
See the nice large comment at the top of `CMake/VisualStudioToolset.cmake` for exactly why this is needed.