### PR TITLE
Update build.ocp for better flow integration

### DIFF
--- a/hphp/hack/00_config.ocp
+++ b/hphp/hack/00_config.ocp
@@ -1,3 +1,7 @@
 
 have_lz4 = false
 debug = false
+(*
+ccopt += [ "-IC:\path\to\lz4\lib" ]
+cclib += [ "-LC:\path\to\lz4\lib" ]
+*)

--- a/hphp/hack/build.ocp
+++ b/hphp/hack/build.ocp
@@ -12,3 +12,233 @@ begin library "ROOTPROJECT"
   files = []
 end
 
+begin library "hh-hhi"
+  requires = [ "hh-globals" "hh-utils" "hh-find" "bigarray" ]
+  files = [
+    "src/hhi/hhi_elf.c"
+    "src/hhi/hhi_win32res_stubs.c"
+    "src/hhi/hhi_win32res.ml"
+    "src/hhi/hhi.ml"
+  ]
+  if (os_type = "Win32") then {
+    (* Embed resources *)
+    hhi_source = "./hhi.rc"
+    hhi_target = "%{hh-hhi_FULL_DST_DIR}%/hhi_res.o"
+    cclib = [ hhi_target ]
+    build_rules = [
+      hhi_target (
+        sources = [ hhi_source ]
+        commands = [
+          { "windres"
+            "--preprocessor=x86_64-w64-mingw32-gcc.exe"
+            "--preprocessor-arg=-E"
+            "--preprocessor-arg=-xc-header"
+            hhi_source hhi_target }
+        ]
+        build_target = true
+      )
+    ]
+  } else if (system = "macosx" && os_type = "Unix") then {
+    cclib = [
+      "-sectcreate" "-__text" "hhi"
+      "%{ROOTPROJECT_FULL_SRC_DIR}%/bin/hhi.tar.gz"
+      "-framework" "CoreServices"
+      "-framework" "CoreFoundation"
+    ]
+  }
+
+end
+
+begin library "hh-server-base"
+  requires = [ "hh-third-party" "hh-utils" "hh-typing"  "hh-search"
+                "hh-stubs" "hh-stubs-ai"  "hh-socket" "hh-dfind" "hh-hhi" ]
+  files = [
+    "src/server/serverFiles.ml"
+    "src/server/serverConfig.ml"
+    "src/server/serverArgs.ml"
+    "src/server/serverEnv.ml"
+    "src/server/serverUtils.ml"
+    "src/server/argumentInfoService.ml"
+    "src/server/autocompleteService.ml"
+    "src/server/fileOutline.ml"
+    "src/server/serverIdeUtils.ml"
+    "src/server/findRefsService.ml"
+    "src/server/identifySymbolService.ml"
+    "src/server/inferAtPosService.ml"
+    "src/server/methodJumps.ml"
+    "src/server/serverArgumentInfo.ml"
+    "src/server/serverAutoComplete.ml"
+    "src/server/serverBuild.ml"
+    "src/server/serverCheckpoint.ml"
+    "src/server/serverColorFile.ml"
+    "src/server/serverCoverageMetric.ml"
+    "src/server/serverError.ml"
+    "src/server/serverFindRefs.ml"
+    "src/server/serverIdentifyFunction.ml"
+    "src/server/serverInferType.ml"
+    "src/server/serverLocalConfig.ml"
+    "src/server/serverLint.ml"
+    "src/server/serverMonitor.ml"
+    "src/server/serverRefactor.ml"
+    "src/server/serverSearch.ml"
+    "src/server/symbolUtils.ml"
+    "src/server/symbolFunCallService.ml"
+    "src/server/symbolTypeService.ml"
+    "src/server/symbolInfoService.ml"
+    "src/server/serverIdle.ml"
+    "src/server/serverRpc.ml"
+    "src/server/serverCheckUtils.ml"
+    "src/server/serverTypeCheck.ml"
+    "src/server/serverCommand.ml"
+    "src/server/serverConvert.ml"
+    "src/server/serverStamp.ml"
+  ]
+end
+
+begin library "hh-server"
+  requires = [
+    "hh-third-party" "hh-utils" "hh-typing"
+    "hh-search"  "hh-stubs"  "hh-stubs-ai"
+    "hh-socket"  "hh-dfind" "hh-watchman" "hh-server-base"
+  ]
+  files = [
+    "src/server/serverEnvBuild.ml"
+    "src/server/serverInit.ml"
+    "src/server/serverMain.ml"
+  ]
+end
+
+begin library "hh-client"
+  requires = [
+    "hh-deps"  "hh-heap"  "hh-parsing"
+    "hh-globals"  "hh-search"  "hh-stubs"
+    "hh-socket"  "hh-server-base"
+  ]
+  files = [
+    "src/client/clientConnectSimple.ml"
+    "src/client/clientStop.ml"
+    "src/client/clientStart.ml"
+    "src/client/clientConnect.ml"
+    "src/client/clientLogCommand.ml"
+    "src/client/clientBuild.ml"
+    "src/client/clientEnv.ml"
+    "src/client/clientCommand.ml"
+    "src/client/clientArgs.ml"
+    "src/client/clientArgumentInfo.ml"
+    "src/client/clientAutocomplete.ml"
+    "src/client/clientCheckStatus.ml"
+    "src/client/colorFile.ml"
+    "src/client/clientColorFile.ml"
+    "src/client/clientCoverageMetric.ml"
+    "src/client/clientFindRefs.ml"
+    "src/client/clientLint.ml"
+    "src/client/clientMethodJumps.ml"
+    "src/client/clientOutline.ml"
+    "src/client/clientRefactor.ml"
+    "src/client/clientSearch.ml"
+    "src/client/clientAiInfo.ml"
+    "src/client/clientSymbolInfo.ml"
+    "src/client/clientTypeAtPos.ml"
+    "src/client/clientCheck.ml"
+    "src/client/clientRestart.ml"
+  ]
+end
+
+begin program "hh_client"
+  requires = [ "hh-client" ]
+  files = [ "src/hh_client.ml" ]
+end
+
+begin program "hh_server"
+  requires = [ "hh-server" ]
+  files = [ "src/hh_server.ml" ]
+end
+
+begin library "hh-emitter"
+  requires = [ "hh-naming" "hh-typing" ]
+
+  files = [
+    "src/emitter/emitter_core.ml"
+    "src/emitter/emitter_consts.ml"
+    "src/emitter/emitter_xhp.ml"
+    "src/emitter/emitter_expr.ml"
+    "src/emitter/emitter_lit.ml"
+    "src/emitter/emitter_stmt.ml"
+    "src/emitter/emitter_types.ml"
+    "src/emitter/emitter.ml"
+  ]
+end
+
+begin library "hh-format"
+  requires = [ "hh-typing-base" ]
+  files = [
+    "src/stubs/formatEventLogger.ml"
+    "src/format/format_hack.ml"
+    "src/format/format_diff.ml"
+    "src/format/format_mode.ml"
+  ]
+end
+
+begin program "hh_format"
+  requires = [ "hh-format" "hh-client" ]
+  files = [ "src/hh_format.ml" ]
+end
+
+begin program "hh_single_type_check"
+  requires = [ "hh-client"  "hh-emitter" ]
+  files = [
+    "src/hh_single_type_check.ml"
+  ]
+end
+
+begin library "hh-match"
+  requires = [ "hh-parsing" "hh-typing-base" "h2tp-unparser"]
+  files = [
+    "src/hh_matcher/astConstructor.ml"
+    "src/hh_matcher/ast_code_extent.ml"
+    "src/hh_matcher/hh_match_utils.ml"
+    "src/hh_matcher/hh_match_test_utils.ml"
+    "src/hh_matcher/patcher.ml"
+    "src/hh_matcher/matcher.ml"
+  ]
+end
+
+begin program "hh_match"
+  requires = [ "hh-match" "hh-client" ]
+  files = [ "src/hh_match.ml" ]
+end
+
+begin program "code_extent_tests"
+  requires = [ "hh-match" "hh-hhi" ]
+  files = [
+    "src/hh_matcher/test/code_extent_tests.ml"
+  ]
+end
+
+begin program "matcher_test"
+  requires = [ "hh-match" "hh-hhi" ]
+  files = [
+    "src/hh_matcher/test/matcher_test.ml"
+  ]
+end
+
+begin program "patcher_module_test"
+  requires = [ "hh-match" "hh-hhi" ]
+  files = [
+    "src/hh_matcher/test/patcher_module_test.ml"
+  ]
+end
+
+begin program "patcher_api_test"
+  requires = [ "hh-match" "hh-hhi" ]
+  files = [
+    "src/hh_matcher/test/patcher_api_test.ml"
+  ]
+end
+
+begin program "patcher_test"
+  requires = [ "hh-match" "hh-hhi" ]
+  files = [
+    "src/hh_matcher/test/patcher_test.ml"
+  ]
+end

--- a/hphp/hack/src/Makefile
+++ b/hphp/hack/src/Makefile
@@ -190,7 +190,7 @@ endif
 	cp ../_obuild/hh_single_type_check/hh_single_type_check.asm ../bin/hh_single_type_check
 	cp ../_obuild/hh_format/hh_format.asm ../bin/hh_format
 	cp ../_obuild/h2tp/h2tp.asm ../bin/h2tp
-	cp ../_obuild/hh_match.asm ../bin/hh_match
+	cp ../_obuild/hh_match/hh_match.asm ../bin/hh_match
 
 copy-match-test-files:
 	mkdir -p ../bin
@@ -207,22 +207,22 @@ copy-match-test-files:
 
 copy-match-test-files-ocp:
 	mkdir -p ../bin
-	cp _obuild/hh_matcher/test/code_extent_tests.asm \
+	cp ../_obuild/code_extent_tests/code_extent_tests.asm \
 		../bin/code_extent_test_driver
-	cp _obuild/hh_matcher/test/matcher_test.asm \
+	cp ../_obuild/matcher_test/matcher_test.asm \
 		../bin/hh_match_test_driver
-	cp _obuild/hh_matcher/test/patcher_module_test.asm \
+	cp ../_obuild/patcher_module_test/patcher_module_test.asm \
 		../bin/hh_patch_module_test_driver
-	cp _obuild/hh_matcher/test/patcher_api_test.asm \
+	cp ../_obuild/patcher_api_test/patcher_api_test.asm \
 		../bin/hh_patch_api_test_driver
-	cp _obuild/hh_matcher/test/patcher_test.asm \
+	cp ../_obuild/patcher_test/patcher_test.asm \
 		../bin/hh_patch_test_driver
 
 .PHONY: test test-ocp do-test
 test: build-hack copy-hack-files copy-match-test-files
 	${MAKE} do-test
 
-test-ocp: build-hack-with-ocp copy-hack-files-ocp copy match-test-files-ocp
+test-ocp: build-hack-with-ocp copy-hack-files-ocp copy-match-test-files-ocp
 	${MAKE} do-test
 
 do-test:

--- a/hphp/hack/src/build.ocp
+++ b/hphp/hack/src/build.ocp
@@ -16,8 +16,8 @@ if debug then {
   link += [ "-g" ]
 }
 
-if os_type = "linux" then {
-  cclib = [ "-lelf" ]
+if os_type = "Unix" then {
+  cclib += [ "-lrt" ]
 }
 
 if have_lz4 then {
@@ -98,6 +98,7 @@ end
 
 begin library "hh-utils-common"
   requires += [ "hh-third-party" "hh-utils-core" "hh-fsnotify" ]
+  ccopt += "-DOSS_SMALL_HH_TABLE_POWS"
   files = [
     "heap/hh_shared.c"
 
@@ -221,6 +222,7 @@ begin library "hh-parsing"
     "parsing/parsing_hooks.ml"
     "parsing/ast_utils.ml"
     "parsing/parsing_service.ml"
+    "parsing/astVisitor.ml"
   ]
 end
 
@@ -277,6 +279,7 @@ begin library "hh-typing"
     "typing/typing_print.ml"
     "typing/typeVisitor.ml"
     "typing/typing_dependent_type.ml"
+    "typing/type_mapper.ml"
     "typing/typing_expand.ml"
     "typing/typing_generic.ml"
     "typing/typing_utils.ml"
@@ -286,6 +289,7 @@ begin library "hh-typing"
     "typing/typing_taccess.ml"
     "typing/typing_structure.ml"
     "typing/typing_tdef.ml"
+    "typing/typing_arrays.ml"
     "typing/typing_unification_env.ml"
     "typing/typing_unify.ml"
     "typing/typing_subtype.ml"
@@ -343,183 +347,5 @@ begin library "hh-socket"
   requires += [ "hh-utils" ]
   files = [
     "socket/socket.ml"
-  ]
-end
-
-begin library "hh-hhi"
-  requires += [ "hh-globals" "hh-utils" "bigarray" ]
-  files = [
-    "hhi/hhi_elf.c"
-    "hhi/hhi_win32res_stubs.c"
-    "hhi/hhi_win32res.ml"
-    "hhi/hhi.ml"
-  ]
-  if (os_type = "Win32") then {
-    (* Embed resources *)
-    hhi_source = "../hhi.rc"
-    hhi_target = "%{hh-hhi_FULL_DST_DIR}%/hhi_res.o"
-    cclib = [ hhi_target ]
-    build_rules = [
-      hhi_target (
-        sources = [ hhi_source ]
-        commands = [
-          { "windres"
-            "--preprocessor=x86_64-w64-mingw32-gcc.exe"
-            "--preprocessor-arg=-E"
-            "--preprocessor-arg=-xc-header"
-            hhi_source hhi_target }
-        ]
-        build_target = true
-      )
-    ]
-  } else if (system = "macosx" && os_type = "Unix") then {
-    cclib = [
-      "-sectcreate" "-__text" "hhi"
-      "%{ROOTPROJECT_FULL_SRC_DIR}%/bin/hhi.tar.gz"
-      "-framework" "CoreServices"
-      "-framework" "CoreFoundation"
-    ]
-  }
-
-end
-
-begin library "hh-server-base"
-  requires += [ "hh-third-party" "hh-utils" "hh-find" "hh-typing"  "hh-search"
-                "hh-stubs" "hh-stubs-ai"  "hh-socket" "hh-dfind" "hh-hhi" ]
-  files = [
-    "server/serverFiles.ml"
-    "server/serverConfig.ml"
-    "server/serverArgs.ml"
-    "server/serverEnv.ml"
-    "server/serverUtils.ml"
-    "server/argumentInfoService.ml"
-    "server/autocompleteService.ml"
-    "server/fileOutline.ml"
-    "server/serverIdeUtils.ml"
-    "server/findRefsService.ml"
-    "server/identifySymbolService.ml"
-    "server/inferAtPosService.ml"
-    "server/methodJumps.ml"
-    "server/serverArgumentInfo.ml"
-    "server/serverAutoComplete.ml"
-    "server/serverBuild.ml"
-    "server/serverCheckpoint.ml"
-    "server/serverColorFile.ml"
-    "server/serverCoverageMetric.ml"
-    "server/serverError.ml"
-    "server/serverFindRefs.ml"
-    "server/serverIdentifyFunction.ml"
-    "server/serverInferType.ml"
-    "server/serverLint.ml"
-    "server/serverLocalConfig.ml"
-    "server/serverMonitor.ml"
-    "server/serverRefactor.ml"
-    "server/serverSearch.ml"
-    "server/symbolUtils.ml"
-    "server/symbolFunCallService.ml"
-    "server/symbolTypeService.ml"
-    "server/symbolInfoService.ml"
-    "server/serverIdle.ml"
-    "server/serverRpc.ml"
-    "server/serverTypeCheck.ml"
-    "server/serverCommand.ml"
-    "server/serverConvert.ml"
-  ]
-end
-
-begin library "hh-server"
-  requires += [
-    "hh-third-party" "hh-utils" "hh-typing"
-    "hh-search"  "hh-stubs"  "hh-stubs-ai"
-    "hh-socket"  "hh-dfind" "hh-watchman" "hh-server-base"
-  ]
-  files = [
-    "server/serverEnvBuild.ml"
-    "server/serverInit.ml"
-    "server/serverMain.ml"
-  ]
-end
-
-begin library "hh-client"
-  requires += [
-    "hh-deps"  "hh-heap"  "hh-parsing"
-    "hh-globals"  "hh-search"  "hh-stubs"
-    "hh-socket"  "hh-server-base"
-  ]
-  files = [
-    "client/clientConnectSimple.ml"
-    "client/clientStop.ml"
-    "client/clientStart.ml"
-    "client/clientConnect.ml"
-    "client/clientLogCommand.ml"
-    "client/clientBuild.ml"
-    "client/clientEnv.ml"
-    "client/clientCommand.ml"
-    "client/clientArgs.ml"
-    "client/clientArgumentInfo.ml"
-    "client/clientAutocomplete.ml"
-    "client/clientCheckStatus.ml"
-    "client/colorFile.ml"
-    "client/clientColorFile.ml"
-    "client/clientCoverageMetric.ml"
-    "client/clientFindRefs.ml"
-    "client/clientLint.ml"
-    "client/clientMethodJumps.ml"
-    "client/clientOutline.ml"
-    "client/clientRefactor.ml"
-    "client/clientSearch.ml"
-    "client/clientAiInfo.ml"
-    "client/clientSymbolInfo.ml"
-    "client/clientTypeAtPos.ml"
-    "client/clientCheck.ml"
-    "client/clientLogCommandUtils.ml"
-    "client/clientRestart.ml"
-  ]
-end
-
-begin program "hh_client"
-  requires += [ "hh-client" ]
-  files = [ "hh_client.ml" ]
-end
-
-begin program "hh_server"
-  requires += [ "hh-server" ]
-  files = [ "hh_server.ml" ]
-end
-
-begin library "hh-emitter"
-  requires += [ "hh-naming" "hh-typing" ]
-
-  files = [
-    "emitter/emitter_core.ml"
-    "emitter/emitter_consts.ml"
-    "emitter/emitter_xhp.ml"
-    "emitter/emitter_expr.ml"
-    "emitter/emitter_lit.ml"
-    "emitter/emitter_stmt.ml"
-    "emitter/emitter_types.ml"
-    "emitter/emitter.ml"
-  ]
-end
-
-begin library "hh-format"
-  requires += [ "hh-typing-base" ]
-  files = [
-    "stubs/formatEventLogger.ml"
-    "format/format_hack.ml"
-    "format/format_diff.ml"
-    "format/format_mode.ml"
-  ]
-end
-
-begin program "hh_format"
-  requires += [ "hh-format" "hh-client" ]
-  files = [ "hh_format.ml" ]
-end
-
-begin program "hh_single_type_check"
-  requires += [ "hh-client"  "hh-emitter" ]
-  files = [
-    "hh_single_type_check.ml"
   ]
 end

--- a/hphp/hack/src/h2tp/build.ocp
+++ b/hphp/hack/src/h2tp/build.ocp
@@ -14,10 +14,8 @@
    about these missing files.
 *)
 
-begin program "h2tp"
-
-  requires += [ "hh-format" ]
-
+begin library "h2tp-common"
+  requires += [ "hh-parsing" "hh-find" ]
   files = [
     "Prepend_require.ml"
     "common/fun.ml"
@@ -27,6 +25,22 @@ begin program "h2tp"
     "common/converter_options.ml"
     "common/sys_ext.ml"
     "common/parser_hack_ext.ml"
+  ]
+end
+
+begin library "h2tp-unparser"
+  requires += [ "h2tp-common" "hh-format" ]
+  files = [
+    "unparser/unparsed.ml"
+    "unparser/unparser.ml"
+  ]
+end
+
+begin program "h2tp"
+
+  requires += [ "h2tp-unparser" ]
+
+  files = [
     "mapper/map_ast.ml"
     "mapper/Deleted_constructs.ml"
     "mapper/constructor_arg_promotion.ml"
@@ -42,8 +56,6 @@ begin program "h2tp"
     "mapper/unsupported_constructs.ml"
     "mapper/value_collections.ml"
     "mapper/yield_break.ml"
-    "unparser/unparsed.ml"
-    "unparser/unparser.ml"
     "engine.ml"
     "h2tp.ml"
   ]


### PR DESCRIPTION
This move all the "program" rules from `hack/src/build.ocp` to `hack/build.ocp`. Then, they are not imported into the `flow` repository. This PR also update the `hack/src/h2tp/build.ocp` in order to fix `make test-ocp`.