### PR TITLE
Fix #6209 Add IntlChar::NO_NUMERIC_VALUE

### DIFF
--- a/hphp/runtime/ext/icu/ext_icu_uchar.cpp
+++ b/hphp/runtime/ext/icu/ext_icu_uchar.cpp
@@ -357,6 +357,8 @@ void IntlExtension::initUChar() {
   IC_CONSTL("CODEPOINT_MAX", UCHAR_MAX_VALUE)
   IC_CONSTL("FOLD_CASE_DEFAULT", U_FOLD_CASE_DEFAULT)
   IC_CONSTL("FOLD_CASE_EXCLUDE_SPECIAL_I", U_FOLD_CASE_EXCLUDE_SPECIAL_I)
+  Native::registerClassConstant<KindOfDouble>
+  (s_IntlChar.get(), makeStaticString("NO_NUMERIC_VALUE"), U_NO_NUMERIC_VALUE);
 
   /* All enums used by the uchar APIs.  There are a LOT of them,
    * so they're separated out into include files,


### PR DESCRIPTION
This is a fix for [#6209](https://github.com/facebook/hhvm/issues/6209).

Note that PHP doesn't currently have this constant either.