### PR TITLE
Eliminate most uses of runtime/base/zend-php-config.h

### DIFF
--- a/hphp/runtime/ext/filter/logical_filters.cpp
+++ b/hphp/runtime/ext/filter/logical_filters.cpp
@@ -25,7 +25,6 @@
 #include "hphp/runtime/base/preg.h"
 #include "hphp/runtime/base/string-buffer.h"
 #include "hphp/runtime/base/zend-functions.h"
-#include "hphp/runtime/base/zend-php-config.h"
 #include "hphp/runtime/base/zend-url.h"
 #include "hphp/runtime/ext/filter/ext_filter.h"
 #include "hphp/runtime/ext/filter/sanitizing_filters.h"
@@ -75,7 +74,7 @@ static int php_filter_parse_int(const char *str, unsigned int str_len,
   }
 
   if ((end - str > MAX_LENGTH_OF_LONG - 1) /* number too long */
-   || (SIZEOF_LONG == 4 && (end - str == MAX_LENGTH_OF_LONG - 1) &&
+   || (sizeof(long) == 4 && (end - str == MAX_LENGTH_OF_LONG - 1) &&
        *str > '2')) {
     /* overflow */
     return -1;
@@ -356,7 +355,7 @@ Variant php_filter_float(PHP_INPUT_FILTER_PARAM_DECL) {
     return (double)lval;
   } else if (isDoubleType(dt)) {
     if ((!dval && p.size() > 1 && strpbrk(p.data(), "123456789")) ||
-         !zend_finite(dval)) {
+         !finite(dval)) {
       goto error;
     }
     return dval;

--- a/hphp/runtime/ext/sockets/ext_sockets.cpp
+++ b/hphp/runtime/ext/sockets/ext_sockets.cpp
@@ -40,7 +40,6 @@
 #include "hphp/runtime/base/socket.h"
 #include "hphp/runtime/base/ssl-socket.h"
 #include "hphp/runtime/server/server-stats.h"
-#include "hphp/runtime/base/zend-php-config.h"
 #include "hphp/runtime/base/mem-file.h"
 #include "hphp/util/logger.h"
 


### PR DESCRIPTION
`zend-php-config.h` doesn't belong in the core runtime, as it's not even remotely portable to other platforms, nor are most of the defines in it even correct.

It was only used for 3 things, logical_filters in ext_filter, it was included in ext_sockets, but not actually used, and ext_gd uses it extensively. This only removes the ext_filter and ext_sockets use of it. ext_gd's dependence will be dealt with in a separate PR.