### PR TITLE
Disable the JIT by default under MSVC

### DIFF
--- a/hphp/runtime/base/runtime-option.cpp
+++ b/hphp/runtime/base/runtime-option.cpp
@@ -438,7 +438,7 @@ static inline bool hhirRelaxGuardsDefault() {
 }
 
 static inline bool evalJitDefault() {
-#ifdef __CYGWIN__
+#if defined(__CYGWIN__) || defined(_MSC_VER)
   return false;
 #else
   return true;


### PR DESCRIPTION
Because there are many many things that need to be done to make the JIT work right.