### PR TITLE
[Const Macros] Switch ext_stream to use the new const registering macros

### DIFF
--- a/hphp/runtime/ext/stream/ext_stream-user-filters.cpp
+++ b/hphp/runtime/ext/stream/ext_stream-user-filters.cpp
@@ -385,18 +385,10 @@ void HHVM_FUNCTION(stream_bucket_prepend, const Resource& bb_res, const Object& 
   cast<BucketBrigade>(bb_res)->prependBucket(bucket);
 }
 
-const StaticString
-  s_STREAM_FILTER_READ("STREAM_FILTER_READ"),
-  s_STREAM_FILTER_WRITE("STREAM_FILTER_WRITE"),
-  s_STREAM_FILTER_ALL("STREAM_FILTER_ALL");
-
 void StandardExtension::initStreamUserFilters() {
-#define SFCNS(v) Native::registerConstant<KindOfInt64> \
-                         (s_STREAM_FILTER_##v.get(), k_STREAM_FILTER_##v)
-  SFCNS(READ);
-  SFCNS(WRITE);
-  SFCNS(ALL);
-#undef SFCNS
+  HHVM_RC_INT(STREAM_FILTER_READ, k_STREAM_FILTER_READ);
+  HHVM_RC_INT(STREAM_FILTER_WRITE, k_STREAM_FILTER_WRITE);
+  HHVM_RC_INT(STREAM_FILTER_ALL, k_STREAM_FILTER_ALL);
 
   HHVM_FE(stream_get_filters);
   HHVM_FE(stream_filter_register);

--- a/hphp/runtime/ext/stream/ext_stream.cpp
+++ b/hphp/runtime/ext/stream/ext_stream.cpp
@@ -60,11 +60,7 @@ namespace HPHP {
 static
 req::ptr<StreamContext> get_stream_context(const Variant& stream_or_context);
 
-#define REGISTER_CONSTANT(name, value)                                         \
-  Native::registerConstant<KindOfInt64>(makeStaticString(#name), value)        \
-
-#define REGISTER_SAME_CONSTANT(name) \
-  Native::registerConstant<KindOfInt64>(makeStaticString(#name), k_ ##name)    \
+#define REGISTER_SAME_CONSTANT(name) HHVM_RC_INT(name, k_ ## name);
 
 static class StreamExtension final : public Extension {
 public:
@@ -146,14 +142,14 @@ public:
     REGISTER_SAME_CONSTANT(STREAM_SOCK_STREAM);
     REGISTER_SAME_CONSTANT(STREAM_USE_PATH);
 
-    REGISTER_CONSTANT(STREAM_AWAIT_READ, FileEventHandler::READ);
-    REGISTER_CONSTANT(STREAM_AWAIT_WRITE, FileEventHandler::WRITE);
-    REGISTER_CONSTANT(STREAM_AWAIT_READ_WRITE, FileEventHandler::READ_WRITE);
+    HHVM_RC_INT(STREAM_AWAIT_READ, FileEventHandler::READ);
+    HHVM_RC_INT(STREAM_AWAIT_WRITE, FileEventHandler::WRITE);
+    HHVM_RC_INT(STREAM_AWAIT_READ_WRITE, FileEventHandler::READ_WRITE);
 
-    REGISTER_CONSTANT(STREAM_AWAIT_ERROR, FileAwait::ERROR);
-    REGISTER_CONSTANT(STREAM_AWAIT_TIMEOUT, FileAwait::TIMEOUT);
-    REGISTER_CONSTANT(STREAM_AWAIT_READY, FileAwait::READY);
-    REGISTER_CONSTANT(STREAM_AWAIT_CLOSED, FileAwait::CLOSED);
+    HHVM_RC_INT(STREAM_AWAIT_ERROR, FileAwait::ERROR);
+    HHVM_RC_INT(STREAM_AWAIT_TIMEOUT, FileAwait::TIMEOUT);
+    HHVM_RC_INT(STREAM_AWAIT_READY, FileAwait::READY);
+    HHVM_RC_INT(STREAM_AWAIT_CLOSED, FileAwait::CLOSED);
 
     REGISTER_SAME_CONSTANT(STREAM_URL_STAT_LINK);
     REGISTER_SAME_CONSTANT(STREAM_URL_STAT_QUIET);


### PR DESCRIPTION
This was split out of #6365 (D48705) to make reviewing easier.