### PR TITLE
[MSVC] Don't generate a 0-sized array if there are no global IDL funcs

### DIFF
--- a/hphp/tools/bootstrap/gen-infotabs.cpp
+++ b/hphp/tools/bootstrap/gen-infotabs.cpp
@@ -114,6 +114,9 @@ int main(int argc, const char* argv[]) {
         << "fg_" << name << ", (void*)(&"
         << func.getPrefixedCppName() << ") }";
   }
+  if (!funcs.size()) {
+    cpp << "  { }";
+  }
   cpp << "\n};\n\n";
 
   for (auto const& klass : classes) {


### PR DESCRIPTION
MSVC won't let you emit a zero sized array, and this particular array is only ever iterated based on `hhbc_ext_funcs_count`, which is `0` in this case, so just output an empty element to keep MSVC happy.