### PR TITLE
[Const Macros] Switch ext_zip to use the new const registering macros

### DIFF
--- a/hphp/runtime/ext/zip/ext_zip.cpp
+++ b/hphp/runtime/ext/zip/ext_zip.cpp
@@ -272,116 +272,6 @@ class ZipDirectory: public SweepableResourceData {
 IMPLEMENT_RESOURCE_ALLOCATION(ZipDirectory);
 
 const StaticString s_ZipArchive("ZipArchive");
-const StaticString s_CREATE("CREATE");
-const int64_t k_CREATE = 1;
-const StaticString s_EXCL("EXCL");
-const int64_t k_EXCL = 2;
-const StaticString s_CHECKCONS("CHECKCONS");
-const int64_t k_CHECKCONS = 4;
-const StaticString s_OVERWRITE("OVERWRITE");
-const int64_t k_OVERWRITE = 8;
-const StaticString s_FL_NOCASE("FL_NOCASE");
-const int64_t k_FL_NOCASE = 1;
-const StaticString s_FL_NODIR("FL_NODIR");
-const int64_t k_FL_NODIR = 2;
-const StaticString s_FL_COMPRESSED("FL_COMPRESSED");
-const int64_t k_FL_COMPRESSED = 4;
-const StaticString s_FL_UNCHANGED("FL_UNCHANGED");
-const int64_t k_FL_UNCHANGED = 8;
-const StaticString s_FL_RECOMPRESS("FL_RECOMPRESS");
-const int64_t k_FL_RECOMPRESS = 16;
-const StaticString s_FL_ENCRYPTED("FL_ENCRYPTED");
-const int64_t k_FL_ENCRYPTED = 32;
-const StaticString s_ER_OK("ER_OK");
-const int64_t k_ER_OK = 0;
-const StaticString s_ER_MULTIDISK("ER_MULTIDISK");
-const int64_t k_ER_MULTIDISK = 1;
-const StaticString s_ER_RENAME("ER_RENAME");
-const int64_t k_ER_RENAME = 2;
-const StaticString s_ER_CLOSE("ER_CLOSE");
-const int64_t k_ER_CLOSE = 3;
-const StaticString s_ER_SEEK("ER_SEEK");
-const int64_t k_ER_SEEK = 4;
-const StaticString s_ER_READ("ER_READ");
-const int64_t k_ER_READ = 5;
-const StaticString s_ER_WRITE("ER_WRITE");
-const int64_t k_ER_WRITE = 6;
-const StaticString s_ER_CRC("ER_CRC");
-const int64_t k_ER_CRC = 7;
-const StaticString s_ER_ZIPCLOSED("ER_ZIPCLOSED");
-const int64_t k_ER_ZIPCLOSED = 8;
-const StaticString s_ER_NOENT("ER_NOENT");
-const int64_t k_ER_NOENT = 9;
-const StaticString s_ER_EXISTS("ER_EXISTS");
-const int64_t k_ER_EXISTS = 10;
-const StaticString s_ER_OPEN("ER_OPEN");
-const int64_t k_ER_OPEN = 11;
-const StaticString s_ER_TMPOPEN("ER_TMPOPEN");
-const int64_t k_ER_TMPOPEN = 12;
-const StaticString s_ER_ZLIB("ER_ZLIB");
-const int64_t k_ER_ZLIB = 13;
-const StaticString s_ER_MEMORY("ER_MEMORY");
-const int64_t k_ER_MEMORY = 14;
-const StaticString s_ER_CHANGED("ER_CHANGED");
-const int64_t k_ER_CHANGED = 15;
-const StaticString s_ER_COMPNOTSUPP("ER_COMPNOTSUPP");
-const int64_t k_ER_COMPNOTSUPP = 16;
-const StaticString s_ER_EOF("ER_EOF");
-const int64_t k_ER_EOF = 17;
-const StaticString s_ER_INVAL("ER_INVAL");
-const int64_t k_ER_INVAL = 18;
-const StaticString s_ER_NOZIP("ER_NOZIP");
-const int64_t k_ER_NOZIP = 19;
-const StaticString s_ER_INTERNAL("ER_INTERNAL");
-const int64_t k_ER_INTERNAL = 20;
-const StaticString s_ER_INCONS("ER_INCONS");
-const int64_t k_ER_INCONS = 21;
-const StaticString s_ER_REMOVE("ER_REMOVE");
-const int64_t k_ER_REMOVE = 22;
-const StaticString s_ER_DELETED("ER_DELETED");
-const int64_t k_ER_DELETED = 23;
-const StaticString s_ER_ENCRNOTSUPP("ER_ENCRNOTSUPP");
-const int64_t k_ER_ENCRNOTSUPP = 24;
-const StaticString s_ER_RDONLY("ER_RDONLY");
-const int64_t k_ER_RDONLY = 25;
-const StaticString s_ER_NOPASSWD("ER_NOPASSWD");
-const int64_t k_ER_NOPASSWD = 26;
-const StaticString s_ER_WRONGPASSWD("ER_WRONGPASSWD");
-const int64_t k_ER_WRONGPASSWD = 27;
-const StaticString s_CM_DEFAULT("CM_DEFAULT");
-const int64_t k_CM_DEFAULT = -1;
-const StaticString s_CM_STORE("CM_STORE");
-const int64_t k_CM_STORE = 0;
-const StaticString s_CM_SHRINK("CM_SHRINK");
-const int64_t k_CM_SHRINK = 1;
-const StaticString s_CM_REDUCE_1("CM_REDUCE_1");
-const int64_t k_CM_REDUCE_1 = 2;
-const StaticString s_CM_REDUCE_2("CM_REDUCE_2");
-const int64_t k_CM_REDUCE_2 = 3;
-const StaticString s_CM_REDUCE_3("CM_REDUCE_3");
-const int64_t k_CM_REDUCE_3 = 4;
-const StaticString s_CM_REDUCE_4("CM_REDUCE_4");
-const int64_t k_CM_REDUCE_4= 5;
-const StaticString s_CM_IMPLODE("CM_IMPLODE");
-const int64_t k_CM_IMPLODE = 6;
-const StaticString s_CM_DEFLATE("CM_DEFLATE");
-const int64_t k_CM_DEFLATE = 8;
-const StaticString s_CM_DEFLATE64("CM_DEFLATE64");
-const int64_t k_CM_DEFLATE64 = 9;
-const StaticString s_CM_PKWARE_IMPLODE("CM_PKWARE_IMPLODE");
-const int64_t k_CM_PKWARE_IMPLODE = 10;
-const StaticString s_CM_BZIP2("CM_BZIP2");
-const int64_t k_CM_BZIP2 = 12;
-const StaticString s_CM_LZMA("CM_LZMA");
-const int64_t k_CM_LZMA = 14;
-const StaticString s_CM_TERSE("CM_TERSE");
-const int64_t k_CM_TERSE = 18;
-const StaticString s_CM_LZ77("CM_LZ77");
-const int64_t k_CM_LZ77 = 19;
-const StaticString s_CM_WAVPACK("CM_WAVPACK");
-const int64_t k_CM_WAVPACK = 97;
-const StaticString s_CM_PPMD("CM_PPMD");
-const int64_t k_CM_PPMD = 98;
 
 template<class T>
 ALWAYS_INLINE
@@ -1400,145 +1290,62 @@ class zipExtension final : public Extension {
     HHVM_ME(ZipArchive, unchangeArchive);
     HHVM_ME(ZipArchive, unchangeIndex);
     HHVM_ME(ZipArchive, unchangeName);
-    Native::registerClassConstant<KindOfInt64>(s_ZipArchive.get(),
-                                               s_CREATE.get(), k_CREATE);
-    Native::registerClassConstant<KindOfInt64>(s_ZipArchive.get(),
-                                               s_EXCL.get(), k_EXCL);
-    Native::registerClassConstant<KindOfInt64>(s_ZipArchive.get(),
-                                               s_CHECKCONS.get(), k_CHECKCONS);
-    Native::registerClassConstant<KindOfInt64>(s_ZipArchive.get(),
-                                               s_OVERWRITE.get(), k_OVERWRITE);
-    Native::registerClassConstant<KindOfInt64>(s_ZipArchive.get(),
-                                               s_FL_NOCASE.get(), k_FL_NOCASE);
-    Native::registerClassConstant<KindOfInt64>(s_ZipArchive.get(),
-                                               s_FL_NODIR.get(), k_FL_NODIR);
-    Native::registerClassConstant<KindOfInt64>(s_ZipArchive.get(),
-                                               s_FL_COMPRESSED.get(),
-                                               k_FL_COMPRESSED);
-    Native::registerClassConstant<KindOfInt64>(s_ZipArchive.get(),
-                                               s_FL_UNCHANGED.get(),
-                                               k_FL_UNCHANGED);
-    Native::registerClassConstant<KindOfInt64>(s_ZipArchive.get(),
-                                               s_FL_RECOMPRESS.get(),
-                                               k_FL_RECOMPRESS);
-    Native::registerClassConstant<KindOfInt64>(s_ZipArchive.get(),
-                                               s_FL_ENCRYPTED.get(),
-                                               k_FL_ENCRYPTED);
-    Native::registerClassConstant<KindOfInt64>(s_ZipArchive.get(),
-                                               s_ER_OK.get(), k_ER_OK);
-    Native::registerClassConstant<KindOfInt64>(s_ZipArchive.get(),
-                                               s_ER_MULTIDISK.get(),
-                                               k_ER_MULTIDISK);
-    Native::registerClassConstant<KindOfInt64>(s_ZipArchive.get(),
-                                               s_ER_RENAME.get(), k_ER_RENAME);
-    Native::registerClassConstant<KindOfInt64>(s_ZipArchive.get(),
-                                               s_ER_CLOSE.get(), k_ER_CLOSE);
-    Native::registerClassConstant<KindOfInt64>(s_ZipArchive.get(),
-                                               s_ER_SEEK.get(), k_ER_SEEK);
-    Native::registerClassConstant<KindOfInt64>(s_ZipArchive.get(),
-                                               s_ER_READ.get(), k_ER_READ);
-    Native::registerClassConstant<KindOfInt64>(s_ZipArchive.get(),
-                                               s_ER_WRITE.get(), k_ER_WRITE);
-    Native::registerClassConstant<KindOfInt64>(s_ZipArchive.get(),
-                                               s_ER_CRC.get(), k_ER_CRC);
-    Native::registerClassConstant<KindOfInt64>(s_ZipArchive.get(),
-                                               s_ER_ZIPCLOSED.get(),
-                                               k_ER_ZIPCLOSED);
-    Native::registerClassConstant<KindOfInt64>(s_ZipArchive.get(),
-                                               s_ER_NOENT.get(), k_ER_NOENT);
-    Native::registerClassConstant<KindOfInt64>(s_ZipArchive.get(),
-                                               s_ER_EXISTS.get(), k_ER_EXISTS);
-    Native::registerClassConstant<KindOfInt64>(s_ZipArchive.get(),
-                                               s_ER_OPEN.get(), k_ER_OPEN);
-    Native::registerClassConstant<KindOfInt64>(s_ZipArchive.get(),
-                                               s_ER_TMPOPEN.get(),
-                                               k_ER_TMPOPEN);
-    Native::registerClassConstant<KindOfInt64>(s_ZipArchive.get(),
-                                               s_ER_ZLIB.get(), k_ER_ZLIB);
-    Native::registerClassConstant<KindOfInt64>(s_ZipArchive.get(),
-                                               s_ER_MEMORY.get(), k_ER_MEMORY);
-    Native::registerClassConstant<KindOfInt64>(s_ZipArchive.get(),
-                                               s_ER_CHANGED.get(),
-                                               k_ER_CHANGED);
-    Native::registerClassConstant<KindOfInt64>(s_ZipArchive.get(),
-                                               s_ER_COMPNOTSUPP.get(),
-                                               k_ER_COMPNOTSUPP);
-    Native::registerClassConstant<KindOfInt64>(s_ZipArchive.get(),
-                                               s_ER_EOF.get(), k_ER_EOF);
-    Native::registerClassConstant<KindOfInt64>(s_ZipArchive.get(),
-                                               s_ER_INVAL.get(), k_ER_INVAL);
-    Native::registerClassConstant<KindOfInt64>(s_ZipArchive.get(),
-                                               s_ER_NOZIP.get(), k_ER_NOZIP);
-    Native::registerClassConstant<KindOfInt64>(s_ZipArchive.get(),
-                                               s_ER_INTERNAL.get(),
-                                               k_ER_INTERNAL);
-    Native::registerClassConstant<KindOfInt64>(s_ZipArchive.get(),
-                                               s_ER_INCONS.get(), k_ER_INCONS);
-    Native::registerClassConstant<KindOfInt64>(s_ZipArchive.get(),
-                                               s_ER_REMOVE.get(), k_ER_REMOVE);
-    Native::registerClassConstant<KindOfInt64>(s_ZipArchive.get(),
-                                               s_ER_DELETED.get(),
-                                               k_ER_DELETED);
-    Native::registerClassConstant<KindOfInt64>(s_ZipArchive.get(),
-                                               s_ER_ENCRNOTSUPP.get(),
-                                               k_ER_ENCRNOTSUPP);
-    Native::registerClassConstant<KindOfInt64>(s_ZipArchive.get(),
-                                               s_ER_RDONLY.get(), k_ER_RDONLY);
-    Native::registerClassConstant<KindOfInt64>(s_ZipArchive.get(),
-                                               s_ER_NOPASSWD.get(),
-                                               k_ER_NOPASSWD);
-    Native::registerClassConstant<KindOfInt64>(s_ZipArchive.get(),
-                                               s_ER_WRONGPASSWD.get(),
-                                               k_ER_WRONGPASSWD);
-    Native::registerClassConstant<KindOfInt64>(s_ZipArchive.get(),
-                                               s_CM_DEFAULT.get(),
-                                               k_CM_DEFAULT);
-    Native::registerClassConstant<KindOfInt64>(s_ZipArchive.get(),
-                                               s_CM_STORE.get(), k_CM_STORE);
-    Native::registerClassConstant<KindOfInt64>(s_ZipArchive.get(),
-                                               s_CM_SHRINK.get(), k_CM_SHRINK);
-    Native::registerClassConstant<KindOfInt64>(s_ZipArchive.get(),
-                                               s_CM_REDUCE_1.get(),
-                                               k_CM_REDUCE_1);
-    Native::registerClassConstant<KindOfInt64>(s_ZipArchive.get(),
-                                               s_CM_REDUCE_2.get(),
-                                               k_CM_REDUCE_2);
-    Native::registerClassConstant<KindOfInt64>(s_ZipArchive.get(),
-                                               s_CM_REDUCE_3.get(),
-                                               k_CM_REDUCE_3);
-    Native::registerClassConstant<KindOfInt64>(s_ZipArchive.get(),
-                                               s_CM_REDUCE_4.get(),
-                                               k_CM_REDUCE_4);
-    Native::registerClassConstant<KindOfInt64>(s_ZipArchive.get(),
-                                               s_CM_IMPLODE.get(),
-                                               k_CM_IMPLODE);
-    Native::registerClassConstant<KindOfInt64>(s_ZipArchive.get(),
-                                               s_CM_DEFLATE.get(),
-                                               k_CM_DEFLATE);
-    Native::registerClassConstant<KindOfInt64>(s_ZipArchive.get(),
-                                               s_CM_DEFLATE64.get(),
-                                               k_CM_DEFLATE64);
-    Native::registerClassConstant<KindOfInt64>(s_ZipArchive.get(),
-                                               s_CM_PKWARE_IMPLODE.get(),
-                                               k_CM_PKWARE_IMPLODE);
-    Native::registerClassConstant<KindOfInt64>(s_ZipArchive.get(),
-                                               s_CM_BZIP2.get(),
-                                               k_CM_BZIP2);
-    Native::registerClassConstant<KindOfInt64>(s_ZipArchive.get(),
-                                               s_CM_LZMA.get(),
-                                               k_CM_LZMA);
-    Native::registerClassConstant<KindOfInt64>(s_ZipArchive.get(),
-                                               s_CM_TERSE.get(),
-                                               k_CM_TERSE);
-    Native::registerClassConstant<KindOfInt64>(s_ZipArchive.get(),
-                                               s_CM_LZ77.get(),
-                                               k_CM_LZ77);
-    Native::registerClassConstant<KindOfInt64>(s_ZipArchive.get(),
-                                               s_CM_WAVPACK.get(),
-                                               k_CM_WAVPACK);
-    Native::registerClassConstant<KindOfInt64>(s_ZipArchive.get(),
-                                               s_CM_PPMD.get(),
-                                               k_CM_PPMD);
+
+    HHVM_RCC_INT(ZipArchive, CREATE, ZIP_CREATE);
+    HHVM_RCC_INT(ZipArchive, EXCL, ZIP_EXCL);
+    HHVM_RCC_INT(ZipArchive, CHECKCONS, ZIP_CHECKCONS);
+    HHVM_RCC_INT(ZipArchive, OVERWRITE, ZIP_TRUNCATE);
+    HHVM_RCC_INT(ZipArchive, FL_NOCASE, ZIP_FL_NOCASE);
+    HHVM_RCC_INT(ZipArchive, FL_NODIR, ZIP_FL_NODIR);
+    HHVM_RCC_INT(ZipArchive, FL_COMPRESSED, ZIP_FL_COMPRESSED);
+    HHVM_RCC_INT(ZipArchive, FL_UNCHANGED, ZIP_FL_UNCHANGED);
+    HHVM_RCC_INT(ZipArchive, FL_RECOMPRESS, ZIP_FL_RECOMPRESS);
+    HHVM_RCC_INT(ZipArchive, FL_ENCRYPTED, ZIP_FL_ENCRYPTED);
+    HHVM_RCC_INT(ZipArchive, ER_OK, ZIP_ER_OK);
+    HHVM_RCC_INT(ZipArchive, ER_MULTIDISK, ZIP_ER_MULTIDISK);
+    HHVM_RCC_INT(ZipArchive, ER_RENAME, ZIP_ER_RENAME);
+    HHVM_RCC_INT(ZipArchive, ER_CLOSE, ZIP_ER_CLOSE);
+    HHVM_RCC_INT(ZipArchive, ER_SEEK, ZIP_ER_SEEK);
+    HHVM_RCC_INT(ZipArchive, ER_READ, ZIP_ER_READ);
+    HHVM_RCC_INT(ZipArchive, ER_WRITE, ZIP_ER_WRITE);
+    HHVM_RCC_INT(ZipArchive, ER_CRC, ZIP_ER_CRC);
+    HHVM_RCC_INT(ZipArchive, ER_ZIPCLOSED, ZIP_ER_ZIPCLOSED);
+    HHVM_RCC_INT(ZipArchive, ER_NOENT, ZIP_ER_NOENT);
+    HHVM_RCC_INT(ZipArchive, ER_EXISTS, ZIP_ER_EXISTS);
+    HHVM_RCC_INT(ZipArchive, ER_OPEN, ZIP_ER_OPEN);
+    HHVM_RCC_INT(ZipArchive, ER_TMPOPEN, ZIP_ER_TMPOPEN);
+    HHVM_RCC_INT(ZipArchive, ER_ZLIB, ZIP_ER_ZLIB);
+    HHVM_RCC_INT(ZipArchive, ER_MEMORY, ZIP_ER_MEMORY);
+    HHVM_RCC_INT(ZipArchive, ER_CHANGED, ZIP_ER_CHANGED);
+    HHVM_RCC_INT(ZipArchive, ER_COMPNOTSUPP, ZIP_ER_COMPNOTSUPP);
+    HHVM_RCC_INT(ZipArchive, ER_EOF, ZIP_ER_EOF);
+    HHVM_RCC_INT(ZipArchive, ER_INVAL, ZIP_ER_INVAL);
+    HHVM_RCC_INT(ZipArchive, ER_NOZIP, ZIP_ER_NOZIP);
+    HHVM_RCC_INT(ZipArchive, ER_INTERNAL, ZIP_ER_INTERNAL);
+    HHVM_RCC_INT(ZipArchive, ER_INCONS, ZIP_ER_INCONS);
+    HHVM_RCC_INT(ZipArchive, ER_REMOVE, ZIP_ER_REMOVE);
+    HHVM_RCC_INT(ZipArchive, ER_DELETED, ZIP_ER_DELETED);
+    HHVM_RCC_INT(ZipArchive, ER_ENCRNOTSUPP, ZIP_ER_ENCRNOTSUPP);
+    HHVM_RCC_INT(ZipArchive, ER_RDONLY, ZIP_ER_RDONLY);
+    HHVM_RCC_INT(ZipArchive, ER_NOPASSWD, ZIP_ER_NOPASSWD);
+    HHVM_RCC_INT(ZipArchive, ER_WRONGPASSWD, ZIP_ER_WRONGPASSWD);
+    HHVM_RCC_INT(ZipArchive, CM_DEFAULT, ZIP_CM_DEFAULT);
+    HHVM_RCC_INT(ZipArchive, CM_STORE, ZIP_CM_STORE);
+    HHVM_RCC_INT(ZipArchive, CM_SHRINK, ZIP_CM_SHRINK);
+    HHVM_RCC_INT(ZipArchive, CM_REDUCE_1, ZIP_CM_REDUCE_1);
+    HHVM_RCC_INT(ZipArchive, CM_REDUCE_2, ZIP_CM_REDUCE_2);
+    HHVM_RCC_INT(ZipArchive, CM_REDUCE_3, ZIP_CM_REDUCE_3);
+    HHVM_RCC_INT(ZipArchive, CM_REDUCE_4, ZIP_CM_REDUCE_4);
+    HHVM_RCC_INT(ZipArchive, CM_IMPLODE, ZIP_CM_IMPLODE);
+    HHVM_RCC_INT(ZipArchive, CM_DEFLATE, ZIP_CM_DEFLATE);
+    HHVM_RCC_INT(ZipArchive, CM_DEFLATE64, ZIP_CM_DEFLATE64);
+    HHVM_RCC_INT(ZipArchive, CM_PKWARE_IMPLODE, ZIP_CM_PKWARE_IMPLODE);
+    HHVM_RCC_INT(ZipArchive, CM_BZIP2, ZIP_CM_BZIP2);
+    HHVM_RCC_INT(ZipArchive, CM_LZMA, ZIP_CM_LZMA);
+    HHVM_RCC_INT(ZipArchive, CM_TERSE, ZIP_CM_TERSE);
+    HHVM_RCC_INT(ZipArchive, CM_LZ77, ZIP_CM_LZ77);
+    HHVM_RCC_INT(ZipArchive, CM_WAVPACK, ZIP_CM_WAVPACK);
+    HHVM_RCC_INT(ZipArchive, CM_PPMD, ZIP_CM_PPMD);
 
     HHVM_FE(zip_close);
     HHVM_FE(zip_entry_close);


### PR DESCRIPTION
This was split out of #6365 (D48705) to make reviewing easier.