### PR TITLE
[MSVC] Port ext_fileinfo to MSVC

### DIFF
--- a/hphp/runtime/ext/fileinfo/libmagic/compress.cpp
+++ b/hphp/runtime/ext/fileinfo/libmagic/compress.cpp
@@ -47,7 +47,7 @@ FILE_RCSID("@(#)$File: compress.c,v 1.70 2012/11/07 17:54:48 christos Exp $")
 #include <string.h>
 #include <errno.h>
 #include <sys/types.h>
-#ifndef PHP_WIN32
+#ifndef _MSC_VER
 #include <sys/ioctl.h>
 #endif
 #ifdef HAVE_SYS_WAIT_H

--- a/hphp/runtime/ext/fileinfo/libmagic/config.h
+++ b/hphp/runtime/ext/fileinfo/libmagic/config.h
@@ -386,3 +386,14 @@
 
 /* Define as `fork' if `vfork' does not work. */
 /* #undef vfork */
+
+// This only bothers to undefine the things that break the MSVC build.
+// Everything else is ignored, even if the define for it is wrong.
+#ifdef _MSC_VER
+# undef HAVE_DAYLIGHT
+# undef HAVE_STRUCT_TM_TM_ZONE
+# undef HAVE_UTIME
+# undef HAVE_UTIMES
+# undef HAVE_UTIME_H
+# undef HAVE_VISIBILITY
+#endif

--- a/hphp/runtime/ext/fileinfo/libmagic/config.h
+++ b/hphp/runtime/ext/fileinfo/libmagic/config.h
@@ -386,14 +386,3 @@
 
 /* Define as `fork' if `vfork' does not work. */
 /* #undef vfork */
-
-// This only bothers to undefine the things that break the MSVC build.
-// Everything else is ignored, even if the define for it is wrong.
-#ifdef _MSC_VER
-# undef HAVE_DAYLIGHT
-# undef HAVE_STRUCT_TM_TM_ZONE
-# undef HAVE_UTIME
-# undef HAVE_UTIMES
-# undef HAVE_UTIME_H
-# undef HAVE_VISIBILITY
-#endif

--- a/hphp/runtime/ext/fileinfo/libmagic/file.h
+++ b/hphp/runtime/ext/fileinfo/libmagic/file.h
@@ -36,15 +36,10 @@
 #include "compat.h"
 #include "config.h"
 
-#ifdef PHP_WIN32
-  #ifdef _WIN64
-    #define SIZE_T_FORMAT "I64"
-  #else
-    #define SIZE_T_FORMAT ""
-  #endif
+#define SIZE_T_FORMAT "z"
+#ifdef _MSC_VER
   #define INT64_T_FORMAT "I64"
 #else
-  #define SIZE_T_FORMAT "z"
   #define INT64_T_FORMAT "ll"
 #endif
 
@@ -57,9 +52,7 @@
 #endif
 
 #include <sys/types.h>
-#ifdef PHP_WIN32
-#include "win32/param.h"
-#else
+#ifndef _MSC_VER
 #include <sys/param.h>
 #endif
 /* Do this here and now, because struct stat gets re-defined on solaris */
@@ -72,7 +65,7 @@
 #define MAGIC "/etc/magic"
 #endif
 
-#if defined(__EMX__) || defined(PHP_WIN32)
+#if defined(__EMX__) || defined(_MSC_VER)
 #define PATHSEP  ';'
 #else
 #define PATHSEP  ':'

--- a/hphp/runtime/ext/fileinfo/libmagic/readcdf.cpp
+++ b/hphp/runtime/ext/fileinfo/libmagic/readcdf.cpp
@@ -214,7 +214,8 @@ cdf_file_property_info(struct magic_set *ms, const cdf_property_info_t *info,
                                         if (cdf_timestamp_to_timespec(&ts, tp) == -1) {
                       return -1;
                     }
-                                        c = cdf_ctime(&ts.tv_sec, tbuf);
+                                        time_t tmp = ts.tv_sec;
+                                        c = cdf_ctime(&tmp, tbuf);
                                         if ((ec = strchr(c, '\n')) != nullptr)
                                                 *ec = '\0';
 


### PR DESCRIPTION
This pokes the condition around a couple of includes and defines, adds a set of `#undef`'s to config.h, and deals with the fact that `time_t` is a 64-bit value and `ts.tv_sec` is only a `long` value.

This extension actually requires quite a bit more poking of the includes, which will come as part of #6158 (D45663), due to their dependence on the upstream folly change.