### PR TITLE
[Aarch64] Relaxes FP Precision of Results

### DIFF
--- a/hphp/runtime/base/array-util.cpp
+++ b/hphp/runtime/base/array-util.cpp
@@ -212,7 +212,7 @@ Variant ArrayUtil::Range(double low, double high, int64_t step /* = 1 */) {
     }
     rangeCheckAlloc((low - high) / step);
     for (; low >= high; low -= step) {
-      ret.append((int64_t)low);
+      ret.append(toInt64(low));
     }
   } else if (high > low) { // Positive steps
     if (high - low < step || step <= 0) {
@@ -221,10 +221,10 @@ Variant ArrayUtil::Range(double low, double high, int64_t step /* = 1 */) {
     }
     rangeCheckAlloc((high - low) / step);
     for (; low <= high; low += step) {
-      ret.append((int64_t)low);
+      ret.append(toInt64(low));
     }
   } else {
-    ret.append((int64_t)low);
+    ret.append(toInt64(low));
   }
   return ret;
 }

--- a/hphp/runtime/ext/array/ext_array.cpp
+++ b/hphp/runtime/ext/array/ext_array.cpp
@@ -1502,7 +1502,7 @@ Variant HHVM_FUNCTION(range,
         return ArrayUtil::Range(d1, d2, dstep);
       }
 
-      int64_t lstep = (int64_t) dstep;
+      int64_t lstep = toInt64(dstep);
       if (type1 == KindOfInt64 || type2 == KindOfInt64) {
         if (type1 != KindOfInt64) n1 = slow.toInt64();
         if (type2 != KindOfInt64) n2 = shigh.toInt64();
@@ -1518,7 +1518,7 @@ Variant HHVM_FUNCTION(range,
     return ArrayUtil::Range(low.toDouble(), high.toDouble(), dstep);
   }
 
-  int64_t lstep = (int64_t) dstep;
+  int64_t lstep = toInt64(dstep);
   return ArrayUtil::Range(low.toDouble(), high.toDouble(), lstep);
 }
 ///////////////////////////////////////////////////////////////////////////////

--- a/hphp/test/slow/ext_date/date_sunrise_test.php
+++ b/hphp/test/slow/ext_date/date_sunrise_test.php
@@ -23,32 +23,32 @@ var_dump( date_sunrise($time) );
 
 echo "\n-- Testing date_sunrise() function by passing two parameters --\n";
 var_dump( date_sunrise($time, SUNFUNCS_RET_STRING) );
-var_dump( date_sunrise($time, SUNFUNCS_RET_DOUBLE) );
+var_dump( round( date_sunrise($time, SUNFUNCS_RET_DOUBLE), 10) );
 var_dump( date_sunrise($time, SUNFUNCS_RET_TIMESTAMP) );
 
 echo "\n-- Testing date_sunrise() function by passing two parameters --\n";
 var_dump( date_sunrise($time, SUNFUNCS_RET_STRING, $latitude) );
-var_dump( date_sunrise($time, SUNFUNCS_RET_DOUBLE, $latitude) );
+var_dump( round( date_sunrise($time, SUNFUNCS_RET_DOUBLE, $latitude), 10) );
 var_dump( date_sunrise($time, SUNFUNCS_RET_TIMESTAMP, $latitude) );
 
 echo "\n-- Testing date_sunrise() function by passing three  parameters --\n";
 var_dump( date_sunrise($time, SUNFUNCS_RET_STRING, $latitude, $longitude) );
-var_dump( date_sunrise($time, SUNFUNCS_RET_DOUBLE, $latitude, $longitude) );
+var_dump( round(date_sunrise($time, SUNFUNCS_RET_DOUBLE, $latitude, $longitude), 10) );
 var_dump( date_sunrise($time, SUNFUNCS_RET_TIMESTAMP, $latitude, $longitude) );
 
 echo "\n-- Testing date_sunrise() function by passing four parameters --\n";
 var_dump( date_sunrise($time, SUNFUNCS_RET_STRING,
   $latitude, $longitude, $zenith) );
-var_dump( date_sunrise($time, SUNFUNCS_RET_DOUBLE,
-  $latitude, $longitude, $zenith) );
+var_dump( round( date_sunrise($time, SUNFUNCS_RET_DOUBLE,
+  $latitude, $longitude, $zenith), 10) );
 var_dump( date_sunrise($time, SUNFUNCS_RET_TIMESTAMP,
   $latitude, $longitude, $zenith) );
 
 echo "\n-- Testing date_sunrise() function by passing five parameters --\n";
 var_dump( date_sunrise($time, SUNFUNCS_RET_STRING,
   $latitude, $longitude, $zenith, $gmt_offset) );
-var_dump( date_sunrise($time, SUNFUNCS_RET_DOUBLE,
-  $latitude, $longitude, $zenith, $gmt_offset) );
+var_dump( round( date_sunrise($time, SUNFUNCS_RET_DOUBLE,
+  $latitude, $longitude, $zenith, $gmt_offset), 10) );
 var_dump( date_sunrise($time, SUNFUNCS_RET_TIMESTAMP,
   $latitude, $longitude, $zenith, $gmt_offset) );
 

--- a/hphp/test/slow/ext_date/date_sunrise_test.php.expect
+++ b/hphp/test/slow/ext_date/date_sunrise_test.php.expect
@@ -5,26 +5,26 @@ string(5) "09:37"
 
 -- Testing date_sunrise() function by passing two parameters --
 string(5) "09:37"
-float(9.622663104669)
+float(9.6226631047)
 int(1356496641)
 
 -- Testing date_sunrise() function by passing two parameters --
 string(5) "09:54"
-float(9.9142368079326)
+float(9.9142368079)
 int(1356497691)
 
 -- Testing date_sunrise() function by passing three  parameters --
 string(5) "12:51"
-float(12.863799485848)
+float(12.8637994858)
 int(1356508309)
 
 -- Testing date_sunrise() function by passing four parameters --
 string(5) "12:55"
-float(12.921003983007)
+float(12.921003983)
 int(1356508515)
 
 -- Testing date_sunrise() function by passing five parameters --
 string(5) "08:55"
-float(8.9210039830067)
+float(8.921003983)
 int(1356508515)
 ===DONE===


### PR DESCRIPTION
Relaxes the expected results for some floating point tests. Switches key double-to-int casts to use the helper routine.