### PR TITLE
Fix the fallback in fls64

### DIFF
--- a/hphp/util/bitops.h
+++ b/hphp/util/bitops.h
@@ -79,7 +79,7 @@ inline bool fls64(I64 input, I64 &out) {
     "cc"
   );
 #else
-  out = folly::findLastSet(input);
+  out = folly::findLastSet(input) - 1;
   retval = input != 0;
 #endif
   return retval;


### PR DESCRIPTION
`folly::findLastSet` returns a base-1 bit index, we need a base-0 index. `folly::findFirstSet` already returns a base-0 index, so there is no problem there. This was actually causing HHVM to never finish saving the registers in the vasm unique stubs, and causing it to attempt to append an infinite number of pop instructions.