### PR TITLE
[MSVC] A couple of misc. fixes for MSVC

### DIFF
--- a/hphp/runtime/vm/jit/alias-analysis.cpp
+++ b/hphp/runtime/vm/jit/alias-analysis.cpp
@@ -164,7 +164,7 @@ ALocBits AliasAnalysis::may_alias(AliasClass acls) const {
     auto const add_mis = [&] (AliasClass cls) {
       assertx(cls.isSingleLocation());
       if (cls <= *mis) {
-        if (auto const meta = find(cls)) {
+        if (auto meta = find(cls)) {
           ret |= ALocBits{meta->conflicts}.set(meta->index);
         } else {
           ret |= all_mistate;

--- a/hphp/runtime/vm/jit/frame-state.cpp
+++ b/hphp/runtime/vm/jit/frame-state.cpp
@@ -1339,7 +1339,9 @@ void FrameStateMgr::spillFrameStack(IRSPOffset offset, FPInvOffset retOffset,
 
 void FrameStateMgr::clearStack() {
   for (auto& state : m_stack) {
-    for (auto& stk : state.stack) stk = StackState{};
+    for (auto& stk : state.stack) {
+      stk = StackState{};
+    }
   }
 }
 


### PR DESCRIPTION
The first is due to a compiler bug causing it to attempt to construct `ALocBits{meta->conflicts}` as a `const` value. Due to the fix for this likely being a breaking change (in MSVC compiler itself), the fix for that won't be in Update 1, so just remove the `const` for now.
The second is due to a random parser issue, and, as far as I know, the original also didn't comply with the normal code style standards of HHVM to begin with, so just put curly brackets on the loop and the problem is solved.