### PR TITLE
Fix MixedArray::InitSmall on platforms not using the inline ASM

### DIFF
--- a/hphp/runtime/base/mixed-array-defs.h
+++ b/hphp/runtime/base/mixed-array-defs.h
@@ -91,7 +91,7 @@ void MixedArray::InitSmall(MixedArray* a, RefCount count, uint32_t size,
     : : "r"(a) : "xmm0"
   );
 #else
-  auto const hash = a->hashTab();
+  auto const hash = mixedHash(mixedData(a), MixedArray::SmallScale);
   auto const emptyVal = int64_t{MixedArray::Empty};
   reinterpret_cast<int64_t*>(hash)[0] = emptyVal;
   reinterpret_cast<int64_t*>(hash)[1] = emptyVal;


### PR DESCRIPTION
This was a massive pain to track down.
The issue here is that `hashTab()` is calculated based on the scale value of the array, but that doesn't get set until farther down. The solution to this is simple, use the `mixed*` helper funcs, which are defined for this exact purpose.