### PR TITLE
[MSVC] Port ext_gd to MSVC

### DIFF
--- a/hphp/runtime/ext/gd/ext_gd.cpp
+++ b/hphp/runtime/ext/gd/ext_gd.cpp
@@ -4725,7 +4725,7 @@ const StaticString s_size("size");
 
 Variant HHVM_FUNCTION(iptcembed, const String& iptcdata,
     const String& jpeg_file_name, int64_t spool /* = 0 */) {
-  char psheader[] = "\xFF\xED\0\0Photoshop 3.0\08BIM\x04\x04\0\0\0\0";
+  char psheader[] = "\xFF\xED\0\0Photoshop 3.0\x008BIM\x04\x04\0\0\0\0";
   unsigned int iptcdata_len = iptcdata.length();
   unsigned int marker, inx;
   unsigned char *spoolbuf = nullptr, *poi = nullptr;

--- a/hphp/runtime/ext/gd/libgd/gd_interpolation.cpp
+++ b/hphp/runtime/ext/gd/libgd/gd_interpolation.cpp
@@ -77,6 +77,10 @@ using std::abs;
 
 #define CLAMP(x, low, high)  (((x) > (high)) ? (high) : (((x) < (low)) ? (low) : (x)))
 
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+
 /* only used here, let do a generic fixed point integers later if required by other
    part of GD */
 typedef long gdFixed;

--- a/hphp/runtime/ext/gd/libgd/gdkanji.cpp
+++ b/hphp/runtime/ext/gd/libgd/gdkanji.cpp
@@ -16,13 +16,17 @@
 #endif
 #endif
 
+#ifndef ICONV_CONST
+# define ICONV_CONST
+#endif
+
 #if defined(HAVE_ICONV_H) && !defined(HAVE_ICONV)
 #define HAVE_ICONV 1
 #endif
 
 #define LIBNAME "any2eucjp()"
 
-#if defined(__MSC__) || defined(__BORLANDC__) || defined(__TURBOC__) || defined(_Windows) || defined(MSDOS)
+#if defined(_MSC_VER) || defined(__BORLANDC__) || defined(__TURBOC__) || defined(_Windows) || defined(MSDOS)
 #ifndef SJISPRE
 #define SJISPRE 1
 #endif
@@ -363,7 +367,7 @@ do_convert (unsigned char *to, unsigned char *from, const char *code)
   from_len = strlen ((const char *) from) + 1;
   to_len = BUFSIZ;
 
-  if ((int) iconv(cd, (char **) &from, &from_len, (char **) &to, &to_len) == -1)
+  if ((int) iconv(cd, (ICONV_CONST char **) &from, &from_len, (char **) &to, &to_len) == -1)
     {
 #ifdef HAVE_ERRNO_H
       if (errno == EINVAL)

--- a/hphp/runtime/ext/gd/libgd/gdkanji.cpp
+++ b/hphp/runtime/ext/gd/libgd/gdkanji.cpp
@@ -26,7 +26,8 @@
 
 #define LIBNAME "any2eucjp()"
 
-#if defined(_MSC_VER) || defined(__BORLANDC__) || defined(__TURBOC__) || defined(_Windows) || defined(MSDOS)
+#if defined(_MSC_VER) || defined(__BORLANDC__) || \
+    defined(__TURBOC__) || defined(_Windows) || defined(MSDOS)
 #ifndef SJISPRE
 #define SJISPRE 1
 #endif
@@ -367,7 +368,8 @@ do_convert (unsigned char *to, unsigned char *from, const char *code)
   from_len = strlen ((const char *) from) + 1;
   to_len = BUFSIZ;
 
-  if ((int) iconv(cd, (ICONV_CONST char **) &from, &from_len, (char **) &to, &to_len) == -1)
+  if ((int) iconv(cd, (ICONV_CONST char **) &from,
+                  &from_len, (char **) &to, &to_len) == -1)
     {
 #ifdef HAVE_ERRNO_H
       if (errno == EINVAL)


### PR DESCRIPTION
The first fix might actually be a fix for all compilers, but it was done because MSVC complains about the `8` being present in what it thinks is an octal escape sequence.
This also adds an ICONV_CONST fix to the iconv use.