### PR TITLE
Remove duplicate defines of HAVE_LIBJPEG and HAVE_LIBPNG.

### DIFF
--- a/hphp/runtime/ext/gd/libgd/php_compat.h
+++ b/hphp/runtime/ext/gd/libgd/php_compat.h
@@ -34,8 +34,6 @@
 // And start the blasted C stuff again
 extern "C" {
 
-#define HAVE_LIBJPEG
-#define HAVE_LIBPNG
 #define emalloc HPHP::req::malloc
 #define ecalloc HPHP::req::calloc
 #define efree HPHP::req::free


### PR DESCRIPTION
They are already defined in HHVMExtensionConfig.cmake.
https://github.com/facebook/hhvm/blob/bbf1a3f443b385af20764cbbd9390605fb9de079/CMake/HHVMExtensionConfig.cmake#L811