### PR TITLE
Fix Timezone transitions

### DIFF
--- a/hphp/runtime/base/timezone.cpp
+++ b/hphp/runtime/base/timezone.cpp
@@ -314,12 +314,12 @@ Array TimeZone::transitions(int64_t timestamp_begin, /* = k_PHP_INT_MIN */
       // first entry, otherwise find the transition before `timestamp_begin`
       uint32_t idx = 0;
       if (timecnt && m_tzi->trans) {
-          while (idx < timecnt && m_tzi->trans[idx] < timestamp_begin) {
-              idx++;
-          }
+        while (idx < timecnt && m_tzi->trans[idx] < timestamp_begin) {
+          idx++;
+        }
 
-          if (idx > 0) idx--;
-          idx = m_tzi->trans_idx[idx];
+        if (idx > 0) idx--;
+        idx = m_tzi->trans_idx[idx];
       }
       ret.append(make_map_array(
             s_ts, timestamp_begin,

--- a/hphp/runtime/base/timezone.cpp
+++ b/hphp/runtime/base/timezone.cpp
@@ -269,6 +269,7 @@ String TimeZone::name() const {
 
 String TimeZone::abbr(int type /* = 0 */) const {
   if (!m_tzi) return String();
+  assert(type < m_tzi->typecnt);
   return String(&m_tzi->timezone_abbr[m_tzi->type[type].abbr_idx], CopyString);
 }
 
@@ -296,19 +297,6 @@ Array TimeZone::transitions(int64_t timestamp_begin, /* = k_PHP_INT_MIN */
                             int64_t timestamp_end /* = k_PHP_INT_MAX */) const {
   Array ret;
   if (m_tzi) {
-    // If explicitly provided add the beginning timestamp to the ret array
-    if (timestamp_begin > k_PHP_INT_MIN) {
-      auto dt = req::make<DateTime>(timestamp_begin);
-      auto idx = m_tzi->trans_idx[0];
-      ret.append(make_map_array(
-            s_ts, timestamp_begin,
-            s_time, dt->toString(DateTime::DateFormat::ISO8601),
-            s_offset, m_tzi->type[idx].offset,
-            s_isdst, (bool)m_tzi->type[idx].isdst,
-            s_abbr, String(m_tzi->timezone_abbr + m_tzi->type[idx].abbr_idx,
-                           CopyString)
-          ));
-    }
     uint32_t timecnt;
 #ifdef FACEBOOK
     // Internal builds embed tzdata into HHVM by keeping timelib updated
@@ -318,17 +306,45 @@ Array TimeZone::transitions(int64_t timestamp_begin, /* = k_PHP_INT_MIN */
     // as this format must be stable, we're keeping timelib stable too
     timecnt = m_tzi->timecnt;
 #endif
+
+    // If explicitly provided add the beginning timestamp to the ret array
+    if (timestamp_begin > k_PHP_INT_MIN) {
+      DateTime dt(timestamp_begin);
+      // Find the appropriate transition, if there are no transitions, use the
+      // first entry, otherwise find the transition before `timestamp_begin`
+      uint32_t idx = 0;
+      if (timecnt && m_tzi->trans) {
+          while (idx < timecnt && m_tzi->trans[idx] < timestamp_begin) {
+              idx++;
+          }
+
+          if (idx > 0) idx--;
+          idx = m_tzi->trans_idx[idx];
+      }
+      ret.append(make_map_array(
+            s_ts, timestamp_begin,
+            s_time, dt.toString(DateTime::DateFormat::ISO8601),
+            s_offset, m_tzi->type[idx].offset,
+            s_isdst, (bool)m_tzi->type[idx].isdst,
+            s_abbr, String(m_tzi->timezone_abbr + m_tzi->type[idx].abbr_idx,
+                           CopyString)
+          ));
+    }
+
+    // No transitions, just return the array here
+    if (!m_tzi->trans) return ret;
+
     for (uint32_t i = 0; i < timecnt; ++i) {
       int timestamp = m_tzi->trans[i];
       if (timestamp > timestamp_begin && timestamp <= timestamp_end) {
         int index = m_tzi->trans_idx[i];
-        auto dt = req::make<DateTime>(timestamp);
+        DateTime dt(timestamp);
         ttinfo &offset = m_tzi->type[index];
         const char *abbr = m_tzi->timezone_abbr + offset.abbr_idx;
 
         ret.append(make_map_array(
           s_ts, timestamp,
-          s_time, dt->toString(DateTime::DateFormat::ISO8601),
+          s_time, dt.toString(DateTime::DateFormat::ISO8601),
           s_offset, offset.offset,
           s_isdst, (bool)offset.isdst,
           s_abbr, String(abbr, CopyString)

--- a/hphp/test/slow/config.ini
+++ b/hphp/test/slow/config.ini
@@ -16,3 +16,5 @@ hhvm.mysql.slow_query_threshold = 0
 hhvm.resource_limit.serialization_size_limit = 134217728
 hhvm.server_variables[ALPHA_CONSOLE] = 1
 hhvm.server_variables[TFBENV] = 16777216
+
+date.timezone = 'UTC';

--- a/hphp/test/slow/datetime/timezone_transitions.php
+++ b/hphp/test/slow/datetime/timezone_transitions.php
@@ -1,0 +1,13 @@
+<?php
+
+function dump_transitions($tz) {
+    $timestamp_begin = 1301574225;
+    $timestamp_end = 1401574225;
+
+    $tz = new DateTimeZone($tz);
+
+    var_dump($tz->getTransitions($timestamp_begin, $timestamp_end));
+}
+
+dump_transitions('UTC');
+dump_transitions('Pacific/Auckland');

--- a/hphp/test/slow/datetime/timezone_transitions.php.expect
+++ b/hphp/test/slow/datetime/timezone_transitions.php.expect
@@ -1,0 +1,121 @@
+array(1) {
+  [0]=>
+  array(5) {
+    ["ts"]=>
+    int(1301574225)
+    ["time"]=>
+    string(24) "2011-03-31T12:23:45+0000"
+    ["offset"]=>
+    int(0)
+    ["isdst"]=>
+    bool(false)
+    ["abbr"]=>
+    string(3) "UTC"
+  }
+}
+array(8) {
+  [0]=>
+  array(5) {
+    ["ts"]=>
+    int(1301574225)
+    ["time"]=>
+    string(24) "2011-03-31T12:23:45+0000"
+    ["offset"]=>
+    int(46800)
+    ["isdst"]=>
+    bool(true)
+    ["abbr"]=>
+    string(4) "NZDT"
+  }
+  [1]=>
+  array(5) {
+    ["ts"]=>
+    int(1301752800)
+    ["time"]=>
+    string(24) "2011-04-02T14:00:00+0000"
+    ["offset"]=>
+    int(43200)
+    ["isdst"]=>
+    bool(false)
+    ["abbr"]=>
+    string(4) "NZST"
+  }
+  [2]=>
+  array(5) {
+    ["ts"]=>
+    int(1316872800)
+    ["time"]=>
+    string(24) "2011-09-24T14:00:00+0000"
+    ["offset"]=>
+    int(46800)
+    ["isdst"]=>
+    bool(true)
+    ["abbr"]=>
+    string(4) "NZDT"
+  }
+  [3]=>
+  array(5) {
+    ["ts"]=>
+    int(1333202400)
+    ["time"]=>
+    string(24) "2012-03-31T14:00:00+0000"
+    ["offset"]=>
+    int(43200)
+    ["isdst"]=>
+    bool(false)
+    ["abbr"]=>
+    string(4) "NZST"
+  }
+  [4]=>
+  array(5) {
+    ["ts"]=>
+    int(1348927200)
+    ["time"]=>
+    string(24) "2012-09-29T14:00:00+0000"
+    ["offset"]=>
+    int(46800)
+    ["isdst"]=>
+    bool(true)
+    ["abbr"]=>
+    string(4) "NZDT"
+  }
+  [5]=>
+  array(5) {
+    ["ts"]=>
+    int(1365256800)
+    ["time"]=>
+    string(24) "2013-04-06T14:00:00+0000"
+    ["offset"]=>
+    int(43200)
+    ["isdst"]=>
+    bool(false)
+    ["abbr"]=>
+    string(4) "NZST"
+  }
+  [6]=>
+  array(5) {
+    ["ts"]=>
+    int(1380376800)
+    ["time"]=>
+    string(24) "2013-09-28T14:00:00+0000"
+    ["offset"]=>
+    int(46800)
+    ["isdst"]=>
+    bool(true)
+    ["abbr"]=>
+    string(4) "NZDT"
+  }
+  [7]=>
+  array(5) {
+    ["ts"]=>
+    int(1396706400)
+    ["time"]=>
+    string(24) "2014-04-05T14:00:00+0000"
+    ["offset"]=>
+    int(43200)
+    ["isdst"]=>
+    bool(false)
+    ["abbr"]=>
+    string(4) "NZST"
+  }
+}

--- a/hphp/test/slow/ext_datetime/date.php.expect
+++ b/hphp/test/slow/ext_datetime/date.php.expect
@@ -25,7 +25,7 @@ string(27) "Sat Mar 10 5:16:18 PST 2001"
 string(19) "05:03:18 m is month"
 string(8) "05:16:18"
 string(8) "19550310"
-string(31) "Tue, 23 Jul 1811 07:06:40 -0800"
+string(31) "Tue, 23 Jul 1811 07:13:42 -0752"
 int(1259308800)
 array(11) {
   ["seconds"]=>

--- a/hphp/test/slow/ext_datetime/date_timezone.php.expect
+++ b/hphp/test/slow/ext_datetime/date_timezone.php.expect
@@ -26,11 +26,11 @@ array(5) {
   ["time"]=>
   string(24) "1970-01-12T05:46:40-0800"
   ["offset"]=>
-  int(0)
+  int(3600)
   ["isdst"]=>
   bool(false)
   ["abbr"]=>
-  string(3) "GMT"
+  string(3) "BST"
 }
 array(5) {
   ["ts"]=>


### PR DESCRIPTION
This fixes two bugs, a segfault when there were no transitions for the timezone (e.g. UTC) and an incompatibility with Zend PHP with the transition list when using a starting timestamp (it would always use the first transition, rather than the one before the starting timestamp).