### PR TITLE
[Const Macros] Switch ext_url to use the new const registering macros

### DIFF
--- a/hphp/runtime/ext/url/ext_url.cpp
+++ b/hphp/runtime/ext/url/ext_url.cpp
@@ -311,51 +311,20 @@ String HHVM_FUNCTION(urlencode, const String& str) {
 
 ///////////////////////////////////////////////////////////////////////////////
 
-const StaticString s_PHP_URL_SCHEME("PHP_URL_SCHEME");
-const StaticString s_PHP_URL_HOST("PHP_URL_HOST");
-const StaticString s_PHP_URL_PORT("PHP_URL_PORT");
-const StaticString s_PHP_URL_USER("PHP_URL_USER");
-const StaticString s_PHP_URL_PASS("PHP_URL_PASS");
-const StaticString s_PHP_URL_PATH("PHP_URL_PATH");
-const StaticString s_PHP_URL_QUERY("PHP_URL_QUERY");
-const StaticString s_PHP_URL_FRAGMENT("PHP_URL_FRAGMENT");
-const StaticString s_PHP_QUERY_RFC1738("PHP_QUERY_RFC1738");
-const StaticString s_PHP_QUERY_RFC3986("PHP_QUERY_RFC3986");
-
 class StandardURLExtension final : public Extension {
  public:
   StandardURLExtension() : Extension("url") {}
   void moduleInit() override {
-    Native::registerConstant<KindOfInt64>(
-      s_PHP_URL_SCHEME.get(), k_PHP_URL_SCHEME
-    );
-    Native::registerConstant<KindOfInt64>(
-      s_PHP_URL_HOST.get(), k_PHP_URL_HOST
-    );
-    Native::registerConstant<KindOfInt64>(
-      s_PHP_URL_PORT.get(), k_PHP_URL_PORT
-    );
-    Native::registerConstant<KindOfInt64>(
-      s_PHP_URL_USER.get(), k_PHP_URL_USER
-    );
-    Native::registerConstant<KindOfInt64>(
-      s_PHP_URL_PASS.get(), k_PHP_URL_PASS
-    );
-    Native::registerConstant<KindOfInt64>(
-      s_PHP_URL_PATH.get(), k_PHP_URL_PATH
-    );
-    Native::registerConstant<KindOfInt64>(
-      s_PHP_URL_QUERY.get(), k_PHP_URL_QUERY
-    );
-    Native::registerConstant<KindOfInt64>(
-      s_PHP_URL_FRAGMENT.get(), k_PHP_URL_FRAGMENT
-    );
-    Native::registerConstant<KindOfInt64>(
-      s_PHP_QUERY_RFC1738.get(), k_PHP_QUERY_RFC1738
-    );
-    Native::registerConstant<KindOfInt64>(
-      s_PHP_QUERY_RFC3986.get(), k_PHP_QUERY_RFC3986
-    );
+    HHVM_RC_INT(PHP_URL_SCHEME, k_PHP_URL_SCHEME);
+    HHVM_RC_INT(PHP_URL_HOST, k_PHP_URL_HOST);
+    HHVM_RC_INT(PHP_URL_PORT, k_PHP_URL_PORT);
+    HHVM_RC_INT(PHP_URL_USER, k_PHP_URL_USER);
+    HHVM_RC_INT(PHP_URL_PASS, k_PHP_URL_PASS);
+    HHVM_RC_INT(PHP_URL_PATH, k_PHP_URL_PATH);
+    HHVM_RC_INT(PHP_URL_QUERY, k_PHP_URL_QUERY);
+    HHVM_RC_INT(PHP_URL_FRAGMENT, k_PHP_URL_FRAGMENT);
+    HHVM_RC_INT(PHP_QUERY_RFC1738, k_PHP_QUERY_RFC1738);
+    HHVM_RC_INT(PHP_QUERY_RFC3986, k_PHP_QUERY_RFC3986);
     HHVM_FE(base64_decode);
     HHVM_FE(base64_encode);
     HHVM_FE(get_headers);


### PR DESCRIPTION
This was split out of #6365 (D48705) to make reviewing easier.