### PR TITLE
Fix linking errors with static versions of ICU

### DIFF
--- a/hphp/runtime/ext/icu/ext_icu_msg_fmt.cpp
+++ b/hphp/runtime/ext/icu/ext_icu_msg_fmt.cpp
@@ -21,7 +21,7 @@ public:
     MessageFormatAdapter() = delete;
 
     static const Formattable::Type* getArgTypeListHHVM(const MessageFormat& m,
-                                                   int32_t& count) {
+                                                       int32_t& count) {
       return m.getArgTypeList(count);
     }
 

--- a/hphp/runtime/ext/icu/ext_icu_msg_fmt.cpp
+++ b/hphp/runtime/ext/icu/ext_icu_msg_fmt.cpp
@@ -20,7 +20,7 @@ class MessageFormatAdapter {
 public:
     MessageFormatAdapter() = delete;
 
-    static const Formattable::Type* getArgTypeList(const MessageFormat& m,
+    static const Formattable::Type* getArgTypeListHHVM(const MessageFormat& m,
                                                    int32_t& count) {
       return m.getArgTypeList(count);
     }
@@ -196,7 +196,7 @@ bool MessageFormatter::processNamedTypes() {
 bool MessageFormatter::processNumericTypes() {
   auto formatter = formatterObj();
   int32_t count = 0;
-  auto types = MessageFormatAdapter::getArgTypeList(*formatter, count);
+  auto types = MessageFormatAdapter::getArgTypeListHHVM(*formatter, count);
 
   clearError();
   m_namedParts.clear();


### PR DESCRIPTION
ICU defines MessageFormatAdapter::getArgTypeList itself internally, and when we link against it as a static lib under MSVC, we get errors because it's defined in multiple places.
To solve this, just name it something different.