### PR TITLE
Fix a memory leak in SSL sockets

### DIFF
--- a/hphp/runtime/base/ssl-socket.cpp
+++ b/hphp/runtime/base/ssl-socket.cpp
@@ -33,7 +33,9 @@ bool SSLSocketData::closeImpl() {
   }
   if (m_handle) {
     SSL_free(m_handle);
+    SSL_CTX_free(m_ctx);
     m_handle = nullptr;
+    m_ctx = nullptr;
   }
   return SocketData::closeImpl();
 }
@@ -535,6 +537,8 @@ bool SSLSocket::setupCrypto(SSLSocket *session /* = NULL */) {
     SSL_CTX_free(ctx);
     return false;
   }
+
+  m_data->m_ctx = ctx;
 
   if (!SSL_set_fd(m_data->m_handle, getFd())) {
     handleError(0, true);

--- a/hphp/runtime/base/ssl-socket.h
+++ b/hphp/runtime/base/ssl-socket.h
@@ -113,6 +113,7 @@ private:
   bool m_state_set{false};
   bool m_is_blocked{true};
   SSL *m_handle{nullptr};
+  SSL_CTX *m_ctx{nullptr};
   SSLSocket::CryptoMethod m_method{(SSLSocket::CryptoMethod)-1};
   double m_connect_timeout{0};
 };


### PR DESCRIPTION
Resolves #6537. The SSL_CTX object was not being freed.