### PR TITLE
Allow to pass null parameters in redis

### DIFF
--- a/hphp/system/php/redis/Redis.php
+++ b/hphp/system/php/redis/Redis.php
@@ -1547,7 +1547,7 @@ class Redis {
 
     $flen = strlen($format);
     for ($i = 0; $i < $flen; $i++) {
-      if (!isset($args[$i])) {
+      if (!array_key_exists($i, $args)) {
         if (isset($func['defaults']) AND
             array_key_exists($func['defaults'], $i)) {
           $args[$i] = $func['defaults'][$i];

--- a/hphp/test/slow/ext_redis/error_null_param.php
+++ b/hphp/test/slow/ext_redis/error_null_param.php
@@ -1,0 +1,6 @@
+<?php
+require __DIR__ . '/redis.inc';
+NewRedisTestInstance()->publish(null, null);
+
+echo "No Fatal";
+

--- a/hphp/test/slow/ext_redis/error_null_param.php.expect
+++ b/hphp/test/slow/ext_redis/error_null_param.php.expect
@@ -1,0 +1,1 @@
+No Fatal

--- a/hphp/test/slow/ext_redis/error_null_param.php.skipif
+++ b/hphp/test/slow/ext_redis/error_null_param.php.skipif
@@ -1,0 +1,12 @@
+<?php
+
+if (!getenv('REDIS_TEST_HOST')) {
+  echo 'skip';
+} else {
+  // Some people might have this variable set, but don't have the server running
+  $output = array();
+  exec("redis-cli ping", $output);
+  if ($output[0] !== "PONG") {
+    echo 'skip';
+  }
+}


### PR DESCRIPTION
isset() checks if isset and not null, so use array_key_exists instead

Fixes #6062

Test Plan: New test, note that this probably will not be executed in sandcastle
You need to set REDIS_TEST_HOST as environment variable