### PR TITLE
Fix persistent sockets not persisting across page loads

### DIFF
--- a/hphp/runtime/base/file.cpp
+++ b/hphp/runtime/base/file.cpp
@@ -198,8 +198,11 @@ void File::sweep() {
   // sweep() is responsible for closing m_fd and any other non-request
   // resources it might have allocated.
   assert(!valid());
-  File::closeImpl();
+
+  // Do not call close. We need any persistent objects to remain open.
+  // If this is the last reference to the data, close will be called for us.
   m_data.reset();
+
   m_wrapperType = nullptr;
   m_streamType = nullptr;
 }

--- a/hphp/runtime/base/socket.cpp
+++ b/hphp/runtime/base/socket.cpp
@@ -112,7 +112,6 @@ Socket::Socket(int sockfd, int type, const char *address /* = NULL */,
 Socket::~Socket() { }
 
 void Socket::sweep() {
-  Socket::closeImpl();
   File::sweep();
   m_data = nullptr;
 }

--- a/hphp/runtime/base/ssl-socket.cpp
+++ b/hphp/runtime/base/ssl-socket.cpp
@@ -229,7 +229,6 @@ SSLSocket::SSLSocket(int sockfd, int type, const req::ptr<StreamContext>& ctx,
 SSLSocket::~SSLSocket() { }
 
 void SSLSocket::sweep() {
-  SSLSocket::closeImpl();
   File::sweep();
   m_data = nullptr;
 }


### PR DESCRIPTION
Sockets were always being closed after a page request. You wouldn't be able to reuse the socket on a new page request. Resolves #6542.