### PR TITLE
Add missing class definition for __PHP_Incomplete_Class

### DIFF
--- a/hphp/hack/hhi/classes.hhi
+++ b/hphp/hack/hhi/classes.hhi
@@ -134,3 +134,5 @@ final class ExternalThreadEventWaitHandle<+T> extends WaitableWaitHandle<T> {
  * be getting extended.
  */
 final class stdClass {}
+
+class __PHP_Incomplete_Class {}


### PR DESCRIPTION
Fixes #4960.