### PR TITLE
Fix SplFixedArray::fromArray performance

### DIFF
--- a/hphp/system/php/spl/datastructures/SplFixedArray.php
+++ b/hphp/system/php/spl/datastructures/SplFixedArray.php
@@ -245,15 +245,20 @@ class SplFixedArray implements \HH\Iterator, ArrayAccess, Countable {
    */
   public static function fromArray($array, $save_indexes = true) {
     $fixed_array = new self;
+    if (!is_array($array)) {
+      trigger_error(
+        sprintf("SplFixedArray::fromArray() expects parameter 1 to be array,".
+                " %s given", gettype($array)),
+        E_WARNING);
+      return $fixed_array;
+    }
     if ($save_indexes) {
+      $fixed_array->setSize(max(array_keys($array)) + 1);
       foreach ($array as $key => $value) {
         if (!is_numeric($key) || $key < 0) {
           throw new InvalidArgumentException(
             'array must contain only positive integer keys'
           );
-        }
-        if ($key >= $fixed_array->count()) {
-          $fixed_array->setSize($key + 1);
         }
         $fixed_array[$key] = $value;
       }


### PR DESCRIPTION
It would execute an array_pad for every entry. This would get bad pretty fast.

This diff also handles these tests, raising a warning on bad input.

Fixes #5671

Test Plan: exisiting tests, no new tests because this is perf only
I checked for perf on my machine with given test script from #5671 and it's way faster