### PR TITLE
Expose apache_request_headers

### DIFF
--- a/hphp/runtime/ext/apache/ext_apache.h
+++ b/hphp/runtime/ext/apache/ext_apache.h
@@ -23,6 +23,8 @@
 
 namespace HPHP {
 
+Array HHVM_FUNCTION(apache_request_headers);
+
 class ApacheExtension final : public Extension {
  public:
   ApacheExtension();


### PR DESCRIPTION
While porting the OAuth extension to HNI, I ran into a spot where this function is needed, so expose it so it can be called.