### PR TITLE
Build with stacktrace support if libbfd and libiberty can be found.

### DIFF
--- a/CMake/HPHPFindLibs.cmake
+++ b/CMake/HPHPFindLibs.cmake
@@ -367,6 +367,14 @@ if (LINUX OR APPLE)
   FIND_LIBRARY (RESOLV_LIB resolv)
 endif()
 
+FIND_LIBRARY (BFD_LIB libbfd.a)
+FIND_LIBRARY (LIBIBERTY_LIB iberty)
+
+if (BFD_LIB AND LIBIBERTY_LIB)
+  message(STATUS "Found libiberty: ${LIBIBERTY_LIB}")
+  add_definitions("-DHAVE_LIBBFD=1")
+endif()
+
 if (FREEBSD)
   FIND_LIBRARY (EXECINFO_LIB execinfo)
   if (NOT EXECINFO_LIB)
@@ -481,6 +489,11 @@ macro(hphp_link target)
     if (PAM_LIBRARY)
       target_link_libraries(${target} ${PAM_LIBRARY})
     endif()
+  endif()
+
+  if (BFD_LIB AND LIBIBERTY_LIB)
+    target_link_libraries(${target} ${BFD_LIB})
+    target_link_libraries(${target} ${LIBIBERTY_LIB})
   endif()
 
   if (LIBPTHREAD_LIBRARIES)

--- a/hphp/util/portability.h
+++ b/hphp/util/portability.h
@@ -193,7 +193,7 @@
 
 //////////////////////////////////////////////////////////////////////
 
-#if FACEBOOK
+#if FACEBOOK && !defined(HAVE_LIBBFD)
 // Linking in libbfd is a gigantic PITA. If you want this yourself in a non-FB
 // build, feel free to define HAVE_LIBBFD and specify the right options to link
 // in libbfd.a in the extra C++ options.


### PR DESCRIPTION
For the systems that are easy to install the libiberty package, build hhvm with
C++ stacktrace support if libbfd and libiberty exists. Recently there are too
many issues on github without a stacktrace, and it's not always possible to
attach gdb.

Fix #6405.