### PR TITLE
[AArch64] Fixes compilation issues.

### DIFF
--- a/CMake/HPHPSetup.cmake
+++ b/CMake/HPHPSetup.cmake
@@ -43,6 +43,7 @@ if (APPLE)
     list(APPEND HHVM_ANCHOR_SYMS -Xlinker -force_load -Xlinker ${lib})
   endforeach()
 elseif (IS_AARCH64)
+  set(ENABLE_FASTCGI 1)
   set(HHVM_ANCHOR_SYMS
     -Wl,--whole-archive ${HHVM_WHOLE_ARCHIVE_LIBRARIES} -Wl,--no-whole-archive)
 elseif(CYGWIN)

--- a/hphp/hack/src/heap/hh_shared.c
+++ b/hphp/hack/src/heap/hh_shared.c
@@ -848,7 +848,13 @@ value hh_mem(value key) {
     // The data is currently in the process of being written, wait until it
     // actually is ready to be used before returning.
     while (hashtbl[slot].addr == (char*)1) {
+#if defined(__x86_64__)
       asm volatile("pause" : : : "memory");
+#elif defined(__aarch64__)
+      asm volatile("yield" : : : "memory");
+#else
+#warning Consider porting this spin loop to your architecture.
+#endif
     }
     return Val_bool(1);
   }

--- a/hphp/runtime/vm/jit/translator-asm-helpers.S
+++ b/hphp/runtime/vm/jit/translator-asm-helpers.S
@@ -145,8 +145,12 @@ ETCH_NAME(handleSRHelper):
 
 ///////////////////////////////////////////////////////////////////////////////
 #elif defined(__AARCH64EL__)
+  .globl handleSRHelper
+handleSRHelper:
   .globl enterTCHelper
 enterTCHelper:
+  .globl enterTCExit
+enterTCExit:
   .globl enterTCServiceReq
 enterTCServiceReq:
   brk 0

--- a/hphp/util/compact-tagged-ptrs.h
+++ b/hphp/util/compact-tagged-ptrs.h
@@ -38,7 +38,7 @@ namespace HPHP {
 
 //////////////////////////////////////////////////////////////////////
 
-#if defined(__x86_64__) || defined(_M_X64) || defined(__powerpc64__)
+#if defined(__x86_64__) || defined(_M_X64) || defined(__powerpc64__) || defined(__aarch64__)
 
 template<class T, class TagType = uint32_t>
 struct CompactTaggedPtr {


### PR DESCRIPTION
Adds missing translator helper placeholder labels for AArch64. Updates
some inline assembly for AArch64 which is missing the pause mnemonic.
Enables compact tagged pointers for AArch64. Enables FASTCGI.

Does not fix any correctness issues. They will be addressed in
subsequent commits.