### PR TITLE
[MSVC] Update ODBC for MSVC

### DIFF
--- a/hphp/runtime/ext/odbc/ext_odbc.cpp
+++ b/hphp/runtime/ext/odbc/ext_odbc.cpp
@@ -15,8 +15,6 @@
    +----------------------------------------------------------------------+
 */
 
-#ifdef HAVE_UODBC
-
 #include "hphp/runtime/ext/extension.h"
 #include "hphp/runtime/vm/jit/translator-inline.h"
 #include <sql.h>
@@ -898,5 +896,3 @@ static class ODBCExtension final : public Extension {
 } s_odbc_extension;
 
 }
-
-#endif // HAVE_UODBC


### PR DESCRIPTION
The outermost #ifdef isn't needed with the new extension config mechanism, and the C99 stack allocated array needs to be an `alloca` instead.