### PR TITLE
[MSVC] <cctype> is important

### DIFF
--- a/hphp/runtime/server/access-log.cpp
+++ b/hphp/runtime/server/access-log.cpp
@@ -17,6 +17,7 @@
 
 #include <sstream>
 #include <string>
+#include <cctype>
 #include <cstdio>
 #include <cstdlib>
 

--- a/hphp/runtime/server/log-writer.cpp
+++ b/hphp/runtime/server/log-writer.cpp
@@ -16,6 +16,7 @@
 
 #include "hphp/runtime/server/log-writer.h"
 
+#include <cctype>
 #include <sstream>
 #include <map>
 


### PR DESCRIPTION
And must be included for MSVC to resolve `std::isalpha` and `std::isspace` in the context where they were referenced in 6f79bee.