### PR TITLE
Fix FileStreamWrapper::mkdir_recursive under MSVC

### DIFF
--- a/hphp/runtime/base/file-stream-wrapper.cpp
+++ b/hphp/runtime/base/file-stream-wrapper.cpp
@@ -133,14 +133,14 @@ int FileStreamWrapper::mkdir_recursive(const String& path, int mode) {
   strncpy(dir, fullpath.data(), sizeof(dir));
 
   for (p = dir + 1; *p; p++) {
-    if (*p == '/') {
+    if (FileUtil::isDirSeparator(*p)) {
       *p = '\0';
       if (::access(dir, F_OK) < 0) {
         if (::mkdir(dir, mode) < 0) {
           return -1;
         }
       }
-      *p = '/';
+      *p = FileUtil::getDirSeparator();
     }
   }
 


### PR DESCRIPTION
This is a fix that I realized was needed after the base PR, #5822 (D43227) was in the very late stages of being merged, so trying to slip it into that would have been a bad idea.

Requires #5822 (D43227)