### PR TITLE
[AArch64] Passes status variable explicitly to ::waitpid.

### DIFF
--- a/hphp/util/light-process.cpp
+++ b/hphp/util/light-process.cpp
@@ -649,7 +649,8 @@ void LightProcess::closeShadow() {
       handleException("closeShadow");
     }
     // removes the "zombie" process, so not to interfere with later waits
-    ::waitpid(m_shadowProcess, nullptr, 0);
+    int status;
+    ::waitpid(m_shadowProcess, &status, 0);
     m_shadowProcess = 0;
   }
   closeFiles();


### PR DESCRIPTION
The documentation for ::waitpid states that status may be a null
pointer, however libc under wily for AArch64 dereferences status
regardless. This patch is a safety net until changes to libc
are upstreamed.

Fixes test/slow/ext_process/lwp.php