### PR TITLE
VASM initial implementation for PPC64

### DIFF
--- a/hphp/ppc64-asm/asm-ppc64.cpp
+++ b/hphp/ppc64-asm/asm-ppc64.cpp
@@ -120,7 +120,7 @@ void Assembler::addis(const Reg64& rt, const Reg64& ra, Immed imm) {
   EmitDForm(15, rn(rt), rn(ra), imm.w());
 }
 
-void Assembler::and_(const Reg64& ra, const Reg64& rs, const Reg64& rb,
+void Assembler::and(const Reg64& ra, const Reg64& rs, const Reg64& rb,
                      bool rc) {
   EmitXForm(31, rn(rs), rn(ra), rn(rb), 28, rc);
 }
@@ -431,7 +431,7 @@ void Assembler::nor(const Reg64& ra, const Reg64& rs, const Reg64& rb,
   EmitXForm(31, rn(rs), rn(ra), rn(rb), 124, rc);
 }
 
-void Assembler::or_(const Reg64& ra, const Reg64& rs, const Reg64& rb,
+void Assembler::or(const Reg64& ra, const Reg64& rs, const Reg64& rb,
                     bool rc) {
   EmitXForm(31, rn(rs), rn(ra), rn(rb), 444, rc);
 }
@@ -669,7 +669,7 @@ void Assembler::twi(uint16_t to, const Reg64& ra, uint16_t imm) {
   EmitDForm(3, rn(to), rn(ra), imm);
 }
 
-void Assembler::xor_(const Reg64& ra, const Reg64& rs, const Reg64& rb,
+void Assembler::xor(const Reg64& ra, const Reg64& rs, const Reg64& rb,
                      bool rc) {
   EmitXForm(31, rn(rs), rn(ra), rn(rb), 316, rc);
 }
@@ -746,7 +746,7 @@ void Assembler::li64 (const Reg64& rt, int64_t imm64) {
   uint8_t missing = 0;
 
   // for assert purposes
-  CodeAddress li64StartPos = frontier();
+  DEBUG_ONLY CodeAddress li64StartPos = frontier();
 
   if (HPHP::jit::deltaFits(imm64, HPHP::sz::word)) {
     // immediate has only low 16 bits set, use simple load immediate
@@ -913,7 +913,7 @@ void Assembler::li32 (const Reg64& rt, int32_t imm32) {
 }
 
 void Assembler::li32un (const Reg64& rt, uint32_t imm32) {
-  xor_(rt, rt, rt);
+  xor(rt, rt, rt);
   if ((imm32 >> 16) == 0) {
     // immediate has only low 16 bits set, use simple load immediate
     ori(rt, rt, static_cast<int16_t>(imm32));

--- a/hphp/ppc64-asm/asm-ppc64.cpp
+++ b/hphp/ppc64-asm/asm-ppc64.cpp
@@ -140,24 +140,24 @@ void Assembler::andis(const Reg64& ra, const Reg64& rs, Immed imm) {
   EmitDForm(29, rn(rs), rn(ra), imm.w());
 }
 
-void Assembler::b(int32_t target_addr) {
-  EmitIForm(18, uint32_t(target_addr));
+void Assembler::b(int32_t offset) {
+  EmitIForm(18, uint32_t(offset));
 }
 
 void Assembler::ba(uint32_t target_addr) {
   EmitIForm(18, target_addr, 1, 0);
 }
 
-void Assembler::bl(int32_t target_addr) {
-  EmitIForm(18, uint32_t(target_addr), 0, 1);
+void Assembler::bl(int32_t offset) {
+  EmitIForm(18, uint32_t(offset), 0, 1);
 }
 
 void Assembler::bla(uint32_t target_addr) {
   EmitIForm(18, target_addr, 1, 1);
 }
 
-void Assembler::bc(uint8_t bo, uint8_t bi, int16_t target_addr) {
-  EmitBForm(16, bo, bi, uint32_t(target_addr), 0, 0);
+void Assembler::bc(uint8_t bo, uint8_t bi, int16_t offset) {
+  EmitBForm(16, bo, bi, uint32_t(offset), 0, 0);
 }
 
 void Assembler::bca(uint8_t bo, uint8_t bi, uint16_t target_addr) {
@@ -172,8 +172,8 @@ void Assembler::bcctrl(uint8_t bo, uint8_t bi, uint16_t bh) {
   EmitXLForm(19, bo, bi, (bh & 0x3), 528, 1);
 }
 
-void Assembler::bcl(uint8_t bo, uint8_t bi, int16_t target_addr) {
-  EmitBForm(16, bo, bi, target_addr, 0, 1);
+void Assembler::bcl(uint8_t bo, uint8_t bi, int16_t offset) {
+  EmitBForm(16, bo, bi, offset, 0, 1);
 }
 
 void Assembler::bcla(uint8_t bo, uint8_t bi, uint16_t target_addr) {
@@ -279,8 +279,8 @@ void Assembler::extsw(const Reg64& ra, const Reg64& rs, bool rc) {
 }
 
 void Assembler::isel(const Reg64& rt, const Reg64& ra, const Reg64& rb,
-                     uint16_t bc) {
-  EmitAForm(31, rn(rt), rn(ra), rn(rb), bc, 15);
+                     uint8_t bc) {
+  EmitAForm(31, rn(rt), rn(ra), rn(rb), rn(bc), 15);
 }
 
 void Assembler::lbz(const Reg64& rt, MemoryRef m) {
@@ -292,11 +292,11 @@ void Assembler::lbzu(const Reg64& rt, MemoryRef m) {
 }
 
 void Assembler::lbzux(const Reg64& rt, MemoryRef m) {
-  EmitXForm(31, rn(rt), rn(m.r.base), rn(m.r.index), 87);
+  EmitXForm(31, rn(rt), rn(m.r.base), rn(m.r.index), 119);
 }
 
 void Assembler::lbzx(const Reg64& rt, MemoryRef m) {
-  EmitXForm(31, rn(rt), rn(m.r.base), rn(m.r.index), 119);
+  EmitXForm(31, rn(rt), rn(m.r.base), rn(m.r.index), 87);
 }
 
 void Assembler::ld(const Reg64& rt, MemoryRef m) {
@@ -312,11 +312,11 @@ void Assembler::ldu(const Reg64& rt, MemoryRef m) {
 }
 
 void Assembler::ldux(const Reg64& rt, MemoryRef m) {
-  EmitXForm(31, rn(rt), rn(m.r.base), rn(m.r.index), 21);
+  EmitXForm(31, rn(rt), rn(m.r.base), rn(m.r.index), 53);
 }
 
 void Assembler::ldx(const Reg64& rt, MemoryRef m) {
-  EmitXForm(31, rn(rt), rn(m.r.base), rn(m.r.index), 53);
+  EmitXForm(31, rn(rt), rn(m.r.base), rn(m.r.index), 21);
 }
 
 void Assembler::lhbrx(const Reg64& rt, MemoryRef m) {
@@ -332,11 +332,11 @@ void Assembler::lhzu(const Reg64& rt, MemoryRef m) {
 }
 
 void Assembler::lhzux(const Reg64& rt, MemoryRef m) {
-  EmitXForm(31, rn(rt), rn(m.r.base), rn(m.r.index), 279);
+  EmitXForm(31, rn(rt), rn(m.r.base), rn(m.r.index), 331);
 }
 
 void Assembler::lhzx(const Reg64& rt, MemoryRef m) {
-  EmitXForm(31, rn(rt), rn(m.r.base), rn(m.r.index), 331);
+  EmitXForm(31, rn(rt), rn(m.r.base), rn(m.r.index), 279);
 }
 
 void Assembler::lha(const Reg64& rt, MemoryRef m) {
@@ -348,11 +348,11 @@ void Assembler::lhau(const Reg64& rt, MemoryRef m) {
 }
 
 void Assembler::lhaux(const Reg64& rt, MemoryRef m) {
-  EmitXForm(31, rn(rt), rn(m.r.base), rn(m.r.index), 343);
+  EmitXForm(31, rn(rt), rn(m.r.base), rn(m.r.index), 375);
 }
 
 void Assembler::lhax(const Reg64& rt, MemoryRef m) {
-  EmitXForm(31, rn(rt), rn(m.r.base), rn(m.r.index), 375);
+  EmitXForm(31, rn(rt), rn(m.r.base), rn(m.r.index), 343);
 }
 
 void Assembler::lmw(const Reg64& rt, MemoryRef m) {
@@ -382,11 +382,11 @@ void Assembler::lwzu(const Reg64& rt, MemoryRef m) {
 }
 
 void Assembler::lwzux(const Reg64& rt, MemoryRef m) {
-  EmitXForm(31, rn(rt), rn(m.r.base), rn(m.r.index), 23);
+  EmitXForm(31, rn(rt), rn(m.r.base), rn(m.r.index), 55);
 }
 
 void Assembler::lwzx(const Reg64& rt, MemoryRef m) {
-  EmitXForm(31, rn(rt), rn(m.r.base), rn(m.r.index), 55);
+  EmitXForm(31, rn(rt), rn(m.r.base), rn(m.r.index), 23);
 }
 
 void Assembler::lwa(const Reg64& rt, MemoryRef m) {
@@ -394,11 +394,11 @@ void Assembler::lwa(const Reg64& rt, MemoryRef m) {
 }
 
 void Assembler::lwaux(const Reg64& rt, MemoryRef m) {
-  EmitXForm(31, rn(rt), rn(m.r.base), rn(m.r.index), 341);
+  EmitXForm(31, rn(rt), rn(m.r.base), rn(m.r.index), 373);
 }
 
 void Assembler::lwax(const Reg64& rt, MemoryRef m) {
-  EmitXForm(31, rn(rt), rn(m.r.base), rn(m.r.index), 373);
+  EmitXForm(31, rn(rt), rn(m.r.base), rn(m.r.index), 341);
 }
 
 void Assembler::lwbrx(const Reg64& rt, MemoryRef m) {
@@ -535,14 +535,17 @@ void Assembler::srad(const Reg64& ra, const Reg64& rs, const Reg64& rb,
   EmitXForm(31, rn(rs), rn(ra), rn(rb), 794, rc);
 }
 
+void Assembler::sradi(const Reg64& ra, const Reg64& rs, uint8_t sh, bool rc) {
+  EmitXSForm(31, rn(rs), rn(ra), sh, 413, rc);
+}
+
 void Assembler::sraw(const Reg64& ra, const Reg64& rs, const Reg64& rb,
                      bool rc) {
   EmitXForm(31, rn(rs), rn(ra), rn(rb), 792, rc);
 }
 
-void Assembler::srawi(const Reg64& ra, const Reg64& rs, const Reg64& rb,
-                      bool rc) {
-  EmitXForm(31, rn(rs), rn(ra), rn(rb), 824, rc);
+void Assembler::srawi(const Reg64& ra, const Reg64& rs, uint8_t sh, bool rc) {
+  EmitXForm(31, rn(rs), rn(ra), rn(sh), 824, rc);
 }
 
 void Assembler::srd(const Reg64& ra, const Reg64& rs, const Reg64& rb,
@@ -564,11 +567,11 @@ void Assembler::stbu(const Reg64& rt, MemoryRef m) {
 }
 
 void Assembler::stbux(const Reg64& rt, MemoryRef m) {
-  EmitXForm(31, rn(rt), rn(m.r.base), rn(m.r.index), 215);
+  EmitXForm(31, rn(rt), rn(m.r.base), rn(m.r.index), 247);
 }
 
 void Assembler::stbx(const Reg64& rt, MemoryRef m) {
-  EmitXForm(31, rn(rt), rn(m.r.base), rn(m.r.index), 247);
+  EmitXForm(31, rn(rt), rn(m.r.base), rn(m.r.index), 215);
 }
 
 void Assembler::sth(const Reg64& rt, MemoryRef m) {
@@ -580,11 +583,11 @@ void Assembler::sthu(const Reg64& rt, MemoryRef m) {
 }
 
 void Assembler::sthux(const Reg64& rt, MemoryRef m) {
-  EmitXForm(31, rn(rt), rn(m.r.base), rn(m.r.index), 407);
+  EmitXForm(31, rn(rt), rn(m.r.base), rn(m.r.index), 439);
 }
 
 void Assembler::sthx(const Reg64& rt, MemoryRef m) {
-  EmitXForm(31, rn(rt), rn(m.r.base), rn(m.r.index), 439);
+  EmitXForm(31, rn(rt), rn(m.r.base), rn(m.r.index), 407);
 }
 
 void Assembler::stw(const Reg64& rt, MemoryRef m) {
@@ -596,11 +599,11 @@ void Assembler::stwu(const Reg64& rt, MemoryRef m) {
 }
 
 void Assembler::stwux(const Reg64& rt, MemoryRef m) {
-  EmitXForm(31, rn(rt), rn(m.r.base), rn(m.r.index), 151);
+  EmitXForm(31, rn(rt), rn(m.r.base), rn(m.r.index), 183);
 }
 
 void Assembler::stwx(const Reg64& rt, MemoryRef m) {
-  EmitXForm(31, rn(rt), rn(m.r.base), rn(m.r.index), 183);
+  EmitXForm(31, rn(rt), rn(m.r.base), rn(m.r.index), 151);
 }
 
 void Assembler::std(const Reg64& rt, MemoryRef m) {
@@ -612,11 +615,11 @@ void Assembler::stdu(const Reg64& rt, MemoryRef m) {
 }
 
 void Assembler::stdux(const Reg64& rt, MemoryRef m) {
-  EmitXForm(31, rn(rt), rn(m.r.base), rn(m.r.index), 149);
+  EmitXForm(31, rn(rt), rn(m.r.base), rn(m.r.index), 181);
 }
 
 void Assembler::stdx(const Reg64& rt, MemoryRef m) {
-  EmitXForm(31, rn(rt), rn(m.r.base), rn(m.r.index), 181);
+  EmitXForm(31, rn(rt), rn(m.r.base), rn(m.r.index), 149);
 }
 
 void Assembler::stq(const Reg64& rt, MemoryRef m) {
@@ -684,12 +687,22 @@ void Assembler::xoris(const Reg64& ra, const Reg64& rs, Immed imm) {
 /* Floating point operations */
 void Assembler::fadd(const RegXMM& frt, const RegXMM& fra, const RegXMM& frb,
                      bool rc) {
-  EmitAForm(63, rn(frt), rn(fra), rn(frb), 0, 21, rc);
+  EmitAForm(63, rn(frt), rn(fra), rn(frb), rn(0), 21, rc);
 }
 
 void Assembler::fsub(const RegXMM& frt, const RegXMM& fra, const RegXMM& frb,
                      bool rc) {
-  EmitAForm(63, rn(frt), rn(fra), rn(frb), 0, 20, rc);
+  EmitAForm(63, rn(frt), rn(fra), rn(frb), rn(0), 20, rc);
+}
+
+void Assembler::fmul(const RegXMM& frt, const RegXMM& fra, const RegXMM& frc,
+                     bool rc) {
+  EmitAForm(63, rn(frt), rn(fra), rn(0), rn(frc), 25, rc);
+}
+
+void Assembler::fdiv(const RegXMM& frt, const RegXMM& fra, const RegXMM& frb,
+                     bool rc) {
+  EmitAForm(63, rn(frt), rn(fra), rn(frb), rn(0), 18, rc);
 }
 
 
@@ -698,21 +711,36 @@ void Assembler::unimplemented(){
   EmitDForm(0, rn(0), rn(0), 0);
 }
 
-void Assembler::li64 (const Reg64& rt, uint64_t imm64) {
-  if ((imm64 >> 16) == 0) {
+void Assembler::li64 (const Reg64& rt, int64_t imm64) {
+  // li64 always emits 5 instructions i.e. 20 bytes of instructions.
+  // Assumes that 0 bytes will be missing in the end.
+  uint8_t missing = 0;
+
+  // for assert purposes
+  CodeAddress li64StartPos = frontier();
+
+  if (HPHP::jit::deltaFits(imm64, HPHP::sz::word)) {
     // immediate has only low 16 bits set, use simple load immediate
     li(rt, static_cast<int16_t>(imm64));
-    if (imm64 & (1ULL << 15)) {
-      // clear extended sign
+    if (imm64 & (1ULL << 15) && !(imm64 & (1ULL << 16))) {
+      // clear extended sign that should not be set
+      // (32bits number. Sets the 16th bit but not the 17th, it's not negative!)
       clrldi(rt, rt, 48);
+      missing = kLi64InstrLen - 2 * kBytesPerInstr;
+    } else {
+      missing = kLi64InstrLen - 1 * kBytesPerInstr;
     }
-  } else if (imm64 >> 32 == 0) {
+  } else if (HPHP::jit::deltaFits(imm64, HPHP::sz::dword)) {
     // immediate has only low 32 bits set
     lis(rt, static_cast<int16_t>(imm64 >> 16));
     ori(rt, rt, static_cast<int16_t>(imm64 & UINT16_MAX));
-    if (imm64 & (1ULL << 31)) {
+    if (imm64 & (1ULL << 31) && !(imm64 & (1ULL << 32))) {
       // clear extended sign
+      // (64bits number. Sets the 32th bit but not the 33th, it's not negative!)
       clrldi(rt, rt, 32);
+      missing = kLi64InstrLen - 3 * kBytesPerInstr;
+    } else {
+      missing = kLi64InstrLen - 2 * kBytesPerInstr;
     }
   } else if (imm64 >> 48 == 0) {
     // immediate has only low 48 bits set
@@ -723,6 +751,8 @@ void Assembler::li64 (const Reg64& rt, uint64_t imm64) {
     if (imm64 & (1ULL << 47)) {
       // clear extended sign
       clrldi(rt, rt, 16);
+    } else {
+      missing = kLi64InstrLen - 4 * kBytesPerInstr;
     }
   } else {
     // load all 64 bits
@@ -732,15 +762,119 @@ void Assembler::li64 (const Reg64& rt, uint64_t imm64) {
     oris(rt, rt, static_cast<int16_t>((imm64 >> 16) & UINT16_MAX));
     ori(rt, rt, static_cast<int16_t>(imm64 & UINT16_MAX));
   }
+  emitNop(missing);
+
+  // guarantee our math with kLi64InstrLen is working
+  assert(kLi64InstrLen == frontier() - li64StartPos);
 }
 
-void Assembler::li32 (const Reg64& rt, uint32_t imm32) {
-  if ((imm32 >> 16) == 0) {
+int64_t Assembler::getLi64(PPC64Instr* pinstr) {
+  // @pinstr should be pointing to the beginning of the li64 block
+  //
+  // It's easier to know how many 16bits of data the immediate uses
+  // by counting how many nops there are inside of the code
+
+  uint8_t nops = [&]() {
+    // TODO(gut) use Decoder, but for now, do it hardcoded
+    auto isNop = [&](PPC64Instr instr) -> bool {
+      D_form_t d_formater {0, 0, 0, 24 }; // check Assembler::ori
+      return instr == d_formater.instruction;
+    };
+
+    uint8_t nNops = 0;
+    for (PPC64Instr* i = pinstr; i < pinstr + kLi64InstrLen/kBytesPerInstr;
+        i++) {
+      nNops += isNop(*i) ? 1 : 0;
+    }
+    return nNops;
+  }();
+
+  // TODO(gut) use Decoder, but for now, do it hardcoded
+  auto hasClearSignBit = [&](PPC64Instr* instr) -> bool {
+    bool op = (*instr >> 26) == 30;         // check opcode
+    bool xop = ((*instr >> 2) & 0x7) == 0;  // check extended opcode
+    return op && xop;
+  };
+
+  // TODO(gut) use Decoder, but for now, do it hardcoded
+  auto getImm = [&](PPC64Instr* instr) -> uint16_t {
+    return *instr & UINT16_MAX;
+  };
+
+  uint8_t immParts = 0;
+  switch (nops) {
+    case 4:
+      immParts = 1;                                   // 16bits, sign bit = 0
+      break;
+    case 3:
+      if (hasClearSignBit(pinstr + 1)) immParts = 1;  // 16bits, sign bit = 1
+      else immParts = 2;                              // 32bits, sign bit = 0
+      break;
+    case 2:
+      immParts = 2;                                   // 32bits, sign bit = 1
+      break;
+    case 1:
+      immParts = 3;                                   // 48bits, sign bit = 0
+      break;
+    case 0:
+      if (hasClearSignBit(pinstr + 4)) immParts = 3;  // 48bits, sign bit = 1
+      else immParts = 4;                              // 64bits, sign bit = 0
+      break;
+    default:
+      assert(false && "Unexpected number of nops in getLi64");
+      break;
+  }
+
+  // first getImm is suppose to get the sign
+  uint64_t imm64 = static_cast<uint64_t>(
+                        static_cast<int16_t>(getImm(pinstr)));
+  switch (immParts) {
+    case 1:
+      break;
+    case 2:
+      imm64 <<= 16;
+      imm64 |= getImm(pinstr + 1);
+      break;
+    case 3:
+      imm64 <<= 16;
+      imm64 |= getImm(pinstr + 1);
+      imm64 <<= 16;
+      imm64 |= getImm(pinstr + 3);  // jumps the sldi
+      break;
+    case 4:
+      imm64 <<= 16;
+      imm64 |= getImm(pinstr + 1);
+      imm64 <<= 16;
+      imm64 |= getImm(pinstr + 3);  // jumps the sldi
+      imm64 <<= 16;
+      imm64 |= getImm(pinstr + 4);
+      break;
+    default:
+      assert(false && "No immediate detected on getLi64");
+      break;
+  }
+
+  return static_cast<int64_t>(imm64);
+}
+
+Reg64 Assembler::getLi64Reg(PPC64Instr* instr) {
+  // First instruction is always either li or lis, both are D-form
+  D_form_t d_instr;
+  d_instr.instruction = *instr;
+  return Reg64(d_instr.RT);
+}
+
+void Assembler::li32 (const Reg64& rt, int32_t imm32) {
+
+  if (HPHP::jit::deltaFits(imm32, HPHP::sz::word)) {
     // immediate has only low 16 bits set, use simple load immediate
     li(rt, static_cast<int16_t>(imm32));
-    if (imm32 & (1ULL << 15)) {
-      // clear extended sign
+    if (imm32 & (1ULL << 15) && !(imm32 & (1ULL << 16))) {
+      // clear extended sign that should not be set
+      // (32bits number. Sets the 16th bit but not the 17th, it's not negative!)
       clrldi(rt, rt, 48);
+    } else {
+      emitNop(kBytesPerInstr); // emit nop for a balanced li32 with 2 instr
     }
   } else {
     // immediate has 32 bits set
@@ -754,6 +888,7 @@ void Assembler::li32un (const Reg64& rt, uint32_t imm32) {
   if ((imm32 >> 16) == 0) {
     // immediate has only low 16 bits set, use simple load immediate
     ori(rt, rt, static_cast<int16_t>(imm32));
+    emitNop(kBytesPerInstr); // emit nop for a balanced li32un with 3 instr
   } else {
     // immediate has 32 bits set
     oris(rt, rt, static_cast<int16_t>(imm32 >> 16));
@@ -761,52 +896,26 @@ void Assembler::li32un (const Reg64& rt, uint32_t imm32) {
   }
 }
 
-std::string Decoder::toString(){
-    /*
-     * TODO(rcardoso):
-     * DRAFT:
-     *     Print Instruction
-     *     1- Read instruction name (done)
-     *     2- Get Operand masks
-     *     3- Convert operands to apropriated string and concat with name
-     *     5- Return formated string
-     * CAVEATS:
-     *   If instruction is kInvalid maybe it's data. What to do in this case?
-     */
-    if(decoded_instr_->form() == Form::kInvalid) {
-      return ".long " + ip_;
-    }
-    return decoded_instr_->mnemonic();
-}
+int32_t Assembler::getLi32(PPC64Instr* pinstr) {
+  // @pinstr should be pointing to the beginning of the li32 block
 
-void Decoder::decode(uint32_t* ip) {
-  /*
-   * TODO(rcardoso):
-   * The decoder table is in fact a hash table. We can have k decoder masks
-   * so we can need to test and retrieve the first who match. In worst case
-   * we have k*x where x is a number of access to decoder table
-   * and depends on number of  collisions in best case 1 (no collisions)
-   * or, in worst case, n (if all keys collide).
-   * And we have k*x + y where y is the number of alternate instructions
-   * (next pointer on DecoderInfo). It's '+' y because we retrieve the whole
-   * structure do a linear search if we need. So, in worst case y=n,
-   * then we have k*n + n => O(k*2n). But in pratice, this will not
-   * gonna happens because we have a limited number of execution modes and
-   * we cannot have a 'n' size collision so, we have O(k*c + c) = O(1) at most.
-   * This is not the best algorithm but this will work. Sorry for any math
-   * mistakes.
-   */
+  // TODO(gut) use Decoder, but for now, do it hardcoded
+  auto getImm = [&](PPC64Instr* instr) -> uint32_t {
+    return *instr & UINT16_MAX;
+  };
 
-  // To decode a instruction we extract the decoder fields
-  // masking the instruction and test if it 'hits' the decoder table.
-  for(int i = 0; i < kDecoderListSize; i++) {
-    uint32_t instr_image = *ip;
-    instr_image &= DecoderList[i];
+  // if first instruction is a li, it's using 16bits only
+  bool is_16b_only = [&](PPC64Instr instr) -> bool {
+    return (instr >> 26) == 14;        // check opcode
+  }(*pinstr);
 
-    decoded_instr_ = decoder_table_.GetInstruction(instr_image);
-    if(decoded_instr_->form() != Form::kInvalid)
-       break;
+  uint32_t imm32 = 0;
+  if (is_16b_only) {
+    imm32 |= static_cast<int16_t>(getImm(pinstr));
+  } else {
+    imm32 |= getImm(pinstr)     << 16;  // lis
+    imm32 |= getImm(pinstr + 1);        // ori
   }
+  return static_cast<int32_t>(imm32);
 }
-
 } // namespace ppc64_asm

--- a/hphp/ppc64-asm/asm-ppc64.h
+++ b/hphp/ppc64-asm/asm-ppc64.h
@@ -525,7 +525,7 @@ struct Assembler {
   void addo(const Reg64& rt, const Reg64& ra, const Reg64& rb, bool rc = 0);
   void addze(const Reg64& rt, const Reg64& ra, bool rc = 0);
   void addzeo(const Reg64& rt, const Reg64& ra, bool rc = 0);
-  void and_(const Reg64& ra, const Reg64& rs, const Reg64& rb, bool rc = 0);
+  void and(const Reg64& ra, const Reg64& rs, const Reg64& rb, bool rc = 0);
   void andc(const Reg64& ra, const Reg64& rs, const Reg64& rb, bool rc = 0);
   void andi(const Reg64& ra, const Reg64& rs, Immed imm);
   void andis(const Reg64& ra, const Reg64& rs, Immed imm);
@@ -640,7 +640,7 @@ struct Assembler {
   void neg(const Reg64& rt, const Reg64& ra, bool rc = 0);
   void nego(const Reg64& rt, const Reg64& ra, bool rc = 0);
   void nor(const Reg64& ra, const Reg64& rs, const Reg64& rb, bool rc = 0);
-  void or_(const Reg64& ra, const Reg64& rs, const Reg64& rb, bool rc = 0);
+  void or(const Reg64& ra, const Reg64& rs, const Reg64& rb, bool rc = 0);
   void orc(const Reg64& ra, const Reg64& rs, const Reg64& rb, bool rc = 0);
   void ori(const Reg64& ra, const Reg64& rs, Immed imm);
   void oris(const Reg64& ra, const Reg64& rs, Immed imm);
@@ -719,7 +719,7 @@ struct Assembler {
   void tdi(uint16_t to, const Reg64& ra, uint16_t imm);
   void tw(uint16_t to, const Reg64& ra, const Reg64& rb);
   void twi(uint16_t to, const Reg64& ra, uint16_t imm);
-  void xor_(const Reg64& ra, const Reg64& rs, const Reg64& rb, bool rc = 0);
+  void xor(const Reg64& ra, const Reg64& rs, const Reg64& rb, bool rc = 0);
   void xori(const Reg64& ra, const Reg64& rs, Immed imm);
   void xoris(const Reg64& ra, const Reg64& rs, Immed imm);
   void xscvdpuxds(const RegXMM& xt, const RegXMM& xb) {
@@ -1822,9 +1822,9 @@ struct Assembler {
   }
   void xnop()           { not_implemented(); }  //Extended
   void mr(const Reg64& rs, const Reg64& ra) {
-    or_(rs, ra, ra);
+    or(rs, ra, ra);
   }
-  void not_()           { not_implemented(); }  //Extended
+  void not()            { not_implemented(); }  //Extended
   void srwi(const Reg64& ra, const Reg64& rs, int8_t sh, bool rc = 0) {
     rlwinm(ra, rs, 32-sh, sh, 31, rc);
   }
@@ -1911,6 +1911,13 @@ struct Assembler {
              const Reg64& rfuncln,
              const Reg64& rvmfp,
              CodeAddress target);
+
+  // checks if the @inst is pointing to a call
+  static inline bool isCall(HPHP::jit::TCA inst) {
+    // a call always begin with a mflr and it's rarely used elsewhere: good tag
+    return ((((inst[3] >> 2) & 0x3F) == 31) &&                          // OPCD
+      ((((inst[1] & 0x3) << 7) | ((inst[0] >> 1) & 0xFF)) == 339));     // XO
+  }
 
   // Retrieve the target defined by li64 instruction
   static int64_t getLi64(PPC64Instr* pinstr);

--- a/hphp/ppc64-asm/asm-ppc64.h
+++ b/hphp/ppc64-asm/asm-ppc64.h
@@ -28,15 +28,16 @@
 #include "hphp/ppc64-asm/isa-ppc64.h"
 #include "hphp/util/asm-x64.h"
 #include "hphp/util/immed.h"
-#include "hphp/util/safe-cast.h"
 
 namespace ppc64_asm {
 
 using HPHP::jit::Reg64;
 using HPHP::jit::RegXMM;
+using HPHP::jit::RegSF;
 using HPHP::jit::MemoryRef;
 using HPHP::jit::Immed;
 using HPHP::CodeAddress;
+using HPHP::jit::ConditionCode;
 
 #define BRANCHES(cr) \
   CR##cr##_LessThan,         \
@@ -82,10 +83,10 @@ class BranchParams {
     };
 
 #define CR_CONDITIONS(cr) \
-      CR##cr##_LessThan          = 0x80000000ULL >> (32 - (0 + (cr * 4))), \
-      CR##cr##_GreaterThan       = 0x80000000ULL >> (32 - (1 + (cr * 4))), \
-      CR##cr##_Equal             = 0x80000000ULL >> (32 - (2 + (cr * 4))), \
-      CR##cr##_SummaryOverflow   = 0x80000000ULL >> (32 - (3 + (cr * 4)))
+      CR##cr##_LessThan          = (0 + (cr * 4)), \
+      CR##cr##_GreaterThan       = (1 + (cr * 4)), \
+      CR##cr##_Equal             = (2 + (cr * 4)), \
+      CR##cr##_SummaryOverflow   = (3 + (cr * 4))
 
     enum class BI {
       CR_CONDITIONS(0),
@@ -150,11 +151,11 @@ class BranchParams {
 
     BranchParams(BranchConditions bc) { defineBoBi(bc); }
 
-    BranchParams(HPHP::jit::ConditionCode cc) {
+    BranchParams(ConditionCode cc) {
       defineBoBi(convertCC(cc));
     }
 
-    static BranchConditions convertCC(HPHP::jit::ConditionCode cc) {
+    static BranchConditions convertCC(ConditionCode cc) {
       BranchConditions ret = BranchConditions::Always;
 
       switch (cc) {
@@ -203,7 +204,54 @@ class BranchParams {
       return ret;
     }
 
+    /*
+     * Get the BranchParams from an emitted conditional branch
+     */
+    BranchParams(PPC64Instr instr) {
+      // first, guarantee that is a conditional branch
+      if (((instr >> 26) == 16) || ((instr >> 26) == 19)) {
+        // bc, bclr, bcctr, bctar
+        m_bo = (BranchParams::BO)((instr >> 21) & 0x1F);
+        m_bi = (BranchParams::BI)((instr >> 16) & 0x1F);
+      } else {
+        assert(false && "Not a valid conditional branch instruction");
+        // also possible: defineBoBi(BranchConditions::Always);
+      }
+    }
+
     ~BranchParams() {}
+
+    /*
+     * Converts to ConditionCode upon casting to it
+     */
+    /* implicit */ operator ConditionCode() {
+      ConditionCode ret = HPHP::jit::CC_None;
+
+      switch (m_bi) {
+        case BI::CR0_LessThan:
+          if (m_bo == BO::CRSet)          ret = HPHP::jit::CC_B;  // CC_S, CC_L
+          else if (m_bo == BO::CRNotSet)  ret = HPHP::jit::CC_AE; // CC_NL
+          break;
+        case BI::CR0_GreaterThan:
+          if (m_bo == BO::CRSet)          ret = HPHP::jit::CC_A;  // CC_NS, CC_G
+          else if (m_bo == BO::CRNotSet)  ret = HPHP::jit::CC_BE; // CC_NG
+          break;
+        case BI::CR0_Equal:
+          if (m_bo == BO::CRSet)          ret = HPHP::jit::CC_E;
+          else if (m_bo == BO::CRNotSet)  ret = HPHP::jit::CC_NE;
+          break;
+        case BI::CR0_SummaryOverflow:
+          if (m_bo == BO::CRSet)          ret = HPHP::jit::CC_O;
+          else if (m_bo == BO::CRNotSet)  ret = HPHP::jit::CC_NO;
+          break;
+        default:
+          assert(false && "Not a valid conditional branch parameter");
+          break;
+      }
+
+      return ret;
+    }
+
 
     uint8_t bo() { return (uint8_t)m_bo; }
     uint8_t bi() { return (uint8_t)m_bi; }
@@ -297,7 +345,7 @@ namespace reg {
   constexpr RegXMM v28(28);
   constexpr RegXMM v29(29);
 
-#define RNAME(x) if (r == x) return "%"#x
+#define RNAME(x) if (r == x) return #x
 
   inline const char* regname(Reg64 r) {
     RNAME(r0);  RNAME(r1);  RNAME(r2);  RNAME(r3);  RNAME(r4);  RNAME(r5);
@@ -319,6 +367,9 @@ namespace reg {
     RNAME(v28); RNAME(v29);
     return nullptr;
   }
+ inline const char* regname(RegSF) {
+    return "cr0";
+ }
 #undef RNAME
 }
 
@@ -409,6 +460,11 @@ struct Assembler {
     PPR32    = 898
   };
 
+  // How many bytes a PPC64 instruction length is
+  static const uint8_t kBytesPerInstr = sizeof(PPC64Instr);
+
+  // Total ammount of bytes that a li64 function emits
+  static const uint8_t kLi64InstrLen = 5 * kBytesPerInstr;
 
   // TODO(rcardoso): Must create a macro for these similar instructions.
   // This will make code more clean.
@@ -447,7 +503,6 @@ struct Assembler {
   // #undef LOAD_STORE_OP
   // #undef LOAD_STORE_OP_BYTE_REVERSED
 
-
   //PPC64 Instructions
   void add(const Reg64& rt, const Reg64& ra, const Reg64& rb, bool rc = 0);
   void addc(const Reg64& rt, const Reg64& ra, const Reg64& rb, bool rc = 0);
@@ -466,15 +521,15 @@ struct Assembler {
   void andc(const Reg64& ra, const Reg64& rs, const Reg64& rb, bool rc = 0);
   void andi(const Reg64& ra, const Reg64& rs, Immed imm);
   void andis(const Reg64& ra, const Reg64& rs, Immed imm);
-  void b(int32_t target_addr);
+  void b(int32_t offset);
   void ba(uint32_t target_addr);
-  void bl(int32_t target_addr);
+  void bl(int32_t offset);
   void bla(uint32_t target_addr);
-  void bc(uint8_t bo, uint8_t bi, int16_t target_addr);
+  void bc(uint8_t bo, uint8_t bi, int16_t offset);
   void bca(uint8_t bo, uint8_t bi, uint16_t target_addr);
   void bcctr(uint8_t bo, uint8_t bi, uint16_t bh);
   void bcctrl(uint8_t bo, uint8_t bi, uint16_t bh);
-  void bcl(uint8_t bo, uint8_t bi, int16_t target_addr);
+  void bcl(uint8_t bo, uint8_t bi, int16_t offset);
   void bcla(uint8_t bo, uint8_t bi, uint16_t target_addr);
   void bclr(uint8_t bo, uint8_t bi, uint16_t bh);
   void bclrl(uint8_t bo, uint8_t bi, uint16_t bh);
@@ -520,13 +575,17 @@ struct Assembler {
                                                                   bool rc = 0);
   void fsub(const RegXMM& frt, const RegXMM& fra, const RegXMM& frb,
                                                                   bool rc = 0);
+  void fmul(const RegXMM& frt, const RegXMM& fra, const RegXMM& frc,
+                                                                  bool rc = 0);
+  void fdiv(const RegXMM& frt, const RegXMM& fra, const RegXMM& frb,
+                                                                  bool rc = 0);
   void lfs(const RegXMM& frt, MemoryRef m) {
     EmitDForm(48, rn(frt), rn(m.r.base), m.r.disp);
   }
-  void lxvw4x(const RegXMM& xt, const Reg64& ra, const Reg64&rb) {
-    EmitXX1Form(31, rn(xt), rn(ra), rn(rb), 780, 0);
+  void lxvw4x(const RegXMM& Xt, const MemoryRef& m) {
+    EmitXX1Form(31, rn(Xt), rn(m.r.base), rn(m.r.index), 780, 0);
   }
-  void isel(const Reg64& rt, const Reg64& ra, const Reg64& rb, uint16_t bc);
+  void isel(const Reg64& rt, const Reg64& ra, const Reg64& rb, uint8_t bc);
   void lbz(const Reg64& rt, MemoryRef m);
   void lbzu(const Reg64& rt, MemoryRef m);
   void lbzux(const Reg64& rt, MemoryRef m);
@@ -605,7 +664,7 @@ struct Assembler {
   void slw(const Reg64& ra, const Reg64& rs, const Reg64& rb, bool rc = 0);
   void srad(const Reg64& ra, const Reg64& rs, const Reg64& rb, bool rc = 0);
   void sraw(const Reg64& ra, const Reg64& rs, const Reg64& rb, bool rc = 0);
-  void srawi(const Reg64& ra, const Reg64& rs, const Reg64& rb, bool rc = 0);
+  void srawi(const Reg64& ra, const Reg64& rs, uint8_t sh, bool rc = 0);
   void srd(const Reg64& ra, const Reg64& rs, const Reg64& rb, bool rc = 0);
   void srw(const Reg64& ra, const Reg64& rs, const Reg64& rb, bool rc = 0);
   void stb(const Reg64& rs, MemoryRef m);
@@ -634,8 +693,8 @@ struct Assembler {
   void stmw(const Reg64& rs, MemoryRef m);
   void stswi(const Reg64& rs, MemoryRef m);
   void stswx(const Reg64& rs, MemoryRef m);
-  void stxvw4x(const RegXMM& xs, const Reg64& ra, const Reg64&rb) {
-    EmitXX1Form(31, rn(xs), rn(ra), rn(rb), 972, 0);
+  void stxvw4x(const RegXMM& xs, const MemoryRef& m) {
+    EmitXX1Form(31, rn(xs), rn(m.r.base), rn(m.r.index), 972, 0);
   }
   void subf(const Reg64& rt, const Reg64& ra, const Reg64& rb, bool rc = 0);
   void subfo(const Reg64& rt, const Reg64& ra, const Reg64& rb, bool rc = 0);
@@ -697,7 +756,9 @@ struct Assembler {
   void dci()            { not_implemented(); }
   void dcmpo()          { not_implemented(); }
   void dcmpoq()         { not_implemented(); }
-  void dcmpu()          { not_implemented(); }
+  void dcmpu(const RegXMM& fra, const RegXMM& frb) {
+    EmitXForm(59, rn(0), rn(fra), rn(frb), 642);
+  }
   void dcmpuq()         { not_implemented(); }
   void dcread()         { not_implemented(); }
   void dctdp()          { not_implemented(); }
@@ -999,16 +1060,26 @@ struct Assembler {
   void evsubfw()        { not_implemented(); }
   void evsubifw()       { not_implemented(); }
   void evxor()          { not_implemented(); }
-  void fabs()           { not_implemented(); }
+  void fabs(const RegXMM& frt, const RegXMM& frb, bool rc = 0) {
+    EmitXForm(63, rn(frt), rn(0), rn(frb), 364, rc);
+  }
   void fadds()          { not_implemented(); }
   void fcfid()          { not_implemented(); }
-  void fcfids()         { not_implemented(); }
+  void fcfids(const RegXMM& frt, const RegXMM& frb, bool rc = 0) {
+    EmitXForm(59, rn(frt), rn(0), rn(frb), 846, rc);
+  }
   void fcfidu()         { not_implemented(); }
   void fcfidus()        { not_implemented(); }
-  void fcmpo()          { not_implemented(); }
-  void fcmpu()          { not_implemented(); }
+  void fcmpo(const RegSF& sf, const RegXMM& fra, const RegXMM& frb) {
+    EmitXForm(63, rn(int(sf) << 2), rn(fra), rn(frb), 32);
+  }
+  void fcmpu(const RegSF& sf, const RegXMM& fra, const RegXMM& frb) {
+    EmitXForm(63, rn(int(sf) << 2), rn(fra), rn(frb), 0);
+  }
   void fcpsgn()         { not_implemented(); }
-  void fctid()          { not_implemented(); }
+  void fctid(const RegXMM& frt, const RegXMM& frb, bool rc = 0) {
+    EmitXForm(63, rn(frt), rn(0), rn(frb), 814, rc);
+  }
   void fctidu()         { not_implemented(); }
   void fctiduz()        { not_implemented(); }
   void fctidz()         { not_implemented(); }
@@ -1020,7 +1091,9 @@ struct Assembler {
   void fdivs()          { not_implemented(); }
   void fmadd()          { not_implemented(); }
   void fmadds()         { not_implemented(); }
-  void fmr()            { not_implemented(); }
+  void fmr(const RegXMM& frt, const RegXMM& frb, bool rc = 0) {
+    EmitXForm(63, rn(frt), rn(0), rn(frb), 72, rc);
+  }
   void fmrgew()         { not_implemented(); }
   void fmrgow()         { not_implemented(); }
   void fmsub()          { not_implemented(); }
@@ -1066,14 +1139,18 @@ struct Assembler {
   void ldcix()          { not_implemented(); }
   void lddx()           { not_implemented(); }
   void ldepx()          { not_implemented(); }
-  void lfd()            { not_implemented(); }
+  void lfd(const RegXMM& frt, MemoryRef m) {
+    EmitDForm(50, rn(frt), rn(m.r.base), m.r.disp);
+  }
   void lfddx()          { not_implemented(); }
   void lfdepx()         { not_implemented(); }
   void lfdp()           { not_implemented(); }
   void lfdpx()          { not_implemented(); }
   void lfdu()           { not_implemented(); }
   void lfdux()          { not_implemented(); }
-  void lfdx()           { not_implemented(); }
+  void lfdx(const RegXMM& rt, MemoryRef m) {
+    EmitXForm(31, rn(rt), rn(m.r.base), rn(m.r.index), 599);
+  }
   void lfiwax()         { not_implemented(); }
   void lfiwzx()         { not_implemented(); }
   void lfsu()           { not_implemented(); }
@@ -1132,7 +1209,9 @@ struct Assembler {
   void mcrfs()          { not_implemented(); }
   void mcrxr()          { not_implemented(); }
   void mfbhrbe()        { not_implemented(); }
-  void mfcr()           { not_implemented(); }
+  void mfcr(const Reg64& rt) {
+    EmitXFXForm(31, rn(rt), static_cast<SpecialReg>(0), 19);
+  }
   void mfdcr()          { not_implemented(); }
   void mfdcrux ()       { not_implemented(); }
   void mfdcrx()         { not_implemented(); }
@@ -1142,7 +1221,9 @@ struct Assembler {
   void mfsr()           { not_implemented(); }
   void mfsrin()         { not_implemented(); }
   void mftbmfvscr()     { not_implemented(); }
-  void mfvsrd()         { not_implemented(); }
+  void mfvsrd(const Reg64& ra, const RegXMM& xs) {
+   EmitXX1Form(31, rn(xs), rn(ra), rn(0) /* reserved */, 51, 0);
+  }
   void mfvsrwz()        { not_implemented(); }
   void msgclr()         { not_implemented(); }
   void msgclrp()        { not_implemented(); }
@@ -1159,7 +1240,9 @@ struct Assembler {
   void mtsr()           { not_implemented(); }
   void mtsrin()         { not_implemented(); }
   void mtvscr()         { not_implemented(); }
-  void mtvsrd()         { not_implemented(); }
+  void mtvsrd(const RegXMM& xt, const Reg64& ra) {
+   EmitXX1Form(31, rn(xt), rn(ra), rn(0) /* reserved */, 179, 0);
+  }
   void mtvsrwa()        { not_implemented(); }
   void mtvsrwz()        { not_implemented(); }
   void mulchw()         { not_implemented(); }
@@ -1197,7 +1280,7 @@ struct Assembler {
   void slbmfev()        { not_implemented(); }
   void slbmte()         { not_implemented(); }
   void sleep()          { not_implemented(); }
-  void sradi()          { not_implemented(); }
+  void sradi(const Reg64& ra, const Reg64& rs, uint8_t sh, bool rc = 0);
   void stbcix()         { not_implemented(); }
   void stbcx()          { not_implemented(); }
   void stbdx()          { not_implemented(); }
@@ -1216,7 +1299,7 @@ struct Assembler {
   void stfdu()          { not_implemented(); }
   void stfdux()         { not_implemented(); }
   void stfdx(const RegXMM& rt, MemoryRef m) {
-    EmitXForm(31, rn(rt), rn(m.r.base), rn(m.r.index), 726);
+    EmitXForm(31, rn(rt), rn(m.r.base), rn(m.r.index), 727);
   }
   void stfiwx()         { not_implemented(); }
   void stfsu()          { not_implemented(); }
@@ -1476,12 +1559,16 @@ struct Assembler {
   void xscpsgndp()      { not_implemented(); }
   void xscvdpsp()       { not_implemented(); }
   void xscvdpspn()      { not_implemented(); }
-  void xscvdpsxds()     { not_implemented(); }
+  void xscvdpsxds(const RegXMM& xt, const RegXMM& xb) {
+   EmitXX2Form(60, rn(xt), 0, rn(xb), 344, 0, 0);
+  }
   void xscvdpsxws()     { not_implemented(); }
   void xscvdpuxws()     { not_implemented(); }
   void xscvspdp()       { not_implemented(); }
   void xscvspdpn()      { not_implemented(); }
-  void xscvsxddp()      { not_implemented(); }
+  void xscvsxddp(const RegXMM& xt, const RegXMM& xb) {
+   EmitXX2Form(60, rn(xt), 0, rn(xb), 376, 0, 0);
+  }
   void xscvsxdsp()      { not_implemented(); }
   void xscvuxddp()      { not_implemented(); }
   void xscvuxdsp()      { not_implemented(); }
@@ -1509,7 +1596,9 @@ struct Assembler {
   void xsnmsubasp()     { not_implemented(); }
   void xsnmsubmdp()     { not_implemented(); }
   void xsnmsubmsp()     { not_implemented(); }
-  void xsrdpi()         { not_implemented(); }
+  void xsrdpi(const RegXMM& xt, const RegXMM& xb) {
+   EmitXX2Form(60, rn(xt), 0, rn(xb), 73, 0, 0);
+  }
   void xsrdpic()        { not_implemented(); }
   void xsrdpim()        { not_implemented(); }
   void xsrdpip()        { not_implemented(); }
@@ -1519,7 +1608,9 @@ struct Assembler {
   void xsrsp()          { not_implemented(); }
   void xsrsqrtedp()     { not_implemented(); }
   void xsrsqrtesp()     { not_implemented(); }
-  void xssqrtdp()       { not_implemented(); }
+  void xssqrtdp(const RegXMM& xt, const RegXMM& xb) {
+   EmitXX2Form(60, rn(xt), 0, rn(xb), 75, 0, 0);
+  }
   void xssqrtsp()       { not_implemented(); }
   void xssubdp()        { not_implemented(); }
   void xssubsp()        { not_implemented(); }
@@ -1543,8 +1634,12 @@ struct Assembler {
   void xvcvdpuxds()     { not_implemented(); }
   void xvcvdpuxws()     { not_implemented(); }
   void xvcvspdp()       { not_implemented(); }
-  void xvcvspsxds()     { not_implemented(); }
-  void xvcvspsxws()     { not_implemented(); }
+  void xvcvspsxds(const RegXMM& xt, const RegXMM& xb) {
+   EmitXX2Form(60, rn(xt), 0, rn(xb), 408, 0, 0);
+  }
+  void xvcvspsxws(const RegXMM& xt, const RegXMM& xb) {
+   EmitXX2Form(60, rn(xt), 0, rn(xb), 152, 0, 0);
+  }
   void xvcvspuxds()     { not_implemented(); }
   void xvcvspuxws()     { not_implemented(); }
   void xvcvsxddp()      { not_implemented(); }
@@ -1610,10 +1705,17 @@ struct Assembler {
   void xxlnor()         { not_implemented(); }
   void xxlor()          { not_implemented(); }
   void xxlorc()         { not_implemented(); }
-  void xxlxor()         { not_implemented(); }
+  void xxlxor(const RegXMM& xt, const RegXMM& xa, const RegXMM& xb) {
+   EmitXX3Form(60, rn(xt), rn(xa), rn(xb), 154, 0, 0, 0);
+  }
   void xxmrghw()        { not_implemented(); }
   void xxmrglw()        { not_implemented(); }
-  void xxpermdi()       { not_implemented(); }
+  void xxpermdi(const RegXMM& tx, const RegXMM& xa, const RegXMM& xb) {
+   EmitXX3Form(60, rn(tx), rn(xa), rn(xb),  10, 0, 0, 0);
+   // Note that I decided to hardcode DM bit as 0
+   // (xo field = 10), because it's sufficent for now.
+   // However, I might not be the case in the future
+  }
   void xxsel()          { not_implemented(); }
   void xxsldwi()        { not_implemented(); }
   void xxspltw()        { not_implemented(); }
@@ -1647,12 +1749,19 @@ struct Assembler {
     addi(rt, Reg64(0), imm);
   }
   void la()             { not_implemented(); }  //Extended addi Rx,Ry,disp
-  void subi()           { not_implemented(); }  //Extended addi Rx,Ry,-value
+  void subi(const Reg64& rt, const Reg64& ra, Immed imm) {
+    addi(rt, ra, -imm);
+  }
   void lis(const Reg64& rt, Immed imm) {
     addis(rt, Reg64(0), imm);
   }
   void subis()          { not_implemented(); }  //Extended addis Rx,Ry,-value
-  void sub()            { not_implemented(); }  //Extended subf Rx,Rz,Ry
+  void sub(const Reg64& rt, const Reg64& ra, const Reg64& rb, bool rc = 0) {
+    subf(rt, rb, ra, rc);
+  }
+  void subo(const Reg64& rt, const Reg64& ra, const Reg64& rb, bool rc = 0) {
+    subfo(rt, rb, ra, rc);
+  }
   void subic()          { not_implemented(); }  //Extended addic Rx,Ry,-value
   void subc()           { not_implemented(); }  //Extended subfc Rx,Rz,Ry
   void cmpdi(const Reg64& ra, Immed imm) {
@@ -1708,29 +1817,32 @@ struct Assembler {
     or_(rs, ra, ra);
   }
   void not_()           { not_implemented(); }  //Extended
-  void srwi(const Reg64& ra, const Reg64& rs, int8_t sh) {
-    rlwinm(ra, rs, 32-sh, sh, 31);
+  void srwi(const Reg64& ra, const Reg64& rs, int8_t sh, bool rc = 0) {
+    rlwinm(ra, rs, 32-sh, sh, 31, rc);
   }
-  void slwi(const Reg64& ra, const Reg64& rs, int8_t sh) {
+  void slwi(const Reg64& ra, const Reg64& rs, int8_t sh, bool rc = 0) {
     /* non-existing mnemonic on ISA, but it's pratical to have it here */
-    rlwinm(ra, rs, sh, 0, 31-sh);
+    rlwinm(ra, rs, sh, 0, 31-sh, rc);
   }
   void clrwi()          { not_implemented(); }  //Extended
   void extwi()          { not_implemented(); }  //Extended
   void rotlw()          { not_implemented(); }  //Extended
   void inslwi()         { not_implemented(); }  //Extended
   void extrdi()         { not_implemented(); }  //Extended
-  void srdi(const Reg64& ra, const Reg64& rs, int8_t sh) {
-    rldicl(ra, rs, 64-sh, sh);
+  void srdi(const Reg64& ra, const Reg64& rs, int8_t sh, bool rc = 0) {
+    rldicl(ra, rs, 64-sh, sh, rc);
   }
-  void clrldi(const Reg64& ra, const Reg64& rs, int8_t sh) {
-    rldicl(ra, rs, 0, sh);
+  void clrldi(const Reg64& ra, const Reg64& rs, int8_t sh, bool rc = 0) {
+    rldicl(ra, rs, 0, sh, rc);
   }
   void extldi()         { not_implemented(); }  //Extended
-  void sldi(const Reg64& ra, const Reg64& rs, int8_t sh) {
-    rldicr(ra, rs, sh, 63-sh);
+  void sldi(const Reg64& ra, const Reg64& rs, int8_t sh, bool rc = 0) {
+    rldicr(ra, rs, sh, 63-sh, rc);
   }
   void clrrdi()         { not_implemented(); }  //Extended
+  void clrrwi(const Reg64& ra, const Reg64& rs, int8_t sh, bool rc = 0) {
+    rlwinm(ra, rs, 0, 0, 31-sh, rc);
+  }
   void clrlsldi()       { not_implemented(); }  //Extended
   void rotld()          { not_implemented(); }  //Extended
   void insrdi()         { not_implemented(); }  //Extended
@@ -1755,7 +1867,7 @@ struct Assembler {
   void bla(Label& l);
 
   void bc(Label& l, BranchConditions bc);
-  void bc(Label& l, HPHP::jit::ConditionCode cc);
+  void bc(Label& l, ConditionCode cc);
   void bca(Label& l, BranchConditions bc);
   void bcl(Label& l, BranchConditions bc);
   void bcla(Label& l, BranchConditions bc);
@@ -1769,23 +1881,50 @@ struct Assembler {
                   LinkReg lr = LinkReg::DoNotTouch);
 
   void branchAuto(CodeAddress c,
-                  HPHP::jit::ConditionCode cc,
+                  ConditionCode cc,
                   LinkReg lr = LinkReg::DoNotTouch);
 
   // ConditionCode variants
-  void bc(HPHP::jit::ConditionCode cc, int16_t address) {
+  void bc(ConditionCode cc, int16_t address) {
     BranchParams bp(cc);
     bc(bp.bo(), bp.bi(), address);
   }
 
   // Auxiliary for loading a complete 64bits immediate into a register
-  void li64 (const Reg64& rt, uint64_t imm64);
+  void li64 (const Reg64& rt, int64_t imm64);
+
+  // Retrieve the target defined by li64 instruction
+  static int64_t getLi64(PPC64Instr* pinstr);
+  static int64_t getLi64(CodeAddress pinstr) {
+    return getLi64(reinterpret_cast<PPC64Instr*>(pinstr));
+  }
+
+  // Retrieve the register used by li64 instruction
+  static Reg64 getLi64Reg(PPC64Instr* instr);
+  static Reg64 getLi64Reg(CodeAddress instr) {
+    return getLi64Reg(reinterpret_cast<PPC64Instr*>(instr));
+  }
 
   // Auxiliary for loading a 32bits immediate into a register
-  void li32 (const Reg64& rt, uint32_t imm32);
+  void li32 (const Reg64& rt, int32_t imm32);
 
   // Auxiliary for loading a 32bits unsigned immediate into a register
   void li32un (const Reg64& rt, uint32_t imm32);
+
+  // Retrieve the target defined by li32 instruction
+  static int32_t getLi32(PPC64Instr* pinstr);
+  static int32_t getLi32(CodeAddress pinstr) {
+    return getLi32(reinterpret_cast<PPC64Instr*>(pinstr));
+  }
+
+  // Retrieve the register used by li32 instruction
+  static Reg64 getLi32Reg(PPC64Instr* instr) {
+    // it also starts with li or lis, so the same as getLi64
+    return getLi64Reg(instr);
+  }
+  static Reg64 getLi32Reg(CodeAddress instr) {
+    return getLi32Reg(reinterpret_cast<PPC64Instr*>(instr));
+  }
 
   //Can be used to generate or force a unimplemented opcode exception
   void unimplemented();
@@ -1799,29 +1938,29 @@ struct Assembler {
     int16_t* BD = (int16_t*)(jmp);    // target address location in instruction
 
     // Keep AA and LK values
-    *BD = HPHP::safe_cast<int16_t>(diff & 0xFFFC) | ((*BD) & 0x3);
+    *BD = static_cast<int16_t>(diff & 0xFFFC) | ((*BD) & 0x3);
   }
 
   static void patchBctr(CodeAddress jmp, CodeAddress dest) {
     // Check Label::branchAuto for details
+    HPHP::CodeBlock cb2;
 
+#ifndef NDEBUG  // avoid "unused variable ‘bctr_addr’" warning on release build
+    // It has to skip the li64 and a mtctr instruction
+    CodeAddress bctr_addr = jmp + kLi64InstrLen + 1 * kBytesPerInstr;
     // Opcode located at the 6 most significant bits
-    assert(((jmp[3] >> 2) & 0x3F) == 19);  // XL-Form
-    ssize_t diff = dest - jmp;
+    assert(((bctr_addr[3] >> 2) & 0x3F) == 19);  // XL-Form
+#endif
 
-    int16_t *imm = (int16_t*)(jmp);     // immediate field of addi
-    *imm = HPHP::safe_cast<int16_t>((diff & (ssize_t(UINT16_MAX) << 32)) >> 32);
-
-    imm += 2*4;                         // skip sldi instruction
-    *imm = HPHP::safe_cast<int16_t>((diff & (ssize_t(UINT16_MAX) << 16)) >> 16);
-
-    imm += 4;                           // next instruction
-    *imm = HPHP::safe_cast<int16_t>(diff & ssize_t(UINT16_MAX));
+    // Initialize code block cb2 pointing to li64
+    cb2.init(jmp, kLi64InstrLen, "patched bctr");
+    Assembler b{ cb2 };
+    b.li64(reg::r12, ssize_t(dest));
   }
 
-  void emitNop(int n) {
-    assert((n % 4 == 0) && "This arch supports only 4 bytes alignment");
-    for (; n > 0; n -= 4)
+  void emitNop(int nbytes) {
+    assert((nbytes % 4 == 0) && "This arch supports only 4 bytes alignment");
+    for (; nbytes > 0; nbytes -= 4)
       nop();
   }
 
@@ -1845,6 +1984,11 @@ protected:
                   const uint16_t xop,
                   const bool rc = 0) {
 
+    // GP Register cannot be greater than 31
+    assert(static_cast<uint32_t>(rb) < 32);
+    assert(static_cast<uint32_t>(ra) < 32);
+    assert(static_cast<uint32_t>(rt) < 32);
+
     XO_form_t xo_formater {
                             rc,
                             xop,
@@ -1862,6 +2006,10 @@ protected:
                  const RegNumber rt,
                  const RegNumber ra,
                  const int16_t imm) {
+
+    // GP Register cannot be greater than 31
+    assert(static_cast<uint32_t>(rt) < 32);
+    assert(static_cast<uint32_t>(ra) < 32);
 
     D_form_t d_formater {
                           static_cast<uint32_t>(imm),
@@ -1924,6 +2072,11 @@ protected:
                   const uint16_t xop,
                   const bool rc = 0){
 
+     // GP Register cannot be greater than 31
+     assert(static_cast<uint32_t>(rb) < 32);
+     assert(static_cast<uint32_t>(ra) < 32);
+     assert(static_cast<uint32_t>(rt) < 32);
+
       X_form_t x_formater {
                             rc,
                             xop,
@@ -1942,6 +2095,10 @@ protected:
                    const uint16_t imm,
                    const uint16_t xop) {
 
+     // GP Register cannot be greater than 31
+     assert(static_cast<uint32_t>(ra) < 32);
+     assert(static_cast<uint32_t>(rt) < 32);
+
       DS_form_t ds_formater {
                              xop,
                              static_cast<uint32_t>(imm) >> 2,
@@ -1957,6 +2114,9 @@ protected:
                    const RegNumber rtp,
                    const RegNumber ra,
                    uint16_t imm){
+
+     // GP Register cannot be greater than 31
+     assert(static_cast<uint32_t>(ra) < 32);
 
       DQ_form_t dq_formater {
                              0x0, //Reserved
@@ -1993,14 +2153,20 @@ protected:
                   const RegNumber rt,
                   const RegNumber ra,
                   const RegNumber rb,
-                  const uint16_t bc,
+                  const RegNumber bc,
                   const uint16_t xop,
                   const bool rc = 0) {
+
+     // GP Register cannot be greater than 31
+     assert(static_cast<uint32_t>(rt) < 32);
+     assert(static_cast<uint32_t>(ra) < 32);
+     assert(static_cast<uint32_t>(rb) < 32);
+     assert(static_cast<uint32_t>(bc) < 32);
 
       A_form_t a_formater {
                            rc,
                            xop,
-                           bc,
+                           static_cast<uint32_t>(bc),
                            static_cast<uint32_t>(rb),
                            static_cast<uint32_t>(ra),
                            static_cast<uint32_t>(rt),
@@ -2017,6 +2183,11 @@ protected:
                   const uint8_t mb,
                   const uint8_t me,
                   const bool rc = 0) {
+
+     // GP Register cannot be greater than 31
+     assert(static_cast<uint32_t>(rb) < 32);
+     assert(static_cast<uint32_t>(ra) < 32);
+     assert(static_cast<uint32_t>(rb) < 32);
 
       M_form_t m_formater {
                            rc,
@@ -2038,6 +2209,10 @@ protected:
                    const uint8_t mb,
                    const uint8_t xop,
                    const bool rc = 0) {
+
+     // GP Register cannot be greater than 31
+     assert(static_cast<uint32_t>(ra) < 32);
+     assert(static_cast<uint32_t>(rs) < 32);
 
       MD_form_t md_formater {
         rc,
@@ -2061,6 +2236,11 @@ protected:
                     const uint8_t xop,
                     const bool rc = 0) {
 
+     // GP Register cannot be greater than 31
+     assert(static_cast<uint32_t>(rb) < 32);
+     assert(static_cast<uint32_t>(ra) < 32);
+     assert(static_cast<uint32_t>(rs) < 32);
+
       MDS_form_t mds_formater {
                                rc,
                                xop,
@@ -2079,6 +2259,10 @@ protected:
                    const SpecialReg spr,
                    const uint16_t xo,
                    const uint8_t rsv = 0) {
+
+    // GP Register cannot be greater than 31
+    assert(static_cast<uint32_t>(rs) < 32);
+
     XFX_form_t xfx_formater {
       rsv,
       xo,
@@ -2087,6 +2271,7 @@ protected:
       static_cast<uint32_t>(rs),
       op
     };
+
     dword(xfx_formater.instruction);
   }
 
@@ -2136,7 +2321,13 @@ protected:
                    const RegNumber rb,
                    const uint16_t xo,
                    const bool tx) {
-    XX3_form_t xx1_formater {
+
+    // GP Register cannot be greater than 31
+    assert(static_cast<uint32_t>(s) < 32);
+    assert(static_cast<uint32_t>(ra) < 32);
+    assert(static_cast<uint32_t>(rb) < 32);
+
+    XX1_form_t xx1_formater {
       tx,
       xo,
       static_cast<uint32_t>(rb),
@@ -2144,15 +2335,58 @@ protected:
       static_cast<uint32_t>(s),
       op
     };
+
     dword(xx1_formater.instruction);
+  }
+
+  void EmitVXForm(const uint8_t op,
+                  const RegNumber rt,
+                  const RegNumber ra,
+                  const RegNumber rb,
+                  const uint16_t xo) {
+
+    assert(static_cast<uint32_t>(rt) < 32);
+    assert(static_cast<uint32_t>(ra) < 32);
+    assert(static_cast<uint32_t>(rb) < 32);
+
+    VX_form_t vx_formater {
+      xo,
+      static_cast<uint32_t>(rb),
+      static_cast<uint32_t>(ra),
+      static_cast<uint32_t>(rt),
+      op
+    };
+
+    dword(vx_formater.instruction);
   }
   //TODO(rcardoso): Unimplemented instruction formaters
   void EmitXFLForm()  { not_implemented(); }
   void EmitXX4Form()  { not_implemented(); }
-  void EmitXSForm()   { not_implemented(); }
+  void EmitXSForm(const uint8_t op,
+                  const RegNumber rt,
+                  const RegNumber ra,
+                  const uint8_t sh,
+                  const uint16_t xop,
+                  const bool rc = 0){
+
+     // GP Register cannot be greater than 31
+     assert(static_cast<uint32_t>(rt) < 32);
+     assert(static_cast<uint32_t>(ra) < 32);
+
+      XS_form_t xs_formater {
+                            rc,
+                            static_cast<uint32_t>(sh >> 5),
+                            xop,
+                            static_cast<uint32_t>(sh & 0x1F),
+                            static_cast<uint32_t>(ra),
+                            static_cast<uint32_t>(rt),
+                            op
+                          };
+
+      dword(xs_formater.instruction);
+   }
   void EmitVAForm()   { not_implemented(); }
   void EmitVCForm()   { not_implemented(); }
-  void EmitVXForm()   { not_implemented(); }
   void EmitZ23Form()  { not_implemented(); }
   void EmitEVXForm()  { not_implemented(); }
   void EmitEVSForm()  { not_implemented(); }
@@ -2182,6 +2416,9 @@ private:
     return RegNumber(int(r));
   }
   RegNumber rn(RegXMM r) {
+    return RegNumber(int(r));
+  }
+  RegNumber rn(RegSF r) {
     return RegNumber(int(r));
   }
   RegNumber rn(int n) {
@@ -2260,38 +2497,19 @@ struct Label {
   }
 
   void branchAuto(Assembler& a, BranchConditions bc, LinkReg lr) {
-    assert(m_address && "Cannot evaluate branch size without defined target");
-    auto delta = m_address - a.frontier();
-    if (HPHP::jit::deltaFits(delta, HPHP::sz::word)) {
-      // Branch by offset
-
-      // TODO(gut): Use a typedef or something to avoid copying code like below:
-      if (LinkReg::Save == lr)
-        a.bcl(*this, bc);
-      else
-        a.bc(*this, bc);
-    } else {
-      // use CTR to perform absolute branch
-      BranchParams bp(bc);
-
-      // TODO(gut): is this really the best way? If only there was a register
-      // that was already filled with the address...
-      const ssize_t address = ssize_t(m_address ? m_address : a.frontier());
-
-      // Use reserved function linkage register
-      a.li64(reg::r12, address);
-      // When branching to another context, r12 need to keep the target address
-      // to correctly set r2 (TOC reference).
-      a.mtctr(reg::r12);
-
-      addJump(&a, BranchType::bctr);  // marking THIS address for patchBctr
-
-      // TODO(gut): Use a typedef or something to avoid copying code like below:
-      if (LinkReg::Save == lr)
-        a.bcctrl(bp.bo(), bp.bi(), 0);
-      else
-        a.bcctr(bp.bo(), bp.bi(), 0);
-    }
+    // use CTR to perform absolute branch
+    BranchParams bp(bc);
+    const ssize_t address = ssize_t(m_address);
+    // Use reserved function linkage register
+    addJump(&a, BranchType::bctr);  // marking THIS address for patchBctr
+    a.li64(reg::r12, address);
+    // When branching to another context, r12 need to keep the target address
+    // to correctly set r2 (TOC reference).
+    a.mtctr(reg::r12);
+    if (LinkReg::Save == lr)
+      a.bcctrl(bp.bo(), bp.bi(), 0);
+    else
+      a.bcctr(bp.bo(), bp.bi(), 0);
   }
 
   void asm_label(Assembler& a) {
@@ -2339,7 +2557,7 @@ inline void Assembler::bla(Label& l) { bcla(l, BranchConditions::Always); }
 inline void Assembler::bc(Label& l, BranchConditions bc) {
   l.branchOffset(*this, bc, LinkReg::DoNotTouch);
 }
-inline void Assembler::bc(Label& l, HPHP::jit::ConditionCode cc) {
+inline void Assembler::bc(Label& l, ConditionCode cc) {
   l.branchOffset(*this, BranchParams::convertCC(cc), LinkReg::DoNotTouch);
 }
 inline void Assembler::bca(Label& l, BranchConditions bc) {
@@ -2364,30 +2582,10 @@ inline void Assembler::branchAuto(CodeAddress c,
   l.branchAuto(*this, bc, lr);
 }
 inline void Assembler::branchAuto(CodeAddress c,
-                                  HPHP::jit::ConditionCode cc,
+                                  ConditionCode cc,
                                   LinkReg lr) {
   branchAuto(c, BranchParams::convertCC(cc), lr);
 }
-
-class Decoder {
-public:
-  explicit Decoder(uint32_t* ip)
-  : ip_(*ip),
-  decoded_instr_(nullptr) { decode(ip); }
-
-  ~Decoder() {
-    delete decoded_instr_;
-    decoded_instr_ = nullptr;
-  }
-
-  std::string toString();
-private:
-  void decode(uint32_t* ip);
-
-  uint32_t ip_;
-  DecoderInfo* decoded_instr_;
-  DecoderTable decoder_table_;
-};
 
 } // namespace ppc64_asm
 

--- a/hphp/ppc64-asm/asm-ppc64.h
+++ b/hphp/ppc64-asm/asm-ppc64.h
@@ -31,13 +31,13 @@
 
 namespace ppc64_asm {
 
-using HPHP::jit::Reg64;
-using HPHP::jit::RegXMM;
-using HPHP::jit::RegSF;
-using HPHP::jit::MemoryRef;
-using HPHP::jit::Immed;
-using HPHP::CodeAddress;
-using HPHP::jit::ConditionCode;
+/* using override */ using HPHP::jit::Reg64;
+/* using override */ using HPHP::jit::RegXMM;
+/* using override */ using HPHP::jit::RegSF;
+/* using override */ using HPHP::jit::MemoryRef;
+/* using override */ using HPHP::jit::Immed;
+/* using override */ using HPHP::CodeAddress;
+/* using override */ using HPHP::jit::ConditionCode;
 
 /* Used to  define a minimal callstack on call/ret vasm */
 // Must be the same value of AROFF(_dummyB).

--- a/hphp/ppc64-asm/asm-ppc64.h
+++ b/hphp/ppc64-asm/asm-ppc64.h
@@ -350,6 +350,8 @@ namespace reg {
   constexpr RegXMM v27(27);
   constexpr RegXMM v28(28);
   constexpr RegXMM v29(29);
+  constexpr RegXMM v30(30);
+  constexpr RegXMM v31(31);
 
 #define RNAME(x) if (r == x) return #x
 

--- a/hphp/runtime/vm/jit/abi-ppc64.cpp
+++ b/hphp/runtime/vm/jit/abi-ppc64.cpp
@@ -37,7 +37,7 @@ const RegSet kGPCallerSaved = reg::r3 | reg::r4 | reg::r5 | reg::r6 | reg::r7 |
 
 const RegSet kGPCalleeSaved = reg::r14 | reg::r15 | reg::r16 | reg::r17 |
   reg::r18 | reg::r19 | reg::r20 | reg::r21 | reg::r22 | reg::r23 | reg::r24 |
-  reg::r25 | reg::r26 |reg::r31;
+  reg::r25 | reg::r26 | reg::r31;
   // r1 is used as rsp
   // r27 is used as rone (value 1)
   // r28 is used as rvmfp
@@ -46,20 +46,20 @@ const RegSet kGPCalleeSaved = reg::r14 | reg::r15 | reg::r16 | reg::r17 |
 
 const RegSet kGPUnreserved = kGPCallerSaved | kGPCalleeSaved;
 
-const RegSet kGPReserved = RegSet(reg::r12) | reg::r2 | rfuncln() | rvmtl() |
-  rvmfp() | rvmsp() | rAsm | rsp() | r_svcreq_stub() | rthreadptr() | rone();
+const RegSet kGPReserved = reg::r12 | reg::r2 | rfuncln() | rvmtl() | rvmfp() |
+  rvmsp() | rAsm | rsp() | r_svcreq_stub() | rthreadptr() | rone();
   // Reserve the r2 TOC register to avoid changing it
 
 const RegSet kGPRegs = kGPUnreserved | kGPReserved;
 
 const RegSet kXMMCallerSaved = reg::f1 | reg::f2 | reg::f3 | reg::f4 |
-    reg::f5 | reg::f6 | reg::f7 | reg::f8 | reg::f9 | reg::f10 | reg::f11 |
-    reg::f12 | reg::f13 | reg::v16 | reg::v17 | reg::v18 | reg::v19;
+  reg::f5 | reg::f6 | reg::f7 | reg::f8 | reg::f9 | reg::f10 | reg::f11 |
+  reg::f12 | reg::f13 | reg::v16 | reg::v17 | reg::v18 | reg::v19;
 
 const RegSet kXMMCalleeSaved = reg::f14 | reg::f15 | reg::v20 | reg::v21 |
-    reg::v22 | reg::v23 | reg::v24 | reg::v25 | reg::v26 | reg::v27 |
-    reg::v28 | reg::v30 | reg::v31;
- // v29 reserved for Vxls::m_tmp
+  reg::v22 | reg::v23 | reg::v24 | reg::v25 | reg::v26 | reg::v27 | reg::v28 |
+  reg::v30 | reg::v31;
+  // v29 reserved for Vxls::m_tmp
 
 const RegSet kXMMUnreserved = kXMMCallerSaved | kXMMCalleeSaved;
 const RegSet kXMMReserved = RegSet(reg::v29);
@@ -123,8 +123,8 @@ constexpr PhysReg gp_args[] = {
 };
 
 constexpr PhysReg simd_args[] = {
-    reg::f1, reg::f2, reg::f3, reg::f4, reg::f5, reg::f6, reg::f7, reg::f8,
-    reg::f9, reg::f10, reg::f11, reg::f12, reg::f13
+  reg::f1, reg::f2, reg::f3, reg::f4, reg::f5, reg::f6, reg::f7, reg::f8,
+  reg::f9, reg::f10, reg::f11, reg::f12, reg::f13
 };
 
 constexpr PhysReg svcreq_args[] = {

--- a/hphp/runtime/vm/jit/abi-ppc64.cpp
+++ b/hphp/runtime/vm/jit/abi-ppc64.cpp
@@ -1,0 +1,193 @@
+/*
+   +----------------------------------------------------------------------+
+   | HipHop for PHP                                                       |
+   +----------------------------------------------------------------------+
+   | (c) Copyright IBM Corporation 2015                                   |
+   +----------------------------------------------------------------------+
+   | This source file is subject to version 3.01 of the PHP license,      |
+   | that is bundled with this package in the file LICENSE, and is        |
+   | available through the world-wide-web at the following url:           |
+   | http://www.php.net/license/3_01.txt                                  |
+   | If you did not receive a copy of the PHP license and are unable to   |
+   | obtain it through the world-wide-web, please send a note to          |
+   | license@php.net so we can mail you a copy immediately.               |
+   +----------------------------------------------------------------------+
+*/
+
+#include "hphp/runtime/vm/jit/abi-ppc64.h"
+
+#include "hphp/runtime/vm/jit/types.h"
+#include "hphp/runtime/vm/jit/abi.h"
+
+namespace HPHP { namespace jit { namespace ppc64 {
+
+///////////////////////////////////////////////////////////////////////////////
+
+namespace {
+
+///////////////////////////////////////////////////////////////////////////////
+
+namespace reg = ppc64_asm::reg;
+
+const RegSet kGPCallerSaved = reg::r3 | reg::r4 | reg::r5 | reg::r6 | reg::r7 |
+  reg::r8 | reg::r9 | reg::r10;
+  // r0 is used in function linkage as rfuncln
+  // r11 is used as a scratch register (rAsm)
+  // r12 is used in function linkage
+
+const RegSet kGPCalleeSaved = reg::r14 | reg::r15 | reg::r16 | reg::r17 |
+  reg::r18 | reg::r19 | reg::r20 | reg::r21 | reg::r22 | reg::r23 | reg::r24 |
+  reg::r25 | reg::r31;
+  // r1 is used as rsp
+  // r26 is used as rbackchain (VM backchain)
+  // r27 is used as rone (value 1)
+  // r28 is used as rvmfp
+  // r29 is used as rvmsp
+  // r30 is used as rvmtl
+
+const RegSet kGPUnreserved = kGPCallerSaved | kGPCalleeSaved;
+
+const RegSet kGPReserved = RegSet(reg::r12) | reg::r2 | rfuncln() | rvmtl() |
+  rvmfp() | rvmsp() | rAsm | rsp() | r_svcreq_stub() | rthreadptr() | rone() |
+  rbackchain();
+  // Reserve the r2 TOC register to avoid changing it
+
+const RegSet kGPRegs = kGPUnreserved | kGPReserved;
+
+const RegSet kXMMCallerSaved = reg::v0 | reg::v1 | reg::v2 | reg::v3 |
+  reg::v4 | reg::v5 | reg::v6 | reg::v7 | reg::v8 | reg::v9 | reg::v10 |
+  reg::v11 | reg::v12 | reg::v13 | reg::v14 | reg::v15 | reg::v16 | reg::v17 |
+  reg::v18 | reg::v19;
+
+const RegSet kXMMCalleeSaved = reg::v20 | reg::v21 | reg::v22 | reg::v23 |
+  reg::v24 | reg::v25 | reg::v26 | reg::v27 | reg::v28;
+ // v29 reserved for Vxls::m_tmp
+ // Ignoring the v30, v31 due to PhysReg::kMaxRegs == 64
+
+
+const RegSet kXMMUnreserved = kXMMCallerSaved | kXMMCalleeSaved;
+const RegSet kXMMReserved = RegSet(reg::v29);
+
+const RegSet kXMMRegs = kXMMUnreserved | kXMMReserved;
+
+const RegSet kCallerSaved = kGPCallerSaved | kXMMCallerSaved;
+const RegSet kCalleeSaved = kGPCalleeSaved | kXMMCalleeSaved;
+
+const RegSet kSF = RegSet(RegSF{0});
+
+///////////////////////////////////////////////////////////////////////////////
+
+/*
+ * Registers that can safely be used for scratch purposes in-between traces.
+ */
+const RegSet kScratchCrossTraceRegs =
+  kXMMCallerSaved | (kGPUnreserved - vm_regs_with_sp());
+
+/*
+ * Helper code ABI registers.
+ */
+const RegSet kGPHelperRegs = ppc64::rAsm | reg::r10; //TODO
+const RegSet kXMMHelperRegs; // TODO
+
+///////////////////////////////////////////////////////////////////////////////
+
+const Abi trace_abi {
+  kGPUnreserved,
+  kGPReserved,
+  kXMMUnreserved,
+  kXMMReserved,
+  kCalleeSaved,
+  kSF,
+  true,
+};
+
+const Abi cross_trace_abi {
+  trace_abi.gp() & kScratchCrossTraceRegs,
+  trace_abi.gp() - kScratchCrossTraceRegs,
+  trace_abi.simd() & kScratchCrossTraceRegs,
+  trace_abi.simd() - kScratchCrossTraceRegs,
+  trace_abi.calleeSaved & kScratchCrossTraceRegs,
+  trace_abi.sf,
+  false
+};
+
+const Abi helper_abi {
+  kGPHelperRegs,
+  trace_abi.gp() - kGPHelperRegs,
+  kXMMHelperRegs,
+  trace_abi.simd() - kXMMHelperRegs,
+  trace_abi.calleeSaved,
+  trace_abi.sf,
+  false
+
+};
+
+constexpr PhysReg gp_args[] = {
+  reg::r3, reg::r4, reg::r5, reg::r6, reg::r7, reg::r8, reg::r9
+};
+
+constexpr PhysReg simd_args[] = {
+    reg::v2, reg::v3, reg::v4, reg::v5, reg::v6, reg::v7, reg::v8, reg::v9,
+    reg::v10, reg::v11, reg::v12, reg::v13
+};
+
+constexpr PhysReg svcreq_args[] = {
+    reg::r4, reg::r5, reg::r6, reg::r7
+};
+
+///////////////////////////////////////////////////////////////////////////////
+
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+const Abi& abi(CodeKind kind) {
+  switch (kind) {
+    case CodeKind::Trace:
+      return trace_abi;
+    case CodeKind::CrossTrace:
+      return cross_trace_abi;
+    case CodeKind::Helper:
+      return helper_abi;
+  }
+  not_reached();
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+PhysReg rret(size_t i) {
+  assertx(i < 2);
+  return i == 0 ? reg::r3 : reg::r4;
+}
+PhysReg rret_simd(size_t i) {
+  assertx(i == 0);
+  return reg::v2;
+}
+
+PhysReg rarg(size_t i) {
+  assertx(i < num_arg_regs());
+  return gp_args[i];
+}
+PhysReg rarg_simd(size_t i) {
+  assertx(i < num_arg_regs_simd());
+  return simd_args[i];
+}
+
+size_t num_arg_regs() {
+  return sizeof(gp_args) / sizeof(PhysReg);
+}
+size_t num_arg_regs_simd() {
+  return sizeof(simd_args) / sizeof(PhysReg);
+}
+
+
+PhysReg r_svcreq_sf() {
+  return abi().sf.findFirst();
+}
+PhysReg r_svcreq_arg(size_t i) {
+  return svcreq_args[i];
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+}}}

--- a/hphp/runtime/vm/jit/abi-ppc64.cpp
+++ b/hphp/runtime/vm/jit/abi-ppc64.cpp
@@ -37,9 +37,8 @@ const RegSet kGPCallerSaved = reg::r3 | reg::r4 | reg::r5 | reg::r6 | reg::r7 |
 
 const RegSet kGPCalleeSaved = reg::r14 | reg::r15 | reg::r16 | reg::r17 |
   reg::r18 | reg::r19 | reg::r20 | reg::r21 | reg::r22 | reg::r23 | reg::r24 |
-  reg::r25 | reg::r31;
+  reg::r25 | reg::r26 |reg::r31;
   // r1 is used as rsp
-  // r26 is used as rbackchain (VM backchain)
   // r27 is used as rone (value 1)
   // r28 is used as rvmfp
   // r29 is used as rvmsp
@@ -48,8 +47,7 @@ const RegSet kGPCalleeSaved = reg::r14 | reg::r15 | reg::r16 | reg::r17 |
 const RegSet kGPUnreserved = kGPCallerSaved | kGPCalleeSaved;
 
 const RegSet kGPReserved = RegSet(reg::r12) | reg::r2 | rfuncln() | rvmtl() |
-  rvmfp() | rvmsp() | rAsm | rsp() | r_svcreq_stub() | rthreadptr() | rone() |
-  rbackchain();
+  rvmfp() | rvmsp() | rAsm | rsp() | r_svcreq_stub() | rthreadptr() | rone();
   // Reserve the r2 TOC register to avoid changing it
 
 const RegSet kGPRegs = kGPUnreserved | kGPReserved;
@@ -127,12 +125,12 @@ constexpr PhysReg gp_args[] = {
 };
 
 constexpr PhysReg simd_args[] = {
-    reg::v2, reg::v3, reg::v4, reg::v5, reg::v6, reg::v7, reg::v8, reg::v9,
-    reg::v10, reg::v11, reg::v12, reg::v13
+  reg::v2, reg::v3, reg::v4, reg::v5, reg::v6, reg::v7, reg::v8, reg::v9,
+  reg::v10, reg::v11, reg::v12, reg::v13
 };
 
 constexpr PhysReg svcreq_args[] = {
-    reg::r4, reg::r5, reg::r6, reg::r7
+  reg::r4, reg::r5, reg::r6, reg::r7
 };
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/hphp/runtime/vm/jit/abi-ppc64.cpp
+++ b/hphp/runtime/vm/jit/abi-ppc64.cpp
@@ -52,16 +52,14 @@ const RegSet kGPReserved = RegSet(reg::r12) | reg::r2 | rfuncln() | rvmtl() |
 
 const RegSet kGPRegs = kGPUnreserved | kGPReserved;
 
-const RegSet kXMMCallerSaved = reg::v0 | reg::v1 | reg::v2 | reg::v3 |
-  reg::v4 | reg::v5 | reg::v6 | reg::v7 | reg::v8 | reg::v9 | reg::v10 |
-  reg::v11 | reg::v12 | reg::v13 | reg::v14 | reg::v15 | reg::v16 | reg::v17 |
-  reg::v18 | reg::v19;
+const RegSet kXMMCallerSaved = reg::f1 | reg::f2 | reg::f3 | reg::f4 |
+    reg::f5 | reg::f6 | reg::f7 | reg::f8 | reg::f9 | reg::f10 | reg::f11 |
+    reg::f12 | reg::f13 | reg::v16 | reg::v17 | reg::v18 | reg::v19;
 
-const RegSet kXMMCalleeSaved = reg::v20 | reg::v21 | reg::v22 | reg::v23 |
-  reg::v24 | reg::v25 | reg::v26 | reg::v27 | reg::v28;
+const RegSet kXMMCalleeSaved = reg::f14 | reg::f15 | reg::v20 | reg::v21 |
+    reg::v22 | reg::v23 | reg::v24 | reg::v25 | reg::v26 | reg::v27 |
+    reg::v28 | reg::v30 | reg::v31;
  // v29 reserved for Vxls::m_tmp
- // Ignoring the v30, v31 due to PhysReg::kMaxRegs == 64
-
 
 const RegSet kXMMUnreserved = kXMMCallerSaved | kXMMCalleeSaved;
 const RegSet kXMMReserved = RegSet(reg::v29);
@@ -125,8 +123,8 @@ constexpr PhysReg gp_args[] = {
 };
 
 constexpr PhysReg simd_args[] = {
-  reg::v2, reg::v3, reg::v4, reg::v5, reg::v6, reg::v7, reg::v8, reg::v9,
-  reg::v10, reg::v11, reg::v12, reg::v13
+    reg::f1, reg::f2, reg::f3, reg::f4, reg::f5, reg::f6, reg::f7, reg::f8,
+    reg::f9, reg::f10, reg::f11, reg::f12, reg::f13
 };
 
 constexpr PhysReg svcreq_args[] = {
@@ -159,7 +157,7 @@ PhysReg rret(size_t i) {
 }
 PhysReg rret_simd(size_t i) {
   assertx(i == 0);
-  return reg::v2;
+  return reg::f1;
 }
 
 PhysReg rarg(size_t i) {

--- a/hphp/runtime/vm/jit/abi-ppc64.h
+++ b/hphp/runtime/vm/jit/abi-ppc64.h
@@ -80,6 +80,9 @@ PhysReg r_svcreq_arg(size_t i);
 
 /*
  * Scratch registers.
+ *
+ * rAsm: a general purpose temporary register
+ * rFasm: a floating point temporary register
  */
 constexpr Reg64 rAsm = ppc64_asm::reg::r11;
 constexpr RegXMM rFasm = ppc64_asm::reg::f15;

--- a/hphp/runtime/vm/jit/abi-ppc64.h
+++ b/hphp/runtime/vm/jit/abi-ppc64.h
@@ -40,10 +40,15 @@ constexpr PhysReg rvmfp()      { return ppc64_asm::reg::r28; }
 constexpr PhysReg rvmsp()      { return ppc64_asm::reg::r29; }
 constexpr PhysReg rvmtl()      { return ppc64_asm::reg::r30; }
 constexpr PhysReg rsp()        { return ppc64_asm::reg::r1;  }
+
 // optional in function linkage/used in function prologues
 constexpr PhysReg rfuncln()    { return ppc64_asm::reg::r0;  }
-// thread pointer
+
+// thread pointer, used to access the thread local storage section.
+// See ABI for more info, page 112, Chapter 3.7.2 "TLS Runtime Handling"
+// https://members.openpowerfoundation.org/document/dl/576
 constexpr PhysReg rthreadptr() { return ppc64_asm::reg::r13; }
+
 // optional in function linkage/function entry address at global entry point
 constexpr PhysReg rfuncentry() { return ppc64_asm::reg::r12; }
 

--- a/hphp/runtime/vm/jit/abi-ppc64.h
+++ b/hphp/runtime/vm/jit/abi-ppc64.h
@@ -82,7 +82,7 @@ PhysReg r_svcreq_arg(size_t i);
  * Scratch registers.
  */
 constexpr Reg64 rAsm = ppc64_asm::reg::r11;
-constexpr RegXMM rFasm = ppc64_asm::reg::f29;
+constexpr RegXMM rFasm = ppc64_asm::reg::f15;
 
 ///////////////////////////////////////////////////////////////////////////////
 

--- a/hphp/runtime/vm/jit/abi-ppc64.h
+++ b/hphp/runtime/vm/jit/abi-ppc64.h
@@ -1,0 +1,97 @@
+/*
+   +----------------------------------------------------------------------+
+   | HipHop for PHP                                                       |
+   +----------------------------------------------------------------------+
+   | (c) Copyright IBM Corporation 2015                                   |
+   +----------------------------------------------------------------------+
+   | This source file is subject to version 3.01 of the PHP license,      |
+   | that is bundled with this package in the file LICENSE, and is        |
+   | available through the world-wide-web at the following url:           |
+   | http://www.php.net/license/3_01.txt                                  |
+   | If you did not receive a copy of the PHP license and are unable to   |
+   | obtain it through the world-wide-web, please send a note to          |
+   | license@php.net so we can mail you a copy immediately.               |
+   +----------------------------------------------------------------------+
+*/
+
+#ifndef incl_HPHP_JIT_ABI_PPC64_H_
+#define incl_HPHP_JIT_ABI_PPC64_H_
+
+#include "hphp/runtime/vm/jit/phys-reg.h"
+#include "hphp/runtime/vm/bytecode.h"
+
+#include "hphp/ppc64-asm/asm-ppc64.h"
+
+namespace HPHP { namespace jit {
+
+struct Abi;
+
+namespace ppc64 {
+
+///////////////////////////////////////////////////////////////////////////////
+/*
+ * Mirrors the API of abi.h.
+ */
+
+const Abi& abi(CodeKind kind = CodeKind::Trace);
+
+/* VM registers must match etch-helpers.h definitions! */
+constexpr PhysReg rvmfp()      { return ppc64_asm::reg::r28; }
+constexpr PhysReg rvmsp()      { return ppc64_asm::reg::r29; }
+constexpr PhysReg rvmtl()      { return ppc64_asm::reg::r30; }
+constexpr PhysReg rsp()        { return ppc64_asm::reg::r1;  }
+constexpr PhysReg rfuncln()    { return ppc64_asm::reg::r0;  }
+constexpr PhysReg rthreadptr() { return ppc64_asm::reg::r13; }
+constexpr PhysReg rfuncentry() { return ppc64_asm::reg::r12; }
+
+// rone() returns register 27, which has the value "1" (Initiated in
+// translator-asm-helpers.S).
+// This is necessary for PPC64 since instructions like "inc" must updates the
+// CR depending the instruction result and instructions like "addi" (using
+// immediate) does not set the CR.
+constexpr PhysReg rone()       { return ppc64_asm::reg::r27; }
+constexpr PhysReg rbackchain() { return ppc64_asm::reg::r26; }
+
+namespace detail {
+  const RegSet kVMRegs      = rvmfp() | rvmtl() | rvmsp();
+  const RegSet kVMRegsNoSP  = rvmfp() | rvmtl();
+}
+
+inline RegSet vm_regs_with_sp() { return detail::kVMRegs; }
+inline RegSet vm_regs_no_sp()   { return detail::kVMRegsNoSP; }
+
+PhysReg rret(size_t i = 0);
+PhysReg rret_simd(size_t i);
+
+PhysReg rarg(size_t i);
+PhysReg rarg_simd(size_t i);
+
+size_t num_arg_regs();
+size_t num_arg_regs_simd();
+
+constexpr PhysReg r_svcreq_req()  { return ppc64_asm::reg::r3; }
+constexpr PhysReg r_svcreq_stub() { return ppc64_asm::reg::r8; }
+PhysReg r_svcreq_sf();
+PhysReg r_svcreq_arg(size_t i);
+
+///////////////////////////////////////////////////////////////////////////////
+
+/* Used on vasm for defining a minimal callstack on call/ret */
+constexpr int min_callstack_size          = AROFF(_dummyB);   // next union
+constexpr int lr_position_on_callstack    = AROFF(m_savedRip);
+constexpr int rvmfp_position_on_callstack = 8;  // CR save area not in use
+
+/* Parameters for push/pop and keep stack aligned */
+constexpr int push_pop_position           = 8;
+
+/*
+ * Scratch register.
+ */
+constexpr Reg64 rAsm = ppc64_asm::reg::r11;
+constexpr RegXMM rFasm = ppc64_asm::reg::f29;
+
+///////////////////////////////////////////////////////////////////////////////
+
+}}}
+
+#endif

--- a/hphp/runtime/vm/jit/abi-ppc64.h
+++ b/hphp/runtime/vm/jit/abi-ppc64.h
@@ -40,8 +40,11 @@ constexpr PhysReg rvmfp()      { return ppc64_asm::reg::r28; }
 constexpr PhysReg rvmsp()      { return ppc64_asm::reg::r29; }
 constexpr PhysReg rvmtl()      { return ppc64_asm::reg::r30; }
 constexpr PhysReg rsp()        { return ppc64_asm::reg::r1;  }
+// optional in function linkage/used in function prologues
 constexpr PhysReg rfuncln()    { return ppc64_asm::reg::r0;  }
+// thread pointer
 constexpr PhysReg rthreadptr() { return ppc64_asm::reg::r13; }
+// optional in function linkage/function entry address at global entry point
 constexpr PhysReg rfuncentry() { return ppc64_asm::reg::r12; }
 
 // rone() returns register 27, which has the value "1" (Initiated in
@@ -50,7 +53,6 @@ constexpr PhysReg rfuncentry() { return ppc64_asm::reg::r12; }
 // CR depending the instruction result and instructions like "addi" (using
 // immediate) does not set the CR.
 constexpr PhysReg rone()       { return ppc64_asm::reg::r27; }
-constexpr PhysReg rbackchain() { return ppc64_asm::reg::r26; }
 
 namespace detail {
   const RegSet kVMRegs      = rvmfp() | rvmtl() | rvmsp();
@@ -76,16 +78,8 @@ PhysReg r_svcreq_arg(size_t i);
 
 ///////////////////////////////////////////////////////////////////////////////
 
-/* Used on vasm for defining a minimal callstack on call/ret */
-constexpr int min_callstack_size          = AROFF(_dummyB);   // next union
-constexpr int lr_position_on_callstack    = AROFF(m_savedRip);
-constexpr int rvmfp_position_on_callstack = 8;  // CR save area not in use
-
-/* Parameters for push/pop and keep stack aligned */
-constexpr int push_pop_position           = 8;
-
 /*
- * Scratch register.
+ * Scratch registers.
  */
 constexpr Reg64 rAsm = ppc64_asm::reg::r11;
 constexpr RegXMM rFasm = ppc64_asm::reg::f29;

--- a/hphp/runtime/vm/jit/align-ppc64.cpp
+++ b/hphp/runtime/vm/jit/align-ppc64.cpp
@@ -1,0 +1,152 @@
+/*
+   +----------------------------------------------------------------------+
+   | HipHop for PHP                                                       |
+   +----------------------------------------------------------------------+
+   | (c) Copyright IBM Corporation 2015                                   |
+   +----------------------------------------------------------------------+
+   | This source file is subject to version 3.01 of the PHP license,      |
+   | that is bundled with this package in the file LICENSE, and is        |
+   | available through the world-wide-web at the following url:           |
+   | http://www.php.net/license/3_01.txt                                  |
+   | If you did not receive a copy of the PHP license and are unable to   |
+   | obtain it through the world-wide-web, please send a note to          |
+   | license@php.net so we can mail you a copy immediately.               |
+   +----------------------------------------------------------------------+
+*/
+
+#include "hphp/runtime/vm/jit/align-ppc64.h"
+
+#include "hphp/runtime/vm/jit/mc-generator.h"
+#include "hphp/runtime/vm/jit/smashable-instr-ppc64.h"
+
+#include "hphp/ppc64-asm/asm-ppc64.h"
+#include "hphp/util/data-block.h"
+
+#include <folly/Bits.h>
+
+#include <utility>
+
+namespace HPHP { namespace jit { namespace ppc64 {
+
+///////////////////////////////////////////////////////////////////////////////
+
+namespace {
+
+///////////////////////////////////////////////////////////////////////////////
+
+/*
+ * Targets of jmps on ppc64 must be aligned to instruction.
+ */
+constexpr size_t kJmpTargetAlign = ppc64_asm::Assembler::kBytesPerInstr;
+
+/*
+ * Alignment info table.
+ */
+constexpr AlignInfo s_aligns[] = {
+  { cache_line_size(),  cache_line_size(),      0 },  // CacheLine
+  { cache_line_size(),  cache_line_size() / 2,  0 },  // CacheLineRoundUp
+  { kJmpTargetAlign,    kJmpTargetAlign,        0 },  // JmpTarget
+  { cache_line_size(),  smashableMovqLen(),     0 },
+  { cache_line_size(),  smashableCmpqLen(),     0 },
+  { cache_line_size(),  smashableCallLen(),     0 },
+  { cache_line_size(),  smashableJmpLen(),      0 },
+  { cache_line_size(),  smashableJccLen(),      0 },
+
+  // Three entries for SmashJccAndJmp, one for each half and one for both
+  // together.  The implementation below relies on this being the last
+  // sequential enum value.
+  { cache_line_size(),  smashableJccLen(),  0 },
+  { cache_line_size(),  smashableJccLen() +
+                        smashableJmpLen(),  smashableJccLen() },
+  { cache_line_size(),  smashableJccLen() +
+                        smashableJmpLen(),  0 }
+};
+
+bool is_aligned(TCA frontier, const AlignInfo& a) {
+  assertx(a.nbytes <= a.align);
+  assertx(folly::isPowTwo(a.align));
+
+  auto const mask = a.align - 1;
+
+  auto const ifrontier = reinterpret_cast<size_t>(frontier);
+  auto const first_byte = ifrontier + a.offset;
+  auto const last_byte  = ifrontier + a.nbytes - 1;
+
+  return (first_byte & ~mask) == (last_byte & ~mask);
+}
+
+size_t align_gap(TCA frontier, const AlignInfo& a) {
+  auto const ifrontier = reinterpret_cast<size_t>(frontier);
+  auto const gap = a.align - ((a.align - 1) & (ifrontier + a.offset));
+
+  return gap == a.align ? 0 : gap;
+}
+
+void pad_for_align(CodeBlock& cb, const AlignInfo& ali, AlignContext context) {
+  ppc64_asm::Assembler a { cb };
+
+  if (is_aligned(cb.frontier(), ali)) return;
+
+  auto gap_sz = align_gap(cb.frontier(), ali);
+
+  switch (context) {
+    case AlignContext::Live:
+      a.emitNop(gap_sz);
+      return;
+
+    case AlignContext::Dead:
+      if (gap_sz > 4) {
+        a.trap();
+        gap_sz -= 4;
+      }
+      if (gap_sz > 0) {
+        a.emitNop(gap_sz);
+      }
+      return;
+  }
+  not_reached();
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+bool is_aligned(TCA frontier, Alignment alignment) {
+  auto const idx = static_cast<uint32_t>(alignment);
+  bool const is_jccandjmp = alignment == Alignment::SmashJccAndJmp;
+
+  return is_aligned(frontier, s_aligns[idx]) &&
+    (!is_jccandjmp || is_aligned(frontier, s_aligns[idx + 1]));
+}
+
+void align(CodeBlock& cb, Alignment alignment, AlignContext context,
+           bool fixups /* = true */) {
+  auto const idx = static_cast<uint32_t>(alignment);
+  bool const is_jccandjmp = alignment == Alignment::SmashJccAndJmp;
+
+  pad_for_align(cb, s_aligns[idx], context);
+  if (is_jccandjmp) pad_for_align(cb, s_aligns[idx + 1], context);
+
+  assertx(is_aligned(cb.frontier(), s_aligns[idx]));
+  if (is_jccandjmp) assertx(is_aligned(cb.frontier(), s_aligns[idx + 1]));
+
+  if (fixups) {
+    mcg->cgFixups().m_alignFixups.emplace(
+      cb.frontier(),
+      std::make_pair(alignment, context)
+    );
+  }
+}
+
+const AlignInfo& alignment_info(Alignment alignment) {
+  auto const idx = static_cast<uint32_t>(alignment);
+  bool const is_jccandjmp = alignment == Alignment::SmashJccAndJmp;
+
+  return s_aligns[is_jccandjmp ? idx + 2 : idx];
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+}}}

--- a/hphp/runtime/vm/jit/align-ppc64.h
+++ b/hphp/runtime/vm/jit/align-ppc64.h
@@ -14,42 +14,50 @@
    +----------------------------------------------------------------------+
 */
 
-#ifndef incl_HPHP_JIT_VASM_EMIT_H_
-#define incl_HPHP_JIT_VASM_EMIT_H_
+#ifndef incl_HPHP_JIT_ALIGN_PPC64_H_
+#define incl_HPHP_JIT_ALIGN_PPC64_H_
 
-namespace HPHP { namespace jit {
-///////////////////////////////////////////////////////////////////////////////
+#include "hphp/runtime/vm/jit/types.h"
+#include "hphp/runtime/vm/jit/alignment.h"
 
-struct Abi;
-struct AsmInfo;
-struct Vtext;
-struct Vunit;
+#include "hphp/util/data-block.h"
 
-///////////////////////////////////////////////////////////////////////////////
-
-/*
- * Optimize, lower for x64, register allocator, and perform more optimizations
- * on `unit'.
- */
-void optimizeX64(Vunit& unit, const Abi&);
-
-/*
- * Emit code for the given unit using the given code areas. The unit should
- * have already been through optimizeX64().
- */
-void emitX64(const Vunit&, Vtext&, AsmInfo*);
-
-/*
- * Optimize, register allocate, and emit ARM code for the given unit.
- */
-void finishARM(Vunit&, Vtext&, const Abi&, AsmInfo*);
-
-/*
- * Optimize, register allocate, and emit PPC64 code for the given unit.
- */
-void finishPPC64(Vunit&, Vtext&, const Abi&, AsmInfo*);
+namespace HPHP { namespace jit { namespace ppc64 {
 
 ///////////////////////////////////////////////////////////////////////////////
-}}
+
+/*
+ * Mirrors the API of align.h.
+ */
+
+bool is_aligned(TCA frontier, Alignment alignment);
+
+void align(CodeBlock& cb, Alignment alignment, AlignContext context,
+           bool fixups = true);
+
+constexpr size_t cache_line_size() { return 128; }
+
+/*
+ * All the Alignments can be expressed by stipulating that the code region
+ * given by
+ *
+ *    [frontier + offset, nbytes)
+ *
+ * fits into the nearest `align'-aligned and -sized line.
+ */
+struct AlignInfo {
+  size_t align;
+  size_t nbytes;
+  size_t offset;
+};
+
+/*
+ * Get the AlignInfo for `alignment'; used by relocation.
+ */
+const AlignInfo& alignment_info(Alignment alignment);
+
+///////////////////////////////////////////////////////////////////////////////
+
+}}}
 
 #endif

--- a/hphp/runtime/vm/jit/func-guard-ppc64.cpp
+++ b/hphp/runtime/vm/jit/func-guard-ppc64.cpp
@@ -56,11 +56,11 @@ void emitFuncGuard(const Func* func, CodeBlock& cb) {
   assertx(ppc64::abi(CodeKind::CrossTrace).gpUnreserved.contains(tmp1));
   assertx(ppc64::abi(CodeKind::CrossTrace).gpUnreserved.contains(tmp2));
 
-  a.  li64   (tmp1, uint64_t(func));
+  emitSmashableMovq(a.code(), uint64_t(func), tmp1);
   a.  ld     (tmp2, rvmfp()[AROFF(m_func)]);
   a.  cmpld  (tmp1, tmp2);
 
-  a.    branchAuto(mcg->tx().uniqueStubs.funcPrologueRedispatch,
+  a.  branchAuto(mcg->tx().uniqueStubs.funcPrologueRedispatch,
                   ppc64_asm::BranchConditions::NotEqual);
 
   DEBUG_ONLY auto guard = funcGuardFromPrologue(a.frontier(), func);
@@ -80,8 +80,7 @@ bool funcGuardMatches(TCA guard, const Func* func) {
 }
 
 void clobberFuncGuard(TCA guard, const Func* func) {
-  not_implemented();
-  return;
+  smashMovq(guard, 0);
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/hphp/runtime/vm/jit/func-guard-ppc64.cpp
+++ b/hphp/runtime/vm/jit/func-guard-ppc64.cpp
@@ -50,7 +50,9 @@ ALWAYS_INLINE bool isPrologueStub(TCA addr) {
 void emitFuncGuard(const Func* func, CodeBlock& cb) {
   ppc64_asm::Assembler a { cb };
 
-  const auto tmp1 = ppc64_asm::reg::r3, tmp2 = ppc64_asm::reg::r4;
+  const auto tmp1 = ppc64_asm::reg::r3;
+  const auto tmp2 = ppc64_asm::reg::r4;
+
   assertx(ppc64::abi(CodeKind::CrossTrace).gpUnreserved.contains(tmp1));
   assertx(ppc64::abi(CodeKind::CrossTrace).gpUnreserved.contains(tmp2));
 

--- a/hphp/runtime/vm/jit/func-guard-ppc64.cpp
+++ b/hphp/runtime/vm/jit/func-guard-ppc64.cpp
@@ -1,0 +1,87 @@
+/*
+   +----------------------------------------------------------------------+
+   | HipHop for PHP                                                       |
+   +----------------------------------------------------------------------+
+   | (c) Copyright IBM Corporation 2015                                   |
+   +----------------------------------------------------------------------+
+   | This source file is subject to version 3.01 of the PHP license,      |
+   | that is bundled with this package in the file LICENSE, and is        |
+   | available through the world-wide-web at the following url:           |
+   | http://www.php.net/license/3_01.txt                                  |
+   | If you did not receive a copy of the PHP license and are unable to   |
+   | obtain it through the world-wide-web, please send a note to          |
+   | license@php.net so we can mail you a copy immediately.               |
+   +----------------------------------------------------------------------+
+*/
+
+#include "hphp/runtime/vm/jit/func-guard-ppc64.h"
+
+#include "hphp/runtime/vm/jit/abi.h"
+#include "hphp/runtime/vm/jit/abi-ppc64.h"
+#include "hphp/runtime/vm/jit/mc-generator.h"
+#include "hphp/runtime/vm/jit/smashable-instr-ppc64.h"
+#include "hphp/runtime/vm/jit/translator.h"
+#include "hphp/runtime/vm/jit/unique-stubs.h"
+
+#include "hphp/ppc64-asm/asm-ppc64.h"
+#include "hphp/util/data-block.h"
+#include "hphp/util/immed.h"
+
+namespace HPHP { namespace jit { namespace ppc64 {
+
+///////////////////////////////////////////////////////////////////////////////
+
+namespace {
+
+///////////////////////////////////////////////////////////////////////////////
+
+constexpr auto kFuncGuardLen = 0x38;
+
+ALWAYS_INLINE bool isPrologueStub(TCA addr) {
+  return addr == mcg->tx().uniqueStubs.fcallHelperThunk;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+void emitFuncGuard(const Func* func, CodeBlock& cb) {
+  ppc64_asm::Assembler a { cb };
+
+  const auto tmp1 = ppc64_asm::reg::r3, tmp2 = ppc64_asm::reg::r4;
+  assertx(ppc64::abi(CodeKind::CrossTrace).gpUnreserved.contains(tmp1));
+  assertx(ppc64::abi(CodeKind::CrossTrace).gpUnreserved.contains(tmp2));
+
+  a.  li64   (tmp1, uint64_t(func));
+  a.  ld     (tmp2, rvmfp()[AROFF(m_func)]);
+  a.  cmpld  (tmp1, tmp2);
+
+  a.    branchAuto(mcg->tx().uniqueStubs.funcPrologueRedispatch,
+                  ppc64_asm::BranchConditions::NotEqual);
+
+  DEBUG_ONLY auto guard = funcGuardFromPrologue(a.frontier(), func);
+  assertx(funcGuardMatches(guard, func));
+}
+
+TCA funcGuardFromPrologue(TCA prologue, const Func* func) {
+  if (isPrologueStub(prologue)) return prologue;
+  return (prologue - kFuncGuardLen);
+}
+
+bool funcGuardMatches(TCA guard, const Func* func) {
+  if (isPrologueStub(guard)) return false;
+
+  auto const ifunc = reinterpret_cast<uintptr_t>(func);
+  return static_cast<uintptr_t>(ppc64_asm::Assembler::getLi64(guard)) == ifunc;
+}
+
+void clobberFuncGuard(TCA guard, const Func* func) {
+  not_implemented();
+  return;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+}}}

--- a/hphp/runtime/vm/jit/func-guard-ppc64.h
+++ b/hphp/runtime/vm/jit/func-guard-ppc64.h
@@ -14,42 +14,32 @@
    +----------------------------------------------------------------------+
 */
 
-#ifndef incl_HPHP_JIT_VASM_EMIT_H_
-#define incl_HPHP_JIT_VASM_EMIT_H_
+#ifndef incl_HPHP_JIT_FUNC_GUARD_PPC64_H
+#define incl_HPHP_JIT_FUNC_GUARD_PPC64_H
 
-namespace HPHP { namespace jit {
-///////////////////////////////////////////////////////////////////////////////
+#include "hphp/runtime/vm/jit/types.h"
 
-struct Abi;
-struct AsmInfo;
-struct Vtext;
-struct Vunit;
+#include "hphp/util/data-block.h"
 
-///////////////////////////////////////////////////////////////////////////////
+namespace HPHP {
 
-/*
- * Optimize, lower for x64, register allocator, and perform more optimizations
- * on `unit'.
- */
-void optimizeX64(Vunit& unit, const Abi&);
+struct Func;
 
-/*
- * Emit code for the given unit using the given code areas. The unit should
- * have already been through optimizeX64().
- */
-void emitX64(const Vunit&, Vtext&, AsmInfo*);
-
-/*
- * Optimize, register allocate, and emit ARM code for the given unit.
- */
-void finishARM(Vunit&, Vtext&, const Abi&, AsmInfo*);
-
-/*
- * Optimize, register allocate, and emit PPC64 code for the given unit.
- */
-void finishPPC64(Vunit&, Vtext&, const Abi&, AsmInfo*);
+namespace jit { namespace ppc64 {
 
 ///////////////////////////////////////////////////////////////////////////////
-}}
+
+/*
+ * Mirrors the API of func-guard.h.
+ */
+
+void emitFuncGuard(const Func* func, CodeBlock& cb);
+TCA funcGuardFromPrologue(TCA prologue, const Func* func);
+bool funcGuardMatches(TCA guard, const Func* func);
+void clobberFuncGuard(TCA guard, const Func* func);
+
+///////////////////////////////////////////////////////////////////////////////
+
+}}}
 
 #endif

--- a/hphp/runtime/vm/jit/smashable-instr-ppc64.cpp
+++ b/hphp/runtime/vm/jit/smashable-instr-ppc64.cpp
@@ -122,7 +122,8 @@ void smashCall(TCA inst, TCA target) {
   CodeCursor cursor { cb, inst };
   ppc64_asm::Assembler a { cb };
 
-  if (!isCall(inst)) always_assert(false && "smashCall has unexpected block");
+  if (!ppc64_asm::Assembler::isCall(inst))
+    always_assert(false && "smashCall has unexpected block");
 
   a.setFrontier(inst + smashableCallSkip());
 
@@ -167,7 +168,7 @@ uint32_t smashableCmpqImm(TCA inst) {
 }
 
 TCA smashableCallTarget(TCA inst) {
-  if (!isCall(inst)) return nullptr;
+  if (!ppc64_asm::Assembler::isCall(inst)) return nullptr;
 
   return reinterpret_cast<TCA>(
       ppc64_asm::Assembler::getLi64(inst + smashableCallSkip()));

--- a/hphp/runtime/vm/jit/smashable-instr-ppc64.cpp
+++ b/hphp/runtime/vm/jit/smashable-instr-ppc64.cpp
@@ -1,0 +1,212 @@
+/*
+   +----------------------------------------------------------------------+
+   | HipHop for PHP                                                       |
+   +----------------------------------------------------------------------+
+   | (c) Copyright IBM Corporation 2015                                   |
+   +----------------------------------------------------------------------+
+   | This source file is subject to version 3.01 of the PHP license,      |
+   | that is bundled with this package in the file LICENSE, and is        |
+   | available through the world-wide-web at the following url:           |
+   | http://www.php.net/license/3_01.txt                                  |
+   | If you did not receive a copy of the PHP license and are unable to   |
+   | obtain it through the world-wide-web, please send a note to          |
+   | license@php.net so we can mail you a copy immediately.               |
+   +----------------------------------------------------------------------+
+*/
+
+#include "hphp/runtime/vm/jit/smashable-instr-ppc64.h"
+
+#include "hphp/runtime/vm/jit/align-ppc64.h"
+#include "hphp/runtime/vm/jit/mc-generator.h"
+
+#include "hphp/ppc64-asm/asm-ppc64.h"
+#include "hphp/util/data-block.h"
+
+namespace HPHP { namespace jit { namespace ppc64 {
+
+///////////////////////////////////////////////////////////////////////////////
+
+/*
+ * Concurrent modification and execution of instructions is safe if all
+ * of the following hold:
+ *
+ *  1/  The modification is done with a single processor store.
+ *  2/  Only one instruction in the original stream is modified.
+ *  3/  The modified instruction does not cross a cacheline boundary.
+ *
+ * Cache alignment is required for mutable instructions to make sure mutations
+ * don't "tear" on remote CPUs.
+ */
+
+#define EMIT_BODY(cb, inst, Inst, ...)  \
+  ([&] {                                \
+    align(cb, Alignment::Smash##Inst,   \
+          AlignContext::Live);          \
+    auto const start = cb.frontier();   \
+    ppc64_asm::Assembler a { cb };      \
+    a.inst(__VA_ARGS__);                \
+    return start;                       \
+  }())
+
+TCA emitSmashableMovq(CodeBlock& cb, uint64_t imm, PhysReg d) {
+  return EMIT_BODY(cb, li64, Movq, d, imm);
+}
+
+TCA emitSmashableCmpq(CodeBlock& cb, int32_t imm, PhysReg r, int8_t disp) {
+  align(cb, Alignment::SmashCmpq, AlignContext::Live);
+
+  // don't use cmpqim because of smashableCmpqImm implementation. A ldimml is
+  // mandatory
+  return vwrap(cb, [&] (Vout& v) {
+    Vreg op1 = v.makeReg(), op2 = v.makeReg();
+    v << ldimml{Immed(imm), op1};
+    v << loadl{r[disp], op2};
+    v << cmpq{op1, op2, VregSF(RegSF{0})};
+  });
+}
+
+TCA emitSmashableCall(CodeBlock& cb, TCA target) {
+  align(cb, Alignment::SmashCmpq, AlignContext::Live);
+
+  return vwrap(cb, [&] (Vout& v) {
+    v << call{target};
+  });
+}
+
+TCA emitSmashableJmp(CodeBlock& cb, TCA target) {
+  return EMIT_BODY(cb, branchAuto, Jmp, target);
+}
+
+TCA emitSmashableJcc(CodeBlock& cb, TCA target, ConditionCode cc) {
+  assertx(cc != CC_None);
+  return EMIT_BODY(cb, branchAuto, Jcc, target, cc);
+}
+
+std::pair<TCA,TCA>
+emitSmashableJccAndJmp(CodeBlock& cb, TCA target, ConditionCode cc) {
+  assertx(cc != CC_None);
+
+  align(cb, Alignment::SmashJccAndJmp, AlignContext::Live);
+
+  ppc64_asm::Assembler a { cb };
+  auto const jcc = cb.frontier();
+  a.branchAuto(target, cc);
+  auto const jmp = cb.frontier();
+  a.branchAuto(target);
+
+  return std::make_pair(jcc, jmp);
+}
+
+#undef EMIT_BODY
+
+///////////////////////////////////////////////////////////////////////////////
+
+void smashMovq(TCA inst, uint64_t imm) {
+  always_assert(is_aligned(inst, Alignment::SmashMovq));
+
+  HPHP::CodeBlock cb;
+  // Initialize code block cb pointing to li64
+  cb.init(inst, ppc64_asm::Assembler::kLi64InstrLen, "smashing Movq");
+  CodeCursor cursor { cb, inst };
+  ppc64_asm::Assembler a { cb };
+
+  Reg64 reg = ppc64_asm::Assembler::getLi64Reg(inst);
+
+  a.li64(reg, imm);
+}
+
+void smashCmpq(TCA inst, uint32_t imm) {
+  always_assert(is_aligned(inst, Alignment::SmashCmpq));
+
+  auto& cb = mcg->code.blockFor(inst);
+  CodeCursor cursor { cb, inst };
+  ppc64_asm::Assembler a { cb };
+
+  // the first instruction is a vasm ldimml, which is a li32
+  Reg64 reg = ppc64_asm::Assembler::getLi32Reg(inst);
+
+  a.li32(reg, imm);
+}
+
+void smashCall(TCA inst, TCA target) {
+  auto& cb = mcg->code.blockFor(inst);
+  CodeCursor cursor { cb, inst };
+  ppc64_asm::Assembler a { cb };
+
+  if (!isCall(inst))
+    always_assert(false && "smashCall has unexpected block");
+
+  a.setFrontier(inst + smashableCallSkip());
+
+  a.li64(ppc64_asm::reg::r12, reinterpret_cast<uint64_t>(target));
+}
+
+void smashJmp(TCA inst, TCA target) {
+  always_assert(is_aligned(inst, Alignment::SmashJmp));
+
+  auto& cb = mcg->code.blockFor(inst);
+  CodeCursor cursor { cb, inst };
+  ppc64_asm::Assembler a { cb };
+
+  if (target > inst && target - inst <= smashableJmpLen()) {
+    a.emitNop(target - inst);
+  } else {
+    a.branchAuto(target);
+  }
+}
+
+void smashJcc(TCA inst, TCA target, ConditionCode cc) {
+  always_assert(is_aligned(inst, Alignment::SmashJcc));
+
+  if (cc == CC_None) {
+    ppc64_asm::Assembler::patchBctr(inst, target);
+  } else {
+    auto& cb = mcg->code.blockFor(inst);
+    CodeCursor cursor { cb, inst };
+    ppc64_asm::Assembler a { cb };
+    a.branchAuto(target, cc);
+  }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+uint64_t smashableMovqImm(TCA inst) {
+  return static_cast<uint64_t>(ppc64_asm::Assembler::getLi64(inst));
+}
+
+uint32_t smashableCmpqImm(TCA inst) {
+  return static_cast<uint32_t>(ppc64_asm::Assembler::getLi32(inst));
+}
+
+TCA smashableCallTarget(TCA inst) {
+  if (!isCall(inst))
+    return nullptr;
+
+  return reinterpret_cast<TCA>(
+      ppc64_asm::Assembler::getLi64(inst + smashableCallSkip()));
+}
+
+TCA smashableJmpTarget(TCA inst) {
+  return smashableJccTarget(inst); // for now, it's the same as Jcc
+}
+
+TCA smashableJccTarget(TCA inst) {
+  // from patchBctr:
+  // It has to skip 6 instructions: li64 (5 instructions) and mtctr
+  CodeAddress bctr_addr = inst + kStdIns * 6;
+  // Opcode located at the 6 most significant bits
+  if (((bctr_addr[3] >> 2) & 0x3F) != 19) return nullptr; // from bctr
+
+  return reinterpret_cast<TCA>(ppc64_asm::Assembler::getLi64(inst));
+}
+
+ConditionCode smashableJccCond(TCA inst) {
+  // skip to the branch instruction in order to get its condition
+  ppc64_asm::BranchParams bp(
+      *reinterpret_cast<ppc64_asm::PPC64Instr*>(inst + smashableJccSkip()));
+  return bp;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+}}}

--- a/hphp/runtime/vm/jit/smashable-instr-ppc64.h
+++ b/hphp/runtime/vm/jit/smashable-instr-ppc64.h
@@ -48,12 +48,6 @@ constexpr size_t smashableCallLen() { return kStdIns * 11; }
 // prologue of call function until the li64 takes place:
 // skips mflr, std, std, addi
 constexpr uint8_t smashableCallSkip() { return kStdIns * 4; }
-// checks if the @inst is pointing to a call
-inline bool isCall(TCA inst) {
-  // a call always begin with a mflr and it's rarely used
-  return ((((inst[3] >> 2) & 0x3F) == 31) &&                            // OPCD
-      ((((inst[1] & 0x3) << 7) | ((inst[0] >> 1) & 0xFF)) == 339));     // XO
-}
 
 // li64 + mtctr + bccrt
 constexpr size_t smashableJccLen()  { return kStdIns * 7; }

--- a/hphp/runtime/vm/jit/smashable-instr-ppc64.h
+++ b/hphp/runtime/vm/jit/smashable-instr-ppc64.h
@@ -1,0 +1,91 @@
+/*
+   +----------------------------------------------------------------------+
+   | HipHop for PHP                                                       |
+   +----------------------------------------------------------------------+
+   | (c) Copyright IBM Corporation 2015                                   |
+   +----------------------------------------------------------------------+
+   | This source file is subject to version 3.01 of the PHP license,      |
+   | that is bundled with this package in the file LICENSE, and is        |
+   | available through the world-wide-web at the following url:           |
+   | http://www.php.net/license/3_01.txt                                  |
+   | If you did not receive a copy of the PHP license and are unable to   |
+   | obtain it through the world-wide-web, please send a note to          |
+   | license@php.net so we can mail you a copy immediately.               |
+   +----------------------------------------------------------------------+
+*/
+
+#ifndef incl_HPHP_JIT_SMASHABLE_INSTR_PPC64_H_
+#define incl_HPHP_JIT_SMASHABLE_INSTR_PPC64_H_
+
+#include "hphp/runtime/vm/jit/types.h"
+#include "hphp/runtime/vm/jit/phys-reg.h"
+
+#include "hphp/runtime/vm/jit/abi-ppc64.h" // For PPC64_HAS_PUSH_POP definition
+#include "hphp/ppc64-asm/asm-ppc64.h"
+#include "hphp/util/data-block.h"
+
+namespace HPHP { namespace jit { namespace ppc64 {
+
+///////////////////////////////////////////////////////////////////////////////
+
+/*
+ * Mirrors the API of smashable-instr.h.
+ */
+
+static constexpr uint8_t kStdIns = ppc64_asm::Assembler::kBytesPerInstr;
+
+// li64
+constexpr size_t smashableMovqLen() { return kStdIns * 5; }
+
+// li64 + cmpd
+constexpr size_t smashableCmpqLen() { return kStdIns * 6; }
+
+// The following instruction size is from the beginning of the smashableCall
+// to the address the LR saves upon branching with bctrl (so the following)
+// Currently this calculation considers:
+// mflr, std, std, addi, li64 (5 instr), mtctr, bctrl
+constexpr size_t smashableCallLen() { return kStdIns * 11; }
+// prologue of call function until the li64 takes place:
+// skips mflr, std, std, addi
+constexpr uint8_t smashableCallSkip() { return kStdIns * 4; }
+// checks if the @inst is pointing to a call
+inline bool isCall(TCA inst) {
+  // a call always begin with a mflr and it's rarely used
+  return ((((inst[3] >> 2) & 0x3F) == 31) &&                            // OPCD
+      ((((inst[1] & 0x3) << 7) | ((inst[0] >> 1) & 0xFF)) == 339));     // XO
+}
+
+// li64 + mtctr + bccrt
+constexpr size_t smashableJccLen()  { return kStdIns * 7; }
+// to analyse the cc, it has to skip the li64 + mtctr
+constexpr size_t smashableJccSkip() { return kStdIns * 6; }
+
+// Same length as Jcc
+constexpr size_t smashableJmpLen()  { return smashableJccLen(); }
+
+TCA emitSmashableMovq(CodeBlock& cb, uint64_t imm, PhysReg d);
+TCA emitSmashableCmpq(CodeBlock& cb, int32_t imm, PhysReg r, int8_t disp);
+TCA emitSmashableCall(CodeBlock& cb, TCA target);
+TCA emitSmashableJmp(CodeBlock& cb, TCA target);
+TCA emitSmashableJcc(CodeBlock& cb, TCA target, ConditionCode cc);
+std::pair<TCA,TCA>
+emitSmashableJccAndJmp(CodeBlock& cb, TCA target, ConditionCode cc);
+
+void smashMovq(TCA inst, uint64_t imm);
+void smashCmpq(TCA inst, uint32_t imm);
+void smashCall(TCA inst, TCA target);
+void smashJmp(TCA inst, TCA target);
+void smashJcc(TCA inst, TCA target, ConditionCode cc = CC_None);
+
+uint64_t smashableMovqImm(TCA inst);
+uint32_t smashableCmpqImm(TCA inst);
+TCA smashableCallTarget(TCA inst);
+TCA smashableJmpTarget(TCA inst);
+TCA smashableJccTarget(TCA inst);
+ConditionCode smashableJccCond(TCA inst);
+
+///////////////////////////////////////////////////////////////////////////////
+
+}}}
+
+#endif

--- a/hphp/runtime/vm/jit/smashable-instr-ppc64.h
+++ b/hphp/runtime/vm/jit/smashable-instr-ppc64.h
@@ -32,7 +32,7 @@ namespace HPHP { namespace jit { namespace ppc64 {
  * Mirrors the API of smashable-instr.h.
  */
 
-static constexpr uint8_t kStdIns = ppc64_asm::Assembler::kBytesPerInstr;
+constexpr uint8_t kStdIns = ppc64_asm::Assembler::kBytesPerInstr;
 
 // li64
 constexpr size_t smashableMovqLen() { return kStdIns * 5; }

--- a/hphp/runtime/vm/jit/vasm-dead.cpp
+++ b/hphp/runtime/vm/jit/vasm-dead.cpp
@@ -36,6 +36,7 @@ typedef boost::dynamic_bitset<> LiveSet;
 bool effectful(Vinstr& inst) {
   switch (inst.op) {
     case Vinstr::absdbl:
+    case Vinstr::addl:
     case Vinstr::addli:
     case Vinstr::addq:
     case Vinstr::addqi:
@@ -72,11 +73,17 @@ bool effectful(Vinstr& inst) {
     case Vinstr::defvmsp:
     case Vinstr::divint:
     case Vinstr::divsd:
+    case Vinstr::extsb:
+    case Vinstr::extsw:
+    case Vinstr::fcmpo:
+    case Vinstr::fcmpu:
     case Vinstr::imul:
     case Vinstr::incl:
     case Vinstr::incq:
+    case Vinstr::incw:
     case Vinstr::ldimmq:
     case Vinstr::ldimml:
+    case Vinstr::ldimmw:
     case Vinstr::ldimmb:
     case Vinstr::ldimmqs:
     case Vinstr::lea:
@@ -87,12 +94,17 @@ bool effectful(Vinstr& inst) {
     case Vinstr::loadl:
     case Vinstr::loadqp:
     case Vinstr::loadsd:
+    case Vinstr::loadw:
     case Vinstr::loadtqb:
     case Vinstr::loadzbl:
     case Vinstr::loadzbq:
     case Vinstr::loadzlq:
+    case Vinstr::mfcr:
+    case Vinstr::mflr:
+    case Vinstr::mfvsrd:
     case Vinstr::movb:
     case Vinstr::movl:
+    case Vinstr::movlk:
     case Vinstr::movtqb:
     case Vinstr::movtql:
     case Vinstr::movzbl:
@@ -143,6 +155,10 @@ bool effectful(Vinstr& inst) {
     case Vinstr::xorl:
     case Vinstr::xorq:
     case Vinstr::xorqi:
+    case Vinstr::xscvdpsxds:
+    case Vinstr::xscvsxddp:
+    case Vinstr::xxlxor:
+    case Vinstr::xxpermdi:
       return false;
 
     case Vinstr::addlm:
@@ -187,6 +203,8 @@ bool effectful(Vinstr& inst) {
     case Vinstr::landingpad:
     case Vinstr::leavetc:
     case Vinstr::mcprep:
+    case Vinstr::mtlr:
+    case Vinstr::mtvsrd:
     case Vinstr::nothrow:
     case Vinstr::orbim:
     case Vinstr::orqim:

--- a/hphp/runtime/vm/jit/vasm-gen.cpp
+++ b/hphp/runtime/vm/jit/vasm-gen.cpp
@@ -19,6 +19,7 @@
 #include "hphp/runtime/base/arch.h"
 #include "hphp/runtime/vm/jit/abi.h"
 #include "hphp/runtime/vm/jit/abi-x64.h"
+#include "hphp/runtime/vm/jit/abi-ppc64.h"
 #include "hphp/runtime/vm/jit/vasm-emit.h"
 #include "hphp/runtime/vm/jit/vasm-instr.h"
 #include "hphp/runtime/vm/jit/vasm-print.h"
@@ -90,7 +91,7 @@ Vauto::~Vauto() {
           finishARM(unit(), m_text, abi(m_kind), nullptr);
           break;
         case Arch::PPC64:
-          not_implemented();
+          finishPPC64(unit(), m_text, abi(m_kind), nullptr);
           break;
       }
       return;

--- a/hphp/runtime/vm/jit/vasm-instr.h
+++ b/hphp/runtime/vm/jit/vasm-instr.h
@@ -74,6 +74,7 @@ struct Vunit;
   O(ldimml, I(s), Un, D(d))\
   O(ldimmq, I(s), Un, D(d))\
   O(ldimmqs, I(s), Un, D(d))\
+  O(ldimmw, I(s), Un, D(d))\
   O(load, Inone, U(s), D(d))\
   O(store, Inone, U(s) U(d), Dn)\
   O(mcprep, Inone, Un, D(d))\
@@ -122,6 +123,7 @@ struct Vunit;
   O(hostcall, I(argc), U(args), Dn)\
   O(tbcc, I(cc) I(bit), U(s), Dn)\
   /* x64 instructions */\
+  O(addl, Inone, U(s0) U(s1), D(d) D(sf)) \
   O(addli, I(s0), UH(s1,d), DH(d,s1) D(sf)) \
   O(addlm, Inone, U(s0) U(m), D(sf)) \
   O(addlim, I(s0), U(m), D(sf)) \
@@ -162,12 +164,13 @@ struct Vunit;
   O(divsd, Inone, UA(s0) U(s1), D(d))\
   O(idiv, Inone, U(s), D(sf))\
   O(imul, Inone, U(s0) U(s1), D(d) D(sf))\
-  O(incwm, Inone, U(m), D(sf))\
   O(incl, Inone, UH(s,d), DH(d,s) D(sf))\
   O(inclm, Inone, U(m), D(sf))\
   O(incq, Inone, UH(s,d), DH(d,s) D(sf))\
   O(incqm, Inone, U(m), D(sf))\
   O(incqmlock, Inone, U(m), D(sf))\
+  O(incw, Inone, UH(s,d), DH(d,s) D(sf))\
+  O(incwm, Inone, U(m), D(sf))\
   O(jcc, I(cc), U(sf), Dn)\
   O(jcci, I(cc), U(sf), Dn)\
   O(jmp, Inone, Un, Dn)\
@@ -251,26 +254,22 @@ struct Vunit;
   O(xorl, Inone, U(s0) U(s1), D(d) D(sf))\
   O(xorq, Inone, U(s0) U(s1), D(d) D(sf))\
   O(xorqi, I(s0), UH(s1,d), DH(d,s1) D(sf))\
-  /* ppc64 instructions */\
-  O(addl, Inone, U(s0) U(s1), D(d) D(sf)) \
+  /* PPC64 instructions */\
+  O(extsb, Inone, UH(s,d), DH(d,s) D(sf))\
+  O(extsw, Inone, UH(s,d), DH(d,s) D(sf))\
   O(loadw, Inone, U(s), D(d))\
   O(fcmpo, Inone, U(s0) U(s1), D(sf))\
   O(fcmpu, Inone, U(s0) U(s1), D(sf))\
-  O(incw, Inone, UH(s,d), DH(d,s) D(sf))\
-  O(ldimmw, I(s), Un, D(d))\
   O(xscvdpsxds, Inone, U(s), D(d))\
   O(mfcr, Inone, Un, D(d))\
   O(mflr, Inone, Un, D(d))\
   O(mfvsrd, Inone, U(s), D(d))\
+  O(movlk, Inone, UH(s,d), DH(d,s))\
   O(mtlr, Inone, U(s), Dn)\
   O(mtvsrd, Inone, U(s), D(d))\
   O(xscvsxddp, Inone, U(s), D(d))\
   O(xxlxor, Inone, U(s0) U(s1), D(d))\
   O(xxpermdi, Inone, U(s0) U(s1), D(d))\
-  /* PPC64 instructions */\
-  O(extsb, Inone, UH(s,d), DH(d,s) D(sf))\
-  O(extsw, Inone, UH(s,d), DH(d,s) D(sf))\
-  O(movlk, Inone, UH(s,d), DH(d,s))\
   /* */
 
 /*

--- a/hphp/runtime/vm/jit/vasm-instr.h
+++ b/hphp/runtime/vm/jit/vasm-instr.h
@@ -251,6 +251,26 @@ struct Vunit;
   O(xorl, Inone, U(s0) U(s1), D(d) D(sf))\
   O(xorq, Inone, U(s0) U(s1), D(d) D(sf))\
   O(xorqi, I(s0), UH(s1,d), DH(d,s1) D(sf))\
+  /* ppc64 instructions */\
+  O(addl, Inone, U(s0) U(s1), D(d) D(sf)) \
+  O(loadw, Inone, U(s), D(d))\
+  O(fcmpo, Inone, U(s0) U(s1), D(sf))\
+  O(fcmpu, Inone, U(s0) U(s1), D(sf))\
+  O(incw, Inone, UH(s,d), DH(d,s) D(sf))\
+  O(ldimmw, I(s), Un, D(d))\
+  O(xscvdpsxds, Inone, U(s), D(d))\
+  O(mfcr, Inone, Un, D(d))\
+  O(mflr, Inone, Un, D(d))\
+  O(mfvsrd, Inone, U(s), D(d))\
+  O(mtlr, Inone, U(s), Dn)\
+  O(mtvsrd, Inone, U(s), D(d))\
+  O(xscvsxddp, Inone, U(s), D(d))\
+  O(xxlxor, Inone, U(s0) U(s1), D(d))\
+  O(xxpermdi, Inone, U(s0) U(s1), D(d))\
+  /* PPC64 instructions */\
+  O(extsb, Inone, UH(s,d), DH(d,s) D(sf))\
+  O(extsw, Inone, UH(s,d), DH(d,s) D(sf))\
+  O(movlk, Inone, UH(s,d), DH(d,s))\
   /* */
 
 /*
@@ -916,7 +936,35 @@ struct xorq { Vreg64 s0, s1, d; VregSF sf; };
 struct xorqi { Immed s0; Vreg64 s1, d; VregSF sf; };
 
 ///////////////////////////////////////////////////////////////////////////////
+//PPC64.
 
+/**
+ * PPC64-specific instructions
+ */
+struct addl  { Vreg32 s0, s1, d; VregSF sf; };
+struct loadw { Vptr s; Vreg16 d; };
+struct fcmpo { VregDbl s0; VregDbl s1; VregSF sf; };
+struct fcmpu { VregDbl s0; VregDbl s1; VregSF sf; };
+struct incw { Vreg16 s, d; VregSF sf; };
+struct ldimmw { Immed s; Vreg16 d; };
+struct xscvdpsxds { Vreg128 s, d; };
+struct mfcr { Vreg64 d; };
+struct mflr { Vreg64 d; };
+struct mfvsrd { Vreg128 s; Vreg64 d; };
+// move 32bits into a register and keep the higher 32bits
+struct movlk { Vreg64 s, d; };
+struct mtlr { Vreg64 s; };
+struct mtvsrd { Vreg64 s; Vreg128 d; };
+struct xscvsxddp { Vreg128 s, d; };
+struct xxlxor { Vreg128 s0, s1, d; };
+struct xxpermdi { Vreg128 s0, s1, d; };
+
+// Extend byte sign
+struct extsb { Vreg64 s; Vreg64 d; VregSF sf; };
+struct extsw { Vreg64 s; Vreg64 d; VregSF sf; };
+
+
+///////////////////////////////////////////////////////////////////////////////
 struct Vinstr {
 #define O(name, imms, uses, defs) name,
   enum Opcode : uint8_t { VASM_OPCODES };

--- a/hphp/runtime/vm/jit/vasm-llvm.cpp
+++ b/hphp/runtime/vm/jit/vasm-llvm.cpp
@@ -1686,6 +1686,24 @@ O(unpcklpd)
       case Vinstr::psllq:
       case Vinstr::psrlq:
       case Vinstr::fallthru:
+      case Vinstr::ldimmw:
+      case Vinstr::addl:
+      case Vinstr::incwm:
+      case Vinstr::extsb:
+      case Vinstr::extsw:
+      case Vinstr::loadw:
+      case Vinstr::fcmpo:
+      case Vinstr::fcmpu:
+      case Vinstr::xscvdpsxds:
+      case Vinstr::mfcr:
+      case Vinstr::mflr:
+      case Vinstr::mfvsrd:
+      case Vinstr::movlk:
+      case Vinstr::mtlr:
+      case Vinstr::mtvsrd:
+      case Vinstr::xscvsxddp:
+      case Vinstr::xxlxor:
+      case Vinstr::xxpermdi:
         always_assert_flog(false,
                            "Banned opcode in B{}: {}",
                            size_t(label), show(m_unit, inst));

--- a/hphp/runtime/vm/jit/vasm-llvm.cpp
+++ b/hphp/runtime/vm/jit/vasm-llvm.cpp
@@ -1688,7 +1688,7 @@ O(unpcklpd)
       case Vinstr::fallthru:
       case Vinstr::ldimmw:
       case Vinstr::addl:
-      case Vinstr::incwm:
+      case Vinstr::incw:
       case Vinstr::extsb:
       case Vinstr::extsw:
       case Vinstr::loadw:

--- a/hphp/runtime/vm/jit/vasm-ppc64.cpp
+++ b/hphp/runtime/vm/jit/vasm-ppc64.cpp
@@ -1,0 +1,1441 @@
+/*
+   +----------------------------------------------------------------------+
+   | HipHop for PHP                                                       |
+   +----------------------------------------------------------------------+
+   | (c) Copyright IBM Corporation 2015                                   |
+   +----------------------------------------------------------------------+
+   | This source file is subject to version 3.01 of the PHP license,      |
+   | that is bundled with this package in the file LICENSE, and is        |
+   | available through the world-wide-web at the following url:           |
+   | http://www.php.net/license/3_01.txt                                  |
+   | If you did not receive a copy of the PHP license and are unable to   |
+   | obtain it through the world-wide-web, please send a note to          |
+   | license@php.net so we can mail you a copy immediately.               |
+   +----------------------------------------------------------------------+
+*/
+
+#include "hphp/runtime/vm/jit/vasm-emit.h"
+
+#include "hphp/runtime/base/arch.h"
+#include "hphp/runtime/vm/jit/abi-ppc64.h"
+#include "hphp/runtime/vm/jit/block.h"
+#include "hphp/runtime/vm/jit/code-gen-helpers.h"
+#include "hphp/runtime/vm/jit/func-guard-ppc64.h"
+#include "hphp/runtime/vm/jit/mc-generator.h"
+#include "hphp/runtime/vm/jit/print.h"
+#include "hphp/runtime/vm/jit/prof-data.h"
+#include "hphp/runtime/vm/jit/service-requests.h"
+#include "hphp/runtime/vm/jit/smashable-instr-ppc64.h"
+#include "hphp/runtime/vm/jit/target-cache.h"
+#include "hphp/runtime/vm/jit/timer.h"
+#include "hphp/runtime/vm/jit/vasm.h"
+#include "hphp/runtime/vm/jit/vasm-instr.h"
+#include "hphp/runtime/vm/jit/vasm-internal.h"
+#include "hphp/runtime/vm/jit/vasm-lower.h"
+#include "hphp/runtime/vm/jit/vasm-print.h"
+#include "hphp/runtime/vm/jit/vasm-unit.h"
+#include "hphp/runtime/vm/jit/vasm-util.h"
+#include "hphp/runtime/vm/jit/vasm-visit.h"
+
+#include <algorithm>
+#include <tuple>
+
+TRACE_SET_MOD(vasm);
+
+namespace HPHP { namespace jit {
+
+///////////////////////////////////////////////////////////////////////////////
+
+using namespace ppc64;
+using namespace ppc64_asm;
+
+namespace {
+///////////////////////////////////////////////////////////////////////////////
+
+struct Vgen {
+  explicit Vgen(Venv& env)
+    : text(env.text)
+    , assem(*env.cb)
+    , a(&assem)
+    , current(env.current)
+    , next(env.next)
+    , jmps(env.jmps)
+    , jccs(env.jccs)
+    , catches(env.catches)
+  {}
+
+  static void patch(Venv& env);
+  static void pad(CodeBlock& cb);
+
+  /////////////////////////////////////////////////////////////////////////////
+
+  template<class Inst> void emit(const Inst& i) {
+    always_assert_flog(false, "unimplemented instruction: {} in B{}\n",
+                       vinst_names[Vinstr(i).op], size_t(current));
+  }
+
+  // intrinsics
+  void emit(const copy& i) {
+    if (i.s == i.d) return;
+    if (i.s.isGP()) {
+      if (i.d.isGP()) {                     // GP => GP
+        a->mr(i.d, i.s);
+      } else {                              // GP => XMM
+        assertx(i.d.isSIMD());
+        a->std(i.s, rsp()[-8]);
+        a->lfd(i.d, rsp()[-8]);
+      }
+    } else {
+      assertx(i.s.isSIMD());
+      if (i.d.isGP()) {                     // XMM => GP
+        a->stfd(i.s, rsp()[-8]);
+        a->ld(i.d, rsp()[-8]);
+      } else {                              // XMM => XMM
+        assertx(i.d.isSIMD());
+        a->fmr(i.d, i.s);
+      }
+    }
+  }
+  void emit(const copy2& i) {
+    assertx(i.s0.isValid() && i.s1.isValid() &&
+            i.d0.isValid() && i.d1.isValid());
+    auto s0 = i.s0, s1 = i.s1, d0 = i.d0, d1 = i.d1;
+    assertx(d0 != d1);
+    if (d0 == s1) {
+      if (d1 == s0) {
+        a->mr(rAsm, s1);
+        a->mr(d0, s0);
+        a->mr(d1, rAsm);
+      } else {
+        // could do this in a simplify pass
+        if (s1 != d1) a->mr(d1, s1); // save s1 first; d1 != s0
+        if (s0 != d0) a->mr(d0, s0);
+      }
+    } else {
+      // could do this in a simplify pass
+      if (s0 != d0) a->mr(d0, s0);
+      if (s1 != d1) a->mr(d1, s1);
+    }
+  }
+  void emit(const fallthru& i) {}
+  void emit(const ldimmb& i);
+  void emit(const ldimmw& i) {
+    // PPC64 specific. i.d is not Vreg but Vreg16, so it can't be a SIMD.
+    a->li(Reg64(i.d), i.s); // should be only 16bits available
+  }
+  void emit(const ldimml& i);
+  void emit(const ldimmq& i);
+  void emit(const ldimmqs& i) { emitSmashableMovq(a->code(), i.s.q(), i.d); }
+  void emit(const nothrow& i) {
+    mcg->registerCatchBlock(a->frontier(), nullptr);
+  }
+  void emit(const landingpad& i) {}
+
+  // instructions
+  void emit(const absdbl& i) {
+    a->fabs(RegXMM(int(i.d)), RegXMM(int(i.s)), false);
+  }
+  void emit(const addl& i) {
+    a->addo(Reg64(i.d), Reg64(i.s1), Reg64(i.s0), true);
+  }
+  void emit(const addq& i) { a->addo(i.d, i.s0, i.s1, true); }
+
+  // Addqi and subqi can't be lowered to addq and subq if the destiny is rsp().
+  // To avoid this issue, addqi and subqi are the only vasms that will be
+  // lowered directly by using rAsm on its emission.
+  void emit(const addqi& i) {
+    if (i.s0.fits(HPHP::sz::word))  a->li(rAsm, i.s0);
+    else                            a->li32(rAsm, i.s0.l());
+    a->addo(i.d, i.s1, rAsm, true);
+  }
+  void emit(const subqi& i) {
+    if (i.s0.fits(HPHP::sz::word))  a->li(rAsm, i.s0);
+    else                            a->li32(rAsm, i.s0.l());
+    a->subo(i.d, i.s1, rAsm, true);
+  }
+  void emit(const addsd& i) { a->fadd(i.d, i.s0, i.s1); }
+  void emit(const andq& i) { a->and_(i.d, i.s0, i.s1, true); }
+  void emit(const andqi& i) { a->andi(i.d, i.s1, i.s0); } // andi changes CR0
+  void emit(const cmpl& i) { a->cmpw(Reg64(i.s1), Reg64(i.s0)); }
+  void emit(const cmpli& i) { a->cmpwi(Reg64(i.s1), i.s0); }
+  void emit(const cmpq& i) { a->cmpd(i.s1, i.s0); }
+  void emit(const cmpqi& i) { a->cmpdi(i.s1, i.s0); }
+  void emit(const xscvdpsxds& i) { a->xscvdpsxds(i.d, i.s); }
+  void emit(const xscvsxddp& i) { a->xscvsxddp(i.d, i.s); }
+  void emit(const xxlxor& i) { a->xxlxor(i.d, i.s1, i.s0); }
+  void emit(const xxpermdi& i) { a->xxpermdi(i.d, i.s1, i.s0); }
+  void emit(const mfvsrd& i) { a->mfvsrd(i.d, i.s); }
+  void emit(const mtvsrd& i) { a->mtvsrd(i.d, i.s); }
+  void emit(const decl& i) { a->subfo(Reg64(i.d), rone(), Reg64(i.s), true); }
+  void emit(const decq& i) { a->subfo(i.d, rone(), i.s, true); }
+  void emit(const imul& i) { a->mulld(i.d, i.s1, i.s0, true); }
+  void emit(const srem& i) {
+    // remainder as described on divd documentation:
+    a->divd(i.d, i.s0, i.s1);   // i.d = quotient
+    a->mulld(i.d, i.d, i.s1);   // i.d = quotient×divisor
+    a->subf(i.d, i.d, i.s0);    // i.d = remainder
+  }
+  void emit(const divint& i) { a->divd(i.d,  i.s0, i.s1, false); }
+  void emit(const mulsd& i) { a->fmul(i.d, i.s1, i.s0); }
+  void emit(const divsd& i) { a->fdiv(i.d, i.s1, i.s0); }
+  void emit(const fcmpo& i) { a->fcmpo(i.sf, i.s1, i.s0); }
+  void emit(const fcmpu& i) { a->fcmpu(i.sf, i.s1, i.s0); }
+  void emit(const incw& i) { a->addo(Reg64(i.d), Reg64(i.s), rone(), true); }
+  void emit(const incl& i) { a->addo(Reg64(i.d), Reg64(i.s), rone(), true); }
+  void emit(const incq& i) { a->addo(i.d, i.s, rone(), true); }
+  void emit(const jmpi& i) {
+    a->branchAuto(i.target, BranchConditions::Always, LinkReg::DoNotTouch);
+  }
+  void emit(const jmpr& i) {
+    a->mtctr(i.target);
+    a->bctr();
+  }
+  void emit(const leap& i) { a->li64(i.d, i.s.r.disp); }
+  void emit(const loadups& i) { a->lxvw4x(i.d,i.s); }
+  void emit(const mfcr& i) { a->mfcr(i.d); }
+  void emit(const mflr& i) { a->mflr(i.d); }
+  void emit(const mtlr& i) { a->mtlr(i.s); }
+  void emit(const movl& i) {
+    int8_t sh = sizeof(int) * CHAR_BIT;
+    a->rlwinm(rAsm, Reg64(i.s), 0, 32-sh, 31);
+    a->mr(Reg64(i.d), rAsm);
+  }
+  void emit(const movlk& i) {
+    int8_t sh = sizeof(int) * CHAR_BIT;
+    a->rlwinm(rAsm, i.s, 0, 32-sh, 31); // extract lower 32bits
+    a->clrrwi(i.d, i.d, sh); // clear lower 32bits on destination
+    // move lower 32bits to destination and keep the higher 32bits
+    a->or_(i.d, i.d, rAsm);
+  }
+  void emit(const movb& i) {
+    int8_t sh = CHAR_BIT;
+    a->rlwinm(rAsm, Reg64(i.s), 0, 32-sh, 31); // extract lower byte
+    a->clrrwi(Reg64(i.d), Reg64(i.d), sh); // clear lower byte on destination
+    // move lower byte to destination and keep the other 56 bits
+    a->or_(Reg64(i.d), Reg64(i.d), rAsm);
+  }
+  void emit(const movzbl& i) {
+    int8_t sh_32 = sizeof(int) * CHAR_BIT;
+    int8_t sh_8 = CHAR_BIT;
+    a->rlwinm(rAsm, Reg64(i.s), 0, 32-sh_8, 31); // extract lower byte
+    // clear lower 32bits on destination
+    a->clrrwi(Reg64(i.d), Reg64(i.d), sh_32);
+    // move lower byte to destination and keep the other 56 bits
+    a->or_(Reg64(i.d), Reg64(i.d), rAsm);
+  }
+  void emit(const movzbq& i) {
+    int8_t sh_8 = CHAR_BIT;
+    a->rlwinm(rAsm, Reg64(i.s), 0, 32-sh_8, 31); // extract lower byte
+    a->mr(i.d, rAsm); // move entire register to reset higher 56bits
+  }
+  void emit(const extsb& i) {
+    a->extsb(i.d, i.s);
+  }
+  void emit(const extsw& i) {
+    a->extsw(i.d, i.s);
+  }
+  void emit(const neg& i) { a->neg(i.d, i.s, true); }
+  void emit(const nop& i) { a->ori(Reg64(0), Reg64(0), 0); } // no-op form
+  void emit(const not& i) { a->nor(i.d, i.s, i.s, false); }
+  void emit(const orq& i) { a->or_(i.d, i.s0, i.s1, true); }
+  void emit(const orqi& i) {
+    if (i.s0.fits(HPHP::sz::word))
+      a->li(rAsm,i.s0);
+    else
+      a->li32(rAsm,i.s0.l());
+
+    a->or_(i.d, i.s1, rAsm, true /** or. implies Rc = 1 **/);
+  }
+  void emit(const roundsd& i) { a->xsrdpi(i.d, i.s); }
+  void emit(const ret& i) {
+    a->blr();
+  }
+  /*Immediate-form logical (unsigned) shift operations are
+    obtained by specifying appropriate masks and shift values for
+    certain Rotate instructions.
+  */
+  void emit(const sar& i) { a->srad(i.d, i.s1, i.s0, true); }
+  void emit(const sarqi& i) { a->sradi(i.d, i.s1, i.s0.b(), true); }
+  void emit(const setcc& i) {
+    ppc64_asm::Label l_true, l_end;
+    Reg64 d(i.d);
+
+    a->bc(l_true, i.cc);
+    a->xor_(d, d, d, false);   /* set output to 0 */
+    a->b(l_end);
+
+    l_true.asm_label(*a);
+    a->li(d, 1);        /* set output to 1 */
+
+    l_end.asm_label(*a);
+  }
+  void emit(const shlli& i) {
+    a->slwi(Reg64(i.d), Reg64(i.s1), i.s0.b(), true);
+  }
+  void emit(const shl& i) { a->sld(i.d, i.s1, i.s0, true); }
+  void emit(const shlqi& i) { a->sldi(i.d, i.s1, i.s0.b(), true); }
+  void emit(const shrli& i) {
+    a->srwi(Reg64(i.d), Reg64(i.s1), i.s0.b(), true);
+  }
+  void emit(const shrqi& i) { a->srdi(i.d, i.s1, i.s0.b(), true); }
+  void emit(const sqrtsd& i) { a->xssqrtdp(i.d,i.s); }
+  void emit(const storeups& i) { a->stxvw4x(i.s,i.m); }
+
+  // macro for commonlizing X-/D-form of load/store instructions
+#define X(instr, dst, ptr)                                \
+  do {                                                    \
+    if (ptr.index.isValid()) a->instr##x(dst, ptr);       \
+    else                     a->instr   (dst, ptr);       \
+  } while(0)
+
+  // As all registers are 64-bits wide, a smaller number from the memory should
+  // have its sign extended after loading except for the 'z' vasm variants
+  void emit(const loadw& i) {
+    X(lhz,  Reg64(i.d), i.s);
+    a->extsh(Reg64(i.d), Reg64(i.d));
+  }
+  void emit(const loadl& i) {
+    X(lwz,  Reg64(i.d), i.s);
+    a->extsw(Reg64(i.d), Reg64(i.d));
+  }
+
+  void emit(const loadb& i)   { X(lbz, Reg64(i.d),  i.s); }
+  void emit(const loadtqb& i) { X(lbz, Reg64(i.d),  i.s); }
+  void emit(const loadzbl& i) { X(lbz,  Reg64(i.d), i.s); }
+  void emit(const loadzbq& i) { X(lbz,  i.d,        i.s); }
+  void emit(const loadzlq& i) { X(lwz,  i.d,        i.s); }
+  void emit(const storeb& i)  { X(stb,  Reg64(i.s), i.m); }
+  void emit(const storel& i)  { X(stw,  Reg64(i.s), i.m); }
+  void emit(const storew& i)  { X(sth,  Reg64(i.s), i.m); }
+  void emit(const loadsd& i)  { X(lfd,  i.d,        i.s); }
+  void emit(const storesd& i) { X(stfd, i.s,        i.m); }
+
+#undef X
+
+  /* Subtractions: d = s1 - s0 */
+  void emit(const subq& i) { a->sub(i.d, i.s1, i.s0, true); }
+  void emit(const subsd& i) { a->fsub(i.d, i.s1, i.s0, false); }
+  void emit(const testq& i) {
+    // More information on:
+    // https://goo.gl/F1wrbO
+    if (i.s0 != i.s1)
+      a->and_(rAsm, i.s0, i.s1, true); // result is not used, only flags
+    else
+      a->cmpdi(i.s0, Immed(0));
+  }
+  void emit(const ucomisd& i) { a->dcmpu(i.s1,i.s0); }              // needs SF
+  void emit(const ud2& i) { a->trap(); }
+  void emit(const xorb& i) {
+    a->xor_(Reg64(i.d), Reg64(i.s0), Reg64(i.s1), true);
+  }
+  void emit(const xorl& i) {
+    a->xor_(Reg64(i.d), Reg64(i.s0), Reg64(i.s1), true);
+  }
+  void emit(const xorq& i) { a->xor_(i.d, i.s0, i.s1, true); }
+  void emit(const xorqi& i) {
+    if (i.s0.fits(HPHP::sz::word))
+      a->li(rAsm, i.s0);
+    else
+      a->li32(rAsm, i.s0.l());
+
+    a->xor_(i.d, i.s1, rAsm, true /** xor. implies Rc = 1 **/);
+  }
+
+
+  // The following vasms reemit other vasms. They are implemented afterwards in
+  // order to guarantee that the desired vasm is already defined or else it'll
+  // fallback to the templated emit function.
+  void emit(const cvtsi2sd& i);
+  void emit(const cvttsd2siq& i);
+  void emit(const callfaststub& i);
+  void emit(const callstub& i);
+  void emit(const jcc& i);
+  void emit(const jcci& i);
+  void emit(const jmp& i);
+  void emit(const load& i);
+  void emit(const pop& i);
+  void emit(const push& i);
+  void emit(const store& i);
+  void emit(const mcprep&);
+  void emit(const syncpoint& i);
+  void emit(const unwind& i);
+  void emit(const callphp&);
+  void emit(const cmovq&);
+  void emit(const leavetc&);
+  void emit(const lea&);
+  void emit(const contenter&);
+
+  // auxiliary for emit(call) and emit(callr)
+  template<class Func>
+  void callExtern(Func func);
+  void emit(const call& i);
+  void emit(const callr& i);
+  void emit(const calls& i);
+  void emit(const stublogue& i);
+  void emit(const stubret& i);
+  void emit(const tailcallstub& i);
+  void emit(const callarray& i);
+
+private:
+  CodeBlock& frozen() { return text.frozen().code; }
+
+  Vtext& text;
+  ppc64_asm::Assembler assem;
+  ppc64_asm::Assembler* a;
+
+  const Vlabel current;
+  const Vlabel next;
+  jit::vector<Venv::LabelPatch>& jmps;
+  jit::vector<Venv::LabelPatch>& jccs;
+  jit::vector<Venv::LabelPatch>& catches;
+};
+
+void Vgen::emit(const cvtsi2sd& i) {
+  // As described on ISA page 727, F.2.6
+  emit(copy{i.s, i.d});
+  a->fcfids(i.d, i.d);
+}
+
+void Vgen::emit(const cvttsd2siq& i) {
+  // As described on ISA page 726, F.2.2
+  a->fctid(rFasm, i.s);
+  emit(copy{rFasm, i.d});
+}
+
+void Vgen::emit(const ldimmb& i) {
+  if (i.d.isGP()) {
+    // This is necessary since x86_64 can load only the byte and do not
+    // touch the other bits of destination register
+    a->li(rAsm, i.s); // should be only 8bits available
+    a->clrrwi(i.d, i.d, CHAR_BIT); // Clear lower byte
+    // Place only the byte into the register, keeping the higher 56bits
+    a->or_(i.d, i.d, rAsm);
+  } else {
+    assertx(i.d.isSIMD());
+    a->li(rAsm, i.s);
+    // no conversion necessary. The i.s already comes converted to FP
+    emit(copy{rAsm, i.d});
+  }
+}
+
+void Vgen::emit(const ldimml& i) {
+  if (i.d.isGP()) {
+    a->li32(i.d, i.s.l());
+  } else {
+    assertx(i.d.isSIMD());
+    a->li32(rAsm, i.s.l());
+    // no conversion necessary. The i.s already comes converted to FP
+    emit(copy{rAsm, i.d});
+  }
+}
+
+void Vgen::emit(const ldimmq& i) {
+  auto val = i.s.q();
+  if (i.d.isGP()) {
+    if (val == 0) {
+      a->xor_(i.d, i.d, i.d);
+      // emit nops to fill a standard li64 instruction block
+      // this will be useful on patching and smashable operations
+      a->emitNop(ppc64_asm::Assembler::kLi64InstrLen -
+          1 * ppc64_asm::Assembler::kBytesPerInstr);
+    } else {
+      a->li64(i.d, val);
+    }
+  } else {
+    assertx(i.d.isSIMD());
+    a->li64(rAsm, i.s.q());
+    // no conversion necessary. The i.s already comes converted to FP
+    emit(copy{rAsm, i.d});
+  }
+}
+
+void Vgen::emit(const contenter& i) {
+ ppc64_asm::Label stub, end;
+ Reg64 fp = i.fp;
+ a->ba(end); // jmp in x64
+
+ stub.asm_label(*a);
+ // The following two lines are equivalent to popm lower.
+ // Since we can't call popm lower function here at the
+ // moment it seems sufficient.
+ // rAsm is a scratch register.
+ emit(pop{rAsm});
+ emit(store{rAsm, fp[AROFF(m_savedRip)]});
+ emit(jmpr{i.target, i.args});
+
+ end.asm_label(*a);
+ a->bla(stub); // call in x64
+
+ emit(unwind{{i.targets[0], i.targets[1]}});
+}
+
+void Vgen::emit(const syncpoint& i) {
+  // As the syncpoint intends to store the return address of the last call vasm,
+  // it's necessary to subtract 3 instructions from the callExtern's "epilogue"
+  // as mtlr, ld, addi exist before current a->frontier().
+  TCA saved_pc = a->frontier() - 3 * ppc64_asm::Assembler::kBytesPerInstr;
+  FTRACE(5, "IR recordSyncPoint: {} {} {}\n", saved_pc,
+         i.fix.pcOffset, i.fix.spOffset);
+  mcg->recordSyncPoint(saved_pc, i.fix);
+}
+
+/*
+ * Push/pop mechanism is as simple as X64: it stores 8 bytes below the SP.
+ */
+void Vgen::emit(const pop& i) {
+  a->ld(i.d, rsp()[0]);                         // popped element
+  a->addi(rsp(), rsp(), push_pop_position);     // recover stack
+}
+void Vgen::emit(const push& i) {
+  a->stdu(i.s, rsp()[-push_pop_position]);      // pushed element
+}
+
+void Vgen::emit(const load& i) {
+  if (i.d.isGP()) {
+    if (i.s.index.isValid()){
+      a->ldx(i.d, i.s);
+    } else {
+      a->ld(i.d, i.s);
+    }
+  } else {
+    assertx(i.d.isSIMD());
+    a->lfd(i.d, i.s);
+  }
+}
+
+void Vgen::emit(const callstub& i) {
+  emit(call{i.target, i.args});
+}
+
+void Vgen::emit(const callfaststub& i) {
+  emit(call{i.target, i.args});
+  emit(syncpoint{i.fix});
+}
+void Vgen::emit(const unwind& i) {
+  catches.push_back({a->frontier(), i.targets[1]});
+  emit(jmp{i.targets[0]});
+}
+void Vgen::emit(const jmp& i) {
+  if (next == i.target) return;
+  jmps.push_back({a->frontier(), i.target});
+
+  // offset to be determined by a->patchBctr
+  a->branchAuto(a->frontier());
+}
+void Vgen::emit(const jcc& i) {
+  if (i.targets[1] != i.targets[0]) {
+    if (next == i.targets[1]) {
+      return emit(jcc{ccNegate(i.cc), i.sf, {i.targets[1], i.targets[0]}});
+    }
+    auto taken = i.targets[1];
+    jccs.push_back({a->frontier(), taken});
+
+    // offset to be determined by a->patchBctr
+    a->branchAuto(a->frontier(), i.cc);
+  }
+  emit(jmp{i.targets[0]});
+}
+void Vgen::emit(const jcci& i) {
+  a->branchAuto(i.taken, i.cc);
+  emit(jmp{i.target});
+}
+
+void Vgen::emit(const cmovq& i) {
+  // A CR bit parameter in ppc64 is a combination of X64's cc and sf variables:
+  // CR group (4 bits per group) is a sf and the CR bit (1 of the 4) is the cc
+  BranchParams bp (i.cc);
+  auto t = i.t;
+  auto f = i.f;
+  if (static_cast<uint8_t>(BranchParams::BO::CRNotSet) == bp.bo()) {
+    // invert the true/false parameters, as only the bp.bi field is used
+    std::swap(t,f);
+  }
+  a->isel(i.d, t, f, (4 * int(i.sf.asReg())) + bp.bi());
+}
+
+void Vgen::patch(Venv& env) {
+  for (auto& p : env.jmps) {
+    assertx(env.addrs[p.target]);
+    ppc64_asm::Assembler::patchBctr(p.instr, env.addrs[p.target]);
+  }
+  for (auto& p : env.jccs) {
+    assertx(env.addrs[p.target]);
+    ppc64_asm::Assembler::patchBctr(p.instr, env.addrs[p.target]);
+  }
+  assertx(env.bccs.empty());
+}
+
+void Vgen::pad(CodeBlock& cb) {
+  ppc64_asm::Assembler a {cb};
+  while (a.available() >= 4) a.trap();
+  assertx(a.available() == 0);
+}
+
+void Vgen::emit(const store& i) {
+  if (i.s.isGP()) {
+    if (i.d.index.isValid()){
+      a->stdx(i.s, i.d);
+    } else {
+      a->std(i.s, i.d);
+    }
+  } else {
+    assertx(i.s.isSIMD());
+    a->stfd(i.s, i.d);
+  }
+}
+
+void Vgen::emit(const mcprep& i) {
+  /*
+   * Initially, we set the cache to hold (addr << 1) | 1 (where `addr' is the
+   * address of the movq) so that we can find the movq from the handler.
+   *
+   * We set the low bit for two reasons: the Class* will never be a valid
+   * Class*, so we'll always miss the inline check before it's smashed, and
+   * handlePrimeCacheInit can tell it's not been smashed yet
+   */
+  auto const mov_addr = emitSmashableMovq(a->code(), 0, r64(i.d));
+  auto const imm = reinterpret_cast<uint64_t>(mov_addr);
+  smashMovq(mov_addr, (imm << 1) | 1);
+
+  mcg->cgFixups().m_addressImmediates.insert(reinterpret_cast<TCA>(~imm));
+}
+
+void Vgen::emit(const callphp& i) {
+  emitSmashableCall(a->code(), i.stub);
+  emit(unwind{{i.targets[0], i.targets[1]}});
+}
+
+void Vgen::emit(const leavetc&) {
+  emit(ret{});
+}
+
+void Vgen::emit(const lea& i) {
+  // could do this in a simplify pass
+  if (i.s.disp == 0 && i.s.base.isValid() && !i.s.index.isValid()) {
+    emit(copy{i.s.base, i.d});
+  } else {
+    // don't reuse addq and addqi as they need a SF
+    Vptr p = i.s;
+    if (p.index.isValid()) {
+      a->add(i.d, p.base, p.index);
+    } else {
+      a->addi(i.d, p.base, p.disp);
+    }
+  }
+}
+
+template<class Func>
+void Vgen::callExtern(Func func) {
+  /*
+   * REMEMBER to update the smashable parameters for call on
+   * smashable-instr-ppc64.h when this function is updated!
+   */
+  a->mflr(rfuncln());
+  a->std(rfuncln(), rsp()[lr_position_on_callstack]);
+  // carry the backchain to VM stack around on all vasm calls
+  a->std(rbackchain(), rsp()[-min_callstack_size]);
+  a->addi(rsp(), rsp(), -min_callstack_size);
+
+  // branch
+  func();
+
+  // pop caller's return address
+  a->addi(rsp(), rsp(), min_callstack_size);
+  a->ld(rfuncln(), rsp()[lr_position_on_callstack]);
+  a->mtlr(rfuncln());
+}
+
+void Vgen::emit(const call& i) {
+  callExtern([&]() {
+      a->branchAuto(i.target, BranchConditions::Always, LinkReg::Save);
+  });
+}
+
+void Vgen::emit(const callr& i) {
+  callExtern([&]() {
+      a->mr(rfuncentry(), i.target);
+      a->mtctr(rfuncentry());
+      a->bctrl();
+  });
+}
+
+void Vgen::emit(const calls& i) {
+  emitSmashableCall(a->code(), i.target);
+}
+
+void Vgen::emit(const callarray& i) {
+  emit(call{i.target, i.args});
+}
+
+/////////////////////////////////////////////////////////////////////////////
+/*
+ * Stub function ABI
+ */
+/*
+ * Unlike X64, the return address is not stored in the stack but on LR. Perform
+ * the prologue simply by saving the rvmfp on current stack
+ */
+void Vgen::emit(const stublogue& i) {
+  if (i.saveframe) {
+    // will not be lowered, but this Vptr doesn't need to be patched, so it's ok
+    emit(store{rvmfp(), rsp()[rvmfp_position_on_callstack]});
+  }
+}
+
+void Vgen::emit(const stubret& i) {
+  if (i.saveframe) {
+    // will not be lowered, but this Vptr doesn't need to be patched, so it's ok
+    emit(load{rsp()[rvmfp_position_on_callstack], rvmfp()});
+  }
+  emit(ret{});
+}
+
+void Vgen::emit(const tailcallstub& i) {
+  emit(jmpi{i.target, i.args});
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+/*
+ * Lower the immediate to a register in order to use ppc64 instructions that
+ * can change required Condition Register (on vasm world, that's the SF
+ * register).
+ */
+void lowerImm(Immed imm, Vout& v, Vreg& tmpRegister) {
+  tmpRegister = v.makeReg();
+  if (imm.fits(HPHP::sz::word)) {
+    v << ldimmw{imm, tmpRegister};
+  } else {
+    v << ldimml{imm, tmpRegister};
+  }
+}
+
+/*
+ * Native ppc64 instructions can't handle an immediate bigger than 16 bits and
+ * need to be loaded into a register in order to be used.
+ */
+bool patchImm(Immed imm, Vout& v, Vreg& tmpRegister) {
+  if (!imm.fits(HPHP::sz::word)) {
+    tmpRegister = v.makeReg();
+    v << ldimml{imm, tmpRegister};
+    return true;
+  } else {
+    return false;
+  }
+}
+
+/*
+ * Vptr struct supports fancy x64 addressing modes.
+ * So we need to patch it to avoid ppc64el unsuported address modes.
+ *
+ * After patching, the Vptr @p will only have either base and index or base and
+ * displacement.
+ */
+void patchVptr(Vptr& p, Vout& v) {
+  // Map all address modes that Vptr can be so it can be handled.
+  enum class AddressModes {
+    kInvalid         = 0,
+    kDisp            = 1, //            Displacement
+    kBase            = 2, //       Base
+    kBase_Disp       = 3, //       Base+Displacement
+    kIndex           = 4, // Index
+    kIndex_Disp      = 5, // Index     +Dispacement
+    kIndex_Base      = 6, // Index+Base
+    kIndex_Base_Disp = 7  // Index+Base+Displacement
+  };
+
+  AddressModes mode = static_cast<AddressModes>(
+                    (((p.disp != 0)     & 0x1) << 0) |
+                    ((p.base.isValid()  & 0x1) << 1) |
+                    ((p.index.isValid() & 0x1) << 2));
+
+  // Index can never be used directly if shifting is necessary. Handling it here
+  uint8_t shift = p.scale == 2 ? 1 :
+                  p.scale == 4 ? 2 :
+                  p.scale == 8 ? 3 : 0;
+
+  if (p.index.isValid() && shift) {
+    Vreg shifted_index_reg = v.makeReg();
+    v << shlqi{shift, p.index, shifted_index_reg, VregSF(RegSF{0})};
+    p.index = shifted_index_reg;
+    p.scale = 1;  // scale is now normalized.
+  }
+
+  // taking care of the displacement, in case it is > 16bits
+  Vreg disp_reg;
+  bool patched_disp = patchImm(Immed(p.disp), v, disp_reg);
+  switch (mode) {
+    case AddressModes::kBase:
+    case AddressModes::kIndex_Base:
+      // ppc64 can handle these address modes. Nothing to do here.
+      break;
+
+    case AddressModes::kBase_Disp:
+      // ppc64 can handle this address mode if displacement < 16bits
+      if (patched_disp) {
+        // disp is loaded on a register. Change address mode to kBase_Index
+        p.index = disp_reg;
+        p.disp = 0;
+      }
+      break;
+
+    case AddressModes::kIndex:
+        // treat it as kBase to avoid a kIndex_Disp asm handling.
+        std::swap(p.base, p.index);
+      break;
+
+    case AddressModes::kDisp:
+    case AddressModes::kIndex_Disp:
+      if (patched_disp) {
+        // disp is loaded on a register. Change address mode to kBase_Index
+        p.base = disp_reg;
+        p.disp = 0;
+      }
+      else {
+        // treat it as kBase_Disp to avoid a kIndex_Disp asm handling.
+        p.base = p.index;
+      }
+      break;
+
+    case AddressModes::kIndex_Base_Disp: {
+      // This mode is not supported: Displacement will be embedded on Index
+      Vreg index_disp_reg = v.makeReg();
+      if (patched_disp) {
+        v << addq{disp_reg, p.index, index_disp_reg, VregSF(RegSF{0})};
+      } else {
+        v << addqi{p.disp, p.index, index_disp_reg, VregSF(RegSF{0})};
+      }
+      p.index = index_disp_reg;
+      p.disp = 0;
+      break;
+    }
+
+    case AddressModes::kInvalid:
+    default:
+      assert(false && "Invalid address mode");
+      break;
+  }
+}
+
+
+/*
+ * Rules for the lowering of these vasms:
+ * 1) All vasms emitted in lowering are already adjusted/patched.
+ *   In other words, it will not be lowered afterwards.
+ * 2) If a vasm has a Vptr that can be removed by emitting load/store, do it!
+ *
+ * Parameter description for every lowering:
+ * Vout& v : the Vout instance so vasms can be emitted
+ * <Type> inst : the current vasm to be lowered
+ */
+
+/* fallback, when a vasm is not lowered */
+template <typename Inst>
+void lowerForPPC64(Vout& v, Inst& inst) {}
+
+/*
+ * Using macro to commonlize vasms lowering
+ */
+
+// Patches the Vptr, retrieve the immediate and emmit a related direct vasm
+#define X(vasm_src, attr_data, vasm_dst, attr_addr, vasm_imm)           \
+void lowerForPPC64(Vout& v, vasm_src& inst) {                           \
+  Vreg tmp = v.makeReg();                                               \
+  Vptr p = inst.attr_addr;                                              \
+  patchVptr(p, v);                                                      \
+  v << vasm_imm{inst.attr_data, tmp} << vasm_dst{tmp, p};               \
+}
+
+X(storebi, s, storeb, m, ldimmb)
+X(storewi, s, storew, m, ldimmw)
+X(storeli, s, storel, m, ldimml)
+X(storeqi, s, store,  m, ldimml)
+
+#undef X
+
+// Simply take care of the vasm's Vptr, reemmiting it if patch occured
+#define X(vasm, attr_addr, attr_1, attr_2)                              \
+void lowerForPPC64(Vout& v, vasm& inst) {                               \
+  patchVptr(inst.attr_addr, v);                                         \
+  if (!v.empty()) v << vasm{inst.attr_1, inst.attr_2};                  \
+}
+
+X(storeb,   m, s, m);
+X(storew,   m, s, m);
+X(storel,   m, s, m);
+X(store,    d, s, d);
+X(storeups, m, s, m);
+X(storesd,  m, s, m);
+X(load,     s, s, d);
+X(loadb,    s, s, d);
+X(loadl,    s, s, d);
+X(loadzbl,  s, s, d);
+X(loadzbq,  s, s, d);
+X(loadzlq,  s, s, d);
+X(loadups,  s, s, d);
+X(lea,      s, s, d);
+
+#undef X
+
+// Auxiliary macros to handle vasms with different attributes
+#define NONE
+#define ONE(attr_1)             inst.attr_1,
+#define TWO(attr_1, attr_2)     inst.attr_1, inst.attr_2,
+#define ONE_R64(attr_1)         Reg64(inst.attr_1),
+#define TWO_R64(attr_1, attr_2) Reg64(inst.attr_1), Reg64(inst.attr_2),
+
+// If it patches the Immed, replace the vasm for its non-immediate variant
+#define X(vasm_src, vasm_dst, attr_imm, attrs)                          \
+void lowerForPPC64(Vout& v, vasm_src& inst) {                           \
+  Vreg tmp;                                                             \
+  lowerImm(inst.attr_imm, v, tmp);                                      \
+  v << vasm_dst{tmp, attrs inst.sf};                                    \
+}
+
+X(addli,  addl,  s0, TWO(s1, d))
+X(andli,  andl,  s0, TWO(s1, d))    // could use patchImm
+X(andqi,  andq,  s0, TWO(s1, d))    // could use patchImm
+X(testqi, testq, s0, ONE(s1))
+X(cmpqi,  cmpq,  s0, ONE(s1))
+
+#undef X
+
+// Simplify MemoryRef vasm types by their direct variant as ppc64 can't
+// change data directly in memory. Patches the Vptr, grab and save the data.
+#define X(vasm_src, vasm_dst, vasm_load, vasm_store, attr_addr, attrs)  \
+void lowerForPPC64(Vout& v, vasm_src& inst) {                           \
+  Vreg tmp = v.makeReg(), tmp2 = v.makeReg();                           \
+  Vptr p = inst.attr_addr;                                              \
+  patchVptr(p, v);                                                      \
+  v << vasm_load{p, tmp} << vasm_dst{attrs tmp, tmp2, inst.sf};         \
+  v << vasm_store{tmp2, p};                                             \
+}
+
+X(incwm, incw, loadw, storew, m, NONE)
+X(inclm, incl, loadl, storel, m, NONE)
+X(incqm, incq, load,  store,  m, NONE)
+X(declm, decl, loadl, storel, m, NONE)
+X(decqm, decq, load,  store,  m, NONE)
+X(addlm, addl, loadw, storew, m, ONE(s0))
+
+#undef X
+
+#undef NONE
+#undef ONE
+#undef TWO
+#undef ONE_R64
+#undef TWO_R64
+
+// Also deals with MemoryRef vasms like above but these ones have Immed data
+// too. Load data and emit a new vasm depending if the Immed fits a direct
+// ppc64 instruction.
+#define X(vasm_src, vasm_dst_reg, vasm_dst_imm, vasm_load,              \
+                  attr_addr, attr_data)                                 \
+void lowerForPPC64(Vout& v, vasm_src& inst) {                           \
+  Vptr p = inst.attr_addr;                                              \
+  patchVptr(p, v);                                                      \
+  Vreg tmp2 = v.makeReg(), tmp;                                         \
+  v << vasm_load{p, tmp2};                                              \
+  if (patchImm(inst.attr_data, v, tmp))                                 \
+    v << vasm_dst_reg{tmp, tmp2, inst.sf};                              \
+  else v << vasm_dst_imm{inst.attr_data, tmp2, inst.sf};                \
+}
+
+X(cmpbim,  cmpl,  cmpli,  loadb, s1, s0)
+X(cmplim,  cmpl,  cmpli,  loadl, s1, s0)
+X(cmpqim,  cmpq,  cmpqi,  load,  s1, s0)
+X(testbim, testq, testqi, loadb, s1, s0)
+X(testwim, testq, testqi, loadw, s1, s0)
+X(testlim, testq, testqi, loadl, s1, s0)
+X(testqim, testq, testqi, load,  s1, s0)
+
+#undef X
+
+// Very similar with the above case: handles MemoryRef and Immed, but also
+// stores the result in the memory.
+#define X(vasm_src, vasm_dst, vasm_load, vasm_store,                    \
+                  attr_addr, attr_data)                                 \
+void lowerForPPC64(Vout& v, vasm_src& inst) {                           \
+  Vreg tmp = v.makeReg(), tmp3 = v.makeReg(), tmp2;                     \
+  Vptr p = inst.attr_addr;                                              \
+  patchVptr(p, v);                                                      \
+  v << vasm_load{p, tmp};                                               \
+  lowerImm(inst.attr_data, v, tmp2);                                    \
+  v << vasm_dst{tmp2, tmp, tmp3, inst.sf};                              \
+  v << vasm_store{tmp3, p};                                             \
+}
+
+X(orwim,   orq,  loadw, storew, m, s0)
+X(orqim,   orq,  load,  store,  m, s0)
+X(addqim,  addq, load,  store,  m, s0)
+
+#undef X
+
+// Handles MemoryRef arguments and load the data input from memory, but these
+// ones have no output other than the sign flag register update (SF)
+#define X(vasm_src, vasm_dst, vasm_load, attr_addr, attr)               \
+void lowerForPPC64(Vout& v, vasm_src& inst) {                           \
+  Vptr p = inst.attr_addr;                                              \
+  patchVptr(p, v);                                                      \
+  Vreg tmp = v.makeReg();                                               \
+  v << vasm_load{p, tmp} << vasm_dst{inst.attr, tmp, inst.sf};          \
+}
+
+X(testqm, testq, load,  s1, s0)
+X(cmplm,  cmpl,  loadl, s1, s0)
+X(cmpqm,  cmpq,  load,  s1, s0)
+
+#undef X
+
+// Other lowers that didn't fit the macros above or are not so numerous.
+void lowerForPPC64(Vout& v, jmpm& inst) {
+  Vptr p = inst.target;
+  patchVptr(p, v);
+  Vreg tmp = v.makeReg();
+  v << load{p, tmp};
+  v << jmpr{tmp, inst.args};
+}
+
+void lowerForPPC64(Vout& v, callm& inst) {
+  Vptr p = inst.target;
+  patchVptr(p, v);
+  auto d = v.makeReg();
+  v << load{p, d};
+  v << callr{d, inst.args};
+}
+
+void lowerForPPC64(Vout& v, loadqp& inst) {
+  // in PPC we don't have anything like a RIP register
+  // RIP register uses a absolute address so we can perform a baseless load in
+  // this case
+  Vptr p = baseless(inst.s.r.disp);
+  patchVptr(p, v);
+  v << load{p, inst.d};
+}
+
+void lowerForPPC64(Vout& v, popm& inst) {
+  auto tmp = v.makeReg();
+  patchVptr(inst.d, v);
+  v << pop{tmp};
+  v << store{tmp, inst.d};
+}
+
+void lowerForPPC64(Vout& v, countbytecode& inst) {
+  v << incqm{inst.base[g_bytecodesVasm.handle()], inst.sf};
+}
+
+/////////////////////////////////////////////////////////////////////////////
+/*
+ * PHP function ABI
+ */
+void lowerForPPC64(Vout& v, phplogue& inst) {
+  Vreg ret_address = v.makeReg();
+  v << mflr{ret_address};
+  v << store{ret_address, inst.fp[AROFF(m_savedRip)]};
+}
+
+void lowerForPPC64(Vout& v, phpret& inst) {
+  Vreg tmp = v.makeReg();
+  v << load{inst.fp[AROFF(m_savedRip)], tmp};
+  if (!inst.noframe) {
+    v << load{inst.fp[AROFF(m_sfp)], inst.d};
+  }
+  v << jmpr{tmp};
+}
+
+/*
+ * Tail call elimination on ppc64: call without creating a stack and keep LR
+ * contents as prior to the call.
+ */
+void lowerForPPC64(Vout& v, tailcallphp& inst) {
+  Vreg new_return = v.makeReg();
+  v << load{inst.fp[AROFF(m_savedRip)], new_return};
+  v << mtlr{new_return};
+  v << jmpr{inst.target, inst.args};
+}
+
+/////////////////////////////////////////////////////////////////////////////
+
+// Lower movs to copy
+void lowerForPPC64(Vout& v, movtqb& inst) { v << copy{inst.s, inst.d}; }
+void lowerForPPC64(Vout& v, movtql& inst) { v << copy{inst.s, inst.d}; }
+
+// For PPC64 there are no instructions to perform operations with only part of
+// a register, differently of x86_64.
+// The VASMs that are composed of these kind of operations, must be lowered to
+// first extract the operator into a register and later perform operation using
+// the entire register, i. e., 64bits. If it needs a result, like subtract
+// operations, the destination register must be filled considering the size of
+// operation. For example:
+// Consider d register with the value "0x44582C24A50CAD2".
+// For a subl instruction (l means 32bits), the result must be placed in the
+// lower 32bits (X means the result value):
+// "0x44582C2XXXXXXXX" and the higher 32bits should not be touched.
+// For operands the treatment is analogous, only the lower 32bits are
+// considered to perform the operation.
+// Lower comparison to cmpq
+void lowerForPPC64(Vout& v, cmpb& inst) {
+  Vreg tmp1 = v.makeReg(),
+      tmp2 = v.makeReg(),
+      tmp3 = v.makeReg(),
+      tmp4 = v.makeReg();
+
+  v << movb{inst.s0, tmp1}; // Extract s0
+  v << extsb {tmp1, tmp2, VregSF(RegSF{0})}; // Extend byte sign
+  v << movb{inst.s1, tmp3}; // Extract s1
+  v << extsb {tmp3, tmp4, VregSF(RegSF{0})}; // Extend byte sign
+  v << cmpq{tmp2, tmp4, inst.sf}; // Compare values
+}
+
+void lowerForPPC64(Vout& v, cmpl& inst) {
+  Vreg tmp1 = v.makeReg(),
+      tmp2 = v.makeReg(),
+      tmp3 = v.makeReg(),
+      tmp4 = v.makeReg();
+
+  v << movl{inst.s0, tmp1}; // Extract byte from s0
+  v << extsw{tmp1, tmp2, VregSF(RegSF{0})}; // Extend word sign
+  v << movl{inst.s1, tmp3}; // extract byte from s1
+  v << extsw{tmp3, tmp4, VregSF(RegSF{0})}; // Extend word sign
+  v << cmpq{tmp3, tmp4, inst.sf}; // Compare the extracted values
+}
+
+// Lower comparison with immediate to cmpqi
+void lowerForPPC64(Vout& v, cmpbi& inst) {
+  Vreg tmp1 = v.makeReg(), tmp2 = v.makeReg();
+
+  v << movb{inst.s1, tmp1}; // extract s0
+  v << extsb {tmp1, tmp2, VregSF(RegSF{0})}; // extend byte sign
+  // compare immed only with the byte extracted
+  v << cmpqi{inst.s0, tmp2, inst.sf};
+}
+
+void lowerForPPC64(Vout& v, cmpli& inst) {
+  // convert cmpli to cmpqi or ldimmq + cmpq by cmpqi's lowering
+  Vreg tmp1 = v.makeReg(), tmp2 = v.makeReg(), tmp3 = v.makeReg();
+
+  v << movl{inst.s1, tmp1}; // Extract s1
+  v << extsw{tmp1, tmp2, VregSF(RegSF{0})}; // Extend word sign
+  // Lowering for cmpqi removed, since movl was emitted, then the empty
+  // will always return false
+  if (patchImm(inst.s0, v, tmp3)) v << cmpq{tmp3, tmp2, inst.sf};
+  else v << cmpqi{inst.s0, tmp2, inst.sf};
+}
+
+// Lower subtraction to subq
+void lowerForPPC64(Vout& v, subl& inst) {
+  Vreg tmp1 = v.makeReg(),
+        tmp2 = v.makeReg(),
+        tmp3 = v.makeReg(),
+        tmp4 = v.makeReg(),
+        tmp5 = v.makeReg();
+
+  v << movl{inst.s0, tmp1}; // Extract s0
+  v << movl{inst.s1, tmp2}; // Extract s1
+  v << extsw{tmp1, tmp3, VregSF(RegSF{0})}; // Extend word sign
+  v << extsw{tmp2, tmp4, VregSF(RegSF{0})}; // Extend word sign
+  v << subq{tmp3, tmp4, tmp5, inst.sf}; // subtract
+  // Move word to d and do not touch the higher 32bits
+  v << movlk{tmp5, Reg64(inst.d)};
+}
+
+void lowerForPPC64(Vout& v, subbi& inst) {
+  Vreg tmp1 = v.makeReg(),
+        tmp2 = v.makeReg(),
+        tmp3 = v.makeReg();
+
+  v << movb{inst.s1, tmp1}; // Extract s1
+  v << extsb{tmp1, tmp2, VregSF(RegSF{0})}; // Extend byte sign
+  v << subqi{inst.s0, tmp2, tmp3, inst.sf}; // subtract immediate
+  // move byte to destiny and do not touch higher 56bits
+  v << movb{tmp3, inst.d};
+}
+
+void lowerForPPC64(Vout& v, subli& inst) {
+  Vreg tmp1 = v.makeReg(),
+        tmp2 = v.makeReg(),
+        tmp3 = v.makeReg();
+
+  v << movl{inst.s1, tmp1}; // Extract s1
+  v << extsw{tmp1, tmp2, VregSF(RegSF{0})}; // Extend word sign
+  v << subqi{inst.s0, tmp2, tmp3, inst.sf}; // Subtract immediate
+  // move word to destiny and do not touch the higher 32bits
+  v << movlk{tmp3, Reg64(inst.d)};
+}
+
+// Lower test to testq
+void lowerForPPC64(Vout& v, testb& inst) {
+  Vreg tmp1 = v.makeReg(),
+        tmp2 = v.makeReg();
+
+  v << movb{inst.s0, tmp1};// Extract s0
+  v << movb{inst.s1, tmp2};// Extract s1
+  v << testq{tmp1, tmp2, inst.sf};// Compare lower byte of each source
+}
+
+void lowerForPPC64(Vout& v, testl& inst) {
+  Vreg tmp1 = v.makeReg(),
+        tmp2 = v.makeReg();
+
+  v << movl{inst.s0, tmp1}; // Extract s0
+  v << movl{inst.s1, tmp2}; // Extract s1
+  v << testq{tmp1, tmp2, inst.sf}; // Compare low 32bits of each source
+}
+
+void lowerForPPC64(Vout& v, testbi& inst) {
+  Vreg tmp1 = v.makeReg(),
+        tmp2 = v.makeReg();
+
+  v << movb{inst.s1, tmp1}; // Extract byte
+  // convert testbi to testqi or ldimmq + testq by testqi's lowering
+  if (patchImm(inst.s0, v, tmp2)) v << testq{tmp2, tmp1, inst.sf};
+  else v << testqi{inst.s0, tmp1, inst.sf}; // perform test operation
+}
+
+void lowerForPPC64(Vout& v, testli& inst) {
+  Vreg tmp1 = v.makeReg(),
+        tmp2 = v.makeReg();
+
+  v << movl{inst.s1, tmp1}; // Extract word
+  // convert testli to testqi or ldimmq + testq by testqi's lowering
+  if (patchImm(inst.s0, v, tmp2)) v << testq{tmp2, tmp1, inst.sf};
+  else v << testqi{inst.s0, tmp1, inst.sf};
+}
+
+// Lower xor to xorq
+void lowerForPPC64(Vout& v, xorb& inst) {
+  Vreg tmp1 = v.makeReg(),
+      tmp2 = v.makeReg(),
+      tmp3 = v.makeReg();
+
+  v << movb{inst.s0, tmp1}; // Extract byte
+  v << movb{inst.s1, tmp2}; // Extract byte
+  v << xorq{tmp1, tmp2, tmp3, inst.sf}; // Perform xorq
+  // Place only byte result into d and do not touch higher 56bits
+  v << movb{tmp3, inst.d};
+}
+void lowerForPPC64(Vout& v, xorl& inst) {
+  Vreg tmp1 = v.makeReg(),
+      tmp2 = v.makeReg(),
+      tmp3 = v.makeReg();
+
+  v << movl{inst.s0, tmp1}; // Extract word
+  v << movl{inst.s1, tmp2}; // Extract word
+  v << xorq{tmp1, tmp2, tmp3, inst.sf}; // Perform xorq
+  // Place only byte result into d and do not touch higher 32bits
+  v << movlk{tmp3, Reg64(inst.d)};
+}
+
+// Lower xor with immediate to xorqi
+void lowerForPPC64(Vout& v, xorbi& inst) {
+  Vreg tmp1 = v.makeReg(),
+      tmp2 = v.makeReg();
+
+  v << movb {inst.s1, tmp1}; // Extract byte
+  v << xorqi {inst.s0, tmp1, tmp2, VregSF(RegSF{0})}; // Perform xorqi
+  // move only the byte result to the destination, keeping the higher 56bits
+  v << movb {inst.d, tmp1};
+}
+
+// Lower and to andq
+void lowerForPPC64(Vout& v, andb& inst) {
+  Vreg tmp1 = v.makeReg(),
+      tmp2 = v.makeReg(),
+      tmp3 = v.makeReg();
+
+  v << movb{inst.s0, tmp1}; // Extract s0
+  v << movb{inst.s1, tmp2}; // Extract s1
+  v << andq{tmp1, tmp2, tmp3, inst.sf};
+  // move only the byte result to the destination, keeping the higher 56bits
+  v << movb{tmp3, inst.d};
+}
+
+void lowerForPPC64(Vout& v, andl& inst) {
+  Vreg tmp1 = v.makeReg(),
+      tmp2 = v.makeReg(),
+      tmp3 = v.makeReg();
+
+  v << movl{inst.s0, tmp1}; // extract s0
+  v << movl{inst.s1, tmp2}; // extract s1
+  v << andq{tmp1, tmp2, tmp3, inst.sf};
+  v << movlk{tmp3, Reg64(inst.d)}; // Move result keeping the higher 32bits
+}
+
+void lowerForPPC64(Vout& v, andbi& inst) {
+  Vreg tmp1 = v.makeReg(),
+      tmp2 = v.makeReg();
+
+  v << movb{inst.s1, tmp1}; // Extract s1
+  // patchImm doesn't need to be called as it should be < 8 bits
+  v << andqi{inst.s0, tmp1, tmp2, inst.sf};
+  // move only the byte result to the destination, keeping the higher 56bits
+  v << movb{tmp2, inst.d};
+}
+
+void lowerForPPC64(Vout& v, cloadq& inst) {
+  auto m = inst.t;
+  patchVptr(m, v);
+  auto tmp = v.makeReg();
+  v << load{m, tmp};
+  v << cmovq{inst.cc, inst.sf, inst.f, tmp, inst.d};
+}
+
+void lowerForPPC64(Vout& v, cmpsd& inst) {
+  auto sf = v.makeReg();
+  auto r64_d = v.makeReg(); // auxiliary for GP -> FP conversion
+
+  // assume standard ComparisonPred as eq_ord
+  Vreg equal = rone();
+  Vreg nequal = v.makeReg();
+  v << ldimmb{0, nequal};
+
+  switch (inst.pred) {
+  case ComparisonPred::eq_ord: { // scope for the zero variable initialization
+    v << fcmpo{inst.s0, inst.s1, sf};
+    // now set the inst.d if the CR's EQ bit is set, else clear it
+    break;
+  }
+  case ComparisonPred::ne_unord:
+    v << fcmpu{inst.s0, inst.s1, sf};
+    // now clear the inst.d if the CR's EQ bit is set, else set it
+    std::swap(equal, nequal);
+    break;
+  default:
+    assert(false && "Invalid ComparisonPred for cmpsd");
+  }
+  v << cmovq{CC_E, sf, nequal, equal, r64_d};
+  v << copy{r64_d, inst.d}; // GP -> FP
+}
+
+void lower_vcallarray(Vunit& unit, Vlabel b) {
+  auto& code = unit.blocks[b].code;
+  // vcallarray can only appear at the end of a block.
+  auto const inst = code.back().get<vcallarray>();
+  auto const origin = code.back().origin;
+
+  auto argRegs = inst.args;
+  auto const& srcs = unit.tuples[inst.extraArgs];
+  jit::vector<Vreg> dsts;
+  for (int i = 0; i < srcs.size(); ++i) {
+    dsts.emplace_back(rarg(i));
+    argRegs |= rarg(i);
+  }
+
+  code.back() = copyargs{unit.makeTuple(srcs), unit.makeTuple(std::move(dsts))};
+  code.emplace_back(callarray{inst.target, argRegs});
+  code.back().origin = origin;
+  code.emplace_back(unwind{{inst.targets[0], inst.targets[1]}});
+  code.back().origin = origin;
+}
+
+
+/*
+ * Lower a few abstractions to facilitate straightforward PPC64 codegen.
+ * PPC64 doesn't have instructions for operating on less than 64 bits data
+ * (except the memory related load/store), therefore all arithmetic vasms
+ * that intend to deal with smaller data will actually operate on 64bits
+ */
+void lowerForPPC64(Vunit& unit) {
+  Timer _t(Timer::vasm_lower);
+
+  // This pass relies on having no critical edges in the unit.
+  splitCriticalEdges(unit);
+
+  // Scratch block can change blocks allocation, hence cannot use regular
+  // iterators.
+  auto& blocks = unit.blocks;
+
+  PostorderWalker{unit}.dfs([&] (Vlabel ib) {
+    assertx(!blocks[ib].code.empty());
+    auto& back = blocks[ib].code.back();
+    if (back.op == Vinstr::vcallarray) {
+      lower_vcallarray(unit, Vlabel{ib});
+    }
+
+    for (size_t ii = 0; ii < blocks[ib].code.size(); ++ii) {
+
+      vlower(unit, ib, ii);
+
+      auto scratch = unit.makeScratchBlock();
+      auto& inst = blocks[ib].code[ii];
+      SCOPE_EXIT {unit.freeScratchBlock(scratch);};
+      Vout v(unit, scratch, inst.origin);
+
+      switch (inst.op) {
+
+        /*
+         * Call every lowering and provide only what is necessary:
+         * Vout& v : the Vout instance so vasms can be emitted
+         * <Type> inst : the current vasm to be lowered
+         *
+         * If any vasm is emitted inside of the lower, then the current vasm
+         * will be replaced by the vector_splice call below.
+         */
+
+#define O(name, imms, uses, defs)                         \
+        case Vinstr::name:                                \
+          lowerForPPC64(v, inst.name##_);                 \
+          if (!v.empty()) {                               \
+            vector_splice(unit.blocks[ib].code, ii, 1,    \
+                          unit.blocks[scratch].code);     \
+          }                                               \
+          break;
+
+          VASM_OPCODES
+
+#undef O
+
+      }
+    }
+  });
+
+  printUnit(kVasmLowerLevel, "after lower for PPC64", unit);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+} // anonymous namespace
+
+void finishPPC64(Vunit& unit, Vtext& text, const Abi& abi, AsmInfo* asmInfo) {
+  // The Timer instances calculate the time while they are alive, hence the
+  // additional scope in order to limit them.
+  {
+    Timer timer(Timer::vasm_optimize);
+
+    removeTrivialNops(unit);
+    optimizePhis(unit);
+    fuseBranches(unit);
+    optimizeJmps(unit);
+    optimizeExits(unit);
+
+    lowerForPPC64(unit);
+
+    simplify(unit);
+
+#if 0 // TODO(gut): not needed?
+    if (!unit.constToReg.empty()) {
+      foldImms<x64::ImmFolder>(unit);
+    }
+#endif
+    {
+      Timer timer(Timer::vasm_copy);
+      optimizeCopies(unit, abi);
+    }
+    if (unit.needsRegAlloc()) {
+      Timer timer(Timer::vasm_xls);
+      removeDeadCode(unit);
+      allocateRegisters(unit, abi);
+    }
+    if (unit.blocks.size() > 1) {
+      Timer timer(Timer::vasm_jumps);
+      optimizeJmps(unit);
+    }
+  }
+
+  {
+    Timer timer(Timer::vasm_gen);
+    vasm_emit<Vgen>(unit, text, asmInfo);
+  }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+}}

--- a/hphp/util/immed.h
+++ b/hphp/util/immed.h
@@ -82,6 +82,8 @@ struct Immed {
 
   bool fits(int sz) const { return deltaFits(m_int, sz); }
 
+  Immed operator-() { return -this->m_int; }
+
 private:
   int32_t m_int;
 };


### PR DESCRIPTION
This change adds the basic VASM instructions for PPC64 architecture.
Other related files like ABI, align, function guard and smashable instructions
were added as well.
The ASM changes are fixes found since last Pull Request.