### PR TITLE
Connection error now throws RedisException

### DIFF
--- a/hphp/system/php/redis/Redis.php
+++ b/hphp/system/php/redis/Redis.php
@@ -1626,10 +1626,10 @@ class Redis {
         $conn    = stream_socket_client(
           $sok, $errno, $errstr, $timeout, 2, $context);
       } else {
-        $conn = pfsockopen($host, $port, $errno, $errstr, $timeout);
+        $conn = @pfsockopen($host, $port, $errno, $errstr, $timeout);
       }
     } else {
-        $conn = fsockopen($host, $port, $errno, $errstr, $timeout);
+        $conn = @fsockopen($host, $port, $errno, $errstr, $timeout);
     }
     $this->last_connect = time();
     $this->host = $host;
@@ -1645,9 +1645,8 @@ class Redis {
     $this->mode = self::ATOMIC;
 
     if (!$this->connection) {
-      trigger_error(
-        "Failed connecting to redis server at {$host}: {$errstr}",
-        E_WARNING);
+      throw new RedisException(
+        "Failed connecting to redis server at {$host}: {$errstr}");
       return false;
     }
     stream_set_blocking($this->connection, true);


### PR DESCRIPTION
Connection errors now throw a RedisException instead of triggering an error. This allows an application to catch the connection problem and handle it gracefully.