### PR TITLE
[AArch64] General correctness fixes

### DIFF
--- a/hphp/hhvm/process-init.cpp
+++ b/hphp/hhvm/process-init.cpp
@@ -56,8 +56,8 @@ void tweak_variant_dtors();
 void ProcessInit() {
   // Create the global mcg object
   jit::mcg = new jit::MCGenerator();
-  // Do not initialize JIT stubs for PPC64 - port under development
-#if !defined(__powerpc64__)
+  // Do not initialize JIT stubs for PPC64 or AARch64 - port under development
+#if !defined(__powerpc64__) || !defined(__aarch64__)
   jit::mcg->initUniqueStubs();
 #endif
 

--- a/hphp/runtime/base/runtime-option.cpp
+++ b/hphp/runtime/base/runtime-option.cpp
@@ -436,8 +436,9 @@ static inline std::string pgoRegionSelectorDefault() {
 }
 
 static inline bool evalJitDefault() {
-// Disable JIT for PPC64 - Port under development
-#if defined(__CYGWIN__) || defined(_MSC_VER) || defined(__powerpc64__)
+// Disable JIT for PPC64 and AArch64- Port under development
+#if defined(__CYGWIN__) || defined(_MSC_VER) || \
+    defined(__powerpc64__) || defined(__aarch64__)
   return false;
 #else
   return true;

--- a/hphp/runtime/vm/native-func-caller.h
+++ b/hphp/runtime/vm/native-func-caller.h
@@ -2200,3 +2200,2814 @@ TypedValue callFuncTVImpl(BuiltinFunction f, int64_t* GP, int GP_count, double* 
   }
 }
 
+void callFuncNonPODImpl(void *ret, BuiltinFunction f, int64_t* GP, int GP_count, double* SIMD, int SIMD_count) {
+  switch (GP_count) {
+    case 0:
+      switch (SIMD_count) {
+        case 0:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)())f)();
+#else
+              ((void (*)(void*))f)(ret);
+#endif
+            return;}
+        case 1:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(double))f)(SIMD[0]);
+#else
+              ((void (*)(void*,double))f)(ret,SIMD[0]);
+#endif
+            return;}
+        case 2:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(double,double))f)(SIMD[0],SIMD[1]);
+#else
+              ((void (*)(void*,double,double))f)(ret,SIMD[0],SIMD[1]);
+#endif
+            return;}
+        case 3:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(double,double,double))f)(SIMD[0],SIMD[1],SIMD[2]);
+#else
+              ((void (*)(void*,double,double,double))f)(ret,SIMD[0],SIMD[1],SIMD[2]);
+#endif
+            return;}
+        case 4:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(double,double,double,double))f)(SIMD[0],SIMD[1],SIMD[2],SIMD[3]);
+#else
+              ((void (*)(void*,double,double,double,double))f)(ret,SIMD[0],SIMD[1],SIMD[2],SIMD[3]);
+#endif
+            return;}
+        case 5:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(double,double,double,double,double))f)(SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4]);
+#else
+              ((void (*)(void*,double,double,double,double,double))f)(ret,SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4]);
+#endif
+            return;}
+        case 6:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(double,double,double,double,double,double))f)(SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5]);
+#else
+              ((void (*)(void*,double,double,double,double,double,double))f)(ret,SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5]);
+#endif
+            return;}
+        case 7:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(double,double,double,double,double,double,double))f)(SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6]);
+#else
+              ((void (*)(void*,double,double,double,double,double,double,double))f)(ret,SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6]);
+#endif
+            return;}
+        case 8:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(double,double,double,double,double,double,double,double))f)(SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6],SIMD[7]);
+#else
+              ((void (*)(void*,double,double,double,double,double,double,double,double))f)(ret,SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6],SIMD[7]);
+#endif
+            return;}
+        default: not_reached();
+      }
+    case 1:
+      switch (SIMD_count) {
+        case 0:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t))f)(GP[0]);
+#else
+              ((void (*)(void*,int64_t))f)(ret,GP[0]);
+#endif
+            return;}
+        case 1:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,double))f)(GP[0],SIMD[0]);
+#else
+              ((void (*)(void*,int64_t,double))f)(ret,GP[0],SIMD[0]);
+#endif
+            return;}
+        case 2:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,double,double))f)(GP[0],SIMD[0],SIMD[1]);
+#else
+              ((void (*)(void*,int64_t,double,double))f)(ret,GP[0],SIMD[0],SIMD[1]);
+#endif
+            return;}
+        case 3:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,double,double,double))f)(GP[0],SIMD[0],SIMD[1],SIMD[2]);
+#else
+              ((void (*)(void*,int64_t,double,double,double))f)(ret,GP[0],SIMD[0],SIMD[1],SIMD[2]);
+#endif
+            return;}
+        case 4:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,double,double,double,double))f)(GP[0],SIMD[0],SIMD[1],SIMD[2],SIMD[3]);
+#else
+              ((void (*)(void*,int64_t,double,double,double,double))f)(ret,GP[0],SIMD[0],SIMD[1],SIMD[2],SIMD[3]);
+#endif
+            return;}
+        case 5:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,double,double,double,double,double))f)(GP[0],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4]);
+#else
+              ((void (*)(void*,int64_t,double,double,double,double,double))f)(ret,GP[0],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4]);
+#endif
+            return;}
+        case 6:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,double,double,double,double,double,double))f)(GP[0],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5]);
+#else
+              ((void (*)(void*,int64_t,double,double,double,double,double,double))f)(ret,GP[0],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5]);
+#endif
+            return;}
+        case 7:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,double,double,double,double,double,double,double))f)(GP[0],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6]);
+#else
+              ((void (*)(void*,int64_t,double,double,double,double,double,double,double))f)(ret,GP[0],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6]);
+#endif
+            return;}
+        case 8:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,double,double,double,double,double,double,double,double))f)(GP[0],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6],SIMD[7]);
+#else
+              ((void (*)(void*,int64_t,double,double,double,double,double,double,double,double))f)(ret,GP[0],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6],SIMD[7]);
+#endif
+            return;}
+        default: not_reached();
+      }
+    case 2:
+      switch (SIMD_count) {
+        case 0:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t))f)(GP[0],GP[1]);
+#else
+              ((void (*)(void*,int64_t,int64_t))f)(ret,GP[0],GP[1]);
+#endif
+            return;}
+        case 1:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,double))f)(GP[0],GP[1],SIMD[0]);
+#else
+              ((void (*)(void*,int64_t,int64_t,double))f)(ret,GP[0],GP[1],SIMD[0]);
+#endif
+            return;}
+        case 2:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,double,double))f)(GP[0],GP[1],SIMD[0],SIMD[1]);
+#else
+              ((void (*)(void*,int64_t,int64_t,double,double))f)(ret,GP[0],GP[1],SIMD[0],SIMD[1]);
+#endif
+            return;}
+        case 3:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,double,double,double))f)(GP[0],GP[1],SIMD[0],SIMD[1],SIMD[2]);
+#else
+              ((void (*)(void*,int64_t,int64_t,double,double,double))f)(ret,GP[0],GP[1],SIMD[0],SIMD[1],SIMD[2]);
+#endif
+            return;}
+        case 4:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,double,double,double,double))f)(GP[0],GP[1],SIMD[0],SIMD[1],SIMD[2],SIMD[3]);
+#else
+              ((void (*)(void*,int64_t,int64_t,double,double,double,double))f)(ret,GP[0],GP[1],SIMD[0],SIMD[1],SIMD[2],SIMD[3]);
+#endif
+            return;}
+        case 5:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,double,double,double,double,double))f)(GP[0],GP[1],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4]);
+#else
+              ((void (*)(void*,int64_t,int64_t,double,double,double,double,double))f)(ret,GP[0],GP[1],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4]);
+#endif
+            return;}
+        case 6:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,double,double,double,double,double,double))f)(GP[0],GP[1],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5]);
+#else
+              ((void (*)(void*,int64_t,int64_t,double,double,double,double,double,double))f)(ret,GP[0],GP[1],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5]);
+#endif
+            return;}
+        case 7:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,double,double,double,double,double,double,double))f)(GP[0],GP[1],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6]);
+#else
+              ((void (*)(void*,int64_t,int64_t,double,double,double,double,double,double,double))f)(ret,GP[0],GP[1],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6]);
+#endif
+            return;}
+        case 8:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,double,double,double,double,double,double,double,double))f)(GP[0],GP[1],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6],SIMD[7]);
+#else
+              ((void (*)(void*,int64_t,int64_t,double,double,double,double,double,double,double,double))f)(ret,GP[0],GP[1],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6],SIMD[7]);
+#endif
+            return;}
+        default: not_reached();
+      }
+    case 3:
+      switch (SIMD_count) {
+        case 0:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t))f)(GP[0],GP[1],GP[2]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t))f)(ret,GP[0],GP[1],GP[2]);
+#endif
+            return;}
+        case 1:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,double))f)(GP[0],GP[1],GP[2],SIMD[0]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,double))f)(ret,GP[0],GP[1],GP[2],SIMD[0]);
+#endif
+            return;}
+        case 2:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,double,double))f)(GP[0],GP[1],GP[2],SIMD[0],SIMD[1]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,double,double))f)(ret,GP[0],GP[1],GP[2],SIMD[0],SIMD[1]);
+#endif
+            return;}
+        case 3:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,double,double,double))f)(GP[0],GP[1],GP[2],SIMD[0],SIMD[1],SIMD[2]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,double,double,double))f)(ret,GP[0],GP[1],GP[2],SIMD[0],SIMD[1],SIMD[2]);
+#endif
+            return;}
+        case 4:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,double,double,double,double))f)(GP[0],GP[1],GP[2],SIMD[0],SIMD[1],SIMD[2],SIMD[3]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],SIMD[0],SIMD[1],SIMD[2],SIMD[3]);
+#endif
+            return;}
+        case 5:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,double,double,double,double,double))f)(GP[0],GP[1],GP[2],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4]);
+#endif
+            return;}
+        case 6:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,double,double,double,double,double,double))f)(GP[0],GP[1],GP[2],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,double,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5]);
+#endif
+            return;}
+        case 7:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,double,double,double,double,double,double,double))f)(GP[0],GP[1],GP[2],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,double,double,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6]);
+#endif
+            return;}
+        case 8:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,double,double,double,double,double,double,double,double))f)(GP[0],GP[1],GP[2],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6],SIMD[7]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,double,double,double,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6],SIMD[7]);
+#endif
+            return;}
+        default: not_reached();
+      }
+    case 4:
+      switch (SIMD_count) {
+        case 0:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t))f)(GP[0],GP[1],GP[2],GP[3]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t))f)(ret,GP[0],GP[1],GP[2],GP[3]);
+#endif
+            return;}
+        case 1:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,double))f)(GP[0],GP[1],GP[2],GP[3],SIMD[0]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,double))f)(ret,GP[0],GP[1],GP[2],GP[3],SIMD[0]);
+#endif
+            return;}
+        case 2:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,double,double))f)(GP[0],GP[1],GP[2],GP[3],SIMD[0],SIMD[1]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],SIMD[0],SIMD[1]);
+#endif
+            return;}
+        case 3:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],SIMD[0],SIMD[1],SIMD[2]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],SIMD[0],SIMD[1],SIMD[2]);
+#endif
+            return;}
+        case 4:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],SIMD[0],SIMD[1],SIMD[2],SIMD[3]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],SIMD[0],SIMD[1],SIMD[2],SIMD[3]);
+#endif
+            return;}
+        case 5:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,double,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4]);
+#endif
+            return;}
+        case 6:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5]);
+#endif
+            return;}
+        case 7:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6]);
+#endif
+            return;}
+        case 8:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6],SIMD[7]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6],SIMD[7]);
+#endif
+            return;}
+        default: not_reached();
+      }
+    case 5:
+      switch (SIMD_count) {
+        case 0:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t))f)(GP[0],GP[1],GP[2],GP[3],GP[4]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4]);
+#endif
+            return;}
+        case 1:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],SIMD[0]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],SIMD[0]);
+#endif
+            return;}
+        case 2:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],SIMD[0],SIMD[1]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],SIMD[0],SIMD[1]);
+#endif
+            return;}
+        case 3:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],SIMD[0],SIMD[1],SIMD[2]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],SIMD[0],SIMD[1],SIMD[2]);
+#endif
+            return;}
+        case 4:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],SIMD[0],SIMD[1],SIMD[2],SIMD[3]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],SIMD[0],SIMD[1],SIMD[2],SIMD[3]);
+#endif
+            return;}
+        case 5:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4]);
+#endif
+            return;}
+        case 6:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5]);
+#endif
+            return;}
+        case 7:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6]);
+#endif
+            return;}
+        case 8:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6],SIMD[7]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6],SIMD[7]);
+#endif
+            return;}
+        default: not_reached();
+      }
+    case 6:
+      switch (SIMD_count) {
+        case 0:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5]);
+#endif
+            return;}
+        case 1:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],SIMD[0]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],SIMD[0]);
+#endif
+            return;}
+        case 2:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],SIMD[0],SIMD[1]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],SIMD[0],SIMD[1]);
+#endif
+            return;}
+        case 3:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],SIMD[0],SIMD[1],SIMD[2]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],SIMD[0],SIMD[1],SIMD[2]);
+#endif
+            return;}
+        case 4:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],SIMD[0],SIMD[1],SIMD[2],SIMD[3]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],SIMD[0],SIMD[1],SIMD[2],SIMD[3]);
+#endif
+            return;}
+        case 5:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4]);
+#endif
+            return;}
+        case 6:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5]);
+#endif
+            return;}
+        case 7:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6]);
+#endif
+            return;}
+        case 8:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6],SIMD[7]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6],SIMD[7]);
+#endif
+            return;}
+        default: not_reached();
+      }
+    case 7:
+      switch (SIMD_count) {
+        case 0:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6]);
+#endif
+            return;}
+        case 1:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],SIMD[0]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],SIMD[0]);
+#endif
+            return;}
+        case 2:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],SIMD[0],SIMD[1]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],SIMD[0],SIMD[1]);
+#endif
+            return;}
+        case 3:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],SIMD[0],SIMD[1],SIMD[2]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],SIMD[0],SIMD[1],SIMD[2]);
+#endif
+            return;}
+        case 4:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],SIMD[0],SIMD[1],SIMD[2],SIMD[3]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],SIMD[0],SIMD[1],SIMD[2],SIMD[3]);
+#endif
+            return;}
+        case 5:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4]);
+#endif
+            return;}
+        case 6:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5]);
+#endif
+            return;}
+        case 7:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6]);
+#endif
+            return;}
+        case 8:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6],SIMD[7]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6],SIMD[7]);
+#endif
+            return;}
+        default: not_reached();
+      }
+    case 8:
+      switch (SIMD_count) {
+        case 0:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7]);
+#endif
+            return;}
+        case 1:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],SIMD[0]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],SIMD[0]);
+#endif
+            return;}
+        case 2:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],SIMD[0],SIMD[1]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],SIMD[0],SIMD[1]);
+#endif
+            return;}
+        case 3:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],SIMD[0],SIMD[1],SIMD[2]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],SIMD[0],SIMD[1],SIMD[2]);
+#endif
+            return;}
+        case 4:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],SIMD[0],SIMD[1],SIMD[2],SIMD[3]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],SIMD[0],SIMD[1],SIMD[2],SIMD[3]);
+#endif
+            return;}
+        case 5:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4]);
+#endif
+            return;}
+        case 6:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5]);
+#endif
+            return;}
+        case 7:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6]);
+#endif
+            return;}
+        case 8:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6],SIMD[7]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6],SIMD[7]);
+#endif
+            return;}
+        default: not_reached();
+      }
+    case 9:
+      switch (SIMD_count) {
+        case 0:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8]);
+#endif
+            return;}
+        case 1:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],SIMD[0]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],SIMD[0]);
+#endif
+            return;}
+        case 2:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],SIMD[0],SIMD[1]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],SIMD[0],SIMD[1]);
+#endif
+            return;}
+        case 3:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],SIMD[0],SIMD[1],SIMD[2]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],SIMD[0],SIMD[1],SIMD[2]);
+#endif
+            return;}
+        case 4:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],SIMD[0],SIMD[1],SIMD[2],SIMD[3]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],SIMD[0],SIMD[1],SIMD[2],SIMD[3]);
+#endif
+            return;}
+        case 5:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4]);
+#endif
+            return;}
+        case 6:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5]);
+#endif
+            return;}
+        case 7:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6]);
+#endif
+            return;}
+        case 8:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6],SIMD[7]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6],SIMD[7]);
+#endif
+            return;}
+        default: not_reached();
+      }
+    case 10:
+      switch (SIMD_count) {
+        case 0:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9]);
+#endif
+            return;}
+        case 1:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],SIMD[0]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],SIMD[0]);
+#endif
+            return;}
+        case 2:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],SIMD[0],SIMD[1]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],SIMD[0],SIMD[1]);
+#endif
+            return;}
+        case 3:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],SIMD[0],SIMD[1],SIMD[2]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],SIMD[0],SIMD[1],SIMD[2]);
+#endif
+            return;}
+        case 4:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],SIMD[0],SIMD[1],SIMD[2],SIMD[3]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],SIMD[0],SIMD[1],SIMD[2],SIMD[3]);
+#endif
+            return;}
+        case 5:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4]);
+#endif
+            return;}
+        case 6:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5]);
+#endif
+            return;}
+        case 7:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6]);
+#endif
+            return;}
+        case 8:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6],SIMD[7]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6],SIMD[7]);
+#endif
+            return;}
+        default: not_reached();
+      }
+    case 11:
+      switch (SIMD_count) {
+        case 0:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10]);
+#endif
+            return;}
+        case 1:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],SIMD[0]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],SIMD[0]);
+#endif
+            return;}
+        case 2:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],SIMD[0],SIMD[1]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],SIMD[0],SIMD[1]);
+#endif
+            return;}
+        case 3:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],SIMD[0],SIMD[1],SIMD[2]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],SIMD[0],SIMD[1],SIMD[2]);
+#endif
+            return;}
+        case 4:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],SIMD[0],SIMD[1],SIMD[2],SIMD[3]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],SIMD[0],SIMD[1],SIMD[2],SIMD[3]);
+#endif
+            return;}
+        case 5:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4]);
+#endif
+            return;}
+        case 6:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5]);
+#endif
+            return;}
+        case 7:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6]);
+#endif
+            return;}
+        case 8:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6],SIMD[7]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6],SIMD[7]);
+#endif
+            return;}
+        default: not_reached();
+      }
+    case 12:
+      switch (SIMD_count) {
+        case 0:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11]);
+#endif
+            return;}
+        case 1:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],SIMD[0]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],SIMD[0]);
+#endif
+            return;}
+        case 2:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],SIMD[0],SIMD[1]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],SIMD[0],SIMD[1]);
+#endif
+            return;}
+        case 3:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],SIMD[0],SIMD[1],SIMD[2]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],SIMD[0],SIMD[1],SIMD[2]);
+#endif
+            return;}
+        case 4:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],SIMD[0],SIMD[1],SIMD[2],SIMD[3]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],SIMD[0],SIMD[1],SIMD[2],SIMD[3]);
+#endif
+            return;}
+        case 5:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4]);
+#endif
+            return;}
+        case 6:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5]);
+#endif
+            return;}
+        case 7:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6]);
+#endif
+            return;}
+        case 8:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6],SIMD[7]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6],SIMD[7]);
+#endif
+            return;}
+        default: not_reached();
+      }
+    case 13:
+      switch (SIMD_count) {
+        case 0:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12]);
+#endif
+            return;}
+        case 1:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],SIMD[0]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],SIMD[0]);
+#endif
+            return;}
+        case 2:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],SIMD[0],SIMD[1]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],SIMD[0],SIMD[1]);
+#endif
+            return;}
+        case 3:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],SIMD[0],SIMD[1],SIMD[2]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],SIMD[0],SIMD[1],SIMD[2]);
+#endif
+            return;}
+        case 4:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],SIMD[0],SIMD[1],SIMD[2],SIMD[3]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],SIMD[0],SIMD[1],SIMD[2],SIMD[3]);
+#endif
+            return;}
+        case 5:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4]);
+#endif
+            return;}
+        case 6:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5]);
+#endif
+            return;}
+        case 7:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6]);
+#endif
+            return;}
+        case 8:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6],SIMD[7]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6],SIMD[7]);
+#endif
+            return;}
+        default: not_reached();
+      }
+    case 14:
+      switch (SIMD_count) {
+        case 0:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13]);
+#endif
+            return;}
+        case 1:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],SIMD[0]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],SIMD[0]);
+#endif
+            return;}
+        case 2:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],SIMD[0],SIMD[1]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],SIMD[0],SIMD[1]);
+#endif
+            return;}
+        case 3:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],SIMD[0],SIMD[1],SIMD[2]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],SIMD[0],SIMD[1],SIMD[2]);
+#endif
+            return;}
+        case 4:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],SIMD[0],SIMD[1],SIMD[2],SIMD[3]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],SIMD[0],SIMD[1],SIMD[2],SIMD[3]);
+#endif
+            return;}
+        case 5:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4]);
+#endif
+            return;}
+        case 6:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5]);
+#endif
+            return;}
+        case 7:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6]);
+#endif
+            return;}
+        case 8:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6],SIMD[7]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6],SIMD[7]);
+#endif
+            return;}
+        default: not_reached();
+      }
+    case 15:
+      switch (SIMD_count) {
+        case 0:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14]);
+#endif
+            return;}
+        case 1:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],SIMD[0]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],SIMD[0]);
+#endif
+            return;}
+        case 2:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],SIMD[0],SIMD[1]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],SIMD[0],SIMD[1]);
+#endif
+            return;}
+        case 3:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],SIMD[0],SIMD[1],SIMD[2]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],SIMD[0],SIMD[1],SIMD[2]);
+#endif
+            return;}
+        case 4:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],SIMD[0],SIMD[1],SIMD[2],SIMD[3]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],SIMD[0],SIMD[1],SIMD[2],SIMD[3]);
+#endif
+            return;}
+        case 5:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4]);
+#endif
+            return;}
+        case 6:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5]);
+#endif
+            return;}
+        case 7:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6]);
+#endif
+            return;}
+        case 8:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6],SIMD[7]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6],SIMD[7]);
+#endif
+            return;}
+        default: not_reached();
+      }
+    case 16:
+      switch (SIMD_count) {
+        case 0:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15]);
+#endif
+            return;}
+        case 1:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],SIMD[0]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],SIMD[0]);
+#endif
+            return;}
+        case 2:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],SIMD[0],SIMD[1]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],SIMD[0],SIMD[1]);
+#endif
+            return;}
+        case 3:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],SIMD[0],SIMD[1],SIMD[2]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],SIMD[0],SIMD[1],SIMD[2]);
+#endif
+            return;}
+        case 4:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],SIMD[0],SIMD[1],SIMD[2],SIMD[3]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],SIMD[0],SIMD[1],SIMD[2],SIMD[3]);
+#endif
+            return;}
+        case 5:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4]);
+#endif
+            return;}
+        case 6:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5]);
+#endif
+            return;}
+        case 7:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6]);
+#endif
+            return;}
+        case 8:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6],SIMD[7]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6],SIMD[7]);
+#endif
+            return;}
+        default: not_reached();
+      }
+    case 17:
+      switch (SIMD_count) {
+        case 0:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16]);
+#endif
+            return;}
+        case 1:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],SIMD[0]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],SIMD[0]);
+#endif
+            return;}
+        case 2:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],SIMD[0],SIMD[1]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],SIMD[0],SIMD[1]);
+#endif
+            return;}
+        case 3:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],SIMD[0],SIMD[1],SIMD[2]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],SIMD[0],SIMD[1],SIMD[2]);
+#endif
+            return;}
+        case 4:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],SIMD[0],SIMD[1],SIMD[2],SIMD[3]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],SIMD[0],SIMD[1],SIMD[2],SIMD[3]);
+#endif
+            return;}
+        case 5:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4]);
+#endif
+            return;}
+        case 6:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5]);
+#endif
+            return;}
+        case 7:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6]);
+#endif
+            return;}
+        case 8:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6],SIMD[7]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6],SIMD[7]);
+#endif
+            return;}
+        default: not_reached();
+      }
+    case 18:
+      switch (SIMD_count) {
+        case 0:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17]);
+#endif
+            return;}
+        case 1:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],SIMD[0]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],SIMD[0]);
+#endif
+            return;}
+        case 2:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],SIMD[0],SIMD[1]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],SIMD[0],SIMD[1]);
+#endif
+            return;}
+        case 3:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],SIMD[0],SIMD[1],SIMD[2]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],SIMD[0],SIMD[1],SIMD[2]);
+#endif
+            return;}
+        case 4:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],SIMD[0],SIMD[1],SIMD[2],SIMD[3]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],SIMD[0],SIMD[1],SIMD[2],SIMD[3]);
+#endif
+            return;}
+        case 5:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4]);
+#endif
+            return;}
+        case 6:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5]);
+#endif
+            return;}
+        case 7:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6]);
+#endif
+            return;}
+        case 8:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6],SIMD[7]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6],SIMD[7]);
+#endif
+            return;}
+        default: not_reached();
+      }
+    case 19:
+      switch (SIMD_count) {
+        case 0:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18]);
+#endif
+            return;}
+        case 1:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],SIMD[0]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],SIMD[0]);
+#endif
+            return;}
+        case 2:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],SIMD[0],SIMD[1]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],SIMD[0],SIMD[1]);
+#endif
+            return;}
+        case 3:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],SIMD[0],SIMD[1],SIMD[2]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],SIMD[0],SIMD[1],SIMD[2]);
+#endif
+            return;}
+        case 4:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],SIMD[0],SIMD[1],SIMD[2],SIMD[3]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],SIMD[0],SIMD[1],SIMD[2],SIMD[3]);
+#endif
+            return;}
+        case 5:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4]);
+#endif
+            return;}
+        case 6:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5]);
+#endif
+            return;}
+        case 7:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6]);
+#endif
+            return;}
+        case 8:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6],SIMD[7]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6],SIMD[7]);
+#endif
+            return;}
+        default: not_reached();
+      }
+    case 20:
+      switch (SIMD_count) {
+        case 0:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19]);
+#endif
+            return;}
+        case 1:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],SIMD[0]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],SIMD[0]);
+#endif
+            return;}
+        case 2:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],SIMD[0],SIMD[1]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],SIMD[0],SIMD[1]);
+#endif
+            return;}
+        case 3:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],SIMD[0],SIMD[1],SIMD[2]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],SIMD[0],SIMD[1],SIMD[2]);
+#endif
+            return;}
+        case 4:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],SIMD[0],SIMD[1],SIMD[2],SIMD[3]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],SIMD[0],SIMD[1],SIMD[2],SIMD[3]);
+#endif
+            return;}
+        case 5:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4]);
+#endif
+            return;}
+        case 6:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5]);
+#endif
+            return;}
+        case 7:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6]);
+#endif
+            return;}
+        case 8:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6],SIMD[7]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6],SIMD[7]);
+#endif
+            return;}
+        default: not_reached();
+      }
+    case 21:
+      switch (SIMD_count) {
+        case 0:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20]);
+#endif
+            return;}
+        case 1:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],SIMD[0]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],SIMD[0]);
+#endif
+            return;}
+        case 2:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],SIMD[0],SIMD[1]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],SIMD[0],SIMD[1]);
+#endif
+            return;}
+        case 3:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],SIMD[0],SIMD[1],SIMD[2]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],SIMD[0],SIMD[1],SIMD[2]);
+#endif
+            return;}
+        case 4:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],SIMD[0],SIMD[1],SIMD[2],SIMD[3]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],SIMD[0],SIMD[1],SIMD[2],SIMD[3]);
+#endif
+            return;}
+        case 5:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4]);
+#endif
+            return;}
+        case 6:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5]);
+#endif
+            return;}
+        case 7:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6]);
+#endif
+            return;}
+        case 8:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6],SIMD[7]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6],SIMD[7]);
+#endif
+            return;}
+        default: not_reached();
+      }
+    case 22:
+      switch (SIMD_count) {
+        case 0:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21]);
+#endif
+            return;}
+        case 1:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],SIMD[0]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],SIMD[0]);
+#endif
+            return;}
+        case 2:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],SIMD[0],SIMD[1]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],SIMD[0],SIMD[1]);
+#endif
+            return;}
+        case 3:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],SIMD[0],SIMD[1],SIMD[2]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],SIMD[0],SIMD[1],SIMD[2]);
+#endif
+            return;}
+        case 4:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],SIMD[0],SIMD[1],SIMD[2],SIMD[3]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],SIMD[0],SIMD[1],SIMD[2],SIMD[3]);
+#endif
+            return;}
+        case 5:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4]);
+#endif
+            return;}
+        case 6:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5]);
+#endif
+            return;}
+        case 7:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6]);
+#endif
+            return;}
+        case 8:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6],SIMD[7]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6],SIMD[7]);
+#endif
+            return;}
+        default: not_reached();
+      }
+    case 23:
+      switch (SIMD_count) {
+        case 0:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22]);
+#endif
+            return;}
+        case 1:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],SIMD[0]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],SIMD[0]);
+#endif
+            return;}
+        case 2:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],SIMD[0],SIMD[1]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],SIMD[0],SIMD[1]);
+#endif
+            return;}
+        case 3:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],SIMD[0],SIMD[1],SIMD[2]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],SIMD[0],SIMD[1],SIMD[2]);
+#endif
+            return;}
+        case 4:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],SIMD[0],SIMD[1],SIMD[2],SIMD[3]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],SIMD[0],SIMD[1],SIMD[2],SIMD[3]);
+#endif
+            return;}
+        case 5:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4]);
+#endif
+            return;}
+        case 6:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5]);
+#endif
+            return;}
+        case 7:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6]);
+#endif
+            return;}
+        case 8:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6],SIMD[7]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6],SIMD[7]);
+#endif
+            return;}
+        default: not_reached();
+      }
+    case 24:
+      switch (SIMD_count) {
+        case 0:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23]);
+#endif
+            return;}
+        case 1:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],SIMD[0]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],SIMD[0]);
+#endif
+            return;}
+        case 2:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],SIMD[0],SIMD[1]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],SIMD[0],SIMD[1]);
+#endif
+            return;}
+        case 3:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],SIMD[0],SIMD[1],SIMD[2]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],SIMD[0],SIMD[1],SIMD[2]);
+#endif
+            return;}
+        case 4:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],SIMD[0],SIMD[1],SIMD[2],SIMD[3]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],SIMD[0],SIMD[1],SIMD[2],SIMD[3]);
+#endif
+            return;}
+        case 5:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4]);
+#endif
+            return;}
+        case 6:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5]);
+#endif
+            return;}
+        case 7:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6]);
+#endif
+            return;}
+        case 8:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6],SIMD[7]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6],SIMD[7]);
+#endif
+            return;}
+        default: not_reached();
+      }
+    case 25:
+      switch (SIMD_count) {
+        case 0:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24]);
+#endif
+            return;}
+        case 1:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],SIMD[0]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],SIMD[0]);
+#endif
+            return;}
+        case 2:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],SIMD[0],SIMD[1]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],SIMD[0],SIMD[1]);
+#endif
+            return;}
+        case 3:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],SIMD[0],SIMD[1],SIMD[2]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],SIMD[0],SIMD[1],SIMD[2]);
+#endif
+            return;}
+        case 4:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],SIMD[0],SIMD[1],SIMD[2],SIMD[3]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],SIMD[0],SIMD[1],SIMD[2],SIMD[3]);
+#endif
+            return;}
+        case 5:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4]);
+#endif
+            return;}
+        case 6:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5]);
+#endif
+            return;}
+        case 7:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6]);
+#endif
+            return;}
+        case 8:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6],SIMD[7]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6],SIMD[7]);
+#endif
+            return;}
+        default: not_reached();
+      }
+    case 26:
+      switch (SIMD_count) {
+        case 0:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25]);
+#endif
+            return;}
+        case 1:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],SIMD[0]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],SIMD[0]);
+#endif
+            return;}
+        case 2:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],SIMD[0],SIMD[1]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],SIMD[0],SIMD[1]);
+#endif
+            return;}
+        case 3:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],SIMD[0],SIMD[1],SIMD[2]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],SIMD[0],SIMD[1],SIMD[2]);
+#endif
+            return;}
+        case 4:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],SIMD[0],SIMD[1],SIMD[2],SIMD[3]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],SIMD[0],SIMD[1],SIMD[2],SIMD[3]);
+#endif
+            return;}
+        case 5:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4]);
+#endif
+            return;}
+        case 6:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5]);
+#endif
+            return;}
+        case 7:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6]);
+#endif
+            return;}
+        case 8:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6],SIMD[7]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6],SIMD[7]);
+#endif
+            return;}
+        default: not_reached();
+      }
+    case 27:
+      switch (SIMD_count) {
+        case 0:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],GP[26]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],GP[26]);
+#endif
+            return;}
+        case 1:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],GP[26],SIMD[0]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],GP[26],SIMD[0]);
+#endif
+            return;}
+        case 2:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],GP[26],SIMD[0],SIMD[1]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],GP[26],SIMD[0],SIMD[1]);
+#endif
+            return;}
+        case 3:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],GP[26],SIMD[0],SIMD[1],SIMD[2]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],GP[26],SIMD[0],SIMD[1],SIMD[2]);
+#endif
+            return;}
+        case 4:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],GP[26],SIMD[0],SIMD[1],SIMD[2],SIMD[3]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],GP[26],SIMD[0],SIMD[1],SIMD[2],SIMD[3]);
+#endif
+            return;}
+        case 5:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],GP[26],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],GP[26],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4]);
+#endif
+            return;}
+        case 6:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],GP[26],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],GP[26],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5]);
+#endif
+            return;}
+        case 7:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],GP[26],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],GP[26],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6]);
+#endif
+            return;}
+        case 8:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],GP[26],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6],SIMD[7]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],GP[26],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6],SIMD[7]);
+#endif
+            return;}
+        default: not_reached();
+      }
+    case 28:
+      switch (SIMD_count) {
+        case 0:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],GP[26],GP[27]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],GP[26],GP[27]);
+#endif
+            return;}
+        case 1:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],GP[26],GP[27],SIMD[0]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],GP[26],GP[27],SIMD[0]);
+#endif
+            return;}
+        case 2:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],GP[26],GP[27],SIMD[0],SIMD[1]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],GP[26],GP[27],SIMD[0],SIMD[1]);
+#endif
+            return;}
+        case 3:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],GP[26],GP[27],SIMD[0],SIMD[1],SIMD[2]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],GP[26],GP[27],SIMD[0],SIMD[1],SIMD[2]);
+#endif
+            return;}
+        case 4:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],GP[26],GP[27],SIMD[0],SIMD[1],SIMD[2],SIMD[3]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],GP[26],GP[27],SIMD[0],SIMD[1],SIMD[2],SIMD[3]);
+#endif
+            return;}
+        case 5:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],GP[26],GP[27],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],GP[26],GP[27],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4]);
+#endif
+            return;}
+        case 6:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],GP[26],GP[27],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],GP[26],GP[27],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5]);
+#endif
+            return;}
+        case 7:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],GP[26],GP[27],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],GP[26],GP[27],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6]);
+#endif
+            return;}
+        case 8:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],GP[26],GP[27],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6],SIMD[7]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],GP[26],GP[27],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6],SIMD[7]);
+#endif
+            return;}
+        default: not_reached();
+      }
+    case 29:
+      switch (SIMD_count) {
+        case 0:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],GP[26],GP[27],GP[28]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],GP[26],GP[27],GP[28]);
+#endif
+            return;}
+        case 1:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],GP[26],GP[27],GP[28],SIMD[0]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],GP[26],GP[27],GP[28],SIMD[0]);
+#endif
+            return;}
+        case 2:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],GP[26],GP[27],GP[28],SIMD[0],SIMD[1]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],GP[26],GP[27],GP[28],SIMD[0],SIMD[1]);
+#endif
+            return;}
+        case 3:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],GP[26],GP[27],GP[28],SIMD[0],SIMD[1],SIMD[2]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],GP[26],GP[27],GP[28],SIMD[0],SIMD[1],SIMD[2]);
+#endif
+            return;}
+        case 4:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],GP[26],GP[27],GP[28],SIMD[0],SIMD[1],SIMD[2],SIMD[3]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],GP[26],GP[27],GP[28],SIMD[0],SIMD[1],SIMD[2],SIMD[3]);
+#endif
+            return;}
+        case 5:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],GP[26],GP[27],GP[28],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],GP[26],GP[27],GP[28],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4]);
+#endif
+            return;}
+        case 6:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],GP[26],GP[27],GP[28],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],GP[26],GP[27],GP[28],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5]);
+#endif
+            return;}
+        case 7:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],GP[26],GP[27],GP[28],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],GP[26],GP[27],GP[28],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6]);
+#endif
+            return;}
+        case 8:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],GP[26],GP[27],GP[28],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6],SIMD[7]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],GP[26],GP[27],GP[28],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6],SIMD[7]);
+#endif
+            return;}
+        default: not_reached();
+      }
+    case 30:
+      switch (SIMD_count) {
+        case 0:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],GP[26],GP[27],GP[28],GP[29]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],GP[26],GP[27],GP[28],GP[29]);
+#endif
+            return;}
+        case 1:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],GP[26],GP[27],GP[28],GP[29],SIMD[0]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],GP[26],GP[27],GP[28],GP[29],SIMD[0]);
+#endif
+            return;}
+        case 2:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],GP[26],GP[27],GP[28],GP[29],SIMD[0],SIMD[1]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],GP[26],GP[27],GP[28],GP[29],SIMD[0],SIMD[1]);
+#endif
+            return;}
+        case 3:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],GP[26],GP[27],GP[28],GP[29],SIMD[0],SIMD[1],SIMD[2]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],GP[26],GP[27],GP[28],GP[29],SIMD[0],SIMD[1],SIMD[2]);
+#endif
+            return;}
+        case 4:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],GP[26],GP[27],GP[28],GP[29],SIMD[0],SIMD[1],SIMD[2],SIMD[3]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],GP[26],GP[27],GP[28],GP[29],SIMD[0],SIMD[1],SIMD[2],SIMD[3]);
+#endif
+            return;}
+        case 5:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],GP[26],GP[27],GP[28],GP[29],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],GP[26],GP[27],GP[28],GP[29],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4]);
+#endif
+            return;}
+        case 6:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],GP[26],GP[27],GP[28],GP[29],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],GP[26],GP[27],GP[28],GP[29],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5]);
+#endif
+            return;}
+        case 7:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],GP[26],GP[27],GP[28],GP[29],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],GP[26],GP[27],GP[28],GP[29],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6]);
+#endif
+            return;}
+        case 8:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],GP[26],GP[27],GP[28],GP[29],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6],SIMD[7]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],GP[26],GP[27],GP[28],GP[29],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6],SIMD[7]);
+#endif
+            return;}
+        default: not_reached();
+      }
+    case 31:
+      switch (SIMD_count) {
+        case 0:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],GP[26],GP[27],GP[28],GP[29],GP[30]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],GP[26],GP[27],GP[28],GP[29],GP[30]);
+#endif
+            return;}
+        case 1:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],GP[26],GP[27],GP[28],GP[29],GP[30],SIMD[0]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],GP[26],GP[27],GP[28],GP[29],GP[30],SIMD[0]);
+#endif
+            return;}
+        case 2:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],GP[26],GP[27],GP[28],GP[29],GP[30],SIMD[0],SIMD[1]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],GP[26],GP[27],GP[28],GP[29],GP[30],SIMD[0],SIMD[1]);
+#endif
+            return;}
+        case 3:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],GP[26],GP[27],GP[28],GP[29],GP[30],SIMD[0],SIMD[1],SIMD[2]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],GP[26],GP[27],GP[28],GP[29],GP[30],SIMD[0],SIMD[1],SIMD[2]);
+#endif
+            return;}
+        case 4:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],GP[26],GP[27],GP[28],GP[29],GP[30],SIMD[0],SIMD[1],SIMD[2],SIMD[3]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],GP[26],GP[27],GP[28],GP[29],GP[30],SIMD[0],SIMD[1],SIMD[2],SIMD[3]);
+#endif
+            return;}
+        case 5:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],GP[26],GP[27],GP[28],GP[29],GP[30],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],GP[26],GP[27],GP[28],GP[29],GP[30],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4]);
+#endif
+            return;}
+        case 6:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],GP[26],GP[27],GP[28],GP[29],GP[30],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],GP[26],GP[27],GP[28],GP[29],GP[30],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5]);
+#endif
+            return;}
+        case 7:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],GP[26],GP[27],GP[28],GP[29],GP[30],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],GP[26],GP[27],GP[28],GP[29],GP[30],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6]);
+#endif
+            return;}
+        case 8:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],GP[26],GP[27],GP[28],GP[29],GP[30],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6],SIMD[7]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],GP[26],GP[27],GP[28],GP[29],GP[30],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6],SIMD[7]);
+#endif
+            return;}
+        default: not_reached();
+      }
+    case 32:
+      switch (SIMD_count) {
+        case 0:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],GP[26],GP[27],GP[28],GP[29],GP[30],GP[31]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],GP[26],GP[27],GP[28],GP[29],GP[30],GP[31]);
+#endif
+            return;}
+        case 1:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],GP[26],GP[27],GP[28],GP[29],GP[30],GP[31],SIMD[0]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],GP[26],GP[27],GP[28],GP[29],GP[30],GP[31],SIMD[0]);
+#endif
+            return;}
+        case 2:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],GP[26],GP[27],GP[28],GP[29],GP[30],GP[31],SIMD[0],SIMD[1]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],GP[26],GP[27],GP[28],GP[29],GP[30],GP[31],SIMD[0],SIMD[1]);
+#endif
+            return;}
+        case 3:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],GP[26],GP[27],GP[28],GP[29],GP[30],GP[31],SIMD[0],SIMD[1],SIMD[2]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],GP[26],GP[27],GP[28],GP[29],GP[30],GP[31],SIMD[0],SIMD[1],SIMD[2]);
+#endif
+            return;}
+        case 4:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],GP[26],GP[27],GP[28],GP[29],GP[30],GP[31],SIMD[0],SIMD[1],SIMD[2],SIMD[3]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],GP[26],GP[27],GP[28],GP[29],GP[30],GP[31],SIMD[0],SIMD[1],SIMD[2],SIMD[3]);
+#endif
+            return;}
+        case 5:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],GP[26],GP[27],GP[28],GP[29],GP[30],GP[31],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],GP[26],GP[27],GP[28],GP[29],GP[30],GP[31],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4]);
+#endif
+            return;}
+        case 6:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],GP[26],GP[27],GP[28],GP[29],GP[30],GP[31],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],GP[26],GP[27],GP[28],GP[29],GP[30],GP[31],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5]);
+#endif
+            return;}
+        case 7:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],GP[26],GP[27],GP[28],GP[29],GP[30],GP[31],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],GP[26],GP[27],GP[28],GP[29],GP[30],GP[31],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6]);
+#endif
+            return;}
+        case 8:
+          {
+#ifdef __aarch64__
+              asm volatile ("mov x8, %0"::"r"(ret):"x8");
+              ((void (*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double,double,double))f)(GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],GP[26],GP[27],GP[28],GP[29],GP[30],GP[31],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6],SIMD[7]);
+#else
+              ((void (*)(void*,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,int64_t,double,double,double,double,double,double,double,double))f)(ret,GP[0],GP[1],GP[2],GP[3],GP[4],GP[5],GP[6],GP[7],GP[8],GP[9],GP[10],GP[11],GP[12],GP[13],GP[14],GP[15],GP[16],GP[17],GP[18],GP[19],GP[20],GP[21],GP[22],GP[23],GP[24],GP[25],GP[26],GP[27],GP[28],GP[29],GP[30],GP[31],SIMD[0],SIMD[1],SIMD[2],SIMD[3],SIMD[4],SIMD[5],SIMD[6],SIMD[7]);
+#endif
+            return;}
+        default: not_reached();
+      }
+    default: not_reached();
+  }
+}
+

--- a/hphp/util/cycles.h
+++ b/hphp/util/cycles.h
@@ -39,6 +39,12 @@ inline uint64_t cpuCycles() {
   uint64_t tb;
   asm volatile("mfspr %0, 268" : "=r" (tb));
   return tb;
+#elif __aarch64__
+  // TODO(CDE): Best approach for AArch64 is to use the perf library as
+  //            the setup must be done by a priviledged user, i.e. in the
+  //            kernel. For now, just return zero effectively breaking
+  //            profiling.
+  return 0;
 #elif _MSC_VER
   return (uint64_t)__rdtsc();
 #else


### PR DESCRIPTION
These commits address general correctness issues for AArch64. Most notably, the native func caller interface has been adapted to explicitly pass a return parameter for return-by-reference calls. This affects x86_64 for when the return value is a non-POD, but code generated should be identical.