### PR TITLE
Fix compile error for CompactTaggedPtr

### DIFF
--- a/hphp/util/compact-tagged-ptrs.h
+++ b/hphp/util/compact-tagged-ptrs.h
@@ -73,7 +73,7 @@ private:
 
 template<class T, class TagType = uint32_t>
 struct CompactTaggedPtr {
-  using Opaque = std::pair<T*,uint32_t>;
+  using Opaque = std::pair<T*,TagType>;
 
   CompactTaggedPtr() { set(TagType{}, 0); }
 

--- a/hphp/util/compact-tagged-ptrs.h
+++ b/hphp/util/compact-tagged-ptrs.h
@@ -78,8 +78,8 @@ struct CompactTaggedPtr {
   CompactTaggedPtr() { set(TagType{}, 0); }
 
   // for save and restore
-  explicit CompactTaggedPtr(Opaque v) : m_ptr(v.first), m_size(v.second) {}
-  Opaque getOpaque() const { return std::make_pair(m_ptr, m_size); }
+  explicit CompactTaggedPtr(Opaque v) : m_ptr(v.first), m_tag(v.second) {}
+  Opaque getOpaque() const { return std::make_pair(m_ptr, m_tag); }
 
   void set(TagType ttag, T* ptr) {
     auto const tag = static_cast<uint32_t>(ttag);


### PR DESCRIPTION
Drive-by cleanup. This path is not active on x64 builds, which is probably why it was never caught.