### PR TITLE
Fixed #6498 Segfault when `extract()` an empty array by ref

### DIFF
--- a/hphp/runtime/ext/std/ext_std_variable.cpp
+++ b/hphp/runtime/ext/std/ext_std_variable.cpp
@@ -394,7 +394,7 @@ int64_t extract_impl(VRefParam vref_array,
   auto& arr = tvAsCVarRef(arr_tv).asCArrRef();
   if (UNLIKELY(reference)) {
     auto extr_refs = [&](Array& arr) {
-      {
+      if (arr.size() > 0) {
         // force arr to escalate (if necessary) by getting an
         // lvalue to the first element.
         ArrayData* ad = arr.get();

--- a/hphp/test/slow/ext_variable/extract_refs.php
+++ b/hphp/test/slow/ext_variable/extract_refs.php
@@ -14,4 +14,13 @@ function heh() {
   var_dump($b['y']);
   var_dump($y);
 }
+
+function extract_empty_ref() {
+    $a = array();
+    extract($a, EXTR_REFS);
+
+    var_dump('OK');
+}
+
 heh();
+extract_empty_ref();

--- a/hphp/test/slow/ext_variable/extract_refs.php.expect
+++ b/hphp/test/slow/ext_variable/extract_refs.php.expect
@@ -33,3 +33,4 @@ array(6) {
 int(42)
 int(2)
 int(42)
+string(2) "OK"


### PR DESCRIPTION
Closes #6498

Change-Id: I98647379ab3dc3a2e23199b079a7493aae63d525