### PR TITLE
Remove support for old versions of timelib in dateinterval.h

### DIFF
--- a/hphp/runtime/base/dateinterval.cpp
+++ b/hphp/runtime/base/dateinterval.cpp
@@ -71,15 +71,11 @@ bool DateInterval::setInterval(const String& date_interval) {
   timelib_rel_time *di = nullptr;
   timelib_error_container *errors = nullptr;
 
-#ifdef TIMELIB_HAVE_INTERVAL
   timelib_time *start = nullptr, *end = nullptr;
   int r = 0;
 
   timelib_strtointerval((char*)date_interval.data(), date_interval.size(),
                         &start, &end, &di, &r, &errors);
-#else
-  throw_not_implemented("timelib too old");
-#endif
 
   int error_count  = errors->error_count;
   DateTime::setLastErrors(errors);
@@ -87,13 +83,11 @@ bool DateInterval::setInterval(const String& date_interval) {
     timelib_rel_time_dtor(di);
     return false;
   } else {
-#ifdef TIMELIB_HAVE_INTERVAL
     if (UNLIKELY(!di && start && end)) {
       timelib_update_ts(start, nullptr);
       timelib_update_ts(end, nullptr);
       di = timelib_diff(start, end);
     }
-#endif
     m_di = DateIntervalPtr(di, dateinterval_deleter());
     return true;
   }

--- a/hphp/runtime/base/datetime.cpp
+++ b/hphp/runtime/base/datetime.cpp
@@ -492,13 +492,11 @@ void DateTime::internalModifyRelative(timelib_rel_time *rel,
   m_time->relative.s = rel->s * bias;
   m_time->relative.weekday = rel->weekday;
   m_time->have_relative = have_relative;
-#ifdef TIMELIB_HAVE_INTERVAL
   m_time->relative.special = rel->special;
   m_time->relative.have_special_relative = rel->have_special_relative;
   m_time->relative.have_weekday_relative = rel->have_weekday_relative;
   m_time->relative.weekday_behavior = rel->weekday_behavior;
   m_time->relative.first_last_day_of = rel->first_last_day_of;
-#endif
   m_time->sse_uptodate = 0;
   update();
   timelib_update_from_sse(m_time.get());
@@ -506,12 +504,12 @@ void DateTime::internalModifyRelative(timelib_rel_time *rel,
 
 void DateTime::add(const req::ptr<DateInterval>& interval) {
   timelib_rel_time *rel = interval->get();
-  internalModifyRelative(rel, true, TIMELIB_REL_INVERT(rel) ? -1 :  1);
+  internalModifyRelative(rel, true, rel->invert ? -1 :  1);
 }
 
 void DateTime::sub(const req::ptr<DateInterval>& interval) {
   timelib_rel_time *rel = interval->get();
-  internalModifyRelative(rel, true, TIMELIB_REL_INVERT(rel) ?  1 : -1);
+  internalModifyRelative(rel, true, rel->invert ?  1 : -1);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -851,13 +849,9 @@ bool DateTime::fromString(const String& input, req::ptr<TimeZone> tz,
   struct timelib_error_container *error;
   timelib_time *t;
   if (format) {
-#ifdef TIMELIB_HAVE_INTERVAL
     t = timelib_parse_from_format((char*)format, (char*)input.data(),
                                   input.size(), &error, TimeZone::GetDatabase(),
                                   TimeZone::GetTimeZoneInfoRaw);
-#else
-    throw_not_implemented("timelib version too old");
-#endif
   } else {
     t = timelib_strtotime((char*)input.data(), input.size(),
                                  &error, TimeZone::GetDatabase(),
@@ -918,15 +912,11 @@ req::ptr<DateTime> DateTime::cloneDateTime() const {
 
 req::ptr<DateInterval>
 DateTime::diff(req::ptr<DateTime> datetime2, bool absolute) {
-#ifdef TIMELIB_HAVE_INTERVAL
   timelib_rel_time *rel = timelib_diff(m_time.get(), datetime2.get()->m_time.get());
   if (absolute) {
-    TIMELIB_REL_INVERT_SET(rel, 0);
+    rel->invert = 0;
   }
   return req::make<DateInterval>(rel);
-#else
-  throw_not_implemented("timelib version too old");
-#endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/hphp/runtime/base/timezone.cpp
+++ b/hphp/runtime/base/timezone.cpp
@@ -343,14 +343,10 @@ Array TimeZone::getLocation() const {
   Array ret;
   if (!m_tzi) return ret;
 
-#ifdef TIMELIB_HAVE_TZLOCATION
   ret.set(s_country_code, String(m_tzi->location.country_code, CopyString));
   ret.set(s_latitude,     m_tzi->location.latitude);
   ret.set(s_longitude,    m_tzi->location.longitude);
   ret.set(s_comments,     String(m_tzi->location.comments, CopyString));
-#else
-  throw_not_implemented("timelib version too old");
-#endif
 
   return ret;
 }

--- a/hphp/runtime/base/timezone.h
+++ b/hphp/runtime/base/timezone.h
@@ -21,10 +21,11 @@
 #include "hphp/runtime/base/type-string.h"
 #include "hphp/system/constants.h"
 
-extern "C" {
-#include <timelib.h>
 #include <map>
 #include <memory>
+
+extern "C" {
+#include <timelib.h>
 }
 
 namespace HPHP {


### PR DESCRIPTION
We already unconditionally use the timelib bundled in hhvm-third-party, and that version is new enough to have these things, so there's no need for these compatibility macros.

This also moves a couple of C++ includes that were being done inside an `extern "C"` block, which, if they hadn't already been included by something else, definitely would not have worked.