### PR TITLE
Reset OOM information before calling shutdown handler functions

### DIFF
--- a/hphp/runtime/base/execution-context.cpp
+++ b/hphp/runtime/base/execution-context.cpp
@@ -597,6 +597,7 @@ void ExecutionContext::onShutdownPreSend() {
     try { obFlushAll(); } catch (...) {}
   };
 
+  MM().resetCouldOOM(isStandardRequest());
   executeFunctions(ShutDown);
 }
 

--- a/hphp/test/slow/memory/oom_does_not_oom_shutdown_handler.php
+++ b/hphp/test/slow/memory/oom_does_not_oom_shutdown_handler.php
@@ -1,0 +1,13 @@
+<?php
+
+ini_set('memory_limit', '5M');
+
+register_shutdown_function(function () {
+    print "IN SHUTDOWN".PHP_EOL;
+});
+
+function foo() {
+  $x = str_repeat('x', 1024 * 1024 * 20);
+}
+
+foo();

--- a/hphp/test/slow/memory/oom_does_not_oom_shutdown_handler.php.expectf
+++ b/hphp/test/slow/memory/oom_does_not_oom_shutdown_handler.php.expectf
@@ -1,0 +1,3 @@
+
+Fatal error: request has exceeded memory limit in %s/hphp/test/slow/memory/oom_does_not_oom_shutdown_handler.php on line 11
+IN SHUTDOWN

--- a/hphp/test/slow/memory/oom_does_not_oom_shutdown_handler.php.expectf
+++ b/hphp/test/slow/memory/oom_does_not_oom_shutdown_handler.php.expectf
@@ -1,3 +1,4 @@
 
-Fatal error: request has exceeded memory limit in %s/hphp/test/slow/memory/oom_does_not_oom_shutdown_handler.php on line 11
+Fatal error: request has exceeded memory limit in %s/hphp/test/slow/memory/oom_does_not_oom_shutdown_handler.php on line 13
 IN SHUTDOWN
+65536

--- a/hphp/test/slow/memory/shutdown_handler_can_still_oom.php
+++ b/hphp/test/slow/memory/shutdown_handler_can_still_oom.php
@@ -4,8 +4,7 @@ ini_set('memory_limit', '5M');
 
 register_shutdown_function(function () {
     print "IN SHUTDOWN".PHP_EOL;
-    $y = str_repeat('x', 1024 * 64);
-    echo strlen($y).PHP_EOL;
+    $y = str_repeat('x', 1024 * 1024 * 20);
 });
 
 function foo() {

--- a/hphp/test/slow/memory/shutdown_handler_can_still_oom.php.expectf
+++ b/hphp/test/slow/memory/shutdown_handler_can_still_oom.php.expectf
@@ -1,0 +1,5 @@
+
+Fatal error: request has exceeded memory limit in %s/hphp/test/slow/memory/shutdown_handler_can_still_oom.php on line 12
+IN SHUTDOWN
+
+Fatal error: request has exceeded memory limit in %s/hphp/test/slow/memory/shutdown_handler_can_still_oom.php on line 8


### PR DESCRIPTION
This diff simply adds in a call to reset OOM housekeeping before calling
user-defined shutdown handlers in ExecutionContext::onShutdownPreSend().
This allows the shutdown handler to run properly after a request runs
out of memory and the stack is unwound.