### PR TITLE
Only output MySQL stats if the MySQL extension is enabled

### DIFF
--- a/hphp/runtime/server/admin-request-handler.cpp
+++ b/hphp/runtime/server/admin-request-handler.cpp
@@ -34,7 +34,9 @@
 
 #include "hphp/runtime/ext/apc/ext_apc.h"
 #include "hphp/runtime/ext/json/ext_json.h"
+#ifdef ENABLE_EXTENSION_MYSQL
 #include "hphp/runtime/ext/mysql/mysql_stats.h"
+#endif
 #include "hphp/runtime/server/http-request-handler.h"
 #include "hphp/runtime/server/http-server.h"
 #include "hphp/runtime/server/memory-stats.h"
@@ -807,7 +809,9 @@ bool AdminRequestHandler::handleCheckRequest(const std::string &cmd,
   if (cmd == "check-sql") {
     string stats = "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n";
     stats += "<SQL>\n";
+#ifdef ENABLE_EXTENSION_MYSQL
     stats += MySqlStats::ReportStats();
+#endif
     stats += "</SQL>\n";
     transport->sendString(stats);
     return true;


### PR DESCRIPTION
Originally #6113 (D45273), but due to some fun with the review tooling, needed to be re-opened.

Because we can't build with MySQL currently under MSVC. Because we can't currently build MySQL 5.6, nor the RC version of 5.7 under MSVC 2015.

This requires #5872 (D43749).