### PR TITLE
Only use wordsame() on 8-byte aligned buffers. Fixes #6408

### DIFF
--- a/hphp/runtime/base/static-string-table.cpp
+++ b/hphp/runtime/base/static-string-table.cpp
@@ -66,17 +66,20 @@ struct strintern_eq {
     assert(k2 >= 0 || k2 < kAhmMagicThreshold);
     auto const sd1 = to_sdata(k1);
     auto const len1 = sd1->size();
+    auto const data1 = sd1->data();
     const char* const* ptr2;
     if (UNLIKELY(k2 < 0)) {
       auto slice2 = to_sslice(k2);
       if (len1 != slice2->size()) return false;
       ptr2 = reinterpret_cast<const char* const*>(slice2);
+      return !memcmp(data1, *ptr2, len1);
     } else {
       auto string2 = to_sdata(k2);
       if (len1 != string2->size()) return false;
       ptr2 = reinterpret_cast<const char* const*>(string2);
+      // only use wordsame on 8-byte aligned addresses
+      return wordsame(data1, *ptr2, len1);
     }
-    return wordsame(sd1->data(), *ptr2, len1);
   }
 };
 

--- a/hphp/util/word-mem.h
+++ b/hphp/util/word-mem.h
@@ -155,6 +155,8 @@ inline void memcpy16_inline(void* dst, const void* src, uint64_t len) {
  * possible in HPHP when you know you dealing with request-allocated memory).
  * The final word compare is adjusted to handle the slack in lenBytes so only
  * the bytes we care about are compared.
+ *
+ * Assumes that the the buffer addresses are 8-bytes aligned.
  */
 ALWAYS_INLINE
 bool wordsame(const void* mem1, const void* mem2, uint32_t lenBytes) {
@@ -162,10 +164,7 @@ bool wordsame(const void* mem1, const void* mem2, uint32_t lenBytes) {
   auto constexpr W = sizeof(T);
 
   assert(reinterpret_cast<const uintptr_t>(mem1) % W == 0);
-  // We would like to make sure `mem2' is also aligned.  But `strintern_eq' has
-  // always been using `wordsame()' on non-aligned pointers, and this doesn't
-  // seem to cause crashes in practice.
-  // assert(reinterpret_cast<const uintptr_t>(mem2) % W == 0);
+  assert(reinterpret_cast<const uintptr_t>(mem2) % W == 0);
 
   // Inverse of lenBytes.  Do the negation here to avoid doing it later on the
   // critical path.


### PR DESCRIPTION
Otherwise, this can result in a segmentation fault if the addresses
are at the "edge" of a memory page.
Seeing no notable performance impact.