### PR TITLE
[MSVC] Header Changes for MSVC

### DIFF
--- a/hphp/compiler/package.cpp
+++ b/hphp/compiler/package.cpp
@@ -17,14 +17,14 @@
 #include "hphp/compiler/package.h"
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <unistd.h>
-#include <dirent.h>
 #include <fstream>
 #include <map>
 #include <memory>
 #include <set>
 #include <utility>
 #include <vector>
+#include <folly/CPortability.h>
+#include <folly/FilePortability.h>
 #include <folly/String.h>
 #include "hphp/compiler/analysis/analysis_result.h"
 #include "hphp/compiler/parser/parser.h"

--- a/hphp/hhbbc/main.cpp
+++ b/hphp/hhbbc/main.cpp
@@ -22,7 +22,6 @@
 #include <memory>
 #include <cstdint>
 #include <algorithm>
-#include <unistd.h>
 #include <exception>
 #include <utility>
 #include <vector>
@@ -30,6 +29,7 @@
 #include <boost/program_options.hpp>
 #include <boost/filesystem.hpp>
 
+#include <folly/FilePortability.h>
 #include <folly/ScopeGuard.h>
 #include <folly/String.h>
 

--- a/hphp/hhvm/process-init.cpp
+++ b/hphp/hhvm/process-init.cpp
@@ -31,9 +31,9 @@
 #include "hphp/system/systemlib.h"
 #include "hphp/util/logger.h"
 
+#include <folly/CPortability.h>
 #include <folly/Singleton.h>
 
-#include <libgen.h> // For dirname(3).
 #include <string>
 
 namespace HPHP {

--- a/hphp/runtime/base/apc-file-storage.cpp
+++ b/hphp/runtime/base/apc-file-storage.cpp
@@ -15,7 +15,7 @@
 */
 #include "hphp/runtime/base/apc-file-storage.h"
 
-#include <sys/mman.h>
+#include <folly/CPortability.h>
 
 #include "hphp/util/alloc.h"
 #include "hphp/util/timer.h"

--- a/hphp/runtime/base/array-common.h
+++ b/hphp/runtime/base/array-common.h
@@ -16,6 +16,7 @@
 #ifndef incl_HPHP_ARRAY_COMMON_H_
 #define incl_HPHP_ARRAY_COMMON_H_
 
+#include <folly/Portability.h>
 #include <sys/types.h>
 
 namespace HPHP {

--- a/hphp/runtime/base/directory.h
+++ b/hphp/runtime/base/directory.h
@@ -22,8 +22,9 @@
 #include "hphp/runtime/base/type-array.h"
 #include "hphp/runtime/base/type-string.h"
 
-#include <dirent.h>
 #include <vector>
+
+#include <folly/CPortability.h>
 
 namespace HPHP {
 ///////////////////////////////////////////////////////////////////////////////

--- a/hphp/runtime/base/emulate-zend.cpp
+++ b/hphp/runtime/base/emulate-zend.cpp
@@ -20,12 +20,13 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <unistd.h>
 
 #include <vector>
 #include <string>
 #include <iostream>
 #include <sstream>
+
+#include <folly/FilePortability.h>
 
 namespace HPHP {
 

--- a/hphp/runtime/base/file-stream-wrapper.h
+++ b/hphp/runtime/base/file-stream-wrapper.h
@@ -19,11 +19,12 @@
 
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <unistd.h>
 
 #include "hphp/runtime/base/file.h"
 #include "hphp/runtime/base/mem-file.h"
 #include "hphp/runtime/base/stream-wrapper.h"
+
+#include <folly/FilePortability.h>
 #include <folly/String.h>
 
 #define ERROR_RAISE_WARNING(exp)        \

--- a/hphp/runtime/base/file-util.cpp
+++ b/hphp/runtime/base/file-util.cpp
@@ -21,11 +21,10 @@
 #include <boost/filesystem.hpp>
 
 #include <sys/types.h>
-#include <dirent.h>
 #include <sys/stat.h>
 #include <fcntl.h>
-#include <libgen.h>
 
+#include <folly/CPortability.h>
 #include <folly/String.h>
 
 #include "hphp/util/lock.h"

--- a/hphp/runtime/base/file.cpp
+++ b/hphp/runtime/base/file.cpp
@@ -39,10 +39,10 @@
 #include "hphp/util/logger.h"
 #include "hphp/util/process.h"
 
+#include <folly/FilePortability.h>
 #include <folly/String.h>
 
 #include <algorithm>
-#include <sys/file.h>
 
 namespace HPHP {
 

--- a/hphp/runtime/base/memory-manager.cpp
+++ b/hphp/runtime/base/memory-manager.cpp
@@ -18,8 +18,6 @@
 #include <algorithm>
 #include <cstdint>
 #include <limits>
-#include <sys/mman.h>
-#include <unistd.h>
 
 #include "hphp/runtime/base/builtin-functions.h"
 #include "hphp/runtime/base/exceptions.h"
@@ -37,8 +35,11 @@
 #include "hphp/util/process.h"
 #include "hphp/util/trace.h"
 
+#include <folly/CPortability.h>
+#include <folly/FilePortability.h>
 #include <folly/Random.h>
 #include <folly/ScopeGuard.h>
+
 #include "hphp/runtime/base/memory-manager-defs.h"
 
 namespace HPHP {

--- a/hphp/runtime/base/plain-file.cpp
+++ b/hphp/runtime/base/plain-file.cpp
@@ -18,7 +18,8 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
-#include <unistd.h>
+
+#include <folly/FilePortability.h>
 
 #include "hphp/runtime/base/request-local.h"
 

--- a/hphp/runtime/base/program-functions.cpp
+++ b/hphp/runtime/base/program-functions.cpp
@@ -88,6 +88,7 @@
 #include "hphp/util/stack-trace.h"
 #include "hphp/util/timer.h"
 
+#include <folly/CPortability.h>
 #include <folly/Range.h>
 #include <folly/Portability.h>
 #include <folly/Singleton.h>
@@ -98,7 +99,6 @@
 #include <boost/program_options/variables_map.hpp>
 #include <boost/filesystem.hpp>
 
-#include <libgen.h>
 #include <oniguruma.h>
 #include <signal.h>
 #include <libxml/parser.h>

--- a/hphp/runtime/base/rds.cpp
+++ b/hphp/runtime/base/rds.cpp
@@ -21,13 +21,13 @@
 #include <atomic>
 #include <vector>
 
-#include <sys/mman.h>
 #if !defined(__CYGWIN__) && !defined(_MSC_VER)
 #include <execinfo.h>
 #endif
 
 #include <folly/String.h>
 #include <folly/Hash.h>
+#include <folly/CPortability.h>
 #include <folly/Bits.h>
 
 #include "hphp/util/maphuge.h"

--- a/hphp/runtime/base/request-injection-data.cpp
+++ b/hphp/runtime/base/request-injection-data.cpp
@@ -21,10 +21,10 @@
 #include <string>
 #include <limits>
 
-#include <sys/time.h>
 #include <signal.h>
 
 #include <boost/filesystem.hpp>
+#include <folly/CPortability.h>
 #include <folly/Optional.h>
 
 #include "hphp/util/logger.h"

--- a/hphp/runtime/base/runtime-option.cpp
+++ b/hphp/runtime/base/runtime-option.cpp
@@ -24,9 +24,7 @@
 #include <set>
 #include <vector>
 
-#include <sys/time.h>
-#include <sys/resource.h>
-
+#include <folly/CPortability.h>
 #include <folly/String.h>
 
 #include "hphp/util/code-cache.h"

--- a/hphp/runtime/base/socket.cpp
+++ b/hphp/runtime/base/socket.cpp
@@ -16,7 +16,8 @@
 #include "hphp/runtime/base/socket.h"
 
 #include <fcntl.h>
-#include <poll.h>
+
+#include <folly/SocketPortability.h>
 
 #include "hphp/runtime/base/request-event-handler.h"
 #include "hphp/runtime/base/thread-info.h"

--- a/hphp/runtime/base/socket.h
+++ b/hphp/runtime/base/socket.h
@@ -19,7 +19,8 @@
 
 #include "hphp/runtime/base/file.h"
 #include <sys/types.h>
-#include <sys/socket.h>
+
+#include <folly/SocketPortability.h>
 
 #ifdef SOCKET_ERROR
 # undef SOCKET_ERROR

--- a/hphp/runtime/base/ssl-socket.cpp
+++ b/hphp/runtime/base/ssl-socket.cpp
@@ -19,9 +19,9 @@
 #include "hphp/runtime/base/req-ptr.h"
 #include "hphp/runtime/base/string-util.h"
 #include "hphp/runtime/server/server-stats.h"
+#include <folly/CPortability.h>
+#include <folly/SocketPortability.h>
 #include <folly/String.h>
-#include <poll.h>
-#include <sys/time.h>
 
 namespace HPHP {
 ///////////////////////////////////////////////////////////////////////////////

--- a/hphp/runtime/base/stat-cache.cpp
+++ b/hphp/runtime/base/stat-cache.cpp
@@ -17,11 +17,11 @@
 
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <unistd.h>
 #include <fcntl.h>
-#include <sys/param.h>
 #include <vector>
 
+#include <folly/CPortability.h>
+#include <folly/FilePortability.h>
 #include <folly/MapUtil.h>
 
 #include "hphp/util/trace.h"

--- a/hphp/runtime/base/stat-cache.h
+++ b/hphp/runtime/base/stat-cache.h
@@ -23,8 +23,8 @@
 
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <unistd.h>
 
+#include <folly/FilePortability.h>
 #include <tbb/concurrent_hash_map.h>
 
 #include "hphp/util/lock.h"

--- a/hphp/runtime/base/thread-hooks.cpp
+++ b/hphp/runtime/base/thread-hooks.cpp
@@ -20,7 +20,8 @@
 #include <execinfo.h>
 #include <dlfcn.h>
 #endif
-#include <unistd.h>
+
+#include <folly/FilePortability.h>
 
 #include "hphp/runtime/base/extended-logger.h"
 #include "hphp/util/assertions.h"

--- a/hphp/runtime/base/timestamp.cpp
+++ b/hphp/runtime/base/timestamp.cpp
@@ -15,7 +15,8 @@
 */
 #include "hphp/runtime/base/timestamp.h"
 
-#include <sys/time.h>
+#include <folly/CPortability.h>
+
 extern "C" {
 #include <timelib.h>
 }

--- a/hphp/runtime/base/user-file.cpp
+++ b/hphp/runtime/base/user-file.cpp
@@ -19,9 +19,9 @@
 #include <cassert>
 
 #include <sys/types.h>
-#include <sys/file.h>
 #include <sys/stat.h>
-#include <unistd.h>
+
+#include <folly/FilePortability.h>
 
 #include "hphp/runtime/base/comparisons.h"
 #include "hphp/runtime/base/array-init.h"

--- a/hphp/runtime/base/zend-rand.cpp
+++ b/hphp/runtime/base/zend-rand.cpp
@@ -15,7 +15,7 @@
    +----------------------------------------------------------------------+
 */
 
-#include <sys/time.h>
+#include <folly/CPortability.h>
 #include <openssl/rand.h>
 
 #include "hphp/runtime/base/zend-math.h"

--- a/hphp/runtime/debugger/cmd/cmd_list.cpp
+++ b/hphp/runtime/debugger/cmd/cmd_list.cpp
@@ -18,7 +18,8 @@
 
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <unistd.h>
+
+#include <folly/FilePortability.h>
 
 #include "hphp/runtime/base/file.h"
 #include "hphp/runtime/debugger/cmd/cmd_info.h"

--- a/hphp/runtime/debugger/debugger_client.cpp
+++ b/hphp/runtime/debugger/debugger_client.cpp
@@ -639,7 +639,7 @@ bool DebuggerClient::tryConnect(const std::string &host, int port,
   struct addrinfo *cur;
   for (cur = ai; cur; cur = cur->ai_next) {
     auto sock = req::make<Socket>(
-      socket(cur->ai_family, cur->ai_socktype, 0),
+      fsp::socket(cur->ai_family, cur->ai_socktype, 0),
       cur->ai_family,
       cur->ai_addr->sa_data,
       port

--- a/hphp/runtime/debugger/debugger_command.cpp
+++ b/hphp/runtime/debugger/debugger_command.cpp
@@ -16,7 +16,7 @@
 
 #include "hphp/runtime/debugger/debugger_command.h"
 
-#include <poll.h>
+#include <folly/SocketPortability.h>
 
 #include "hphp/runtime/debugger/debugger.h"
 #include "hphp/runtime/debugger/cmd/all.h"

--- a/hphp/runtime/debugger/debugger_server.cpp
+++ b/hphp/runtime/debugger/debugger_server.cpp
@@ -15,8 +15,9 @@
 */
 #include "hphp/runtime/debugger/debugger_server.h"
 
-#include <poll.h>
 #include <exception>
+
+#include <folly/SocketPortability.h>
 
 #include "hphp/runtime/debugger/debugger_client.h"
 #include "hphp/runtime/debugger/debugger.h"
@@ -99,7 +100,7 @@ bool DebuggerServer::start() {
   /* use a cur pointer so we still have ai to be able to free the struct */
   struct addrinfo *cur;
   for (cur = ai; cur; cur = cur->ai_next) {
-    int s_fd = socket(cur->ai_family, cur->ai_socktype, cur->ai_protocol);
+    int s_fd = fsp::socket(cur->ai_family, cur->ai_socktype, cur->ai_protocol);
     if (s_fd < 0 && errno == EAFNOSUPPORT) {
       continue;
     }

--- a/hphp/runtime/ext/apc/ext_apc.cpp
+++ b/hphp/runtime/ext/apc/ext_apc.cpp
@@ -21,13 +21,14 @@
 #ifndef _MSC_VER
 #include <dlfcn.h>
 #endif
-#include <sys/time.h> // gettimeofday
 #include <limits>
 #include <memory>
 #include <set>
 #include <vector>
 #include <stdexcept>
 #include <type_traits>
+
+#include <folly/CPortability.h>
 
 #include "hphp/util/alloc.h"
 #include "hphp/util/hdf.h"

--- a/hphp/runtime/ext/fb/ext_fb.cpp
+++ b/hphp/runtime/ext/fb/ext_fb.cpp
@@ -18,8 +18,6 @@
 
 #include <fstream>
 
-#include <netinet/in.h>
-
 #include <unicode/uchar.h>
 #include <unicode/utf8.h>
 #include <algorithm>
@@ -27,6 +25,7 @@
 #include <utility>
 #include <vector>
 
+#include <folly/SocketPortability.h>
 #include <folly/String.h>
 
 #include "hphp/util/htonll.h"

--- a/hphp/runtime/ext/fileinfo/ext_fileinfo.cpp
+++ b/hphp/runtime/ext/fileinfo/ext_fileinfo.cpp
@@ -16,7 +16,8 @@
 */
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <unistd.h>
+
+#include <folly/FilePortability.h>
 
 #include "hphp/runtime/ext/extension.h"
 #include "hphp/runtime/base/stream-wrapper-registry.h"

--- a/hphp/runtime/ext/fileinfo/libmagic/apprentice.cpp
+++ b/hphp/runtime/ext/fileinfo/libmagic/apprentice.cpp
@@ -47,15 +47,8 @@ FILE_RCSID("@(#)$File: apprentice.c,v 1.191 2013/02/26 21:02:48 christos Exp $")
 #endif
 #endif
 
-#ifdef PHP_WIN32
-#include "win32/unistd.h" // @nolint
-#if _MSC_VER <= 1300
-# include "win32/php_strtoi64.h" // @nolint
-#endif
-#define strtoull _strtoui64
-#else
-#include <unistd.h>
-#endif
+#include <folly/FilePortability.h>
+
 #include <string.h>
 #include <assert.h>
 #include <ctype.h>

--- a/hphp/runtime/ext/fileinfo/libmagic/ascmagic.cpp
+++ b/hphp/runtime/ext/fileinfo/libmagic/ascmagic.cpp
@@ -43,9 +43,8 @@ FILE_RCSID("@(#)$File: ascmagic.c,v 1.85 2012/08/09 16:33:15 christos Exp $")
 #include <memory.h>
 #include <ctype.h>
 #include <stdlib.h>
-#ifdef HAVE_UNISTD_H
-#include <unistd.h>
-#endif
+
+#include <folly/FilePortability.h>
 
 #define MAXLINELEN 300  /* longest sane line length */
 #define ISSPC(x) ((x) == ' ' || (x) == '\t' || (x) == '\r' || (x) == '\n' \

--- a/hphp/runtime/ext/fileinfo/libmagic/cdf.cpp
+++ b/hphp/runtime/ext/fileinfo/libmagic/cdf.cpp
@@ -44,11 +44,7 @@ FILE_RCSID("@(#)$File: cdf.c,v 1.53 2013/02/26 16:20:42 christos Exp $")
 #endif
 #include <stdlib.h>
 
-#ifdef PHP_WIN32
-#include "win32/unistd.h"
-#else
-#include <unistd.h>
-#endif
+#include <folly/FilePortability.h>
 
 #ifndef UINT32_MAX
 # define UINT32_MAX (0xffffffff)

--- a/hphp/runtime/ext/fileinfo/libmagic/compress.cpp
+++ b/hphp/runtime/ext/fileinfo/libmagic/compress.cpp
@@ -41,20 +41,15 @@ FILE_RCSID("@(#)$File: compress.c,v 1.70 2012/11/07 17:54:48 christos Exp $")
 
 #include "magic.h"
 #include <stdlib.h>
-#ifdef HAVE_UNISTD_H
-#include <unistd.h>
-#endif
+
+#include <folly/CPortability.h>
+#include <folly/FilePortability.h>
+
 #include <string.h>
 #include <errno.h>
 #include <sys/types.h>
 #ifndef PHP_WIN32
 #include <sys/ioctl.h>
-#endif
-#ifdef HAVE_SYS_WAIT_H
-#include <sys/wait.h>
-#endif
-#if defined(HAVE_SYS_TIME_H)
-#include <sys/time.h>
 #endif
 #if defined(HAVE_ZLIB_H) && defined(HAVE_LIBZ)
 #define BUILTIN_DECOMPRESS

--- a/hphp/runtime/ext/fileinfo/libmagic/file.h
+++ b/hphp/runtime/ext/fileinfo/libmagic/file.h
@@ -57,6 +57,7 @@
 #endif
 
 #include <sys/types.h>
+#include <folly/CPortability.h>
 #ifdef PHP_WIN32
 #include "win32/param.h"
 #else

--- a/hphp/runtime/ext/fileinfo/libmagic/fsmagic.cpp
+++ b/hphp/runtime/ext/fileinfo/libmagic/fsmagic.cpp
@@ -37,9 +37,7 @@ FILE_RCSID("@(#)$File: fsmagic.c,v 1.67 2013/03/17 15:43:20 christos Exp $")
 
 #include "magic.h"
 #include <string.h>
-#ifdef HAVE_UNISTD_H
-#include <unistd.h>
-#endif
+#include <folly/FilePortability.h>
 #include <stdlib.h>
 /* Since major is a function on SVR4, we cannot use `ifndef major'.  */
 #ifdef MAJOR_IN_MKDEV

--- a/hphp/runtime/ext/fileinfo/libmagic/magic.cpp
+++ b/hphp/runtime/ext/fileinfo/libmagic/magic.cpp
@@ -34,16 +34,9 @@ FILE_RCSID("@(#)$File: magic.c,v 1.78 2013/01/07 18:20:19 christos Exp $")
 #include "magic.h" // @nolint
 
 #include <stdlib.h>
-#ifdef PHP_WIN32
-#include "win32/unistd.h" // @nolint
-#else
-#include <unistd.h>
-#endif
+#include <folly/CPortability.h>
+#include <folly/FilePortability.h>
 #include <string.h>
-
-#ifdef PHP_WIN32
-#include <shlwapi.h>
-#endif
 
 #include <limits.h>  /* for PIPE_BUF */
 
@@ -55,10 +48,6 @@ FILE_RCSID("@(#)$File: magic.c,v 1.78 2013/01/07 18:20:19 christos Exp $")
 # elif defined(HAVE_UTIME_H)
 #  include <utime.h>
 # endif
-#endif
-
-#ifdef HAVE_UNISTD_H
-#include <unistd.h>  /* for read() */
 #endif
 
 #ifndef PIPE_BUF

--- a/hphp/runtime/ext/fileinfo/libmagic/print.cpp
+++ b/hphp/runtime/ext/fileinfo/libmagic/print.cpp
@@ -40,15 +40,9 @@ FILE_RCSID("@(#)$File: print.c,v 1.76 2013/02/26 18:25:00 christos Exp $")
 #include <string.h>
 #include <stdarg.h>
 #include <stdlib.h>
-#ifdef HAVE_UNISTD_H
-#include <unistd.h>
-#endif
+#include <folly/CPortability.h>
+#include <folly/FilePortability.h>
 #include <time.h>
-
-#ifdef PHP_WIN32
-# define asctime_r php_asctime_r
-# define ctime_r php_ctime_r
-#endif
 
 #define SZOF(a)  (sizeof(a) / sizeof(a[0]))
 

--- a/hphp/runtime/ext/fileinfo/libmagic/readcdf.cpp
+++ b/hphp/runtime/ext/fileinfo/libmagic/readcdf.cpp
@@ -30,11 +30,7 @@ FILE_RCSID("@(#)$File: readcdf.c,v 1.33 2012/06/20 21:52:36 christos Exp $")
 #endif
 
 #include <stdlib.h>
-#ifdef PHP_WIN32
-#include "win32/unistd.h"
-#else
-#include <unistd.h>
-#endif
+#include <folly/FilePortability.h>
 #include <string.h>
 #include <time.h>
 #include <ctype.h>

--- a/hphp/runtime/ext/fileinfo/libmagic/readelf.cpp
+++ b/hphp/runtime/ext/fileinfo/libmagic/readelf.cpp
@@ -34,9 +34,7 @@ FILE_RCSID("@(#)$File: readelf.c,v 1.97 2013/03/06 03:35:30 christos Exp $")
 #include <string.h>
 #include <ctype.h>
 #include <stdlib.h>
-#ifdef HAVE_UNISTD_H
-#include <unistd.h>
-#endif
+#include <folly/FilePortability.h>
 
 #include "readelf.h"
 #include "magic.h"

--- a/hphp/runtime/ext/filter/logical_filters.cpp
+++ b/hphp/runtime/ext/filter/logical_filters.cpp
@@ -17,7 +17,7 @@
 
 #include "hphp/runtime/ext/filter/logical_filters.h"
 
-#include <arpa/inet.h>
+#include <folly/SocketPortability.h>
 #include <pcre.h>
 
 #include "hphp/runtime/base/array-init.h"

--- a/hphp/runtime/ext/gd/ext_gd.cpp
+++ b/hphp/runtime/ext/gd/ext_gd.cpp
@@ -18,7 +18,8 @@
 
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <unistd.h>
+
+#include <folly/FilePortability.h>
 
 #include "hphp/runtime/ext/std/ext_std_file.h"
 #include "hphp/runtime/base/array-init.h"

--- a/hphp/runtime/ext/gd/libgd/gdft.cpp
+++ b/hphp/runtime/ext/gd/libgd/gdft.cpp
@@ -12,21 +12,7 @@
 #include "gd.h"
 #include "gdhelpers.h"
 
-#ifndef MSWIN32
-#include <unistd.h>
-#else
-#include <io.h>
-#ifndef R_OK
-# define R_OK 04			/* Needed in Windows */
-#endif
-#endif
-
-#ifdef WIN32
-#define access _access
-#ifndef R_OK
-#define R_OK 2
-#endif
-#endif
+#include <folly/FilePortability.h>
 
 /* number of antialised colors for indexed bitmaps */
 /* overwrite Windows GDI define in case of windows build */

--- a/hphp/runtime/ext/hash/hash_furc.cpp
+++ b/hphp/runtime/ext/hash/hash_furc.cpp
@@ -33,12 +33,12 @@
 
 #include <assert.h>
 #include <stdint.h>
-#include <sys/time.h>
 #include <stdio.h>
 #include <string.h>
 #include <math.h>
 
 #include "hphp/runtime/ext/hash/hash_murmur.h"
+#include <folly/CPortability.h>
 
 namespace HPHP {
 ///////////////////////////////////////////////////////////////////////////////

--- a/hphp/runtime/ext/hotprofiler/ext_hotprofiler.cpp
+++ b/hphp/runtime/ext/hotprofiler/ext_hotprofiler.cpp
@@ -34,8 +34,6 @@
 #include "hphp/runtime/ext/extension-registry.h"
 #include "hphp/runtime/base/request-event-handler.h"
 
-#include <sys/time.h>
-#include <sys/resource.h>
 #include <iostream>
 #include <fstream>
 #include <zlib.h>
@@ -44,6 +42,8 @@
 #include <new>
 #include <utility>
 #include <vector>
+
+#include <folly/CPortability.h>
 
 // Append the delimiter
 #define HP_STACK_DELIM        "==>"

--- a/hphp/runtime/ext/phar/ext_phar.cpp
+++ b/hphp/runtime/ext/phar/ext_phar.cpp
@@ -16,7 +16,8 @@
 */
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <unistd.h>
+
+#include <folly/FilePortability.h>
 
 #include "hphp/runtime/base/array-init.h"
 #include "hphp/runtime/ext/extension.h"

--- a/hphp/runtime/ext/session/ext_session.cpp
+++ b/hphp/runtime/ext/session/ext_session.cpp
@@ -19,13 +19,12 @@
 #include <string>
 
 #include <sys/types.h>
-#include <sys/time.h>
 #include <sys/stat.h>
-#include <sys/file.h>
 #include <fcntl.h>
-#include <dirent.h>
 #include <vector>
 
+#include <folly/CPortability.h>
+#include <folly/FilePortability.h>
 #include <folly/String.h>
 
 #include "hphp/util/lock.h"

--- a/hphp/runtime/ext/std/ext_std_network.cpp
+++ b/hphp/runtime/ext/std/ext_std_network.cpp
@@ -17,13 +17,9 @@
 #include "hphp/runtime/ext/std/ext_std_network.h"
 #include "hphp/runtime/ext/std/ext_std_network-internal.h"
 
-#include <arpa/inet.h>
-#include <netdb.h>
-#include <netinet/in.h>
-#include <sys/socket.h>
-
 #include <folly/IPAddress.h>
 #include <folly/ScopeGuard.h>
+#include <folly/SocketPortability.h>
 
 #include "hphp/runtime/base/builtin-functions.h"
 #include "hphp/runtime/base/file.h"

--- a/hphp/runtime/ext/std/ext_std_network.h
+++ b/hphp/runtime/ext/std/ext_std_network.h
@@ -21,7 +21,8 @@
 #include "hphp/runtime/ext/std/ext_std.h"
 #include "hphp/runtime/ext/stream/ext_stream.h"
 #include "hphp/util/network.h"
-#include <syslog.h>
+
+#include <folly/CPortability.h>
 
 namespace HPHP {
 

--- a/hphp/runtime/ext/std/ext_std_options.cpp
+++ b/hphp/runtime/ext/std/ext_std_options.cpp
@@ -18,13 +18,14 @@
 
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <sys/time.h>
-#include <sys/resource.h>
+#ifndef _MSC_VER
 #include <sys/utsname.h>
 #include <pwd.h>
+#endif
 #include <algorithm>
 #include <vector>
 
+#include <folly/CPortability.h>
 #include <folly/ScopeGuard.h>
 #include <folly/String.h>
 

--- a/hphp/runtime/ext/std/ext_std_process.cpp
+++ b/hphp/runtime/ext/std/ext_std_process.cpp
@@ -22,12 +22,10 @@
 #include <string>
 #include <iostream>
 
-#include <sys/time.h>
-#include <sys/resource.h>
-#include <unistd.h>
-#include <fcntl.h>
 #include <signal.h>
 
+#include <folly/CPortability.h>
+#include <folly/FilePortability.h>
 #include <folly/String.h>
 
 #include "hphp/util/light-process.h"

--- a/hphp/runtime/ext/stream/ext_stream.cpp
+++ b/hphp/runtime/ext/stream/ext_stream.cpp
@@ -38,16 +38,13 @@
 #include "hphp/system/systemlib.h"
 #include "hphp/util/network.h"
 #include <memory>
-#include <unistd.h>
 #include <fcntl.h>
-#include <poll.h>
 #include <sys/types.h>
-#include <sys/socket.h>
 #include <sys/stat.h>
-#if defined(AF_UNIX)
-#include <sys/un.h>
 #include <algorithm>
-#endif
+
+#include <folly/FilePortability.h>
+#include <folly/SocketPortability.h>
 
 #define PHP_STREAM_COPY_ALL     (-1)
 

--- a/hphp/runtime/ext/thrift/binary.cpp
+++ b/hphp/runtime/ext/thrift/binary.cpp
@@ -26,8 +26,8 @@
 #include "hphp/util/logger.h"
 
 #include <sys/types.h>
-#include <netinet/in.h>
-#include <unistd.h>
+#include <folly/FilePortability.h>
+#include <folly/SocketPortability.h>
 #include <stdexcept>
 
 namespace HPHP { namespace thrift {

--- a/hphp/runtime/ext/thrift/transport.h
+++ b/hphp/runtime/ext/thrift/transport.h
@@ -23,8 +23,9 @@
 #include "hphp/util/logger.h"
 #include "hphp/util/htonll.h"
 
+#include <folly/FilePortability.h>
+
 #include <sys/types.h>
-#include <unistd.h>
 #include <stdexcept>
 
 namespace HPHP { namespace thrift {

--- a/hphp/runtime/ext/xdebug/xdebug_server.cpp
+++ b/hphp/runtime/ext/xdebug/xdebug_server.cpp
@@ -29,11 +29,10 @@
 #include "hphp/util/network.h"
 
 #include <fcntl.h>
-#include <poll.h>
-#include <thread>
-#include <netinet/tcp.h>
 #include <sys/types.h>
-#include <sys/socket.h>
+#include <thread>
+
+#include <folly/SocketPortability.h>
 
 namespace HPHP {
 ///////////////////////////////////////////////////////////////////////////////
@@ -172,7 +171,7 @@ int XDebugServer::createSocket(const char* hostname, int port) {
   lookupHostname(hostname, address.sin_addr);
 
   // Create the socket
-  auto const sockfd = socket(address.sin_family, SOCK_STREAM, 0);
+  auto const sockfd = fsp::socket(address.sin_family, SOCK_STREAM, 0);
   if (sockfd < 0) {
     log("create_debugger_socket(\"%s\", %d) socket: %s\n",
         hostname, port, folly::errnoStr(errno).c_str());

--- a/hphp/runtime/ext_zend_compat/ftp/ftp.cpp
+++ b/hphp/runtime/ext_zend_compat/ftp/ftp.cpp
@@ -1391,7 +1391,7 @@ ftp_getdata(ftpbuf_t *ftp TSRMLS_DC)
 
 	sa = (struct sockaddr *) &ftp->localaddr;
 	/* bind/listen */
-	if ((fd = socket(sa->sa_family, SOCK_STREAM, 0)) == SOCK_ERR) {
+	if ((fd = fsp::socket(sa->sa_family, SOCK_STREAM, 0)) == SOCK_ERR) {
 		php_error_docref(NULL TSRMLS_CC, E_WARNING, "socket() failed: %s (%d)", strerror(errno), errno);
 		goto bail;
 	}

--- a/hphp/runtime/ext_zend_compat/php-src/Zend/zend_virtual_cwd.cpp
+++ b/hphp/runtime/ext_zend_compat/php-src/Zend/zend_virtual_cwd.cpp
@@ -25,7 +25,8 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
-#include <unistd.h>
+
+#include <folly/FilePortability.h>
 
 // Unimplemented:
 // CWD_API int virtual_file_ex(cwd_state *state, const char *path, verify_path_func verify_path, int use_realpath TSRMLS_DC)

--- a/hphp/runtime/server/admin-request-handler.cpp
+++ b/hphp/runtime/server/admin-request-handler.cpp
@@ -52,6 +52,7 @@
 #include "hphp/util/timer.h"
 
 #include <folly/Conv.h>
+#include <folly/FilePortability.h>
 
 #include <boost/lexical_cast.hpp>
 
@@ -59,8 +60,6 @@
 #include <string>
 #include <sstream>
 #include <iomanip>
-
-#include <unistd.h>
 
 #ifdef GOOGLE_CPU_PROFILER
 #include <google/profiler.h>

--- a/hphp/runtime/server/http-protocol.cpp
+++ b/hphp/runtime/server/http-protocol.cpp
@@ -15,12 +15,11 @@
 */
 #include "hphp/runtime/server/http-protocol.h"
 
-#include <sys/time.h>
-
 #include <map>
 #include <string>
 
 #include <folly/Conv.h>
+#include <folly/CPortability.h>
 
 #include "hphp/util/logger.h"
 #include "hphp/util/text-util.h"

--- a/hphp/runtime/server/ip-block-map.cpp
+++ b/hphp/runtime/server/ip-block-map.cpp
@@ -16,7 +16,7 @@
 
 #include "hphp/runtime/server/ip-block-map.h"
 
-#include <arpa/inet.h>
+#include <folly/SocketPortability.h>
 
 #include "hphp/util/logger.h"
 #include "hphp/runtime/base/config.h"

--- a/hphp/runtime/server/ip-block-map.h
+++ b/hphp/runtime/server/ip-block-map.h
@@ -19,7 +19,8 @@
 
 #include "hphp/util/hdf.h"
 #include "hphp/runtime/base/ini-setting.h"
-#include <netinet/in.h>
+
+#include <folly/SocketPortability.h>
 
 namespace HPHP {
 ///////////////////////////////////////////////////////////////////////////////

--- a/hphp/runtime/server/memory-stats.cpp
+++ b/hphp/runtime/server/memory-stats.cpp
@@ -16,13 +16,14 @@
 #include "hphp/runtime/server/memory-stats.h"
 
 #include <stdio.h>
-#include <unistd.h>
 #include <ios>
 #include <iostream>
 #include <string>
 #include <sstream>
 #include <fstream>
 #include <algorithm>
+
+#include <folly/FilePortability.h>
 
 #include "hphp/runtime/base/static-string-table.h"
 #include "hphp/runtime/vm/jit/mc-generator.h"

--- a/hphp/runtime/server/request-uri.cpp
+++ b/hphp/runtime/server/request-uri.cpp
@@ -17,7 +17,8 @@
 
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <unistd.h>
+
+#include <folly/FilePortability.h>
 
 #include "hphp/runtime/base/file-util.h"
 #include "hphp/runtime/base/runtime-option.h"

--- a/hphp/runtime/vm/bytecode.cpp
+++ b/hphp/runtime/vm/bytecode.cpp
@@ -26,9 +26,7 @@
 
 #include <boost/filesystem.hpp>
 
-#include <libgen.h>
-#include <sys/mman.h>
-
+#include <folly/CPortability.h>
 #include <folly/String.h>
 
 #include "hphp/util/debug.h"

--- a/hphp/runtime/vm/debug/debug.cpp
+++ b/hphp/runtime/vm/debug/debug.cpp
@@ -25,11 +25,12 @@
 #include <sys/types.h>
 #include <stdio.h>
 #include <string.h>
-#include <unistd.h>
 #include <errno.h>
 #ifndef _MSC_VER
 #include <cxxabi.h>
 #endif
+
+#include <folly/FilePortability.h>
 
 #ifdef HAVE_LIBBFD
 #include <bfd.h>

--- a/hphp/runtime/vm/debug/gdb-jit.cpp
+++ b/hphp/runtime/vm/debug/gdb-jit.cpp
@@ -19,7 +19,8 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <sys/mman.h>
+
+#include <folly/CPortability.h>
 
 using namespace HPHP;
 

--- a/hphp/runtime/vm/jit/mc-generator.cpp
+++ b/hphp/runtime/vm/jit/mc-generator.cpp
@@ -22,8 +22,6 @@
 #include <stdarg.h>
 #include <stdint.h>
 #include <stdio.h>
-#include <sys/mman.h>
-#include <unistd.h>
 #ifndef _MSC_VER
 #include <unwind.h>
 #endif
@@ -37,6 +35,8 @@
 #include <unordered_set>
 #include <vector>
 
+#include <folly/CPortability.h>
+#include <folly/FilePortability.h>
 #include <folly/Format.h>
 #include <folly/MapUtil.h>
 #include <folly/Optional.h>

--- a/hphp/runtime/vm/jit/write-lease.cpp
+++ b/hphp/runtime/vm/jit/write-lease.cpp
@@ -19,7 +19,7 @@
 #include "hphp/runtime/vm/bytecode.h"
 #include "hphp/runtime/vm/jit/mc-generator.h"
 
-#include <sys/mman.h>
+#include <folly/CPortability.h>
 
 namespace HPHP { namespace jit {
 TRACE_SET_MOD(txlease);

--- a/hphp/runtime/vm/repo.h
+++ b/hphp/runtime/vm/repo.h
@@ -25,12 +25,13 @@
 
 #include <sqlite3.h>
 
-// For sysconf(3).
-#include <unistd.h>
 // For getpwuid_r(3).
 #include <sys/types.h>
+#ifndef _MSC_VER
 #include <pwd.h>
+#endif
 
+#include <folly/FilePortability.h>
 #include "hphp/runtime/vm/class.h"
 #include "hphp/runtime/vm/func.h"
 #include "hphp/runtime/vm/litstr-repo-proxy.h"

--- a/hphp/runtime/vm/treadmill.cpp
+++ b/hphp/runtime/vm/treadmill.cpp
@@ -22,12 +22,12 @@
 #include <memory>
 #include <algorithm>
 
-#include <sys/time.h>
-
 #include <stdlib.h>
 #include <pthread.h>
 #include <stdio.h>
 #include <signal.h>
+
+#include <folly/CPortability.h>
 
 #include "hphp/util/logger.h"
 #include "hphp/util/process.h"

--- a/hphp/util/alloc.cpp
+++ b/hphp/util/alloc.cpp
@@ -17,9 +17,6 @@
 
 #include <atomic>
 
-#include <sys/time.h>
-#include <sys/resource.h>
-#include <sys/mman.h>
 #include <stdlib.h>
 #include <errno.h>
 
@@ -29,6 +26,7 @@
 #endif
 
 #include <folly/Bits.h>
+#include <folly/CPortability.h>
 #include <folly/Format.h>
 
 #include "hphp/util/logger.h"

--- a/hphp/util/async-func.cpp
+++ b/hphp/util/async-func.cpp
@@ -15,10 +15,9 @@
 */
 #include "hphp/util/async-func.h"
 
-#include <sys/time.h>
-#include <sys/resource.h>
-#include <sys/mman.h>
-#include <unistd.h>
+#include <folly/CPortability.h>
+#include <folly/FilePortability.h>
+#include <folly/Portability.h>
 
 namespace HPHP {
 ///////////////////////////////////////////////////////////////////////////////

--- a/hphp/util/async-job.h
+++ b/hphp/util/async-job.h
@@ -19,7 +19,7 @@
 
 #include <algorithm>
 
-#include <sys/time.h>
+#include <folly/CPortability.h>
 
 #include "hphp/util/async-func.h"
 #include "hphp/util/lock.h"

--- a/hphp/util/byte-order.h
+++ b/hphp/util/byte-order.h
@@ -18,7 +18,7 @@
 
 #include <cstdint>
 
-#include <arpa/inet.h>
+#include <folly/SocketPortability.h>
 
 namespace HPHP {
 

--- a/hphp/util/cache/cache-data.cpp
+++ b/hphp/util/cache/cache-data.cpp
@@ -18,12 +18,12 @@
 
 #include <sys/stat.h>
 #include <sys/types.h>
-#include <unistd.h>
 
 #include <cstdint>
 #include <random>
 #include <string>
 
+#include <folly/FilePortability.h>
 #include <folly/Format.h>
 #include <folly/ScopeGuard.h>
 #include "hphp/util/cache/cache-saver.h"

--- a/hphp/util/cache/cache-manager.cpp
+++ b/hphp/util/cache/cache-manager.cpp
@@ -17,7 +17,6 @@
 #include "hphp/util/cache/cache-manager.h"
 
 #include <fcntl.h>
-#include <sys/mman.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 
@@ -28,6 +27,8 @@
 #include <string>
 #include <utility>
 #include <vector>
+
+#include <folly/CPortability.h>
 
 #include "hphp/util/cache/cache-data.h"
 #include "hphp/util/cache/cache-saver.h"

--- a/hphp/util/cache/cache-saver.cpp
+++ b/hphp/util/cache/cache-saver.cpp
@@ -17,12 +17,12 @@
 #include "hphp/util/cache/cache-saver.h"
 
 #include <sys/types.h>
-#include <unistd.h>
 
 #include <cstdint>
 #include <string>
 #include <vector>
 
+#include <folly/FilePortability.h>
 #include <folly/FileUtil.h>
 #include <folly/Format.h>
 #include "hphp/util/cache/magic-numbers.h"

--- a/hphp/util/cache/cache-saver.h
+++ b/hphp/util/cache/cache-saver.h
@@ -75,13 +75,13 @@
 #define incl_HPHP_CACHE_SAVER_H_
 
 #include <sys/types.h>
-#include <unistd.h>
 
 #include <cstdint>
 #include <string>
 #include <vector>
 
 #include <boost/utility.hpp>
+#include <folly/FilePortability.h>
 
 namespace HPHP {
 

--- a/hphp/util/cache/mmap-file.cpp
+++ b/hphp/util/cache/mmap-file.cpp
@@ -16,13 +16,13 @@
 
 #include "hphp/util/cache/mmap-file.h"
 
-#include <sys/mman.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 
 #include <cstdint>
 #include <string>
 
+#include <folly/CPortability.h>
 #include <folly/Format.h>
 #include "hphp/util/logger.h"
 

--- a/hphp/util/compatibility.cpp
+++ b/hphp/util/compatibility.cpp
@@ -25,9 +25,10 @@
 #include <cstring>
 #include <fcntl.h>
 #include <sys/stat.h>
-#include <sys/time.h>
 #include <sys/types.h>
-#include <unistd.h>
+
+#include <folly/CPortability.h>
+#include <folly/FilePortability.h>
 
 namespace HPHP {
 ///////////////////////////////////////////////////////////////////////////////

--- a/hphp/util/compatibility.h
+++ b/hphp/util/compatibility.h
@@ -18,7 +18,8 @@
 
 #include <cstdint>
 #include <time.h>
-#include <unistd.h>
+
+#include <folly/FilePortability.h>
 
 #include <folly/Singleton.h>
 

--- a/hphp/util/cronoutils.h
+++ b/hphp/util/cronoutils.h
@@ -83,16 +83,11 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <limits.h>
-#ifndef _WIN32
-#include <unistd.h>
-#else
-#include <io.h>
-#include <direct.h>
-#endif
 #include <string.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 
+#include <folly/FilePortability.h>
 
 #if TIME_WITH_SYS_TIME
 # include <sys/time.h>

--- a/hphp/util/current-executable.cpp
+++ b/hphp/util/current-executable.cpp
@@ -15,7 +15,7 @@
 */
 
 #include "hphp/util/current-executable.h"
-#include <unistd.h>
+#include <folly/FilePortability.h>
 #include <limits.h>
 
 #ifdef __APPLE__

--- a/hphp/util/data-block.h
+++ b/hphp/util/data-block.h
@@ -21,9 +21,9 @@
 #include <set>
 #include <cstdint>
 #include <cstring>
-#include <sys/mman.h>
 
 #include <folly/Bits.h>
+#include <folly/CPortability.h>
 #include <folly/Format.h>
 
 #include "hphp/util/assertions.h"

--- a/hphp/util/embedded-data.cpp
+++ b/hphp/util/embedded-data.cpp
@@ -25,7 +25,7 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <string.h>
-#include <unistd.h>
+#include <folly/FilePortability.h>
 
 #ifdef __APPLE__
 #include <mach-o/getsect.h>

--- a/hphp/util/embedded-vfs.cpp
+++ b/hphp/util/embedded-vfs.cpp
@@ -24,7 +24,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 
-#include <unistd.h>
+#include <folly/FilePortability.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>

--- a/hphp/util/htonll.h
+++ b/hphp/util/htonll.h
@@ -23,7 +23,7 @@
  * to be worth pulling out.
  */
 
-#include <arpa/inet.h>
+#include <folly/SocketPortability.h>
 #if defined(__FreeBSD__)
 # include <sys/endian.h>
 #elif defined(__APPLE__)

--- a/hphp/util/log-file-flusher.cpp
+++ b/hphp/util/log-file-flusher.cpp
@@ -16,7 +16,8 @@
 #include "hphp/util/log-file-flusher.h"
 
 #include <sys/types.h>
-#include <unistd.h>
+
+#include <folly/FilePortability.h>
 
 namespace HPHP {
 

--- a/hphp/util/log-file-flusher.h
+++ b/hphp/util/log-file-flusher.h
@@ -18,7 +18,7 @@
 
 #include <cstdio>
 #include <atomic>
-#include <unistd.h>
+#include <folly/FilePortability.h>
 
 #include "hphp/util/compatibility.h"
 

--- a/hphp/util/logger.cpp
+++ b/hphp/util/logger.cpp
@@ -15,7 +15,7 @@
 */
 #include "hphp/util/logger.h"
 
-#include <syslog.h>
+#include <folly/CPortability.h>
 
 #include "hphp/util/stack-trace.h"
 #include "hphp/util/process.h"

--- a/hphp/util/maphuge.cpp
+++ b/hphp/util/maphuge.cpp
@@ -17,8 +17,8 @@
 #include "hphp/util/maphuge.h"
 #include "hphp/util/kernel-version.h"
 
-#include <unistd.h>
-#include <sys/mman.h>
+#include <folly/CPortability.h>
+#include <folly/FilePortability.h>
 
 namespace HPHP {
 

--- a/hphp/util/network.cpp
+++ b/hphp/util/network.cpp
@@ -15,15 +15,13 @@
 */
 #include "hphp/util/network.h"
 
-#include <netinet/in.h>
-#include <arpa/inet.h>
-
 #ifndef _MSC_VER
 #include <arpa/nameser.h>
 #include <resolv.h>
 #include <sys/utsname.h>
 #endif
 
+#include <folly/SocketPortability.h>
 #include <folly/String.h>
 #include <folly/IPAddress.h>
 
@@ -147,7 +145,7 @@ static std::string normalizeIPv6Address(const std::string& address) {
   }
 
   char ipPresentation[INET6_ADDRSTRLEN];
-  if (inet_ntop(AF_INET6, &addr, ipPresentation, INET6_ADDRSTRLEN) == nullptr) {
+  if (::inet_ntop(AF_INET6, &addr, ipPresentation, INET6_ADDRSTRLEN) == nullptr) {
     return std::string();
   }
 

--- a/hphp/util/network.h
+++ b/hphp/util/network.h
@@ -18,11 +18,10 @@
 #define incl_HPHP_NETWORK_H_
 
 #include <string>
-#include <netdb.h>
-#include <sys/socket.h>
 #include <stdlib.h>
 
 #include <folly/IPAddress.h>
+#include <folly/SocketPortability.h>
 
 /**
  * Network utility functions.

--- a/hphp/util/process.h
+++ b/hphp/util/process.h
@@ -22,13 +22,11 @@
 #include <cstdio>
 
 #include <sys/types.h>
-#ifdef _MSC_VER
-# include <windows.h>
-#else
-# include <sys/syscall.h>
-# include <unistd.h>
-#endif
 #include <pthread.h>
+
+#include <folly/CPortability.h>
+#include <folly/FilePortability.h>
+#include <folly/WindowsPortability.h>
 
 namespace HPHP {
 ///////////////////////////////////////////////////////////////////////////////

--- a/hphp/util/read-only-arena.cpp
+++ b/hphp/util/read-only-arena.cpp
@@ -15,9 +15,9 @@
 */
 #include "hphp/util/read-only-arena.h"
 
-#include <sys/mman.h>
 #include <stdlib.h>
 
+#include <folly/CPortability.h>
 #include <folly/Exception.h>
 
 #include "hphp/util/assertions.h"

--- a/hphp/util/ringbuffer.cpp
+++ b/hphp/util/ringbuffer.cpp
@@ -20,9 +20,9 @@
 #include <atomic>
 #include <cstdio>
 #include <cstring>
-#include <unistd.h>
 
 #include <folly/Bits.h>
+#include <folly/FilePortability.h>
 
 #include "hphp/util/assertions.h"
 

--- a/hphp/util/smalllocks.h
+++ b/hphp/util/smalllocks.h
@@ -17,13 +17,14 @@
 #define incl_HPHP_SMALLLOCKS_H_
 
 #include <atomic>
-#include <unistd.h>
 #include <iostream>
 #ifdef __linux__
 #include <syscall.h>
 #include <linux/futex.h>
 #include <sys/time.h>
 #endif
+
+#include <folly/FilePortability.h>
 
 namespace HPHP {
 

--- a/hphp/util/timer.cpp
+++ b/hphp/util/timer.cpp
@@ -22,8 +22,7 @@
 #include <mach/mach.h>
 #endif
 
-#include <sys/time.h>
-#include <sys/resource.h>
+#include <folly/CPortability.h>
 
 #include "hphp/util/logger.h"
 #include "hphp/util/trace.h"

--- a/hphp/util/timer.h
+++ b/hphp/util/timer.h
@@ -19,8 +19,8 @@
 
 #include <cstdint>
 #include <string>
-#include <sys/resource.h>
-#include <sys/time.h>
+
+#include <folly/CPortability.h>
 
 #include "hphp/util/compatibility.h"
 

--- a/hphp/util/trace.h
+++ b/hphp/util/trace.h
@@ -21,6 +21,7 @@
 #include <vector>
 #include <stdarg.h>
 
+#include <folly/FilePortability.h>
 #include <folly/Format.h>
 
 #include "hphp/util/assertions.h"


### PR DESCRIPTION
This is the HHVM counterpart to [folly#287](https://github.com/facebook/folly/pull/287), and is the core of the MSVC port. It switches from including certain posix headers to including the appropriate folly portability headers instead.

This PR touches a lot of files, but all changes are to the includes, all except for a few changes in the following files, which were done to deal with portability with WinSock:
```
hphp/runtime/debugger/debugger_client.cpp
hphp/runtime/debugger/debugger_server.cpp
hphp/runtime/ext/sockets/ext_sockets.cpp
hphp/runtime/ext/std/ext_std_network.cpp
hphp/runtime/ext/xdebug/xdebug_server.cpp
hphp/util/network.cpp
```

This requires [folly#287](https://github.com/facebook/folly/pull/287) to be merged upstream first.