### PR TITLE
Define 'zero' vasm instruction to clear register

### DIFF
--- a/hphp/runtime/vm/jit/vasm-instr.h
+++ b/hphp/runtime/vm/jit/vasm-instr.h
@@ -439,7 +439,7 @@ struct debugtrap {};
 struct fallthru {};
 
 /*
- * Load an immedate value without mutating status flags.
+ * Load an immediate value without mutating status flags.
  */
 struct ldimmb { Immed s; Vreg d; };
 struct ldimml { Immed s; Vreg d; };

--- a/hphp/runtime/vm/jit/vasm-xls.cpp
+++ b/hphp/runtime/vm/jit/vasm-xls.cpp
@@ -1888,7 +1888,9 @@ void insertCopiesAt(const VxlsContext& ctx,
     } else if (ivl->constant) {
       if (ivl->val.isUndef) continue;
 
-      auto const use_xor = ivl->val.val == 0 && dst.isGP() && !sf_live(pos);
+      // Other archs can zero a register without mutating status flags
+      auto const use_xor = arch() == Arch::X64 &&
+                           ivl->val.val == 0 && dst.isGP() && !sf_live(pos);
 
       switch (ivl->val.kind) {
         case Vconst::Quad:


### PR DESCRIPTION
Summary: Some architectures might not use xor as an effective way of
zeroing a register. On top of that it forbids xor from being lowered as
the Vxls::insertCopiesAt is called after lowering step. It'd be good to
have a specific vasm instruction for doing that.

This approach will give the flexibility needed for other architectures
that might want to zero differently or lower the xor vasm instructions.