### PR TITLE
Remove nonexistent functions in linker commands.

### DIFF
--- a/CMake/HPHPSetup.cmake
+++ b/CMake/HPHPSetup.cmake
@@ -33,7 +33,6 @@ endif()
 if (APPLE)
   set(ENABLE_FASTCGI 1)
   set(HHVM_ANCHOR_SYMS
-    -Wl,-u,_register_fastcgi_server
     -Wl,-pagezero_size,0x00001000
     # Set the .text.keep section to be executable.
     -Wl,-segprot,.text,rx,rx)
@@ -56,7 +55,6 @@ elseif (MSVC)
 else()
   set(ENABLE_FASTCGI 1)
   set(HHVM_ANCHOR_SYMS
-    -Wl,-uregister_libevent_server,-uregister_fastcgi_server
     -Wl,--whole-archive ${HHVM_WHOLE_ARCHIVE_LIBRARIES} -Wl,--no-whole-archive)
 endif()
 


### PR DESCRIPTION
This fixes linker error because libevent server was removed in f4cb063 and
register_fastcgi_server was removed in c8340da.