### PR TITLE
Include <algorithm> for std::min

### DIFF
--- a/hphp/runtime/ext/hash/hash_keccak.cpp
+++ b/hphp/runtime/ext/hash/hash_keccak.cpp
@@ -17,6 +17,8 @@
 
 #include "hphp/runtime/ext/hash/hash_keccak.h"
 
+#include <algorithm>
+
 namespace HPHP {
 ///////////////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
Currently this is depending on the include chain of the standard library being used. For MSVC, `<algorithm>` is not part of this chain, so should be included explicitly.