### PR TITLE
Fix CmdExtended::CreateExtendedCommand

### DIFF
--- a/hphp/runtime/debugger/cmd/cmd_extended.cpp
+++ b/hphp/runtime/debugger/cmd/cmd_extended.cpp
@@ -186,7 +186,7 @@ DebuggerCommandPtr CmdExtended::CreateExtendedCommand(const std::string &cls) {
   std::shared_ptr<CmdExtended> ret;
   if (cls == "CmdExample") {
     ret = std::make_shared<CmdExample>();
-  } else if (cls == "CmdExtension"); {
+  } else if (cls == "CmdExtension") {
     ret = std::make_shared<CmdExtension>();
   }
 


### PR DESCRIPTION
I have no idea how, or even if this worked correctly before, but it definitely shouldn't be this way.