### PR TITLE
[MSVC] Use auto for the return type of the ARCH_SWITCH_CALL lambda

### DIFF
--- a/hphp/runtime/base/arch.h
+++ b/hphp/runtime/base/arch.h
@@ -35,7 +35,7 @@ inline Arch arch() {
  * We need to specify the return type explicitly, or else we may drop refs.
  */
 #define ARCH_SWITCH_CALL(func, ...)     \
-  ([&]() -> auto {  \
+  ([&]() -> auto {                      \
     switch (arch()) {                   \
       case Arch::X64:                   \
         return x64::func(__VA_ARGS__);  \

--- a/hphp/runtime/base/arch.h
+++ b/hphp/runtime/base/arch.h
@@ -35,7 +35,7 @@ inline Arch arch() {
  * We need to specify the return type explicitly, or else we may drop refs.
  */
 #define ARCH_SWITCH_CALL(func, ...)     \
-  ([&]() -> auto {                      \
+  ([&]() -> decltype(auto) {            \
     switch (arch()) {                   \
       case Arch::X64:                   \
         return x64::func(__VA_ARGS__);  \

--- a/hphp/runtime/base/arch.h
+++ b/hphp/runtime/base/arch.h
@@ -18,8 +18,6 @@
 
 #include "hphp/runtime/base/runtime-option.h"
 
-#include <boost/type_traits.hpp>
-
 namespace HPHP {
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -37,7 +35,7 @@ inline Arch arch() {
  * We need to specify the return type explicitly, or else we may drop refs.
  */
 #define ARCH_SWITCH_CALL(func, ...)     \
-  ([&]() -> boost::function_traits<decltype(x64::func)>::result_type {  \
+  ([&]() -> auto {  \
     switch (arch()) {                   \
       case Arch::X64:                   \
         return x64::func(__VA_ARGS__);  \


### PR DESCRIPTION
Because using the explicit type makes MSVC grumpy and it complains about a function pointer type not being allowed to have default arguments.

Also, this is far cleaner.