### PR TITLE
Perform dirname at compile time when possible.

### DIFF
--- a/hphp/runtime/vm/jit/irgen-builtin.cpp
+++ b/hphp/runtime/vm/jit/irgen-builtin.cpp
@@ -214,7 +214,7 @@ SSATmp* opt_dirname(IRGS& env, uint32_t numArgs) {
 
   // Return the directory portion of the path
   auto const path = top(env, BCSPOffset{0})->strVal()->toCppString();
-  return cns(env, makeStaticString(HHVM_FN(dirname(path))));
+  return cns(env, makeStaticString(HHVM_FN(dirname)(path)));
 }
 
 /*


### PR DESCRIPTION
If the argument to dirname() is a string literal (or equivalent), we can call dirname() at compile time and just return the precomputed value at runtime. This is already done for ini_get().

This makes
 dirname(__FILE__) . "/some_relative_file"
as efficient as using a hardcoded absolute path.

I don't see a measurable performance improvement with WordPress, but I don't see a downside to this optimization.