### PR TITLE
Remove the global LibIConv requirement

### DIFF
--- a/CMake/HHVMExtensionConfig.cmake
+++ b/CMake/HHVMExtensionConfig.cmake
@@ -581,7 +581,6 @@ function (HHVM_EXTENSION_INTERNAL_HANDLE_LIBRARY_DEPENDENCY extensionID dependen
     ${libraryName} STREQUAL "editline" OR
     ${libraryName} STREQUAL "fastlz" OR
     ${libraryName} STREQUAL "folly" OR
-    ${libraryName} STREQUAL "iconv" OR
     ${libraryName} STREQUAL "lz4" OR
     ${libraryName} STREQUAL "mbfl" OR
     ${libraryName} STREQUAL "mcrouter" OR

--- a/CMake/HPHPFindLibs.cmake
+++ b/CMake/HPHPFindLibs.cmake
@@ -53,14 +53,6 @@ if (LIBINOTIFY_INCLUDE_DIR)
   include_directories(${LIBINOTIFY_INCLUDE_DIR})
 endif()
 
-# iconv checks
-find_package(Libiconv REQUIRED)
-include_directories(${LIBICONV_INCLUDE_DIR})
-if (LIBICONV_CONST)
-  message(STATUS "Using const for input to iconv() call")
-  add_definitions("-DICONV_CONST=const")
-endif()
-
 # mysql checks - if we're using async mysql, we use webscalesqlclient from
 # third-party/ instead
 if (ENABLE_ASYNC_MYSQL)
@@ -475,10 +467,6 @@ macro(hphp_link target)
 
   if (LIBINOTIFY_LIBRARY)
     target_link_libraries(${target} ${LIBINOTIFY_LIBRARY})
-  endif()
-
-  if (LIBICONV_LIBRARY)
-    target_link_libraries(${target} ${LIBICONV_LIBRARY})
   endif()
 
   if (LINUX)


### PR DESCRIPTION
LibIConv is currently required globally, but only `ext_iconv` and `ext_gd` use it.

This was originally opened as #5723 (D42495), but old age caught up with it, and it ended up being closed before it was merged.

Due to other changes, the only pieces of this PR that were left being needed are the actual removal of the global check, and, apparently, also the removal from the list of libs that are implemented globally in the extension config mechanism.