### PR TITLE
Allow implicit conversion of nullptr to Variant

### DIFF
--- a/hphp/runtime/base/type-variant.h
+++ b/hphp/runtime/base/type-variant.h
@@ -76,6 +76,9 @@ struct Variant : private TypedValue {
   explicit Variant(NullInit) noexcept { m_type = KindOfNull; }
   explicit Variant(NoInit) noexcept {}
 
+  /* implicit */ Variant(nullptr_t) noexcept {
+    m_type = KindOfNull;
+  }
   /* implicit */ Variant(bool    v) noexcept {
     m_type = KindOfBoolean; m_data.num = v;
   }


### PR DESCRIPTION
Constructing a Variant representing null is currently quite verbose.
This makes it possible to implicitly construct a Variant from nullptr via the nullptr_t type.