### PR TITLE
[Const Macros] Switch ext_datetime to use the new const registering macros

### DIFF
--- a/hphp/runtime/ext/datetime/ext_datetime.cpp
+++ b/hphp/runtime/ext/datetime/ext_datetime.cpp
@@ -26,17 +26,17 @@
 namespace HPHP {
 
 static int check_id_allowed(const String& id, long bf) {
-  if (bf & q_DateTimeZone$$AFRICA && id.find("Africa/") == 0) return 1;
-  if (bf & q_DateTimeZone$$AMERICA && id.find("America/") == 0) return 1;
-  if (bf & q_DateTimeZone$$ANTARCTICA && id.find("Antarctica/") == 0) return 1;
-  if (bf & q_DateTimeZone$$ARCTIC && id.find("Arctic/") == 0) return 1;
-  if (bf & q_DateTimeZone$$ASIA && id.find("Asia/") == 0) return 1;
-  if (bf & q_DateTimeZone$$ATLANTIC && id.find("Atlantic/") == 0) return 1;
-  if (bf & q_DateTimeZone$$AUSTRALIA && id.find("Australia/") == 0) return 1;
-  if (bf & q_DateTimeZone$$EUROPE && id.find("Europe/") == 0) return 1;
-  if (bf & q_DateTimeZone$$INDIAN && id.find("Indian/") == 0) return 1;
-  if (bf & q_DateTimeZone$$PACIFIC && id.find("Pacific/") == 0) return 1;
-  if (bf & q_DateTimeZone$$UTC && id.find("UTC") == 0) return 1;
+  if (bf & DateTimeZoneData::AFRICA && id.find("Africa/") == 0) return 1;
+  if (bf & DateTimeZoneData::AMERICA && id.find("America/") == 0) return 1;
+  if (bf & DateTimeZoneData::ANTARCTICA && id.find("Antarctica/") == 0) return 1;
+  if (bf & DateTimeZoneData::ARCTIC && id.find("Arctic/") == 0) return 1;
+  if (bf & DateTimeZoneData::ASIA && id.find("Asia/") == 0) return 1;
+  if (bf & DateTimeZoneData::ATLANTIC && id.find("Atlantic/") == 0) return 1;
+  if (bf & DateTimeZoneData::AUSTRALIA && id.find("Australia/") == 0) return 1;
+  if (bf & DateTimeZoneData::EUROPE && id.find("Europe/") == 0) return 1;
+  if (bf & DateTimeZoneData::INDIAN && id.find("Indian/") == 0) return 1;
+  if (bf & DateTimeZoneData::PACIFIC && id.find("Pacific/") == 0) return 1;
+  if (bf & DateTimeZoneData::UTC && id.find("UTC") == 0) return 1;
   return 0;
 }
 
@@ -77,25 +77,6 @@ IMPLEMENT_THREAD_LOCAL(DateGlobals, s_date_globals);
 
 ///////////////////////////////////////////////////////////////////////////////
 // constants
-
-#define DEFINE_TIME_ZONE_CONSTANT(name, value)                                 \
-  const int64_t q_DateTimeZone$$##name(value);                                 \
-  const StaticString s_DateTimeZone$$##name(#name)                             \
-
-DEFINE_TIME_ZONE_CONSTANT(AFRICA, 1);
-DEFINE_TIME_ZONE_CONSTANT(AMERICA, 2);
-DEFINE_TIME_ZONE_CONSTANT(ANTARCTICA, 4);
-DEFINE_TIME_ZONE_CONSTANT(ARCTIC, 8);
-DEFINE_TIME_ZONE_CONSTANT(ASIA, 16);
-DEFINE_TIME_ZONE_CONSTANT(ATLANTIC, 32);
-DEFINE_TIME_ZONE_CONSTANT(AUSTRALIA, 64);
-DEFINE_TIME_ZONE_CONSTANT(EUROPE, 128);
-DEFINE_TIME_ZONE_CONSTANT(INDIAN, 256);
-DEFINE_TIME_ZONE_CONSTANT(PACIFIC, 512);
-DEFINE_TIME_ZONE_CONSTANT(UTC, 1024);
-DEFINE_TIME_ZONE_CONSTANT(ALL, 2047);
-DEFINE_TIME_ZONE_CONSTANT(ALL_WITH_BC, 4095);
-DEFINE_TIME_ZONE_CONSTANT(PER_COUNTRY, 4096);
 
 const StaticString s_data("data");
 const StaticString s_getTimestamp("getTimestamp");
@@ -401,7 +382,7 @@ Variant HHVM_STATIC_METHOD(DateTimeZone, listIdentifiers,
                            const String& country) {
   // This is the same check that PHP5 performs, no validation needed.
   // See ext/date/php_date.c lines 4496-4499
-  if (what == q_DateTimeZone$$PER_COUNTRY && country.length() != 2) {
+  if (what == DateTimeZoneData::PER_COUNTRY && country.length() != 2) {
     raise_notice("A two-letter ISO 3166-1 compatible country code is expected");
     return false;
   }
@@ -418,8 +399,8 @@ Variant HHVM_STATIC_METHOD(DateTimeZone, listIdentifiers,
     // There is no known better way to extract this information out.
     const char* infoString = (const char*)&tzdb->data[table[i].pos];
     String countryCode = String(&infoString[5], 2, CopyString);
-    if ((what == q_DateTimeZone$$PER_COUNTRY && equal(country, countryCode))
-        || what == q_DateTimeZone$$ALL_WITH_BC
+    if ((what == DateTimeZoneData::PER_COUNTRY && equal(country, countryCode))
+        || what == DateTimeZoneData::ALL_WITH_BC
         || (check_id_allowed(table[i].id, what)
             && tzdb->data[table[i].pos + 4] == '\1')) {
 
@@ -854,23 +835,21 @@ Variant date_sunrise_sunset(int64_t numArgs,
 
 ///////////////////////////////////////////////////////////////////////////////
 
-#define REGISTER_TIME_ZONE_CONSTANT(name)                                      \
-  Native::registerClassConstant<KindOfInt64>(                                  \
-    DateTimeZoneData::s_className.get(), s_DateTimeZone$$##name.get(),         \
-    q_DateTimeZone$$##name)                                                    \
+static const StaticString
+  s_DateTimeZone("DateTimeZone"),
+  s_DateTime("DateTime");
 
-const StaticString
-  k_DATE_ATOM("Y-m-d\\TH:i:sP"),
-  k_DATE_COOKIE("l, d-M-y H:i:s T"),
-  k_DATE_ISO8601("Y-m-d\\TH:i:sO"),
-  k_DATE_RFC822("D, d M y H:i:s O"),
-  k_DATE_RFC850("l, d-M-y H:i:s T"),
-  k_DATE_RFC1036("D, d M y H:i:s O"),
-  k_DATE_RFC1123("D, d M Y H:i:s O"),
-  k_DATE_RFC2822("D, d M Y H:i:s O"),
-  k_DATE_RFC3339("Y-m-d\\TH:i:sP"),
-  k_DATE_RSS("D, d M Y H:i:s O"),
-  k_DATE_W3C("Y-m-d\\TH:i:sP");
+#define DATE_ATOM "Y-m-d\\TH:i:sP"
+#define DATE_COOKIE "l, d-M-y H:i:s T"
+#define DATE_ISO8601 "Y-m-d\\TH:i:sO"
+#define DATE_RFC822 "D, d M y H:i:s O"
+#define DATE_RFC850 "l, d-M-y H:i:s T"
+#define DATE_RFC1036 "D, d M y H:i:s O"
+#define DATE_RFC1123 "D, d M Y H:i:s O"
+#define DATE_RFC2822 "D, d M Y H:i:s O"
+#define DATE_RFC3339 "Y-m-d\\TH:i:sP"
+#define DATE_RSS "D, d M Y H:i:s O"
+#define DATE_W3C "Y-m-d\\TH:i:sP"
 
 static class DateTimeExtension final : public Extension {
 public:
@@ -900,39 +879,43 @@ public:
     Native::registerNativeDataInfo<DateTimeData>(
       DateTimeData::s_className.get(), Native::NDIFlags::NO_SWEEP);
 
-#define DATETIME_FORMAT(cns) \
-  Native::registerConstant<KindOfString> \
-    (makeStaticString("DATE_" #cns), k_DATE_ ## cns.get()); \
-  Native::registerClassConstant<KindOfString> \
-    (DateTimeData::s_className.get(), makeStaticString(#cns), \
-      k_DATE_ ## cns.get());
-    DATETIME_FORMAT(ATOM);
-    DATETIME_FORMAT(COOKIE);
-    DATETIME_FORMAT(ISO8601);
-    DATETIME_FORMAT(RFC822);
-    DATETIME_FORMAT(RFC850);
-    DATETIME_FORMAT(RFC1036);
-    DATETIME_FORMAT(RFC1123);
-    DATETIME_FORMAT(RFC2822);
-    DATETIME_FORMAT(RFC3339);
-    DATETIME_FORMAT(RSS);
-    DATETIME_FORMAT(W3C);
-#undef DATETIME_FORMAT
+    HHVM_RC_STR_SAME(DATE_ATOM);
+    HHVM_RCC_STR(DateTime, ATOM, DATE_ATOM);
+    HHVM_RC_STR_SAME(DATE_COOKIE);
+    HHVM_RCC_STR(DateTime, COOKIE, DATE_COOKIE);
+    HHVM_RC_STR_SAME(DATE_ISO8601);
+    HHVM_RCC_STR(DateTime, ISO8601, DATE_ISO8601);
+    HHVM_RC_STR_SAME(DATE_RFC822);
+    HHVM_RCC_STR(DateTime, RFC822, DATE_RFC822);
+    HHVM_RC_STR_SAME(DATE_RFC850);
+    HHVM_RCC_STR(DateTime, RFC850, DATE_RFC850);
+    HHVM_RC_STR_SAME(DATE_RFC1036);
+    HHVM_RCC_STR(DateTime, RFC1036, DATE_RFC1036);
+    HHVM_RC_STR_SAME(DATE_RFC1123);
+    HHVM_RCC_STR(DateTime, RFC1123, DATE_RFC1123);
+    HHVM_RC_STR_SAME(DATE_RFC2822);
+    HHVM_RCC_STR(DateTime, RFC2822, DATE_RFC2822);
+    HHVM_RC_STR_SAME(DATE_RFC3339);
+    HHVM_RCC_STR(DateTime, RFC3339, DATE_RFC3339);
+    HHVM_RC_STR_SAME(DATE_RSS);
+    HHVM_RCC_STR(DateTime, RSS, DATE_RSS);
+    HHVM_RC_STR_SAME(DATE_W3C);
+    HHVM_RCC_STR(DateTime, W3C, DATE_W3C);
 
-    REGISTER_TIME_ZONE_CONSTANT(AFRICA);
-    REGISTER_TIME_ZONE_CONSTANT(AMERICA);
-    REGISTER_TIME_ZONE_CONSTANT(ANTARCTICA);
-    REGISTER_TIME_ZONE_CONSTANT(ARCTIC);
-    REGISTER_TIME_ZONE_CONSTANT(ASIA);
-    REGISTER_TIME_ZONE_CONSTANT(ATLANTIC);
-    REGISTER_TIME_ZONE_CONSTANT(AUSTRALIA);
-    REGISTER_TIME_ZONE_CONSTANT(EUROPE);
-    REGISTER_TIME_ZONE_CONSTANT(INDIAN);
-    REGISTER_TIME_ZONE_CONSTANT(PACIFIC);
-    REGISTER_TIME_ZONE_CONSTANT(UTC);
-    REGISTER_TIME_ZONE_CONSTANT(ALL);
-    REGISTER_TIME_ZONE_CONSTANT(ALL_WITH_BC);
-    REGISTER_TIME_ZONE_CONSTANT(PER_COUNTRY);
+    HHVM_RCC_INT(DateTimeZone, AFRICA, DateTimeZoneData::AFRICA);
+    HHVM_RCC_INT(DateTimeZone, AMERICA, DateTimeZoneData::AMERICA);
+    HHVM_RCC_INT(DateTimeZone, ANTARCTICA, DateTimeZoneData::ANTARCTICA);
+    HHVM_RCC_INT(DateTimeZone, ARCTIC, DateTimeZoneData::ARCTIC);
+    HHVM_RCC_INT(DateTimeZone, ASIA, DateTimeZoneData::ASIA);
+    HHVM_RCC_INT(DateTimeZone, ATLANTIC, DateTimeZoneData::ATLANTIC);
+    HHVM_RCC_INT(DateTimeZone, AUSTRALIA, DateTimeZoneData::AUSTRALIA);
+    HHVM_RCC_INT(DateTimeZone, EUROPE, DateTimeZoneData::EUROPE);
+    HHVM_RCC_INT(DateTimeZone, INDIAN, DateTimeZoneData::INDIAN);
+    HHVM_RCC_INT(DateTimeZone, PACIFIC, DateTimeZoneData::PACIFIC);
+    HHVM_RCC_INT(DateTimeZone, UTC, DateTimeZoneData::UTC);
+    HHVM_RCC_INT(DateTimeZone, ALL, DateTimeZoneData::ALL);
+    HHVM_RCC_INT(DateTimeZone, ALL_WITH_BC, DateTimeZoneData::ALL_WITH_BC);
+    HHVM_RCC_INT(DateTimeZone, PER_COUNTRY, DateTimeZoneData::PER_COUNTRY);
 
     HHVM_ME(DateTimeZone, __construct);
     HHVM_ME(DateTimeZone, getLocation);
@@ -981,14 +964,10 @@ public:
     HHVM_FE(timezone_name_from_abbr);
     HHVM_FE(timezone_version_get);
 
-#define SUNFUNCS_CNS(name, type) \
-    Native::registerConstant<KindOfInt64> \
-      (makeStaticString("SUNFUNCS_RET_" #name), \
-      (int64_t)DateTime::SunInfoFormat::Return##type);
-    SUNFUNCS_CNS(DOUBLE, Double);
-    SUNFUNCS_CNS(STRING, String);
-    SUNFUNCS_CNS(TIMESTAMP, TimeStamp);
-#undef SUNFUNCS_CNS
+    HHVM_RC_INT(SUNFUNCS_RET_DOUBLE, DateTime::SunInfoFormat::ReturnDouble);
+    HHVM_RC_INT(SUNFUNCS_RET_STRING, DateTime::SunInfoFormat::ReturnString);
+    HHVM_RC_INT(SUNFUNCS_RET_TIMESTAMP,
+                DateTime::SunInfoFormat::ReturnTimeStamp);
 
     loadSystemlib("datetime");
   }

--- a/hphp/runtime/ext/datetime/ext_datetime.h
+++ b/hphp/runtime/ext/datetime/ext_datetime.h
@@ -29,18 +29,6 @@ namespace HPHP {
 ///////////////////////////////////////////////////////////////////////////////
 // class DateTime
 
-extern const StaticString q_DateTime$$ATOM;
-extern const StaticString q_DateTime$$COOKIE;
-extern const StaticString q_DateTime$$ISO8601;
-extern const StaticString q_DateTime$$RFC822;
-extern const StaticString q_DateTime$$RFC850;
-extern const StaticString q_DateTime$$RFC1036;
-extern const StaticString q_DateTime$$RFC1123;
-extern const StaticString q_DateTime$$RFC2822;
-extern const StaticString q_DateTime$$RFC3339;
-extern const StaticString q_DateTime$$RSS;
-extern const StaticString q_DateTime$$W3C;
-
 class DateTimeData {
 public:
   DateTimeData() {}
@@ -118,21 +106,6 @@ Array HHVM_METHOD(DateTime, __debuginfo);
 ///////////////////////////////////////////////////////////////////////////////
 // class DateTimeZone
 
-extern const int64_t q_DateTimeZone$$AFRICA;
-extern const int64_t q_DateTimeZone$$AMERICA;
-extern const int64_t q_DateTimeZone$$ANTARCTICA;
-extern const int64_t q_DateTimeZone$$ARCTIC;
-extern const int64_t q_DateTimeZone$$ASIA;
-extern const int64_t q_DateTimeZone$$ATLANTIC;
-extern const int64_t q_DateTimeZone$$AUSTRALIA;
-extern const int64_t q_DateTimeZone$$EUROPE;
-extern const int64_t q_DateTimeZone$$INDIAN;
-extern const int64_t q_DateTimeZone$$PACIFIC;
-extern const int64_t q_DateTimeZone$$UTC;
-extern const int64_t q_DateTimeZone$$ALL;
-extern const int64_t q_DateTimeZone$$ALL_WITH_BC;
-extern const int64_t q_DateTimeZone$$PER_COUNTRY;
-
 class DateTimeZoneData {
 public:
   DateTimeZoneData() {}
@@ -152,6 +125,21 @@ public:
   req::ptr<TimeZone> m_tz;
   static Class* s_class;
   static const StaticString s_className;
+
+  static const int64_t AFRICA = 1;
+  static const int64_t AMERICA = 2;
+  static const int64_t ANTARCTICA = 4;
+  static const int64_t ARCTIC = 8;
+  static const int64_t ASIA = 16;
+  static const int64_t ATLANTIC = 32;
+  static const int64_t AUSTRALIA = 64;
+  static const int64_t EUROPE = 128;
+  static const int64_t INDIAN = 256;
+  static const int64_t PACIFIC = 512;
+  static const int64_t UTC = 1024;
+  static const int64_t ALL = 2047;
+  static const int64_t ALL_WITH_BC = 4095;
+  static const int64_t PER_COUNTRY = 4096;
 };
 
 void HHVM_METHOD(DateTimeZone, __construct,


### PR DESCRIPTION
This was split out of #6365 (D48705) to make reviewing easier.