### PR TITLE
Fix places where MSVC warns about truncation of literals in a cast

### DIFF
--- a/hphp/compiler/analysis/emitter.cpp
+++ b/hphp/compiler/analysis/emitter.cpp
@@ -168,8 +168,8 @@ namespace StackSym {
   static const char P = 0x50; // Property marker
   static const char S = 0x60; // Static property marker
   static const char M = 0x70; // Non elem/prop/W part of M-vector
-  static const char K = (char)0x80; // Marker for information about a class base
-  static const char Q = (char)0x90; // NullSafe Property marker
+  static const char K = (char)0x80u; // Marker for information about a class base
+  static const char Q = (char)0x90u; // NullSafe Property marker
 
   static const char CN = C | N;
   static const char CG = C | G;

--- a/hphp/runtime/vm/hhbc-codec.h
+++ b/hphp/runtime/vm/hhbc-codec.h
@@ -60,7 +60,7 @@ void encode_op(Op op, F write_byte) {
                 "Op encoding scheme doesn't support Ops >= 0x1fe");
   auto rawVal = static_cast<size_t>(op);
   if (rawVal >= 0xff) {
-    write_byte(static_cast<uint8_t>(~0xff));
+    write_byte(static_cast<uint8_t>(0));
     rawVal -= 0xff;
   }
   assert(rawVal < 0xff);

--- a/hphp/runtime/vm/hhbc-codec.h
+++ b/hphp/runtime/vm/hhbc-codec.h
@@ -60,6 +60,7 @@ void encode_op(Op op, F write_byte) {
                 "Op encoding scheme doesn't support Ops >= 0x1fe");
   auto rawVal = static_cast<size_t>(op);
   if (rawVal >= 0xff) {
+    // Write a 0xff signal byte, with its bits flipped.
     write_byte(static_cast<uint8_t>(0));
     rawVal -= 0xff;
   }

--- a/hphp/runtime/vm/jit/code-gen-x64.cpp
+++ b/hphp/runtime/vm/jit/code-gen-x64.cpp
@@ -4687,7 +4687,7 @@ void CodeGenerator::cgContStartedCheck(IRInstruction* inst) {
 
   // Take exit if state == 0.
   auto const sf = v.makeReg();
-  v << testbim{int8_t(0xff), contReg[stateOff], sf};
+  v << testbim{int8_t(0xffu), contReg[stateOff], sf};
   v << jcc{CC_Z, sf, {label(inst->next()), label(inst->taken())}};
 }
 

--- a/hphp/runtime/vm/jit/debug-guards.cpp
+++ b/hphp/runtime/vm/jit/debug-guards.cpp
@@ -62,7 +62,7 @@ void addDbgGuardImpl(SrcKey sk, SrcRec* sr) {
 
     x64::emitTLSLoad(v, ThreadInfo::s_threadInfo, tinfo);
     v << loadb{tinfo[dbgOff], attached};
-    v << testbi{static_cast<int8_t>(0xff), attached, sf};
+    v << testbi{static_cast<int8_t>(0xffu), attached, sf};
 
     v << jcci{CC_NZ, sf, done, mcg->tx().uniqueStubs.interpHelper};
 


### PR DESCRIPTION
I've ignored the couple of places where MSVC complained about this so far, because there is no difference, at least, not in these cases, in the resulting value if done on a signed or unsigned value. However, c8c6fb91 added a spot in `hhbc-codec.h` that triggered this warning, and, because it is in a template, the warning ends up showing up everywhere, and that finally prompted me to create the PR to eliminate them.