### PR TITLE
[MSVC] A pair of minor fixes for MSVC

### DIFF
--- a/hphp/runtime/base/runtime-option.cpp
+++ b/hphp/runtime/base/runtime-option.cpp
@@ -1258,7 +1258,7 @@ void RuntimeOption::Load(
                  "Server.PspCpuTimeoutSeconds", 0);
     Config::Bind(ServerMemoryHeadRoom, ini, config, "Server.MemoryHeadRoom", 0);
     Config::Bind(RequestMemoryMaxBytes, ini, config,
-                 "Server.RequestMemoryMaxBytes", (16l << 30)); // 16GiB
+                 "Server.RequestMemoryMaxBytes", (16LL << 30)); // 16GiB
     Config::Bind(ResponseQueueCount, ini, config, "Server.ResponseQueueCount",
                  0);
     if (ResponseQueueCount <= 0) {

--- a/hphp/runtime/base/zend-string.cpp
+++ b/hphp/runtime/base/zend-string.cpp
@@ -22,7 +22,9 @@
 #include "hphp/util/lock.h"
 #include "hphp/util/overflow.h"
 #include <math.h>
+#ifndef _MSC_VER
 #include <monetary.h>
+#endif
 
 #include "hphp/util/bstring.h"
 #include "hphp/runtime/base/exceptions.h"

--- a/hphp/runtime/ext/xdebug/xdebug_command.cpp
+++ b/hphp/runtime/ext/xdebug/xdebug_command.cpp
@@ -299,6 +299,7 @@ struct FeatureGetCmd : XDebugCommand {
     // Check against the defined features
     #define FEATURE(name, supported, val, free)                                \
       if (!match && m_feature == name) {                                       \
+        __pragma(warning(suppress: 4130))                                      \
         if (val != nullptr) {                                                  \
           xdebug_xml_add_text(&xml, val, free);                                \
         }                                                                      \


### PR DESCRIPTION
The first is a shift that was causing `RequestMemoryMaxBytes` to be set to `0`, although I have no idea why that never caused an issue.
The second is to only include `monetary.h`, which declares `strfmon`, if not under MSVC, because MSVC will be using a portability implementation.
The final change is to suppress a warning that MSVC generates about comparing against the address of a string literal.