### PR TITLE
Accept a const Variant& for Native::setProp

### DIFF
--- a/hphp/runtime/vm/native-prop-handler.cpp
+++ b/hphp/runtime/vm/native-prop-handler.cpp
@@ -101,11 +101,12 @@ Variant getProp(const Object& obj, const String& name) {
   return nph->get(obj, name);
 }
 
-Variant setProp(const Object& obj, const String& name, Variant& value) {
+Variant setProp(const Object& obj, const String& name, const Variant& value) {
   auto nph = obj->getVMClass()->getNativePropHandler();
   assert(nph);
   assert(nph->set);
-  return nph->set(obj, name, value);
+  Variant val = value;
+  return nph->set(obj, name, val);
 }
 
 Variant issetProp(const Object& obj, const String& name) {

--- a/hphp/runtime/vm/native-prop-handler.h
+++ b/hphp/runtime/vm/native-prop-handler.h
@@ -263,7 +263,7 @@ private:
  * Example: Native::getProp(this, propName);
  */
 Variant getProp(const Object& obj, const String& name);
-Variant setProp(const Object& obj, const String& name, Variant& value);
+Variant setProp(const Object& obj, const String& name, const Variant& value);
 Variant issetProp(const Object& obj, const String& name);
 Variant unsetProp(const Object& obj, const String& name);
 


### PR DESCRIPTION
The current API, which is not used anywhere in HHVM, poses some significant usability problems.

In order to call the current API without using a non-standard C++ extension (one that MSVC supports, but that HHVM doesn't use anywhere), in order to pass anything for the value parameter, it must already be in a `Variant` typed location, which leads to messes like this, where locals are created just to be able to call it:
```C++
auto thisObj = Object(this_);
auto ck = Variant(consumerKey);
Native::setProp(thisObj, OAuthAttr::ConsumerKey, ck);
Native::setProp(thisObj, OAuthAttr::ConsumerSecret, consSecret);
auto sm = Variant(sigMeth);
Native::setProp(thisObj, OAuthAttr::SigMethod, sm);
auto am = Variant(authMethod);
Native::setProp(thisObj, OAuthAttr::AuthMethod, am);
auto v = Variant("1.0");
Native::setProp(thisObj, OAuthAttr::OAuthNonce, v);
```

Note that, if you eliminate the locals and do the `Variant` construction directly in the param, it's a non-standard C++ extension:
```C++
Native::setProp(thisObj, OAuthAttr::OAuthNonce, Variant("1.0"));
```


By simply changing the `Native::setProp` function to accept a `const Variant&` rather than a `Variant&`, we can eliminate the need for all of this, and it also makes it possible to do it without even explicitly constructing the `Variant`, meaning the earlier code becomes:
```C++
auto thisObj = Object(this_);
Native::setProp(thisObj, OAuthAttr::ConsumerKey, consumerKey);
Native::setProp(thisObj, OAuthAttr::ConsumerSecret, consSecret);
Native::setProp(thisObj, OAuthAttr::SigMethod, sigMeth);
Native::setProp(thisObj, OAuthAttr::AuthMethod, authMethod);
Native::setProp(thisObj, OAuthAttr::OAuthNonce, "1.0");
```


I chose not to add the `const` all the way down the chain simply because there are things that use the underlying APIs, and I don't want to deal with changing them. (such a change would break every use of a `NativePropHandler`)