### PR TITLE
Allow setting the timeout of a URLFile after construction

### DIFF
--- a/hphp/runtime/base/url-file.h
+++ b/hphp/runtime/base/url-file.h
@@ -41,6 +41,7 @@ public:
 
   void setProxy(const String& proxy_host, int proxy_port,
                 const String& proxy_user, const String& proxy_pass);
+  void setTimeout(int timeout) { m_timeout = timeout; }
   bool open(const String& filename, const String& mode) override;
   int64_t writeImpl(const char *buffer, int64_t length) override;
   bool seekable() override { return false; }


### PR DESCRIPTION
This is needed to port the OAuth extension to HNI.