### PR TITLE
[Const Macros] Switch ext_gmp to use the new const registering macros

### DIFF
--- a/hphp/runtime/ext/gmp/ext_gmp.cpp
+++ b/hphp/runtime/ext/gmp/ext_gmp.cpp
@@ -1427,21 +1427,11 @@ class GMPExtension final : public Extension {
 public:
   GMPExtension() : Extension("gmp", "2.0.0-hhvm") { };
   void moduleInit() override {
-    Native::registerConstant<KindOfInt64>(
-      s_GMP_MAX_BASE.get(), GMP_MAX_BASE
-    );
-    Native::registerConstant<KindOfInt64>(
-      s_GMP_ROUND_ZERO.get(), GMP_ROUND_ZERO
-    );
-    Native::registerConstant<KindOfInt64>(
-      s_GMP_ROUND_PLUSINF.get(), GMP_ROUND_PLUSINF
-    );
-    Native::registerConstant<KindOfInt64>(
-      s_GMP_ROUND_MINUSINF.get(), GMP_ROUND_MINUSINF
-    );
-    Native::registerConstant<KindOfStaticString>(
-      s_GMP_VERSION.get(), k_GMP_VERSION.get()
-    );
+    HHVM_RC_INT_SAME(GMP_MAX_BASE);
+    HHVM_RC_INT_SAME(GMP_ROUND_ZERO);
+    HHVM_RC_INT_SAME(GMP_ROUND_PLUSINF);
+    HHVM_RC_INT_SAME(GMP_ROUND_MINUSINF);
+    HHVM_RC_STR(GMP_VERSION, gmp_version);
 
     HHVM_FE(gmp_abs);
     HHVM_FE(gmp_add);

--- a/hphp/runtime/ext/gmp/ext_gmp.h
+++ b/hphp/runtime/ext/gmp/ext_gmp.h
@@ -57,14 +57,6 @@ const StaticString s_GMP_s("s");
 const StaticString s_GMP_t("t");
 const StaticString s_GMP_g("g");
 
-// Global defines Strings
-const StaticString s_GMP_MAX_BASE("GMP_MAX_BASE");
-const StaticString s_GMP_ROUND_ZERO("GMP_ROUND_ZERO");
-const StaticString s_GMP_ROUND_PLUSINF("GMP_ROUND_PLUSINF");
-const StaticString s_GMP_ROUND_MINUSINF("GMP_ROUND_MINUSINF");
-const StaticString s_GMP_VERSION("GMP_VERSION");
-const StaticString k_GMP_VERSION(gmp_version);
-
 // Error strings
 const char* const cs_GMP_INVALID_TYPE =
   "%s(): Unable to convert variable to GMP - wrong type";


### PR DESCRIPTION
This was split out of #6365 (D48705) to make reviewing easier.