### PR TITLE
[Windows] Don't assert that the freeLocalsHelpers are < 4 cache lines under Windows

### DIFF
--- a/hphp/runtime/vm/jit/unique-stubs-x64.cpp
+++ b/hphp/runtime/vm/jit/unique-stubs-x64.cpp
@@ -229,8 +229,12 @@ TCA emitFreeLocalsHelpers(CodeBlock& cb, UniqueStubs& us) {
   vwrap(cb, [] (Vout& v) { v << ret{}; });
 
   // This stub is hot, so make sure to keep it small.
+  // Alas, we have more work to do in this under Windows,
+  // so we can't be this small :(
+#ifndef _WIN32
   always_assert(Stats::enabled() ||
                 (cb.frontier() - release <= 4 * x64::cache_line_size()));
+#endif
 
   return release;
 }


### PR DESCRIPTION
Unfortunately, we have a bit more work to do in these under Windows due to calling conventions, meaning we don't fit in 4 cache lines, so disable the check for now.