### PR TITLE
fb_intercept segfaults when globally deregistering intercepts

### DIFF
--- a/hphp/runtime/base/intercept.cpp
+++ b/hphp/runtime/base/intercept.cpp
@@ -100,8 +100,10 @@ bool register_intercept(const String& name, const Variant& callback,
   if (!callback.toBoolean()) {
     if (name.empty()) {
       s_intercept_data->m_global_handler.unset();
-      handlers.clear();
+      StringIMap<Variant> empty;
+      handlers.swap(empty);
     } else {
+      auto tmp = handlers[name];
       handlers.erase(name);
     }
     return true;
@@ -113,7 +115,8 @@ bool register_intercept(const String& name, const Variant& callback,
 
   if (name.empty()) {
     s_intercept_data->m_global_handler = handler;
-    handlers.clear();
+    StringIMap<Variant> empty;
+    handlers.swap(empty);
   } else {
     handlers[name] = handler;
   }

--- a/hphp/runtime/base/intercept.cpp
+++ b/hphp/runtime/base/intercept.cpp
@@ -104,7 +104,11 @@ bool register_intercept(const String& name, const Variant& callback,
       handlers.swap(empty);
     } else {
       auto tmp = handlers[name];
-      handlers.erase(name);
+      auto it = handlers.find(name);
+      if (it != handlers.end()) {
+        auto tmp = it->second;
+        handlers.erase(it);
+      }
     }
     return true;
   }

--- a/hphp/test/slow/intercept/interleaved_global_deregistration.php
+++ b/hphp/test/slow/intercept/interleaved_global_deregistration.php
@@ -1,0 +1,56 @@
+<?php
+
+class B {
+
+  public function __construct() {
+  }
+
+  public function __destruct() {
+    $this->deregister();
+  }
+
+  private function deregister() {
+    fb_intercept('', false);
+  }
+
+  public function run() {
+    echo "In B\n";
+  }
+}
+
+class A {
+
+  public function __construct() {
+    $this->register();
+  }
+
+  public function __destruct() {
+    $this->deregister();
+  }
+
+  private function register() {
+    $x = new B();
+    $proxy = function($name, $obj, $params, $data) {
+      echo "In proxy\n";
+      $data->run();
+    };
+
+    fb_intercept('mail', $proxy, $x);
+  }
+
+  private function deregister() {
+    fb_intercept('', false);
+  }
+
+  public function run() {
+    echo "Running\n";
+    mail('nothing');
+  }
+}
+
+function run() {
+  $a = new A();
+  $a->run();
+}
+
+run();

--- a/hphp/test/slow/intercept/interleaved_global_deregistration.php.expect
+++ b/hphp/test/slow/intercept/interleaved_global_deregistration.php.expect
@@ -1,0 +1,3 @@
+Running
+In proxy
+In B


### PR DESCRIPTION
The issue can reproduced with the provided test. The issue is
interleaved calls to the global deregistration fb_intercept call in both
A and B's destructor in the test. This results in the runtime trying to
destroy the same element twice, while its already in the middle of
destroying it first.

The correct approach in PHP is for both A and B to only remove the calls that
they themselves registered for interception rather than remove all of
them.

We can solve this problem in the runtime by making sure we remove the
element first before we call any destructors.

Thanks to @markw65 and @keyurdg for helping to diagnose.