### PR TITLE
[MSVC] Don't use __attribute__((__constructor__)) functions to register the fastcgi and proxygen servers

### DIFF
--- a/hphp/runtime/server/fastcgi/fastcgi-server-factory.cpp
+++ b/hphp/runtime/server/fastcgi/fastcgi-server-factory.cpp
@@ -32,16 +32,14 @@ public:
 
 }
 
-extern "C" {
-
 /*
- * Automatically register FastCGIServerFactory on program start
- */
-void register_fastcgi_server() __attribute__((__constructor__));
-void register_fastcgi_server() {
-  auto registry = HPHP::ServerFactoryRegistry::getInstance();
-  auto factory = std::make_shared<HPHP::FastCGIServerFactory>();
-  registry->registerFactory("fastcgi", factory);
-}
-
-}
+* Automatically register FastCGIServerFactory on program start
+*/
+static struct RegisterFastCGIServer {
+public:
+  RegisterFastCGIServer() {
+    auto registry = HPHP::ServerFactoryRegistry::getInstance();
+    auto factory = std::make_shared<HPHP::FastCGIServerFactory>();
+    registry->registerFactory("fastcgi", factory);
+  }
+} s_RegisterFastCGIServer;

--- a/hphp/runtime/server/fastcgi/fastcgi-server-factory.cpp
+++ b/hphp/runtime/server/fastcgi/fastcgi-server-factory.cpp
@@ -32,10 +32,11 @@ public:
 
 }
 
+namespace {
 /*
 * Automatically register FastCGIServerFactory on program start
 */
-static struct RegisterFastCGIServer {
+struct RegisterFastCGIServer {
 public:
   RegisterFastCGIServer() {
     auto registry = HPHP::ServerFactoryRegistry::getInstance();
@@ -43,3 +44,4 @@ public:
     registry->registerFactory("fastcgi", factory);
   }
 } s_RegisterFastCGIServer;
+}

--- a/hphp/runtime/server/proxygen/proxygen-server-factory.cpp
+++ b/hphp/runtime/server/proxygen/proxygen-server-factory.cpp
@@ -29,10 +29,11 @@ public:
 
 }
 
+namespace {
 /*
 * Automatically register ProxygenServerFactory on program start
 */
-static struct RegisterProxygenServer {
+struct RegisterProxygenServer {
 public:
   RegisterProxygenServer() {
     auto registry = HPHP::ServerFactoryRegistry::getInstance();
@@ -40,3 +41,4 @@ public:
     registry->registerFactory("proxygen", factory);
   }
 } s_RegisterProxygenServer;
+}

--- a/hphp/runtime/server/proxygen/proxygen-server-factory.cpp
+++ b/hphp/runtime/server/proxygen/proxygen-server-factory.cpp
@@ -29,16 +29,14 @@ public:
 
 }
 
-extern "C" {
-
 /*
- * Automatically register ProxygenServerFactory on program start
- */
-void register_proxygen_server() __attribute__((__constructor__));
-void register_proxygen_server() {
-  auto registry = HPHP::ServerFactoryRegistry::getInstance();
-  auto factory = std::make_shared<HPHP::ProxygenServerFactory>();
-  registry->registerFactory("proxygen", factory);
-}
-
-}
+* Automatically register ProxygenServerFactory on program start
+*/
+static struct RegisterProxygenServer {
+public:
+  RegisterProxygenServer() {
+    auto registry = HPHP::ServerFactoryRegistry::getInstance();
+    auto factory = std::make_shared<HPHP::ProxygenServerFactory>();
+    registry->registerFactory("proxygen", factory);
+  }
+} s_RegisterProxygenServer;


### PR DESCRIPTION
Because these won't work under MSVC. Use dynamic initializers instead, because the static runtime is already being fully linked in.