### PR TITLE
Clarify documentation around $name in fb_intercept callbacks.

### DIFF
--- a/hphp/runtime/ext/fb/ext_fb.php
+++ b/hphp/runtime/ext/fb/ext_fb.php
@@ -48,13 +48,13 @@ function fb_compact_unserialize(mixed $thing,
  * handler returns FALSE, code will continue with original function.
  * Otherwise, it will return what handler tells. The handler function looks
  * like "intercept_handler($name, $obj, $params, $data, &$done)", where $name
- * is original function's name, $obj is $this for an instance method call or
- * null for static method call or function calls, and $params are original
- * call's parameters. $data is what's passed to fb_intercept() and set $done
- * to false to indicate function should continue its execution with old
- * function as if interception did not happen. By default $done is true so it
- * will return handler's return immediately without executing old function's
- * code. Note that built-in functions are not interceptable.
+ * is original function's fully-qualified name ('Class::method'), $obj is $this
+ * for an instance method call or null for static method call or function calls,
+ * and $params are original call's parameters. $data is what's passed to
+ * fb_intercept() and set $done to false to indicate function should continue its
+ * execution with old function as if interception did not happen. By default $done
+ * is true so it will return handler's return immediately without executing old
+ * function's code. Note that built-in functions are not interceptable.
  * @param string $name - The function or class method name to intercept. Use
  * "class::method" for method name. If empty, all functions will be
  * intercepted by the specified handler and registered individual handlers


### PR DESCRIPTION
It was not entirely intuitive for $name to be in the fully-qualified
Class::method form. This caused some headache when implementing an
intercept function. Perhaps worse than the lack of clarity is PHP's
willingness to allow callables in this way  ([$instance, 'Class::method']).