### PR TITLE
Fix mysqli_get_charset fataling every call

### DIFF
--- a/hphp/runtime/ext/mysql/ext_mysqli.php
+++ b/hphp/runtime/ext/mysql/ext_mysqli.php
@@ -256,16 +256,19 @@ class mysqli {
     return $this->real_escape_string($escapestr);
   }
 
-  /**
+ /**
    * Returns a character set object
    *
-   * @return object - The function returns a character set object with
-   *   the following properties:   charset Character set name   collation
-   *   Collation name   dir Directory the charset description was fetched
-   *   from (?) or "" for built-in character sets   min_length Minimum
-   *   character length in bytes   max_length Maximum character length in
-   *   bytes   number Internal character set number   state Character set
-   *   status (?)
+   * @return object - The function returns a character set object with the
+   *   following properties:   
+   *   - charset Character set name
+   *   - collation Collation name
+   *   - dir Directory the charset description was fetched from (?) or "" for
+   *         built-in character sets
+   *   - min_length Minimum character length in bytes
+   *   - max_length Maximum character length in bytes
+   *   - number Internal character set number
+   *   - state Character set status (?)
    */
   <<__Native>>
   public function get_charset(): mixed;
@@ -1714,14 +1717,17 @@ function mysqli_field_count(mysqli $link): ?int {
  * @param mysqli $link -
  *
  * @return object - The function returns a character set object with the
- *   following properties:   charset Character set name   collation
- *   Collation name   dir Directory the charset description was fetched
- *   from (?) or "" for built-in character sets   min_length Minimum
- *   character length in bytes   max_length Maximum character length in
- *   bytes   number Internal character set number   state Character set
- *   status (?)
+ *   following properties:   
+ *   - charset Character set name
+ *   - collation Collation name
+ *   - dir Directory the charset description was fetched from (?) or "" for
+ *         built-in character sets
+ *   - min_length Minimum character length in bytes
+ *   - max_length Maximum character length in bytes
+ *   - number Internal character set number
+ *   - state Character set status (?)
  */
-function mysqli_get_charset(mysqli $link): object {
+function mysqli_get_charset(mysqli $link): mixed {
   return $link->get_charset();
 }
 

--- a/hphp/test/slow/ext_mysqli/get_charset.php
+++ b/hphp/test/slow/ext_mysqli/get_charset.php
@@ -1,0 +1,13 @@
+<?php
+
+$host   = getenv("MYSQL_TEST_HOST")   ? getenv("MYSQL_TEST_HOST") : "localhost";
+$port   = getenv("MYSQL_TEST_PORT")   ? getenv("MYSQL_TEST_PORT") : 3306;
+$user   = getenv("MYSQL_TEST_USER")   ? getenv("MYSQL_TEST_USER") : "root";
+$passwd = getenv("MYSQL_TEST_PASSWD") ? getenv("MYSQL_TEST_PASSWD") : "";
+$db     = getenv("MYSQL_TEST_DB")     ? getenv("MYSQL_TEST_DB") : "test";
+
+$mysqli = new mysqli($host, $user, $passwd, $db, $port);
+
+$mysqli->set_charset("utf8");
+var_dump($mysqli->get_charset()->charset);
+var_dump(mysqli_get_charset($mysqli)->charset);

--- a/hphp/test/slow/ext_mysqli/get_charset.php.expect
+++ b/hphp/test/slow/ext_mysqli/get_charset.php.expect
@@ -1,0 +1,2 @@
+string(4) "utf8"
+string(4) "utf8"

--- a/hphp/test/slow/ext_mysqli/get_charset.php.skipif
+++ b/hphp/test/slow/ext_mysqli/get_charset.php.skipif
@@ -1,0 +1,2 @@
+<?php
+if (!getenv('MYSQL_TEST_HOST')) echo 'skip';


### PR DESCRIPTION
StdClass can only be typed as mixed apparently.
When this was introduced,  mysqli::get_charset was changed but
mysqli_get_charset was forgotten.

Closes #6231

Test Plan:
new test, be aware that this test probably doesn't get executed in sandcastle