### PR TITLE
[Const Macros] Switch ext_readline to use the new const registering macros

### DIFF
--- a/hphp/runtime/ext/readline/ext_readline.cpp
+++ b/hphp/runtime/ext/readline/ext_readline.cpp
@@ -271,13 +271,9 @@ static class ReadlineExtension final : public Extension {
     ReadlineExtension() : Extension("readline") {}
     void moduleInit() override {
 #ifdef USE_EDITLINE
-      Native::registerConstant<KindOfStaticString>(
-          makeStaticString("READLINE_LIB"), makeStaticString("libedit")
-      );
+      HHVM_RC_STR(READLINE_LIB, "libedit");
 #else
-      Native::registerConstant<KindOfStaticString>(
-          makeStaticString("READLINE_LIB"), makeStaticString("readline")
-      );
+      HHVM_RC_STR(READLINE_LIB, "readline");
 #endif
       HHVM_FE(readline);
       HHVM_FE(readline_add_history);


### PR DESCRIPTION
This was split out of #6365 (D48705) to make reviewing easier.