### PR TITLE
Generate the resource file at configure time for Windows

### DIFF
--- a/hphp/hhvm/CMakeLists.txt
+++ b/hphp/hhvm/CMakeLists.txt
@@ -2,22 +2,9 @@ set(CXX_SOURCES)
 auto_sources(files "*.cpp" "")
 list(APPEND CXX_SOURCES ${files})
 
-# Windows targets use a generate rc file for embedding libraries
+# Windows targets use a generated rc file for embedding libraries
 if(CYGWIN OR MSVC OR MINGW)
-  add_custom_target(generate_embed
-    COMMAND echo LANGUAGE 0, 0 > ${CMAKE_CURRENT_BINARY_DIR}/embed.rc
-    COMMENT "generating embed.rc")
-
-  # this is a cmake trick to allow items added later to depend properly
-  add_custom_target(generate_rc
-    DEPENDS generate_embed
-    COMMENT "Generating RC file")
-
-    list(APPEND CXX_SOURCES ${CMAKE_CURRENT_BINARY_DIR}/embed.rc)
-    set_directory_properties(PROPERTIES ADDITIONAL_MAKE_CLEAN_FILES
-      ${CMAKE_CURRENT_BINARY_DIR}/embed.rc)
-    set_source_files_properties(${CMAKE_CURRENT_BINARY_DIR}/embed.rc
-      PROPERTIES GENERATED TRUE)
+  list(APPEND CXX_SOURCES ${CMAKE_CURRENT_BINARY_DIR}/embed.rc)
 endif()
 
 find_package(Gold)
@@ -60,11 +47,7 @@ endif()
 set(CMAKE_REQUIRED_FLAGS ${OLD_CMAKE_REQUIRED_FLAGS})
 
 embed_all_systemlibs(hhvm "${CMAKE_CURRENT_BINARY_DIR}/.." "${CMAKE_CURRENT_BINARY_DIR}/hhvm")
-if(CYGWIN OR MSVC OR MINGW)
-  add_dependencies(hhvm generate_rc)
-else()
-  add_dependencies(hhvm systemlib)
-endif()
+add_dependencies(hhvm systemlib)
 
 if (CMAKE_HOST_UNIX)
   add_custom_command(TARGET hhvm POST_BUILD


### PR DESCRIPTION
Rather than using a pair of always out of date targets to regenerate the file every single time you build. Visual Studio is smart enough to detect the change to the files linked to by the resource, so let it do what it's good at, and make it so I can start hhvm with debugging after having just built it, without having to tell it I don't want to rebuild the resource files again -_-...