### PR TITLE
Changed decode_xx functions from inline to ALWAYS_INLINE.

### DIFF
--- a/hphp/runtime/vm/bytecode.cpp
+++ b/hphp/runtime/vm/bytecode.cpp
@@ -284,19 +284,19 @@ inline StringData* decode_litstr(PC& pc) {
   return vmfp()->m_func->unit()->lookupLitstrId(id);
 }
 
-inline int32_t decode_la(PC& pc) {
+ALWAYS_INLINE int32_t decode_la(PC& pc) {
   return decode_iva(pc);
 }
 
-inline int32_t decode_ia(PC& pc) {
+ALWAYS_INLINE int32_t decode_ia(PC& pc) {
   return decode_iva(pc);
 }
 
-inline Offset decode_ba(PC& pc) {
+ALWAYS_INLINE Offset decode_ba(PC& pc) {
   return decode<Offset>(pc);
 }
 
-inline Offset peek_ba(PC& pc) {
+ALWAYS_INLINE Offset peek_ba(PC& pc) {
   return peek<Offset>(pc);
 }
 

--- a/hphp/runtime/vm/hhbc-codec.h
+++ b/hphp/runtime/vm/hhbc-codec.h
@@ -136,7 +136,7 @@ int32_t decodeVariableSizeImm(PC* immPtr) {
   return (int32_t)(small >> 1);
 }
 
-inline int32_t decode_iva(PC& pc) {
+ALWAYS_INLINE int32_t decode_iva(PC& pc) {
   return decodeVariableSizeImm(&pc);
 }
 


### PR DESCRIPTION
Several decode_xx functions in the bytecode interpreter were marked as inline but not ALWAYS_INLINE. Because of this, they were not inlined into the main interpreter loop. Declaring these ALWAYS_INLINE results in about 3% speedup on WordPress when running without jit. With JIT and -VEval.JitPseudomain=false, it gives about 1% speedup. With -VEval.JitPseudomain=true, there is no measurable difference. Increases image size ~7k.