### PR TITLE
Don't cast a wide string literal to char*

### DIFF
--- a/hphp/runtime/base/zend-collator.cpp
+++ b/hphp/runtime/base/zend-collator.cpp
@@ -287,7 +287,7 @@ static String intl_convert_str_utf8_to_utf16(const String& utf8_str,
                              utf8_str.data(), utf8_str.length(),
                              status);
   if (U_FAILURE(*status)) {
-    return (const char *)(L"");
+    return empty_string();
   }
   return String((char*)ustr, UBYTES(ustr_len), AttachString);
 }


### PR DESCRIPTION
To make matters worse, it was then being implicitly converted to a `String`.
This just returns an empty string rather than whatever this was trying to do.