### PR TITLE
Fix for compiling with GCC 5.2

### DIFF
--- a/hphp/runtime/vm/jit/phys-reg.h
+++ b/hphp/runtime/vm/jit/phys-reg.h
@@ -151,8 +151,8 @@ struct PhysReg {
   template<typename T>
   struct Map {
     Map() {
-      // Workaround for a potential GCC 5 bug, value initializing m_elms seems to
-      // use zero-initialization instead of default initialization.
+      // Workaround for a potential GCC 5 bug, value initializing m_elms seems
+      // to use zero-initialization instead of default initialization.
       for (auto& elm : m_elms) {
         elm = T();
       }

--- a/hphp/runtime/vm/jit/phys-reg.h
+++ b/hphp/runtime/vm/jit/phys-reg.h
@@ -150,7 +150,9 @@ struct PhysReg {
    */
   template<typename T>
   struct Map {
-    Map() : m_elms() {
+  Map() {
+      for (int i = 0; i < kMaxRegs; i++)
+        m_elms[i] = T();
     }
 
     T& operator[](const PhysReg& r) {
@@ -204,7 +206,7 @@ struct PhysReg {
       return { m_elms, sizeof(m_elms) / sizeof(m_elms[0]) };
     }
 
-   private:
+  private:
     T m_elms[kMaxRegs];
   };
 

--- a/hphp/runtime/vm/jit/phys-reg.h
+++ b/hphp/runtime/vm/jit/phys-reg.h
@@ -150,9 +150,12 @@ struct PhysReg {
    */
   template<typename T>
   struct Map {
-  Map() {
-      for (int i = 0; i < kMaxRegs; i++)
-        m_elms[i] = T();
+    Map() {
+      // Workaround for a potential GCC 5 bug, value initializing m_elms seems to
+      // use zero-initialization instead of default initialization.
+      for (auto& elm : m_elms) {
+        elm = T();
+      }
     }
 
     T& operator[](const PhysReg& r) {

--- a/hphp/runtime/vm/jit/service-requests.cpp
+++ b/hphp/runtime/vm/jit/service-requests.cpp
@@ -109,7 +109,7 @@ void emit_svcreq(CodeBlock& cb,
       }
       live_out |= r;
     }
-    FTRACE(2, ") : stub@{}");
+    FTRACE(2, ") : stub@");
 
     if (persist) {
       FTRACE(2, "<none>");

--- a/hphp/runtime/vm/jit/vasm-arm.cpp
+++ b/hphp/runtime/vm/jit/vasm-arm.cpp
@@ -222,11 +222,6 @@ void Vgen::emit(const copy& i) {
 
 void Vgen::emit(const copy2& i) {
   MovePlan moves;
-  for (auto reg : moves) {
-    // Work around what appears to be a bug in GCC 5. The MovePlan is
-    // initialized with register #0 instead of InvalidReg (-1).
-    moves[reg] = InvalidReg;
-  }
   Reg64 d0 = i.d0, d1 = i.d1, s0 = i.s0, s1 = i.s1;
   moves[d0] = s0;
   moves[d1] = s1;

--- a/hphp/runtime/vm/jit/vasm-arm.cpp
+++ b/hphp/runtime/vm/jit/vasm-arm.cpp
@@ -221,7 +221,12 @@ void Vgen::emit(const copy& i) {
 }
 
 void Vgen::emit(const copy2& i) {
-  PhysReg::Map<PhysReg> moves;
+  MovePlan moves;
+  for (auto reg : moves) {
+    // Work around what appears to be a bug in GCC 5. The MovePlan is
+    // initialized with register #0 instead of InvalidReg (-1).
+    moves[reg] = InvalidReg;
+  }
   Reg64 d0 = i.d0, d1 = i.d1, s0 = i.s0, s1 = i.s1;
   moves[d0] = s0;
   moves[d1] = s1;

--- a/hphp/runtime/vm/jit/vasm-xls.cpp
+++ b/hphp/runtime/vm/jit/vasm-xls.cpp
@@ -2043,6 +2043,10 @@ void Vxls::insertCopiesAt(jit::vector<Vinstr>& code, unsigned& j,
   MovePlan moves;
   jit::vector<Vinstr> loads;
   for (auto dst : copies) {
+    // Work around what appears to be a bug in GCC 5. The MovePlan is
+    // initialized with register #0 instead of InvalidReg (-1).
+    moves[dst] = InvalidReg;
+
     auto ivl = copies[dst];
     if (!ivl) continue;
     if (ivl->reg != InvalidReg) {

--- a/hphp/runtime/vm/jit/vasm-xls.cpp
+++ b/hphp/runtime/vm/jit/vasm-xls.cpp
@@ -2043,10 +2043,6 @@ void Vxls::insertCopiesAt(jit::vector<Vinstr>& code, unsigned& j,
   MovePlan moves;
   jit::vector<Vinstr> loads;
   for (auto dst : copies) {
-    // Work around what appears to be a bug in GCC 5. The MovePlan is
-    // initialized with register #0 instead of InvalidReg (-1).
-    moves[dst] = InvalidReg;
-
     auto ivl = copies[dst];
     if (!ivl) continue;
     if (ivl->reg != InvalidReg) {


### PR DESCRIPTION
For some reason, the MovePlan was being initialized with the wrong
values, specifically register #0 instead of InvalidReg like it is
supposed to. This meant that the entire move plan started out
representing a move from register #0 to every other physical register.

The extra copies generated bloated the code blowing, through the
translation caches almost immediately (each copy instruction would turn
into 32 copy instructions). This resulted in HHVM being unable to start
at all.

This patch explicitly sets the map's contents to InvalidReg as a
workaround.