### PR TITLE
Be compatible with OCaml-4.03 (unreleased) (fix #6120)

### DIFF
--- a/hphp/hack/src/Makefile
+++ b/hphp/hack/src/Makefile
@@ -143,7 +143,7 @@ build-hack-native-deps: build-hack-stubs
 # `$(ROOT)/scripts/gen_build_id.ml` used on Windows.
 build-hack-stubs:
 	REV="const char* const BuildInfo_kRevision = \"$$(git rev-parse HEAD || hg id -i)\";"; \
-	if [ "$$REV" != "$$(cat utils/get_build_id.gen.c)" ]; then echo "$$REV" > utils/get_build_id.gen.c; fi
+	if [ "$$REV" != "$$(cat utils/get_build_id.gen.c 2>/dev/null)" ]; then echo "$$REV" > utils/get_build_id.gen.c; fi
 
 build-hack-stubs-with-ocp:
 	ocaml unix.cma $(ROOT)/scripts/gen_build_id.ml \


### PR DESCRIPTION
Futur version of OCaml will rename 'uint64' (as defined in `<caml/config.h>` usually imported through `<caml/mlvalues.h>`) into `uint64_t` in order to stick with typedef introduced in C99.

Meanwhile, the MinGW compiler when called by `ocamlopt` is not called with `-std=c99` and the type `uint64_t` is not defined. This patch partially revert #5680 and introduce a typedef specific to MinGW.