### PR TITLE
fix SplFixedArray::setSize on wrong parameter type

### DIFF
--- a/hphp/system/php/spl/datastructures/SplFixedArray.php
+++ b/hphp/system/php/spl/datastructures/SplFixedArray.php
@@ -192,7 +192,15 @@ class SplFixedArray implements \HH\Iterator, ArrayAccess, Countable {
    * @return     mixed   No value is returned.
    */
   public function setSize($size) {
+    if (is_bool($size) || is_float($size) || $size === null) {
+      $size = (int) $size;
+    }
     if (!is_numeric($size)) {
+      trigger_error(
+        sprintf("SplFixedArray::setSize() expects parameter 1 to be long,".
+                " %s given", gettype($size)
+               ),
+        E_WARNING);
       return;
     }
     if ($size < 0) {

--- a/hphp/test/slow/ext_spl_datastructures/splfixedarray_setSize_errors.php
+++ b/hphp/test/slow/ext_spl_datastructures/splfixedarray_setSize_errors.php
@@ -1,0 +1,18 @@
+<?php
+
+$fixedarr = new SplFixedArray();
+
+echo "Errors:", PHP_EOL;
+$fixedarr->setSize([]);
+$fixedarr->setSize("notanint");
+
+echo "No Error:", PHP_EOL;
+$fixedarr->setSize("5");
+$fixedarr->setSize("6.6");
+var_dump($fixedarr->getSize() == 6);
+$fixedarr->setSize(2.2);
+var_dump($fixedarr->getSize() == 2);
+$fixedarr->setSize(true);
+var_dump($fixedarr->getSize() == 1); // because php...
+$fixedarr->setSize(false);
+var_dump($fixedarr->getSize() == 0); // because php...

--- a/hphp/test/slow/ext_spl_datastructures/splfixedarray_setSize_errors.php.expectf
+++ b/hphp/test/slow/ext_spl_datastructures/splfixedarray_setSize_errors.php.expectf
@@ -1,0 +1,10 @@
+Errors:
+
+Warning: SplFixedArray::setSize() expects parameter 1 to be long, array given in %s/splfixedarray_setSize_errors.php on line 6
+
+Warning: SplFixedArray::setSize() expects parameter 1 to be long, string given in %s/splfixedarray_setSize_errors.php on line 7
+No Error:
+bool(true)
+bool(true)
+bool(true)
+bool(true)

--- a/hphp/test/slow/ext_spl_datastructures/splfixedarray_setSize_null.php
+++ b/hphp/test/slow/ext_spl_datastructures/splfixedarray_setSize_null.php
@@ -1,0 +1,9 @@
+<?php
+/*
+ * This basically copies zend/ext/spl/tests/SplFixedArray_setSize_param_null.php
+ * but changes the expectf to match hhvm's var_dump output
+*/
+
+$fixed_array = new SplFixedArray(2);
+$fixed_array->setSize(null);
+var_dump($fixed_array);

--- a/hphp/test/slow/ext_spl_datastructures/splfixedarray_setSize_null.php.expectf
+++ b/hphp/test/slow/ext_spl_datastructures/splfixedarray_setSize_null.php.expectf
@@ -1,0 +1,5 @@
+object(SplFixedArray)#%d (%d) {
+  ["data":protected]=>
+  array(0) {
+  }
+}


### PR DESCRIPTION
Yep... This is what php does. This is what php thinks makes sense.
It tells you it expects a long. However a boolean or float is fine too.
Added a test for this bogus.

Test Plan: new tests and slow spl tests