### PR TITLE
Add a set of macros for registering constants

### DIFF
--- a/hphp/runtime/vm/native.h
+++ b/hphp/runtime/vm/native.h
@@ -150,6 +150,12 @@ class Object;
 #define HHVM_RC_SAME_I(const_name)                                  \
   Native::registerConstant<KindOfInt64>(                            \
     makeStaticString(#const_name), (int64_t)const_name);
+#define HHVM_RC_SAME_K_S(const_name)                                \
+  Native::registerConstant<KindOfString>(                           \
+    makeStaticString(#const_name), makeStaticString(k_##const_name));
+#define HHVM_RC_SAME_K_I(const_name)                                \
+  Native::registerConstant<KindOfInt64>(                            \
+    makeStaticString(#const_name), (int64_t)k_##const_name);
 #define HHVM_RCC_S(class_name, const_name, const_value)             \
   Native::registerClassConstant<KindOfString>(s_##class_name.get(), \
     makeStaticString(#const_name), makeStaticString(const_value));

--- a/hphp/runtime/vm/native.h
+++ b/hphp/runtime/vm/native.h
@@ -138,28 +138,22 @@ class Object;
 /* Macros related to declaring/registering constants. Note that the
  * HHVM_RCC_* macros expect a StaticString to be present via s_##class_name.
  */
-#define HHVM_RC_S(const_name, const_value)                          \
+#define HHVM_RC_STR(const_name, const_value)                        \
   Native::registerConstant<KindOfString>(                           \
     makeStaticString(#const_name), makeStaticString(const_value));
-#define HHVM_RC_I(const_name, const_value)                          \
+#define HHVM_RC_INT(const_name, const_value)                        \
   Native::registerConstant<KindOfInt64>(                            \
     makeStaticString(#const_name), (int64_t)const_value);
-#define HHVM_RC_SAME_S(const_name)                                  \
+#define HHVM_RC_STR_SAME(const_name)                                \
   Native::registerConstant<KindOfString>(                           \
     makeStaticString(#const_name), makeStaticString(const_name));
-#define HHVM_RC_SAME_I(const_name)                                  \
+#define HHVM_RC_INT_SAME(const_name)                                \
   Native::registerConstant<KindOfInt64>(                            \
     makeStaticString(#const_name), (int64_t)const_name);
-#define HHVM_RC_SAME_K_S(const_name)                                \
-  Native::registerConstant<KindOfString>(                           \
-    makeStaticString(#const_name), makeStaticString(k_##const_name));
-#define HHVM_RC_SAME_K_I(const_name)                                \
-  Native::registerConstant<KindOfInt64>(                            \
-    makeStaticString(#const_name), (int64_t)k_##const_name);
-#define HHVM_RCC_S(class_name, const_name, const_value)             \
+#define HHVM_RCC_STR(class_name, const_name, const_value)           \
   Native::registerClassConstant<KindOfString>(s_##class_name.get(), \
     makeStaticString(#const_name), makeStaticString(const_value));
-#define HHVM_RCC_I(class_name, const_name, const_value)             \
+#define HHVM_RCC_INT(class_name, const_name, const_value)           \
   Native::registerClassConstant<KindOfInt64>(s_##class_name.get(),  \
     makeStaticString(#const_name), (int64_t)const_value);
 

--- a/hphp/runtime/vm/native.h
+++ b/hphp/runtime/vm/native.h
@@ -135,6 +135,28 @@ class Object;
 #define HHVM_STATIC_MALIAS(cn,fn,calias,falias) \
   HHVM_NAMED_STATIC_ME(cn,fn,HHVM_STATIC_MN(calias,falias))
 
+/* Macros related to declaring/registering constants. Note that the
+ * HHVM_RCC_* macros expect a StaticString to be present via s_##class_name.
+ */
+#define HHVM_RC_S(const_name, const_value)                          \
+  Native::registerConstant<KindOfString>(                           \
+    makeStaticString(#const_name), makeStaticString(const_value));
+#define HHVM_RC_I(const_name, const_value)                          \
+  Native::registerConstant<KindOfInt64>(                            \
+    makeStaticString(#const_name), (int64_t)const_value);
+#define HHVM_RC_SAME_S(const_name)                                  \
+  Native::registerConstant<KindOfString>(                           \
+    makeStaticString(#const_name), makeStaticString(const_name));
+#define HHVM_RC_SAME_I(const_name)                                  \
+  Native::registerConstant<KindOfInt64>(                            \
+    makeStaticString(#const_name), (int64_t)const_name);
+#define HHVM_RCC_S(class_name, const_name, const_value)             \
+  Native::registerClassConstant<KindOfString>(s_##class_name.get(), \
+    makeStaticString(#const_name), makeStaticString(const_value));
+#define HHVM_RCC_I(class_name, const_name, const_value)             \
+  Native::registerClassConstant<KindOfInt64>(s_##class_name.get(),  \
+    makeStaticString(#const_name), (int64_t)const_value);
+
 namespace HPHP { namespace Native {
 //////////////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
Various forms of these macros are present in many different extensions, so declare a single set of macros instead.

This doesn't change any of the use cases yet, that can come in a later PR.