### PR TITLE
[Const Macros] Switch ext_server to use the new const registering macros

### DIFF
--- a/hphp/runtime/ext/server/ext_server.cpp
+++ b/hphp/runtime/ext/server/ext_server.cpp
@@ -32,19 +32,13 @@
 
 namespace HPHP {
 
-static const StaticString s_PAGELET_NOT_READY("PAGELET_NOT_READY");
-static const StaticString s_PAGELET_READY("PAGELET_READY");
-static const StaticString s_PAGELET_DONE("PAGELET_DONE");
-
 static class ServerExtension final : public Extension {
 public:
   ServerExtension() : Extension("server", NO_EXTENSION_VERSION_YET) {}
   void moduleInit() override {
-    Native::registerConstant<KindOfInt64>(s_PAGELET_NOT_READY.get(),
-                                          k_PAGELET_NOT_READY);
-    Native::registerConstant<KindOfInt64>(s_PAGELET_READY.get(),
-                                          k_PAGELET_READY);
-    Native::registerConstant<KindOfInt64>(s_PAGELET_DONE.get(), k_PAGELET_DONE);
+    HHVM_RC_INT_SAME(PAGELET_NOT_READY);
+    HHVM_RC_INT_SAME(PAGELET_READY);
+    HHVM_RC_INT_SAME(PAGELET_DONE);
 
     HHVM_FE(hphp_thread_type);
     HHVM_FE(dangling_server_proxy_old_request);
@@ -115,10 +109,6 @@ bool HHVM_FUNCTION(dangling_server_proxy_old_request) {
 
 ///////////////////////////////////////////////////////////////////////////////
 // Pagelet Server
-
-const int64_t k_PAGELET_NOT_READY = PAGELET_NOT_READY;
-const int64_t k_PAGELET_READY     = PAGELET_READY;
-const int64_t k_PAGELET_DONE      = PAGELET_DONE;
 
 bool HHVM_FUNCTION(pagelet_server_is_enabled) {
   return PageletServer::Enabled();

--- a/hphp/runtime/ext/server/ext_server.h
+++ b/hphp/runtime/ext/server/ext_server.h
@@ -25,10 +25,6 @@
 namespace HPHP {
 ///////////////////////////////////////////////////////////////////////////////
 
-extern const int64_t k_PAGELET_NOT_READY;
-extern const int64_t k_PAGELET_READY;
-extern const int64_t k_PAGELET_DONE;
-
 enum PageletStatusType {
   PAGELET_NOT_READY,
   PAGELET_READY,


### PR DESCRIPTION
This was split out of #6365 (D48705) to make reviewing easier.