### PR TITLE
Implements file watcher on Windows.

### DIFF
--- a/hphp/hack/src/build.ocp
+++ b/hphp/hack/src/build.ocp
@@ -58,6 +58,7 @@ end
 
 begin library "hh-fsnotify-darwin"
   if not (system = "macosx" && os_type = "Unix") then enabled = false
+  requires += [ "ROOTPROJECT" ]
   cclib = [
     "-sectcreate" "-__text" "hhi" "%{ROOTPROJECT_FULL_SRC_DIR}%/bin/hhi.tar.gz"
     "-framework" "CoreServices"
@@ -68,13 +69,16 @@ begin library "hh-fsnotify-darwin"
     "fsevents/fsevents.ml"
     "fsnotify_darwin/fsnotify.ml"
   ]
-  requires += [ "ROOTPROJECT" ]
+  requires += [ "hh-utils-core" ]
 end
 
 begin library "hh-fsnotify-win"
   if not (os_type = "Win32") then enabled = false
-  requires += [ "ROOTPROJECT" ]
-  files = [ "fsnotify_win/fsnotify.ml" ]
+  files = [
+    "fsnotify_win/fsnotify_stubs.c"
+    "fsnotify_win/fsnotify.ml"
+  ]
+  requires += [ "hh-utils-core" ]
 end
 
 begin library "hh-fsnotify"
@@ -114,6 +118,7 @@ begin library "hh-utils-common"
     "utils/config_file.ml"
     "utils/tail.ml"
     "utils/handle.ml"
+    "utils/stats.ml"
   ]
 end
 
@@ -362,6 +367,7 @@ begin library "hh-server-base"
     "server/symbolFunCallService.ml"
     "server/symbolTypeService.ml"
     "server/symbolInfoService.ml"
+    "server/serverIdle.ml"
     "server/serverRpc.ml"
     "server/serverTypeCheck.ml"
     "server/serverCommand.ml"
@@ -377,7 +383,6 @@ begin library "hh-server"
   ]
   files = [
     "server/serverEnvBuild.ml"
-    "server/serverIdle.ml"
     "server/serverInit.ml"
     "server/serverMain.ml"
   ]

--- a/hphp/hack/src/fsnotify_win/fsnotify.ml
+++ b/hphp/hack/src/fsnotify_win/fsnotify.ml
@@ -8,21 +8,120 @@
  *
  *)
 
-exception Error of string * int
+(*
 
-type event = {
-  path : string; (* The full path for the file/directory that changed *)
-  wpath : string; (* The watched path that triggered this event *)
+   Principles:
+
+   We create a new thread for every roots directory to be watched (see
+   `raw_add_watch`). This thread loops on the function
+   `ReadDirectoryChangesW` and store received events in a lock-less
+   shared list. Whenever a new events is inserted in the shared list,
+   this thread also pushes a single character in a given pipe.
+
+   On the OCaml side, we wait for new event by passing the pipe to
+   `Unix.select`. Then we recover events by calling `raw_read_events`.
+
+*)
+
+open Core
+
+(* Abstract data type for notifier context. *)
+type fsenv
+
+(* Abstract data type for a watching thread. *)
+type watcher_id
+
+module SSet = Set.Make(String)
+
+type env = {
+  fsenv: fsenv;
+  fd: Unix.file_descr;
+  watchers: watcher_id list;
+  mutable wpaths: SSet.t;
 }
 
+type event = {
+  path: string;  (* The full path for the file/directory that changed *)
+  wpath: string; (* The watched path that triggered this event *)
+}
+
+(** Stubs *)
+
+external raw_init:
+  Unix.file_descr -> fsenv = "caml_fsnotify_init"
+
+(* [raw_add_watch out_fd dir] creates a thread that monitor [dir] and
+   push a single charactes into the pipe 'out_fd' whenever a events is
+   ready to be read with [raw_read_events].
+
+   The return value is an opaque `watcher_id`, currently it contains
+   the corresponding thread id. *)
+external raw_add_watch: fsenv -> string -> watcher_id = "caml_fsnotify_add_watch"
+
+external raw_read_events:
+  fsenv -> event list = "caml_fsnotify_read_events"
+
+
+(** Init *)
+
+let init roots =
+  let in_fd, out_fd = Unix.pipe () in
+  Unix.set_close_on_exec in_fd;
+  Unix.set_close_on_exec out_fd;
+  let fsenv = raw_init out_fd in
+  let watchers = List.map roots ~f:(raw_add_watch fsenv) in
+  { fsenv; fd = in_fd; watchers; wpaths = SSet.empty }
+
+
+(** Faked add_watch, as for `fsnotify_darwin`. *)
+
+(* Returns None if we're already watching that path and Some watch otherwise *)
+let add_watch env path =
+  (* The function `ReadDirectoryChangesW` used in `init` is watching
+   * the whole directory. No need to register every files in it. *)
+  if SSet.mem path env.wpaths then
+    None
+  else begin
+    env.wpaths <- SSet.add path env.wpaths;
+    Some ()
+  end
+
+(** Select *)
+
+module FDMap = Map.Make(struct
+    type t = Unix.file_descr
+    let compare = compare
+  end)
 type fd_select = Unix.file_descr * (unit -> unit)
+let make_callback fdmap (fd, callback) = FDMap.add fd callback fdmap
+let invoke_callback fdmap fd  =
+  let callback =
+    try FDMap.find fd fdmap
+    with _ -> assert false in
+  callback ()
 
-type watch
+let read_events env =
+  (* read pop only one char from pipe, in order never to block. *)
+  ignore (Unix.read env.fd " " 0 1 : int);
+  (* prefix the root path *)
+  List.map (raw_read_events env.fsenv)
+    ~f:(fun ev -> { ev with path = Filename.concat ev.wpath ev.path })
 
-type env
+let select env ?(read_fdl=[]) ?(write_fdl=[]) ~timeout callback =
+  let callback () = callback (read_events env) in
+  let read_fdl = (env.fd, callback) :: read_fdl in
+  let read_callbacks =
+    List.fold_left ~f:make_callback ~init:FDMap.empty read_fdl in
+  let write_callbacks =
+    List.fold_left ~f:make_callback ~init:FDMap.empty write_fdl in
+  let read_ready, write_ready, _ =
+    Unix.select (List.map read_fdl fst) (List.map write_fdl fst) [] timeout
+  in
+  List.iter write_ready (invoke_callback write_callbacks);
+  List.iter read_ready (invoke_callback read_callbacks)
 
-let init roots = assert false
 
-let add_watch env path = assert false
+(** Unused, for compatibility with `fsnotify_linux/fsnotify.mli` only. *)
 
-let select env ?(read_fdl=[]) ?(write_fdl=[]) ~timeout callback = assert false
+type watch = unit
+exception Error of string * int

--- a/hphp/hack/src/fsnotify_win/fsnotify.mli
+++ b/hphp/hack/src/fsnotify_win/fsnotify.mli
@@ -1,5 +1,5 @@
 (**
- * Copyright (c) 2014, Facebook, Inc.
+ * Copyright (c) 2015, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
@@ -8,35 +8,22 @@
  *
  *)
 
+(* This is a replicate of `fsnotify_linux/fsnotify.mli`.` *)
+
 exception Error of string * int
-
-(* Contains all the fsevents context *)
 type env
-
-(* A subscription to events for a directory *)
 type watch
-
 type event = {
-  path : string; (* The full path for the file/directory that changed *)
-  wpath : string; (* The watched path that triggered this event *)
+  path : string;
+  wpath : string;
 }
-
 val init : string list -> env
-
-(* Returns None if we're already watching that path and Some watch otherwise *)
 val add_watch : env -> string -> watch option
-
-(* A file descriptor and what to do when it is selected *)
 type fd_select = Unix.file_descr * (unit -> unit)
 val select :
-  (* The fsevents context *)
   env ->
-  (* Additional file descriptor to select for reading *)
   ?read_fdl:(fd_select list) ->
-  (* Additional file descriptor to select for writing *)
   ?write_fdl:(fd_select list) ->
-  (* Timeout...like Unix.select *)
   timeout:float ->
-  (* The callback for file system events *)
   (event list -> unit) ->
   unit

--- a/hphp/hack/src/fsnotify_win/fsnotify_stubs.c
+++ b/hphp/hack/src/fsnotify_win/fsnotify_stubs.c
@@ -1,0 +1,211 @@
+/**
+ * Copyright (c) 2015, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the "hack" directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+/* See `fsnotify_win/fsnotify.ml` for a general description. */
+
+#include <caml/mlvalues.h>
+#include <caml/memory.h>
+#include <caml/alloc.h>
+#include <caml/custom.h>
+#include <caml/fail.h>
+#include <caml/signals.h>
+#include <caml/callback.h>
+#include <caml/unixsupport.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <Windows.h>
+#include <assert.h>
+
+// Terrible guesstimate of ~1k files, highly unlikely,
+// but it's ~16kb buffer.
+#define FILE_NOTIFY_BUFFER_LENGTH ((sizeof(DWORD) * 4) * 1000)
+#define FILE_NOTIFY_CONDITIONS (\
+FILE_NOTIFY_CHANGE_FILE_NAME | \
+FILE_NOTIFY_CHANGE_DIR_NAME | \
+FILE_NOTIFY_CHANGE_SIZE | \
+FILE_NOTIFY_CHANGE_LAST_WRITE | \
+FILE_NOTIFY_CHANGE_CREATION)
+
+// list of event
+struct events {
+  struct events *next;
+  char *wpath;                   // the root directory
+  FILE_NOTIFY_INFORMATION *info; // the list of changed files
+};
+
+// OCaml: Fsnotify.fsenv
+struct fsenv {
+  struct events *events; // the lock-less list of events
+  HANDLE pipe;           // the pipe to wakeup the OCaml program
+};
+
+// Parameter to the watching thread
+struct wenv {
+  char *wpath;         // the directory to be watched
+  struct fsenv* fsenv; // where to store the events.
+};
+
+// The pipes are only used signal the other thread that something is ready. So
+// writing '.' to the pipe is sufficient.
+static void signal_on_pipe(struct fsenv *fsenv)
+{
+  char dot = '.';
+  DWORD bytesWritten;
+  WriteFile(fsenv->pipe, &dot, sizeof(dot), &bytesWritten, NULL);
+  // If `WriteFail` fails, that's probably because the pipe is full,
+  // or closed. Then we don't care.
+}
+
+// Push a new event in the shared list and wakeup the OCaml thread
+static void push_info(struct wenv *wenv, FILE_NOTIFY_INFORMATION *info)
+{
+  struct events *ev = (struct events*)malloc(sizeof(struct events));
+  struct fsenv *fsenv = wenv->fsenv;
+  ev->info = info;
+  ev->wpath = wenv->wpath;
+  do {
+    ev->next = fsenv->events;
+  } while (InterlockedCompareExchangePointer((void**)&(fsenv->events),
+                                             ev, ev->next) != ev->next);
+  signal_on_pipe(fsenv);
+}
+
+// Pop all events from the shared list
+static struct events *pop_events(struct fsenv *fsenv)
+{
+  struct events *res;
+  do {
+    res = fsenv->events;
+  } while (InterlockedCompareExchangePointer((void**)&(fsenv->events),
+                                             NULL, res) != res);
+  return res;
+}
+
+// Converts a `struct events *` in an OCaml value of type `Fsnotify.event list`
+static value parse_events(struct events *events)
+{
+  CAMLparam0();
+  CAMLlocal4(res, cell, ev, wpath);
+  res = Val_unit;
+  for (;;) {
+    if (events == NULL) break;
+    FILE_NOTIFY_INFORMATION *fileInfo = events->info;
+    wpath = caml_copy_string(events->wpath);
+    for (;;) {
+      // Forcefully null terminate the filename.
+      wchar_t oldMem = fileInfo->FileName[fileInfo->FileNameLength];
+      fileInfo->FileName[fileInfo->FileNameLength] = L'\0';
+      char* modifiedFilename =
+        (char*)malloc(sizeof(wchar_t) * fileInfo->FileNameLength);
+      size_t filenameLen =
+        wcstombs_s(NULL, modifiedFilename,
+                   sizeof(wchar_t) * fileInfo->FileNameLength,
+                   fileInfo->FileName,
+                   (sizeof(wchar_t) * fileInfo->FileNameLength) - 1);
+      fileInfo->FileName[fileInfo->FileNameLength] = oldMem;
+      // Allocate 'Fsnotify.events'
+      ev = caml_alloc_tuple(2);
+      Store_field(ev, 0, caml_copy_string(modifiedFilename));
+      Store_field(ev, 1, wpath);
+      // Allocate list cell
+      cell = caml_alloc_tuple(2);
+      Store_field(cell, 0, ev);
+      Store_field(cell, 1, res);
+      res = cell;
+      // Next info
+      if (fileInfo->NextEntryOffset == 0)
+        break;
+      FILE_NOTIFY_INFORMATION *old = fileInfo;
+      fileInfo =
+        (FILE_NOTIFY_INFORMATION*)
+        ((char*)fileInfo + fileInfo->NextEntryOffset);
+      free(old);
+    }
+    // Next event
+    struct events *old = events;
+    events = events->next;
+    free(old);
+  }
+  CAMLreturn(res);
+}
+
+// Main function for the watching thread
+static DWORD watcher_thread_main(LPVOID param) {
+
+  char *buf;
+  struct wenv *wenv = (struct wenv *)param;
+  HANDLE dir_handle = CreateFile(wenv->wpath,
+    FILE_LIST_DIRECTORY, FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+    NULL,
+    OPEN_EXISTING,
+    FILE_FLAG_BACKUP_SEMANTICS,
+    NULL);
+
+  if (dir_handle == INVALID_HANDLE_VALUE) {
+    win32_maperr(GetLastError());
+    uerror("CreateFile", Nothing);
+  }
+
+  while(TRUE) {
+    DWORD size;
+    buf = malloc(FILE_NOTIFY_BUFFER_LENGTH);
+    if(!ReadDirectoryChangesW(dir_handle,
+                              buf, FILE_NOTIFY_BUFFER_LENGTH,
+                              TRUE,
+                              FILE_NOTIFY_CONDITIONS,
+                              &size, NULL, NULL)) {
+      fprintf(stderr, "FATAL ERROR\n");
+      fflush(stderr);
+      break;
+    };
+    push_info(wenv, (FILE_NOTIFY_INFORMATION*) buf);
+  }
+
+  free(buf);
+  CloseHandle(dir_handle);
+  return 0;
+}
+
+// Stub: create a watching thread for a given directory
+value caml_fsnotify_add_watch(value vfsenv, value path)
+{
+  CAMLparam2(vfsenv, path);
+  char output[_MAX_PATH];
+  struct fsenv *fsenv = (struct fsenv*)vfsenv;
+  struct wenv *wenv = malloc(sizeof(struct wenv));
+  wenv->wpath = _strdup(_fullpath(output, String_val(path), _MAX_PATH));
+  wenv->fsenv = fsenv;
+  HANDLE th = CreateThread(NULL, 0, watcher_thread_main, wenv, 0, NULL);
+  if (th == INVALID_HANDLE_VALUE) {
+    win32_maperr(GetLastError());
+    uerror("CreateThread", Nothing);
+  }
+  CAMLreturn(Val_long(th));
+}
+
+// Stub: read all events from the shared list
+value caml_fsnotify_read_events(value vfsenv)
+{
+  CAMLparam1(vfsenv);
+  struct fsenv *fsenv = (struct fsenv*)vfsenv;
+  struct events *events = pop_events(fsenv);
+  CAMLreturn(parse_events(events));
+}
+
+// Stub: initialize the environment
+value caml_fsnotify_init(value pipe)
+{
+  CAMLparam1(pipe);
+  struct fsenv *fsenv = malloc(sizeof(fsenv));
+  fsenv->pipe = Handle_val(pipe);
+  fsenv->events = NULL;
+  CAMLreturn((value)fsenv);
+}

--- a/hphp/hack/src/server/serverEnvBuild.ml
+++ b/hphp/hack/src/server/serverEnvBuild.ml
@@ -27,7 +27,7 @@ let make_genv options config watch_paths =
     else
       Some (Worker.make nbr_procs gc_control) in
   let dfind =
-    if Sys.win32 || check_mode then
+    if check_mode then
       None
     else
       Some (DfindLib.init watch_paths) in


### PR DESCRIPTION
This a simplifed version of Orvid patch (D39327).

We create a new thread for every roots directory to be watched. This
thread loops on the function `ReadDirectoryChangesW` and store
received events in a lock-less shared list. Whenever a new events is
inserted in the shared list, this thread also pushes a single
character in a given pipe. On the OCaml side, we might wait for new
event with `Unix.select` over the same pipe.