### PR TITLE
Replace equivalent external commands on Windows.

### DIFF
--- a/hphp/hack/src/h2tp/common/sys_ext.ml
+++ b/hphp/hack/src/h2tp/common/sys_ext.ml
@@ -84,7 +84,14 @@ let set_extension f ext =
   then (Str.matched_group 1 f) ^ ext
   else failwith "Regex match failure on extension"
 
-let copy_file s d = ignore (command ("cp -p \"" ^ s ^ "\" \"" ^ d ^ "\""))
+let copy_file s d =
+  if Sys.win32 then begin
+    let st = Unix.stat s in
+    ignore (command ("copy \"" ^ s ^ "\" \"" ^ d ^ "\""));
+    (* `copy` does not preserve last access time (`atime`). *)
+    Unix.(utimes d st.st_atime st.st_mtime)
+  end else
+    ignore (command ("cp -p \"" ^ s ^ "\" \"" ^ d ^ "\""))
 
 let rec mkdir_p = function
   | "" -> raise CE.Impossible

--- a/hphp/hack/src/hh_format.ml
+++ b/hphp/hack/src/hh_format.ml
@@ -83,8 +83,12 @@ let debug () fnl =
         let oc = open_out file2 in
         output_string oc content2;
         close_out oc;
-        let _ = Sys.command ("diff "^file1^" "^file2) in
-        let _ = Sys.command ("rm "^file1^" "^file2) in
+        if Sys.win32 then
+          ignore (Sys.command ("fc "^file1^" "^file2))
+        else
+          ignore (Sys.command ("diff "^file1^" "^file2));
+        Sys_utils.unlink_no_fail file1;
+        Sys_utils.unlink_no_fail file2;
         flush stdout
       end;
 


### PR DESCRIPTION
- `cp`: use `copy` on Windows and manually update set the last access time;
- `rm`: use `del` on Windows;
- `diff`: use `fc` on Windows.