### PR TITLE
HHVM does not check the rc from open(2) correctly.

### DIFF
--- a/hphp/test/slow/compilation/open-rc-check.php
+++ b/hphp/test/slow/compilation/open-rc-check.php
@@ -1,0 +1,16 @@
+<?php
+
+register_shutdown_function('fatal_handler');
+
+$file = tempnam(sys_get_temp_dir(), 'cannotopen');
+$data = "//Nothing";
+$GLOBALS['file'] = $file;
+
+if (file_put_contents($GLOBALS['file'], $data) !== false && chmod($GLOBALS['file'], 0000)) {
+    require $GLOBALS['file'];
+}
+
+function fatal_handler() {
+    chmod($GLOBALS['file'], 0600);
+    @unlink($GLOBALS['file']);
+}

--- a/hphp/test/slow/compilation/open-rc-check.php.expectf
+++ b/hphp/test/slow/compilation/open-rc-check.php.expectf
@@ -1,0 +1,1 @@
+Fatal error: File not found: %s in %s on line 10


### PR DESCRIPTION
For example, if open returns an error like EACCES, HHVM will merrily
assume the file is 0 bytes and continue on. This patch fixes that.
It also adds support for ctime based reloading of non-repo-auth units.