### PR TITLE
Mark the 'MemExceededFlag' as not sticky

### DIFF
--- a/hphp/runtime/base/surprise-flags.h
+++ b/hphp/runtime/base/surprise-flags.h
@@ -49,16 +49,17 @@ enum SurpriseFlag : size_t {
   /* Set if a GC should be run at the next safe point. */
   PendingGCFlag        = 1ull << 60,
 
-  /*
-   * Flags that shouldn't be cleared by fetchAndClearSurpriseFlags, because
-   * fetchAndClearSurpriseFlags is only supposed to touch flags related to
-   * PHP-visible signals/exceptions and resource limits.
-   */
   ResourceFlags =
     MemExceededFlag |
     TimedOutFlag |
     CPUTimedOutFlag |
     PendingGCFlag,
+
+  /*
+   * Flags that shouldn't be cleared by fetchAndClearSurpriseFlags, because
+   * fetchAndClearSurpriseFlags is only supposed to touch flags related to
+   * PHP-visible signals/exceptions and resource limits.
+   */
 
   StickyFlags =
     AsyncEventHookFlag |
@@ -67,7 +68,9 @@ enum SurpriseFlag : size_t {
     InterceptFlag |
     XenonSignalFlag |
     IntervalTimerFlag |
-    ResourceFlags,
+    TimedOutFlag |
+    CPUTimedOutFlag |
+    PendingGCFlag,
 };
 
 /*

--- a/hphp/runtime/base/surprise-flags.h
+++ b/hphp/runtime/base/surprise-flags.h
@@ -50,7 +50,6 @@ enum SurpriseFlag : size_t {
   PendingGCFlag        = 1ull << 60,
 
   ResourceFlags =
-    MemExceededFlag |
     TimedOutFlag |
     CPUTimedOutFlag |
     PendingGCFlag,
@@ -68,9 +67,8 @@ enum SurpriseFlag : size_t {
     InterceptFlag |
     XenonSignalFlag |
     IntervalTimerFlag |
-    TimedOutFlag |
-    CPUTimedOutFlag |
-    PendingGCFlag,
+    MemExceededFlag |
+    ResourceFlags,
 };
 
 /*

--- a/hphp/test/slow/memory/oom_does_not_oom_shutdown_handler.php
+++ b/hphp/test/slow/memory/oom_does_not_oom_shutdown_handler.php
@@ -1,0 +1,13 @@
+<?php
+
+ini_set('memory_limit', '5M');
+
+register_shutdown_function(function () {
+    print "IN SHUTDOWN".PHP_EOL;
+});
+
+function foo() {
+  $x = str_repeat('x', 1024 * 1024 * 20);
+}
+
+foo();

--- a/hphp/test/slow/memory/oom_does_not_oom_shutdown_handler.php.expectf
+++ b/hphp/test/slow/memory/oom_does_not_oom_shutdown_handler.php.expectf
@@ -1,0 +1,3 @@
+
+Fatal error: request has exceeded memory limit in %s/hphp/test/slow/memory/oom_does_not_oom_shutdown_handler.php on line 11
+IN SHUTDOWN


### PR DESCRIPTION
This diff changes the surprise flag that denotes that the current
request has run out of memory as not 'sticky', meaning that it will
now be cleared when surprise flags are checked and cleared. It should
_not_ be sticky because this will cause all subsequent calls to OOM,
even after the stack has been unwound and everything cleared (for
example, this causes shutdown handlers to OOM deterministically even
when there is ample memory).

The previous behavior was likely an unintended consequence of commit
40f9d9547b3e13767575534686e5e1b061d2d029.