### PR TITLE
Refactor out spots that directly divide by zero

### DIFF
--- a/hphp/runtime/base/tv-arith.cpp
+++ b/hphp/runtime/base/tv-arith.cpp
@@ -172,7 +172,7 @@ struct Div {
       raise_warning(Strings::DIVISION_BY_ZERO);
       if (RuntimeOption::PHP7_IntSemantics) {
         // PHP7 uses the IEEE definition (+/- INF and NAN).
-        return make_dbl(t / 0.0);
+        return make_dbl(ieeeDivByZero(t));
       } else {
         return make_tv<KindOfBoolean>(false);
       }

--- a/hphp/runtime/base/tv-arith.h
+++ b/hphp/runtime/base/tv-arith.h
@@ -186,6 +186,25 @@ void cellBitNot(Cell&);
 
 //////////////////////////////////////////////////////////////////////
 
+/*
+ * PHP 7 requires IEEE compliance with the result of dividing a value by
+ * zero. MSVC warns about the direct division by zero, and the literal division
+ * may not be portable to all platforms, so abstract the division out so
+ * that we can both keep MSVC quiet, and also handle platforms that don't
+ * have the same semantics as x86_64.
+ */
+ALWAYS_INLINE
+#pragma warning(suppress: 4723)
+double ieeeDivByZero(double d) {
+#if defined(__x86_64__) || defined(_M_X64)
+  return d / 0.0;
+#else
+# error How does this platform handle division by zero?
+#endif
+}
+
+//////////////////////////////////////////////////////////////////////
+
 }
 
 #endif


### PR DESCRIPTION
MSVC produces a warning complaining about the "potential" divide by 0. This may also not be fully portable to other architectures, so only allow it under x86_64 for now.