### PR TITLE
Added missing cursor increment in rfc1867PostHandler. Fixes #1706

### DIFF
--- a/hphp/runtime/server/upload.cpp
+++ b/hphp/runtime/server/upload.cpp
@@ -260,6 +260,7 @@ static uint32_t read_post(multipart_buffer *self, char *buf,
     memcpy(buf + bytes_read, self->cursor, extra_byte_read);
     bytes_to_read -= extra_byte_read;
     bytes_read += extra_byte_read;
+    self->cursor += extra_byte_read;
   }
   return bytes_read;
 }


### PR DESCRIPTION
The missing multipart_buffer cursor increment causes some of the post data to be duplicated when read from the buffer.

Here is one example of the resulting data in the buffer
```
------WebKitFormBoundary8pfe3ho8C5p2ZXwA
Content-Disposition: form-data; name="single-0"

0
------WebKitFormBoundary8pfe3ho8C5p2ZXwA
Content-Disposition: form-data; name="single-1"

1
------WebKitFormBoundary8pfe3ho8C5p2ZXwA
Content-Disposition: form-data; name="single-2"

2
------WebKitFormBoundary8pfe3ho8C5p2ZXwA
Content-Disposition: form-data; name="single-3"

3
------WebKitFormBoundary8pfe3ho8C5p2ZXwA
Content-Disposition: form-data; name="single-4"

4
------WebKitFormBoundary8pfe3ho8C5p2ZXwA
Content-Disposition: form-data; name="single-5"

5
------WebKitFormBoundary8pfe3ho8C5p2ZXwA
Content-Disposition: form-data; name="single-6"

6
------WebKitFormBoundary8pfe3ho8C5p2ZXwA
Content-Disposition: form-data; name="single-7"

7
------WebKitFormBoundary8pfe3ho8C5p2ZXwA--

4"

4
------WebKitFormBoundary8pfe3ho8C5p2ZXwA
Content-Disposition: form-data; name="single-5"

5
------WebKitFormBoundary8pfe3ho8C5p2ZXwA
Content-Disposition: form-data; name="single-6"

6
------WebKitFormBoundary8pfe3ho8C5p2ZXwA
Content-Disposition: form-data; name="single-7"

7
------WebKitFormBoundary8pfe3ho8C5p2ZXwA--
```

As you can see, the last part of the post data have been read twice and elements single-5, single-6 and single-7 are duplicated.

In the above case you don't notice this since the array elements in `$_POST['single-5'], $_POST['single-6'], $_POST['single-7']` will just be overwritten.

However, if the form contains array elements (`<input name="array[]"/>` for example) the data in `$_POST` will be duplicated.

```
$_POST['array'] =>
    0 => 0
    1 => 1
    2 => 2
    3 => 3
    4 => 4
    5 => 5
    6 => 6
    7 => 7
    8 => 5
    9 => 6
    10 => 7
```