### PR TITLE
Disable the use of backtrace_symbols in thread-hooks under MSVC

### DIFF
--- a/hphp/runtime/base/thread-hooks.cpp
+++ b/hphp/runtime/base/thread-hooks.cpp
@@ -55,10 +55,12 @@ PthreadInfo::PthreadInfo(start_routine_t start, void* arg) :
 }
 
 PthreadInfo::~PthreadInfo() {
-#ifndef _MSC_VER
-  free(parent_bt_names);
-  free(start_name_ptr);
-#endif
+  if (parent_bt_names) {
+    free(parent_bt_names);
+  }
+  if (start_name_ptr) {
+    free(start_name_ptr);
+  }
 }
 
 std::string get_thread_mem_usage() {

--- a/hphp/runtime/base/thread-hooks.cpp
+++ b/hphp/runtime/base/thread-hooks.cpp
@@ -35,6 +35,7 @@ PthreadInfo::PthreadInfo(start_routine_t start, void* arg) :
     start_routine(start), start_routine_arg(arg) {
   pid = getpid();
 
+#ifndef _MSC_VER
   if (RuntimeOption::EvalLogThreadCreateBacktraces) {
     num_frames = backtrace(reinterpret_cast<void **>(&parent_bt),
                            max_num_frames);
@@ -50,11 +51,14 @@ PthreadInfo::PthreadInfo(start_routine_t start, void* arg) :
       Logger::Error("pthread_create: unable to get start_routine name");
     }
   }
+#endif
 }
 
 PthreadInfo::~PthreadInfo() {
+#ifndef _MSC_VER
   free(parent_bt_names);
   free(start_name_ptr);
+#endif
 }
 
 std::string get_thread_mem_usage() {


### PR DESCRIPTION
Because, while we do have backtrace implemented, backtrace_symbols is not yet implemented.