### PR TITLE
Let gcc 5.2 compile hhvm using Cxx11 ABI

### DIFF
--- a/CMake/HPHPCompiler.cmake
+++ b/CMake/HPHPCompiler.cmake
@@ -74,7 +74,7 @@ elseif (${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU")
   endif()
 
   if(GCC_VERSION VERSION_GREATER 5.1 OR GCC_VERSION VERSION_EQUAL 5.1)
-    set(GNUCC_OPT "${GNUCC_OPT} -D_GLIBCXX_USE_CXX11_ABI=0 -Wno-bool-compare -DFOLLY_HAVE_MALLOC_H")
+    set(GNUCC_OPT "${GNUCC_OPT} -Wno-bool-compare -DFOLLY_HAVE_MALLOC_H")
   endif()
 
   # Enabled GCC/LLVM stack-smashing protection


### PR DESCRIPTION
After folly update (see commit facebook/folly@50b33d29c25c9cb), hhvm can be compiled without problem using the new abi, and the new abi needs to be used if we want to be able to use dependencies installed by distributions, for instance libboost in debian stretch.