### PR TITLE
Replace translator-asm-helpers.S' magic registers to synonyms as defined by abi

### DIFF
--- a/hphp/runtime/vm/jit/abi-x64.h
+++ b/hphp/runtime/vm/jit/abi-x64.h
@@ -36,6 +36,7 @@ namespace x64 {
 
 const Abi& abi(CodeKind kind = CodeKind::Trace);
 
+/* VM registers must match etch-helpers.h definitions! */
 constexpr PhysReg rvmfp() { return reg::rbp; }
 constexpr PhysReg rvmsp() { return reg::rbx; }
 constexpr PhysReg rvmtl() { return reg::r12; }

--- a/hphp/runtime/vm/jit/translator-asm-helpers.S
+++ b/hphp/runtime/vm/jit/translator-asm-helpers.S
@@ -106,9 +106,9 @@ ETCH_LABEL(enterTCHelper$prologue):
 /*
  * handleSRHelper
  *
- * Translated code will jump to this stub to perform all
- * service requests. It calls out to C++ to handle the request, then jumps
- * to the returned address (which may be the callToExit stub).
+ * Translated code will jump to this stub to perform all service requests. It
+ * calls out to C++ to handle the request, then jumps to the returned address
+ * (which may be the callToExit stub).
  *
  * The columns are registers of:
  * X64 ABI

--- a/hphp/runtime/vm/jit/translator-asm-helpers.S
+++ b/hphp/runtime/vm/jit/translator-asm-helpers.S
@@ -33,7 +33,7 @@ ETCH_NAME(enterTCHelper):
   ETCH_GET_ARG5
   ETCH_GET_ARG6
 
-  push %rbp
+  push ETCH_R_VM_FP
   CFI2(adjust_cfa_offset, 8) // cfa is now 8 bytes further from rsp than it was before
   CFI3C(offset, rbp, -16)    // Where to find previous value of rbp, relative to cfa
 
@@ -41,9 +41,9 @@ ETCH_NAME(enterTCHelper):
   mov %rsp, (ETCH_ARG4)
 
   // Set up special registers used for translated code.
-  mov ETCH_ARG1, %rbx          // rVmSp
-  mov ETCH_ARG5, %r12          // rVmTl
-  mov ETCH_ARG2, %rbp          // rVmFp
+  mov ETCH_ARG1, ETCH_R_VM_SP
+  mov ETCH_ARG5, ETCH_R_VM_TL
+  mov ETCH_ARG2, ETCH_R_VM_FP
 
   sub $8, %rsp // align native stack
   CFI2(adjust_cfa_offset, 8)
@@ -63,7 +63,7 @@ ETCH_NAME(enterTCHelper):
   jz ETCH_LABEL(enterTCHelper$callTC)
   push ETCH_NAME_REL(enterTCExit)
   push 0x8(ETCH_ARG6)
-  mov ETCH_ARG6, %rbp
+  mov ETCH_ARG6, ETCH_R_VM_FP
   call ETCH_LABEL(enterTCHelper$prologue)
 
   /*
@@ -85,13 +85,13 @@ ETCH_NAME(enterTCExit):
   /*
    * Eager vm-reg save. Must match values in rds-header.h
    */
-  mov %rbx, 0x10(%r12)
-  mov %rbp, 0x20(%r12)
+  mov ETCH_R_VM_SP, 0x10(ETCH_R_VM_TL)
+  mov ETCH_R_VM_FP, 0x20(ETCH_R_VM_TL)
   add $8, %rsp
   CFI2(adjust_cfa_offset, -8)
 
   // Epilogue
-  pop %rbp
+  pop ETCH_R_VM_FP
   CFI2(restore, rbp)
   CFI2(adjust_cfa_offset, -8)
   ret
@@ -113,8 +113,8 @@ ETCH_NAME(handleSRHelper):
   CFI(startproc)
 
   // Sync vmsp & vmfp
-  mov %rbx, 0x10(%r12)
-  mov %rbp, 0x20(%r12)
+  mov ETCH_R_VM_SP, 0x10(ETCH_R_VM_TL)
+  mov ETCH_R_VM_FP, 0x20(ETCH_R_VM_TL)
 
   // Push a ServiceReqInfo struct onto the stack and call handleServiceRequest.
   push %r8
@@ -136,8 +136,8 @@ ETCH_NAME(handleSRHelper):
 
   // rVmTl was preserved by the callee, but vmsp and vmfp might've changed if
   // we interpreted anything. Reload them.
-  mov 0x10(%r12), %rbx
-  mov 0x20(%r12), %rbp
+  mov 0x10(ETCH_R_VM_TL), ETCH_R_VM_SP
+  mov 0x20(ETCH_R_VM_TL), ETCH_R_VM_FP
 
   jmp *%rax
   CFI(endproc)

--- a/hphp/runtime/vm/jit/translator-asm-helpers.S
+++ b/hphp/runtime/vm/jit/translator-asm-helpers.S
@@ -116,7 +116,7 @@ ETCH_NAME(handleSRHelper):
   mov ETCH_R_VM_SP, 0x10(ETCH_R_VM_TL)
   mov ETCH_R_VM_FP, 0x20(ETCH_R_VM_TL)
 
-  // Push a ServiceReqInfo struct onto the stack and call handleServiceRequest.
+  // Push a ReqInfo struct onto the stack and call handleServiceRequest.
   push %r8
   push %rcx
   push %rdx
@@ -130,7 +130,7 @@ ETCH_NAME(handleSRHelper):
   mov %rsp, ETCH_ARG2
   call MCGenerator_handleServiceRequest
 
-  // Pop the ServiceReqInfo off the stack.
+  // Pop the ReqInfo struct off the stack.
   add $0x30, %rsp
   CFI2(adjust_cfa_offset, -0x30)
 

--- a/hphp/runtime/vm/jit/translator-asm-helpers.S
+++ b/hphp/runtime/vm/jit/translator-asm-helpers.S
@@ -33,7 +33,7 @@ ETCH_NAME(enterTCHelper):
   ETCH_GET_ARG5
   ETCH_GET_ARG6
 
-  push ETCH_R_VM_FP
+  push ETCH_VMFP
   CFI2(adjust_cfa_offset, 8) // cfa is now 8 bytes further from rsp than it was before
   CFI3C(offset, rbp, -16)    // Where to find previous value of rbp, relative to cfa
 
@@ -41,9 +41,9 @@ ETCH_NAME(enterTCHelper):
   mov %rsp, (ETCH_ARG4)
 
   // Set up special registers used for translated code.
-  mov ETCH_ARG1, ETCH_R_VM_SP
-  mov ETCH_ARG5, ETCH_R_VM_TL
-  mov ETCH_ARG2, ETCH_R_VM_FP
+  mov ETCH_ARG1, ETCH_VMSP
+  mov ETCH_ARG5, ETCH_VMTL
+  mov ETCH_ARG2, ETCH_VMFP
 
   sub $8, %rsp // align native stack
   CFI2(adjust_cfa_offset, 8)
@@ -63,7 +63,7 @@ ETCH_NAME(enterTCHelper):
   jz ETCH_LABEL(enterTCHelper$callTC)
   push ETCH_NAME_REL(enterTCExit)
   push 0x8(ETCH_ARG6)
-  mov ETCH_ARG6, ETCH_R_VM_FP
+  mov ETCH_ARG6, ETCH_VMFP
   call ETCH_LABEL(enterTCHelper$prologue)
 
   /*
@@ -85,13 +85,13 @@ ETCH_NAME(enterTCExit):
   /*
    * Eager vm-reg save. Must match values in rds-header.h
    */
-  mov ETCH_R_VM_SP, 0x10(ETCH_R_VM_TL)
-  mov ETCH_R_VM_FP, 0x20(ETCH_R_VM_TL)
+  mov ETCH_VMSP, 0x10(ETCH_VMTL)
+  mov ETCH_VMFP, 0x20(ETCH_VMTL)
   add $8, %rsp
   CFI2(adjust_cfa_offset, -8)
 
   // Epilogue
-  pop ETCH_R_VM_FP
+  pop ETCH_VMFP
   CFI2(restore, rbp)
   CFI2(adjust_cfa_offset, -8)
   ret
@@ -126,8 +126,8 @@ ETCH_NAME(handleSRHelper):
   CFI(startproc)
 
   // Sync vmsp & vmfp
-  mov ETCH_R_VM_SP, 0x10(ETCH_R_VM_TL)
-  mov ETCH_R_VM_FP, 0x20(ETCH_R_VM_TL)
+  mov ETCH_VMSP, 0x10(ETCH_VMTL)
+  mov ETCH_VMFP, 0x20(ETCH_VMTL)
 
   // Push a ReqInfo struct onto the stack and call handleServiceRequest.
   push ETCH_SVCREQ_ARG4
@@ -149,8 +149,8 @@ ETCH_NAME(handleSRHelper):
 
   // rVmTl was preserved by the callee, but vmsp and vmfp might've changed if
   // we interpreted anything. Reload them.
-  mov 0x10(ETCH_R_VM_TL), ETCH_R_VM_SP
-  mov 0x20(ETCH_R_VM_TL), ETCH_R_VM_FP
+  mov 0x10(ETCH_VMTL), ETCH_VMSP
+  mov 0x20(ETCH_VMTL), ETCH_VMFP
 
   jmp *ETCH_RET1
 

--- a/hphp/runtime/vm/jit/translator-asm-helpers.S
+++ b/hphp/runtime/vm/jit/translator-asm-helpers.S
@@ -103,9 +103,22 @@ ETCH_LABEL(enterTCHelper$prologue):
   CFI(endproc)
   ETCH_SIZE(enterTCHelper)
 
-  // handleSRHelper: Translated code will jump to this stub to perform all
-  // service requests. It calls out to C++ to handle the request, then jumps
-  // to the returned address (which may be the callToExit stub).
+/*
+ * handleSRHelper
+ *
+ * Translated code will jump to this stub to perform all
+ * service requests. It calls out to C++ to handle the request, then jumps
+ * to the returned address (which may be the callToExit stub).
+ *
+ * The columns are registers of:
+ * X64 ABI
+ *   rdi:  ServiceRequest req (r_svcreq_req)
+ *   r10:  TCA stub (r_svcreq_stub)
+ *   rsi:  args[0]
+ *   rdx:  args[1]
+ *   rcx:  args[2]
+ *   r8 :  args[3]
+ */
   ETCH_ALIGN16
   ETCH_SECTION(handleSRHelper)
   .globl ETCH_NAME(handleSRHelper)
@@ -117,12 +130,12 @@ ETCH_NAME(handleSRHelper):
   mov ETCH_R_VM_FP, 0x20(ETCH_R_VM_TL)
 
   // Push a ReqInfo struct onto the stack and call handleServiceRequest.
-  push %r8
-  push %rcx
-  push %rdx
-  push %rsi
-  push %r10
-  push %rdi
+  push ETCH_SVCREQ_ARG4
+  push ETCH_SVCREQ_ARG3
+  push ETCH_SVCREQ_ARG2
+  push ETCH_SVCREQ_ARG1
+  push ETCH_SVCREQ_STUB
+  push ETCH_SVCREQ_REQ
   CFI2(adjust_cfa_offset, 0x30)
 
   // call mcg->handleServiceRequest(%rsp)
@@ -139,7 +152,8 @@ ETCH_NAME(handleSRHelper):
   mov 0x10(ETCH_R_VM_TL), ETCH_R_VM_SP
   mov 0x20(ETCH_R_VM_TL), ETCH_R_VM_FP
 
-  jmp *%rax
+  jmp *ETCH_RET1
+
   CFI(endproc)
   ETCH_SIZE(handleSRHelper)
 

--- a/hphp/util/etch-helpers.h
+++ b/hphp/util/etch-helpers.h
@@ -26,9 +26,9 @@
 #define ETCH_GET_ARG6     mov 0x30(%rsp), %r11
 #define ETCH_RET1         %rax
 /* VM Registers must match definition on abi-x64.h */
-#define ETCH_R_VM_FP      %rbp
-#define ETCH_R_VM_SP      %rbx
-#define ETCH_R_VM_TL      %r12
+#define ETCH_VMFP         %rbp
+#define ETCH_VMSP         %rbx
+#define ETCH_VMTL         %r12
 /* Service Request Registers must match svcreq_args list on abi-x64.cpp */
 #define ETCH_SVCREQ_REQ   %rdi
 #define ETCH_SVCREQ_STUB  %r10
@@ -60,9 +60,9 @@
 #define ETCH_GET_ARG6     /* not used */
 #define ETCH_RET1         %rax
 /* VM Registers must match definition on abi-x64.h */
-#define ETCH_R_VM_FP      %rbp
-#define ETCH_R_VM_SP      %rbx
-#define ETCH_R_VM_TL      %r12
+#define ETCH_VMFP         %rbp
+#define ETCH_VMSP         %rbx
+#define ETCH_VMTL         %r12
 /* Service Request Registers must match svcreq_args list on abi-x64.cpp */
 #define ETCH_SVCREQ_REQ   %rdi
 #define ETCH_SVCREQ_STUB  %r10
@@ -94,9 +94,9 @@
 #define ETCH_GET_ARG6     /* not used */
 #define ETCH_RET1         %rax
 /* VM Registers must match definition on abi-x64.h */
-#define ETCH_R_VM_FP      %rbp
-#define ETCH_R_VM_SP      %rbx
-#define ETCH_R_VM_TL      %r12
+#define ETCH_VMFP         %rbp
+#define ETCH_VMSP         %rbx
+#define ETCH_VMTL         %r12
 /* Service Request Registers must match svcreq_args list on abi-x64.cpp */
 #define ETCH_SVCREQ_REQ   %rdi
 #define ETCH_SVCREQ_STUB  %r10

--- a/hphp/util/etch-helpers.h
+++ b/hphp/util/etch-helpers.h
@@ -29,6 +29,13 @@
 #define ETCH_R_VM_FP      %rbp
 #define ETCH_R_VM_SP      %rbx
 #define ETCH_R_VM_TL      %r12
+/* Service Request Registers must match svcreq_args list on abi-x64.cpp */
+#define ETCH_SVCREQ_REQ   %rdi
+#define ETCH_SVCREQ_STUB  %r10
+#define ETCH_SVCREQ_ARG1  %rsi
+#define ETCH_SVCREQ_ARG2  %rdx
+#define ETCH_SVCREQ_ARG3  %rcx
+#define ETCH_SVCREQ_ARG4  %r8
 
 #elif defined(__APPLE__)
 #define CFI(x)            .cfi_##x
@@ -56,6 +63,13 @@
 #define ETCH_R_VM_FP      %rbp
 #define ETCH_R_VM_SP      %rbx
 #define ETCH_R_VM_TL      %r12
+/* Service Request Registers must match svcreq_args list on abi-x64.cpp */
+#define ETCH_SVCREQ_REQ   %rdi
+#define ETCH_SVCREQ_STUB  %r10
+#define ETCH_SVCREQ_ARG1  %rsi
+#define ETCH_SVCREQ_ARG2  %rdx
+#define ETCH_SVCREQ_ARG3  %rcx
+#define ETCH_SVCREQ_ARG4  %r8
 
 #else /* Other x86 (e.g. linux) */
 #define CFI(x)            .cfi_##x
@@ -83,6 +97,13 @@
 #define ETCH_R_VM_FP      %rbp
 #define ETCH_R_VM_SP      %rbx
 #define ETCH_R_VM_TL      %r12
+/* Service Request Registers must match svcreq_args list on abi-x64.cpp */
+#define ETCH_SVCREQ_REQ   %rdi
+#define ETCH_SVCREQ_STUB  %r10
+#define ETCH_SVCREQ_ARG1  %rsi
+#define ETCH_SVCREQ_ARG2  %rdx
+#define ETCH_SVCREQ_ARG3  %rcx
+#define ETCH_SVCREQ_ARG4  %r8
 #endif
 
 #endif // incl_ETCH_HELPERS_H

--- a/hphp/util/etch-helpers.h
+++ b/hphp/util/etch-helpers.h
@@ -24,6 +24,10 @@
  * since Windows only has four registers args in its ABI */
 #define ETCH_GET_ARG5   mov 0x28(%rsp), %r10
 #define ETCH_GET_ARG6   mov 0x30(%rsp), %r11
+/* VM Registers must match definition on abi-x64.h */
+#define ETCH_R_VM_FP    %rbp
+#define ETCH_R_VM_SP    %rbx
+#define ETCH_R_VM_TL    %r12
 
 #elif defined(__APPLE__)
 #define CFI(x)          .cfi_##x
@@ -46,6 +50,10 @@
 #define ETCH_ARG6       %r9
 #define ETCH_GET_ARG5   /* not used */
 #define ETCH_GET_ARG6   /* not used */
+/* VM Registers must match definition on abi-x64.h */
+#define ETCH_R_VM_FP    %rbp
+#define ETCH_R_VM_SP    %rbx
+#define ETCH_R_VM_TL    %r12
 
 #else /* Other x86 (e.g. linux) */
 #define CFI(x)          .cfi_##x
@@ -68,6 +76,10 @@
 #define ETCH_ARG6       %r9
 #define ETCH_GET_ARG5   /* not used */
 #define ETCH_GET_ARG6   /* not used */
+/* VM Registers must match definition on abi-x64.h */
+#define ETCH_R_VM_FP    %rbp
+#define ETCH_R_VM_SP    %rbx
+#define ETCH_R_VM_TL    %r12
 #endif
 
 #endif // incl_ETCH_HELPERS_H

--- a/hphp/util/etch-helpers.h
+++ b/hphp/util/etch-helpers.h
@@ -2,84 +2,87 @@
 #define incl_ETCH_HELPERS_H
 
 #if defined(__CYGWIN__) || defined(__MINGW__) || defined(_MSC_VER)
-#define CFI(x)          .cfi_##x
-#define CFI2(x, y)      .cfi_##x y
-#define CFI3C(x, y, z)  .cfi_##x y##, z
-#define ETCH_ALIGN16    .align 16
-#define ETCH_ALIGN8     .align 8
-#define ETCH_ALIGN4     .align 4
-#define ETCH_SECTION(x) .section .text.x
-#define ETCH_SIZE(x)    /* Not used with PE/COFF on windows */
-#define ETCH_NAME(x)    x
-#define ETCH_LABEL(x)   .L##x
-#define ETCH_TYPE(x, y) /* Not used on Windows */
-#define ETCH_NAME_REL(x) $ x
-#define ETCH_ARG1       %rcx
-#define ETCH_ARG2       %rdx
-#define ETCH_ARG3       %r8
-#define ETCH_ARG4       %r9
-#define ETCH_ARG5       %r10  /* Use r10 here */
-#define ETCH_ARG6       %r11  /* Use r11 here */
+#define CFI(x)            .cfi_##x
+#define CFI2(x, y)        .cfi_##x y
+#define CFI3C(x, y, z)    .cfi_##x y##, z
+#define ETCH_ALIGN16      .align 16
+#define ETCH_ALIGN8       .align 8
+#define ETCH_ALIGN4       .align 4
+#define ETCH_SECTION(x)   .section .text.x
+#define ETCH_SIZE(x)      /* Not used with PE/COFF on windows */
+#define ETCH_NAME(x)      x
+#define ETCH_LABEL(x)     .L##x
+#define ETCH_TYPE(x, y)   /* Not used on Windows */
+#define ETCH_NAME_REL(x)  $ x
+#define ETCH_ARG1         %rcx
+#define ETCH_ARG2         %rdx
+#define ETCH_ARG3         %r8
+#define ETCH_ARG4         %r9
+#define ETCH_ARG5         %r10  /* Use r10 here */
+#define ETCH_ARG6         %r11  /* Use r11 here */
 /* Borrow scratch registers for the 5th and 6th args
  * since Windows only has four registers args in its ABI */
-#define ETCH_GET_ARG5   mov 0x28(%rsp), %r10
-#define ETCH_GET_ARG6   mov 0x30(%rsp), %r11
+#define ETCH_GET_ARG5     mov 0x28(%rsp), %r10
+#define ETCH_GET_ARG6     mov 0x30(%rsp), %r11
+#define ETCH_RET1         %rax
 /* VM Registers must match definition on abi-x64.h */
-#define ETCH_R_VM_FP    %rbp
-#define ETCH_R_VM_SP    %rbx
-#define ETCH_R_VM_TL    %r12
+#define ETCH_R_VM_FP      %rbp
+#define ETCH_R_VM_SP      %rbx
+#define ETCH_R_VM_TL      %r12
 
 #elif defined(__APPLE__)
-#define CFI(x)          .cfi_##x
-#define CFI2(x, y)      .cfi_##x y
-#define CFI3C(x, y, z)  .cfi_##x y##, z
-#define ETCH_ALIGN16    .align 4 // on OSX this is 2^value
-#define ETCH_ALIGN8     .align 3
-#define ETCH_ALIGN4     .align 2
-#define ETCH_SECTION(x) .text
-#define ETCH_SIZE(x)    /* not used on OSX */
-#define ETCH_NAME(x)    _##x
-#define ETCH_LABEL(x)   .L##_##x
-#define ETCH_TYPE(x, y) /* not used on OSX */
-#define ETCH_NAME_REL(x) _##x@GOTPCREL(%rip)
-#define ETCH_ARG1       %rdi
-#define ETCH_ARG2       %rsi
-#define ETCH_ARG3       %rdx
-#define ETCH_ARG4       %rcx
-#define ETCH_ARG5       %r8
-#define ETCH_ARG6       %r9
-#define ETCH_GET_ARG5   /* not used */
-#define ETCH_GET_ARG6   /* not used */
+#define CFI(x)            .cfi_##x
+#define CFI2(x, y)        .cfi_##x y
+#define CFI3C(x, y, z)    .cfi_##x y##, z
+#define ETCH_ALIGN16      .align 4 // on OSX this is 2^value
+#define ETCH_ALIGN8       .align 3
+#define ETCH_ALIGN4       .align 2
+#define ETCH_SECTION(x)   .text
+#define ETCH_SIZE(x)      /* not used on OSX */
+#define ETCH_NAME(x)      _##x
+#define ETCH_LABEL(x)     .L##_##x
+#define ETCH_TYPE(x, y)   /* not used on OSX */
+#define ETCH_NAME_REL(x)  _##x@GOTPCREL(%rip)
+#define ETCH_ARG1         %rdi
+#define ETCH_ARG2         %rsi
+#define ETCH_ARG3         %rdx
+#define ETCH_ARG4         %rcx
+#define ETCH_ARG5         %r8
+#define ETCH_ARG6         %r9
+#define ETCH_GET_ARG5     /* not used */
+#define ETCH_GET_ARG6     /* not used */
+#define ETCH_RET1         %rax
 /* VM Registers must match definition on abi-x64.h */
-#define ETCH_R_VM_FP    %rbp
-#define ETCH_R_VM_SP    %rbx
-#define ETCH_R_VM_TL    %r12
+#define ETCH_R_VM_FP      %rbp
+#define ETCH_R_VM_SP      %rbx
+#define ETCH_R_VM_TL      %r12
 
 #else /* Other x86 (e.g. linux) */
-#define CFI(x)          .cfi_##x
-#define CFI2(x, y)      .cfi_##x y
-#define CFI3C(x, y, z)  .cfi_##x y##, z
-#define ETCH_ALIGN16    .align 16
-#define ETCH_ALIGN8     .align 8
-#define ETCH_ALIGN4     .align 4
-#define ETCH_SECTION(x) .section .text.x,"ax"
-#define ETCH_SIZE(x)    .size x, .-x
-#define ETCH_NAME(x)    x
-#define ETCH_LABEL(x)   .L##x
-#define ETCH_TYPE(x, y) .type x, y
-#define ETCH_NAME_REL(x) $ x
-#define ETCH_ARG1       %rdi
-#define ETCH_ARG2       %rsi
-#define ETCH_ARG3       %rdx
-#define ETCH_ARG4       %rcx
-#define ETCH_ARG5       %r8
-#define ETCH_ARG6       %r9
-#define ETCH_GET_ARG5   /* not used */
-#define ETCH_GET_ARG6   /* not used */
+#define CFI(x)            .cfi_##x
+#define CFI2(x, y)        .cfi_##x y
+#define CFI3C(x, y, z)    .cfi_##x y##, z
+#define ETCH_ALIGN16      .align 16
+#define ETCH_ALIGN8       .align 8
+#define ETCH_ALIGN4       .align 4
+#define ETCH_SECTION(x)   .section .text.x,"ax"
+#define ETCH_SIZE(x)      .size x, .-x
+#define ETCH_NAME(x)      x
+#define ETCH_LABEL(x)     .L##x
+#define ETCH_TYPE(x, y)   .type x, y
+#define ETCH_NAME_REL(x)  $ x
+#define ETCH_ARG1         %rdi
+#define ETCH_ARG2         %rsi
+#define ETCH_ARG3         %rdx
+#define ETCH_ARG4         %rcx
+#define ETCH_ARG5         %r8
+#define ETCH_ARG6         %r9
+#define ETCH_GET_ARG5     /* not used */
+#define ETCH_GET_ARG6     /* not used */
+#define ETCH_RET1         %rax
 /* VM Registers must match definition on abi-x64.h */
-#define ETCH_R_VM_FP    %rbp
-#define ETCH_R_VM_SP    %rbx
-#define ETCH_R_VM_TL    %r12
+#define ETCH_R_VM_FP      %rbp
+#define ETCH_R_VM_SP      %rbx
+#define ETCH_R_VM_TL      %r12
 #endif
 
 #endif // incl_ETCH_HELPERS_H


### PR DESCRIPTION
Summary: Improved code readability by replacing the following:
%rbx -> ETCH_R_VM_SP
%r12 -> ETCH_R_VM_TL
%rbp -> ETCH_R_VM_FP

This also reduces efforts to make new ports based on existing code.