### PR TITLE
Fix the copyright symbol in the Windows resource file

### DIFF
--- a/hphp/hhvm/hhvm.rc
+++ b/hphp/hhvm/hhvm.rc
@@ -28,7 +28,7 @@ BEGIN
       VALUE "FileDescription", "Hip Hop Virtual Machine\0"
       VALUE "FileVersion", STRVER4(HHVM_VERSION_MAJOR, HHVM_VERSION_MINOR, HHVM_VERSION_PATCH, HHVM_VERSION_PATCH)
       VALUE "InternalName", "hhvm\0"
-      VALUE "LegalCopyright", "Copyright ? 2010-2015 Facebook, Inc.\0"
+      VALUE "LegalCopyright", "Copyright © 2010-2015 Facebook, Inc.\0"
       VALUE "LegalTrademarks", "hhvm\0"
       VALUE "OriginalFilename", "hhvm.exe\0"
       VALUE "PrivateBuild", "\0"


### PR DESCRIPTION
Something along the way didn't like it, and converted it to a question mark. I did this directly via github to hopefully get it to work right.