### PR TITLE
[MSVC] Deal with MSVC being grumpy about imagickThrow

### DIFF
--- a/hphp/runtime/ext/imagick/ext_imagick.h
+++ b/hphp/runtime/ext/imagick/ext_imagick.h
@@ -104,6 +104,7 @@ void imagickThrow(ATTRIBUTE_PRINTF_STRING const char* fmt, ...)
   ATTRIBUTE_PRINTF(1, 2);
 
 template<typename T>
+ATTRIBUTE_NORETURN
 void imagickThrow(const char* fmt, ...) {
   va_list ap;
   std::string msg;


### PR DESCRIPTION
MSVC doesn't like `imagickThrow` being marked as `noreturn` on the declaration but not the definition of the template. (it treats it as if it doesn't have the attribute at all) This just adds the attribute to the definition as well.