### PR TITLE
Don't mark the Systemlib as always out of date

### DIFF
--- a/hphp/hhvm/CMakeLists.txt
+++ b/hphp/hhvm/CMakeLists.txt
@@ -47,7 +47,6 @@ endif()
 set(CMAKE_REQUIRED_FLAGS ${OLD_CMAKE_REQUIRED_FLAGS})
 
 embed_all_systemlibs(hhvm "${CMAKE_CURRENT_BINARY_DIR}/.." "${CMAKE_CURRENT_BINARY_DIR}/hhvm")
-add_dependencies(hhvm systemlib)
 
 if (CMAKE_HOST_UNIX)
   add_custom_command(TARGET hhvm POST_BUILD

--- a/hphp/system/CMakeLists.txt
+++ b/hphp/system/CMakeLists.txt
@@ -51,8 +51,7 @@ foreach(cls ${SYSTEMLIB_CLASSES})
   endif()
 endforeach()
 
-add_custom_command(
-  OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/systemlib.php
+add_custom_command(TARGET hhvm PRE_BUILD
   DEPENDS "php.txt" ${SYSTEMLIB_SRCS}
   COMMAND "INSTALL_DIR=${CMAKE_CURRENT_BINARY_DIR}"
           "FBCODE_DIR=${CMAKE_CURRENT_SOURCE_DIR}/../.."
@@ -61,7 +60,3 @@ add_custom_command(
           "--fbcode_dir=${CMAKE_CURRENT_SOURCE_DIR}/.."
           "${SYSTEMLIB_SRCS_STR}"
   COMMENT "Generating systemlib.php")
-
-add_custom_target(
-  systemlib
-  DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/systemlib.php)


### PR DESCRIPTION
Currently the systemlib is generated via add_custom_target, which is always considered out of date by CMake, which gets annoying when trying to build and debug HHVM in Visual Studio.
This switches systemlib generation to a PRE_BUILD (PRE_LINK for everything except Visual Studio) command of hhvm, eliminating the problem.