### PR TITLE
Eliminate the cs_GMP_FUNC_NAME_* globals

### DIFF
--- a/hphp/runtime/ext/gmp/ext_gmp.cpp
+++ b/hphp/runtime/ext/gmp/ext_gmp.cpp
@@ -172,7 +172,7 @@ static Variant HHVM_FUNCTION(gmp_abs,
                              const Variant& data) {
   mpz_t gmpReturn, gmpData;
 
-  if (!variantToGMPData(cs_GMP_FUNC_NAME_GMP_ABS, gmpData, data)) {
+  if (!variantToGMPData("gmp_abs", gmpData, data)) {
     return false;
   }
 
@@ -193,10 +193,10 @@ static Variant HHVM_FUNCTION(gmp_add,
                              const Variant& dataB) {
   mpz_t gmpDataA, gmpDataB, gmpReturn;
 
-  if (!variantToGMPData(cs_GMP_FUNC_NAME_GMP_ADD, gmpDataA, dataA)) {
+  if (!variantToGMPData("gmp_add", gmpDataA, dataA)) {
     return false;
   }
-  if (!variantToGMPData(cs_GMP_FUNC_NAME_GMP_ADD, gmpDataB, dataB)) {
+  if (!variantToGMPData("gmp_add", gmpDataB, dataB)) {
     mpz_clear(gmpDataA);
     return false;
   }
@@ -219,10 +219,10 @@ static Variant HHVM_FUNCTION(gmp_and,
                              const Variant& dataB) {
   mpz_t gmpDataA, gmpDataB, gmpReturn;
 
-  if (!variantToGMPData(cs_GMP_FUNC_NAME_GMP_AND, gmpDataA, dataA)) {
+  if (!variantToGMPData("gmp_and", gmpDataA, dataA)) {
     return false;
   }
-  if (!variantToGMPData(cs_GMP_FUNC_NAME_GMP_AND, gmpDataB, dataB)) {
+  if (!variantToGMPData("gmp_and", gmpDataB, dataB)) {
     mpz_clear(gmpDataA);
     return false;
   }
@@ -245,20 +245,19 @@ static void HHVM_FUNCTION(gmp_clrbit,
                           int64_t index) {
 
   if (index < 0) {
-    raise_warning(cs_GMP_INVALID_INDEX_IS_NEGATIVE,
-                  cs_GMP_FUNC_NAME_GMP_CLRBIT);
+    raise_warning(cs_GMP_INVALID_INDEX_IS_NEGATIVE, "gmp_clrbit");
     return;
   }
 
   Object gmpObject = data.toObject();
   if (!gmpObject.instanceof(s_GMP_GMP)) {
-    raise_warning(cs_GMP_INVALID_OBJECT, cs_GMP_FUNC_NAME_GMP_CLRBIT);
+    raise_warning(cs_GMP_INVALID_OBJECT, "gmp_clrbit");
     return;
   }
 
   auto gmpData = Native::data<GMPData>(gmpObject);
   if (!gmpData) {
-    raise_warning(cs_GMP_INVALID_OBJECT, cs_GMP_FUNC_NAME_GMP_CLRBIT);
+    raise_warning(cs_GMP_INVALID_OBJECT, "gmp_clrbit");
     return;
   }
 
@@ -271,10 +270,10 @@ static Variant HHVM_FUNCTION(gmp_cmp,
                              const Variant& dataB) {
   mpz_t gmpDataA, gmpDataB;
 
-  if (!variantToGMPData(cs_GMP_FUNC_NAME_GMP_CMP, gmpDataA, dataA)) {
+  if (!variantToGMPData("gmp_cmp", gmpDataA, dataA)) {
     return false;
   }
-  if (!variantToGMPData(cs_GMP_FUNC_NAME_GMP_CMP, gmpDataB, dataB)) {
+  if (!variantToGMPData("gmp_cmp", gmpDataB, dataB)) {
     mpz_clear(gmpDataA);
     return false;
   }
@@ -292,7 +291,7 @@ static Variant HHVM_FUNCTION(gmp_com,
                              const Variant& data) {
   mpz_t gmpReturn, gmpData;
 
-  if (!variantToGMPData(cs_GMP_FUNC_NAME_GMP_COM, gmpData, data)) {
+  if (!variantToGMPData("gmp_com", gmpData, data)) {
     return false;
   }
 
@@ -314,10 +313,10 @@ static Variant HHVM_FUNCTION(gmp_div_q,
                              int64_t round = GMP_ROUND_ZERO) {
   mpz_t gmpDataA, gmpDataB, gmpReturn;
 
-  if (!variantToGMPData(cs_GMP_FUNC_NAME_GMP_DIV_Q, gmpDataA, dataA)) {
+  if (!variantToGMPData("gmp_div_q", gmpDataA, dataA)) {
     return false;
   }
-  if (!variantToGMPData(cs_GMP_FUNC_NAME_GMP_DIV_Q, gmpDataB, dataB)) {
+  if (!variantToGMPData("gmp_div_q", gmpDataB, dataB)) {
     mpz_clear(gmpDataA);
     return false;
   }
@@ -326,8 +325,7 @@ static Variant HHVM_FUNCTION(gmp_div_q,
     mpz_clear(gmpDataA);
     mpz_clear(gmpDataB);
 
-    raise_warning(cs_GMP_INVALID_VALUE_MUST_NOT_BE_ZERO,
-                  cs_GMP_FUNC_NAME_GMP_DIV_Q);
+    raise_warning(cs_GMP_INVALID_VALUE_MUST_NOT_BE_ZERO, "gmp_div_q");
     return false;
   }
 
@@ -350,7 +348,7 @@ static Variant HHVM_FUNCTION(gmp_div_q,
     mpz_clear(gmpDataA);
     mpz_clear(gmpDataB);
     mpz_clear(gmpReturn);
-    raise_warning(cs_GMP_INVALID_ROUNDING_MODE, cs_GMP_FUNC_NAME_GMP_DIV_Q);
+    raise_warning(cs_GMP_INVALID_ROUNDING_MODE, "gmp_div_q");
     return false;
   }
 
@@ -370,10 +368,10 @@ static Variant HHVM_FUNCTION(gmp_div_qr,
                              int64_t round = GMP_ROUND_ZERO) {
   mpz_t gmpDataA, gmpDataB, gmpReturnQ, gmpReturnR;
 
-  if (!variantToGMPData(cs_GMP_FUNC_NAME_GMP_DIV_QR, gmpDataA, dataA)) {
+  if (!variantToGMPData("gmp_div_qr", gmpDataA, dataA)) {
     return false;
   }
-  if (!variantToGMPData(cs_GMP_FUNC_NAME_GMP_DIV_QR, gmpDataB, dataB)) {
+  if (!variantToGMPData("gmp_div_qr", gmpDataB, dataB)) {
     mpz_clear(gmpDataA);
     return false;
   }
@@ -382,8 +380,7 @@ static Variant HHVM_FUNCTION(gmp_div_qr,
     mpz_clear(gmpDataA);
     mpz_clear(gmpDataB);
 
-    raise_warning(cs_GMP_INVALID_VALUE_MUST_NOT_BE_ZERO,
-                  cs_GMP_FUNC_NAME_GMP_DIV_QR);
+    raise_warning(cs_GMP_INVALID_VALUE_MUST_NOT_BE_ZERO, "gmp_div_qr");
     return false;
   }
 
@@ -409,7 +406,7 @@ static Variant HHVM_FUNCTION(gmp_div_qr,
     mpz_clear(gmpDataB);
     mpz_clear(gmpReturnQ);
     mpz_clear(gmpReturnR);
-    raise_warning(cs_GMP_INVALID_ROUNDING_MODE, cs_GMP_FUNC_NAME_GMP_DIV_QR);
+    raise_warning(cs_GMP_INVALID_ROUNDING_MODE, "gmp_div_qr");
     return false;
   }
 
@@ -432,10 +429,10 @@ static Variant HHVM_FUNCTION(gmp_div_r,
                              int64_t round = GMP_ROUND_ZERO) {
   mpz_t gmpDataA, gmpDataB, gmpReturn;
 
-  if (!variantToGMPData(cs_GMP_FUNC_NAME_GMP_DIV_R, gmpDataA, dataA)) {
+  if (!variantToGMPData("gmp_div_r", gmpDataA, dataA)) {
     return false;
   }
-  if (!variantToGMPData(cs_GMP_FUNC_NAME_GMP_DIV_R, gmpDataB, dataB)) {
+  if (!variantToGMPData("gmp_div_r", gmpDataB, dataB)) {
     mpz_clear(gmpDataA);
     return false;
   }
@@ -444,8 +441,7 @@ static Variant HHVM_FUNCTION(gmp_div_r,
     mpz_clear(gmpDataA);
     mpz_clear(gmpDataB);
 
-    raise_warning(cs_GMP_INVALID_VALUE_MUST_NOT_BE_ZERO,
-                  cs_GMP_FUNC_NAME_GMP_DIV_R);
+    raise_warning(cs_GMP_INVALID_VALUE_MUST_NOT_BE_ZERO, "gmp_div_r");
     return false;
   }
 
@@ -467,7 +463,7 @@ static Variant HHVM_FUNCTION(gmp_div_r,
     mpz_clear(gmpDataA);
     mpz_clear(gmpDataB);
     mpz_clear(gmpReturn);
-    raise_warning(cs_GMP_INVALID_ROUNDING_MODE, cs_GMP_FUNC_NAME_GMP_DIV_R);
+    raise_warning(cs_GMP_INVALID_ROUNDING_MODE, "gmp_div_r");
     return false;
   }
 
@@ -487,17 +483,16 @@ static Variant HHVM_FUNCTION(gmp_divexact,
                              const Variant& dataB) {
   mpz_t gmpDataA, gmpDataB, gmpReturn;
 
-  if (!variantToGMPData(cs_GMP_FUNC_NAME_GMP_DIVEXACT, gmpDataA, dataA)) {
+  if (!variantToGMPData("gmp_divexact", gmpDataA, dataA)) {
     return false;
   }
-  if (!variantToGMPData(cs_GMP_FUNC_NAME_GMP_DIVEXACT, gmpDataB, dataB)) {
+  if (!variantToGMPData("gmp_divexact", gmpDataB, dataB)) {
     mpz_clear(gmpDataA);
     return false;
   }
 
   if (mpz_sgn(gmpDataB) == 0) {
-    raise_warning(cs_GMP_INVALID_VALUE_MUST_NOT_BE_ZERO,
-                  cs_GMP_FUNC_NAME_GMP_DIVEXACT);
+    raise_warning(cs_GMP_INVALID_VALUE_MUST_NOT_BE_ZERO, "gmp_divexact");
     mpz_clear(gmpDataA);
     mpz_clear(gmpDataB);
     return false;
@@ -522,15 +517,14 @@ static Variant HHVM_FUNCTION(gmp_fact,
 
   if (data.isObject()) {
     mpz_t gmpData;
-    if (!variantToGMPData(cs_GMP_FUNC_NAME_GMP_FACT, gmpData, data)) {
+    if (!variantToGMPData("gmp_fact", gmpData, data)) {
       return false;
     }
 
     if (mpz_sgn(gmpData) < 0) {
       mpz_clear(gmpData);
 
-      raise_warning(cs_GMP_INVALID_VALUE_MUST_BE_POSITIVE,
-                    cs_GMP_FUNC_NAME_GMP_FACT);
+      raise_warning(cs_GMP_INVALID_VALUE_MUST_BE_POSITIVE, "gmp_fact");
       return false;
     }
 
@@ -540,8 +534,7 @@ static Variant HHVM_FUNCTION(gmp_fact,
     mpz_clear(gmpData);
   } else {
     if (data.toInt64() < 0) {
-      raise_warning(cs_GMP_INVALID_VALUE_MUST_BE_POSITIVE,
-                    cs_GMP_FUNC_NAME_GMP_FACT);
+      raise_warning(cs_GMP_INVALID_VALUE_MUST_BE_POSITIVE, "gmp_fact");
       return false;
     }
 
@@ -561,10 +554,10 @@ static Variant HHVM_FUNCTION(gmp_gcd,
                              const Variant& dataB) {
   mpz_t gmpDataA, gmpDataB, gmpReturn;
 
-  if (!variantToGMPData(cs_GMP_FUNC_NAME_GMP_GCD, gmpDataA, dataA)) {
+  if (!variantToGMPData("gmp_gcd", gmpDataA, dataA)) {
     return false;
   }
-  if (!variantToGMPData(cs_GMP_FUNC_NAME_GMP_GCD, gmpDataB, dataB)) {
+  if (!variantToGMPData("gmp_gcd", gmpDataB, dataB)) {
     mpz_clear(gmpDataA);
     return false;
   }
@@ -587,10 +580,10 @@ static Variant HHVM_FUNCTION(gmp_gcdext,
                              const Variant& dataB) {
   mpz_t gmpDataA, gmpDataB, gmpReturnG, gmpReturnS, gmpReturnT;
 
-  if (!variantToGMPData(cs_GMP_FUNC_NAME_GMP_GCDEXCT, gmpDataA, dataA)) {
+  if (!variantToGMPData("gmp_gcdexct", gmpDataA, dataA)) {
     return false;
   }
-  if (!variantToGMPData(cs_GMP_FUNC_NAME_GMP_GCDEXCT, gmpDataB, dataB)) {
+  if (!variantToGMPData("gmp_gcdexct", gmpDataB, dataB)) {
     mpz_clear(gmpDataA);
     return false;
   }
@@ -621,10 +614,10 @@ static Variant HHVM_FUNCTION(gmp_hamdist,
                              const Variant& dataB) {
   mpz_t gmpDataA, gmpDataB;
 
-  if (!variantToGMPData(cs_GMP_FUNC_NAME_GMP_HAMDIST, gmpDataA, dataA)) {
+  if (!variantToGMPData("gmp_hamdist", gmpDataA, dataA)) {
     return false;
   }
-  if (!variantToGMPData(cs_GMP_FUNC_NAME_GMP_HAMDIST, gmpDataB, dataB)) {
+  if (!variantToGMPData("gmp_hamdist", gmpDataB, dataB)) {
     mpz_clear(gmpDataA);
     return false;
   }
@@ -644,14 +637,11 @@ static Variant HHVM_FUNCTION(gmp_init,
   mpz_t gmpData;
 
   if (base < GMP_MIN_BASE || base == -1 || base == 1 || base > GMP_MAX_BASE) {
-    raise_warning(cs_GMP_INVALID_BASE_VALUE,
-                  cs_GMP_FUNC_NAME_GMP_INIT,
-                  base,
-                  GMP_MAX_BASE);
+    raise_warning(cs_GMP_INVALID_BASE_VALUE, "gmp_init", base, GMP_MAX_BASE);
     return false;
   }
 
-  if (!variantToGMPData(cs_GMP_FUNC_NAME_GMP_INIT, gmpData, data, base)) {
+  if (!variantToGMPData("gmp_init", gmpData, data, base)) {
     return false;
   }
 
@@ -671,7 +661,7 @@ static int64_t HHVM_FUNCTION(gmp_intval,
       || data.isResource()
       || (data.isString() && data.toString().empty())
       || (data.isObject() && !data.toObject().instanceof(s_GMP_GMP))
-      || !variantToGMPData(cs_GMP_FUNC_NAME_GMP_INTVAL, gmpData, data)) {
+      || !variantToGMPData("gmp_intval", gmpData, data)) {
     return data.toInt64();
   }
 
@@ -688,10 +678,10 @@ static Variant HHVM_FUNCTION(gmp_invert,
                              const Variant& dataB) {
   mpz_t gmpDataA, gmpDataB, gmpReturn;
 
-  if (!variantToGMPData(cs_GMP_FUNC_NAME_GMP_INVERT, gmpDataA, dataA)) {
+  if (!variantToGMPData("gmp_invert", gmpDataA, dataA)) {
     return false;
   }
-  if (!variantToGMPData(cs_GMP_FUNC_NAME_GMP_INVERT, gmpDataB, dataB)) {
+  if (!variantToGMPData("gmp_invert", gmpDataB, dataB)) {
     mpz_clear(gmpDataA);
     return false;
   }
@@ -719,10 +709,10 @@ static Variant HHVM_FUNCTION(gmp_jacobi,
                              const Variant& dataB) {
   mpz_t gmpDataA, gmpDataB;
 
-  if (!variantToGMPData(cs_GMP_FUNC_NAME_GMP_JACOBI, gmpDataA, dataA)) {
+  if (!variantToGMPData("gmp_jacobi", gmpDataA, dataA)) {
     return false;
   }
-  if (!variantToGMPData(cs_GMP_FUNC_NAME_GMP_JACOBI, gmpDataB, dataB)) {
+  if (!variantToGMPData("gmp_jacobi", gmpDataB, dataB)) {
     mpz_clear(gmpDataA);
     return false;
   }
@@ -741,10 +731,10 @@ static Variant HHVM_FUNCTION(gmp_legendre,
                              const Variant& dataB) {
   mpz_t gmpDataA, gmpDataB;
 
-  if (!variantToGMPData(cs_GMP_FUNC_NAME_GMP_LEGENDRE, gmpDataA, dataA)) {
+  if (!variantToGMPData("gmp_legendre", gmpDataA, dataA)) {
     return false;
   }
-  if (!variantToGMPData(cs_GMP_FUNC_NAME_GMP_LEGENDRE, gmpDataB, dataB)) {
+  if (!variantToGMPData("gmp_legendre", gmpDataB, dataB)) {
     mpz_clear(gmpDataA);
     return false;
   }
@@ -763,17 +753,16 @@ static Variant HHVM_FUNCTION(gmp_mod,
                              const Variant& dataB) {
   mpz_t gmpDataA, gmpDataB, gmpReturn;
 
-  if (!variantToGMPData(cs_GMP_FUNC_NAME_GMP_MOD, gmpDataA, dataA)) {
+  if (!variantToGMPData("gmp_mod", gmpDataA, dataA)) {
     return false;
   }
-  if (!variantToGMPData(cs_GMP_FUNC_NAME_GMP_MOD, gmpDataB, dataB)) {
+  if (!variantToGMPData("gmp_mod", gmpDataB, dataB)) {
     mpz_clear(gmpDataA);
     return false;
   }
 
   if (mpz_sgn(gmpDataB) == 0) {
-    raise_warning(cs_GMP_INVALID_VALUE_MUST_NOT_BE_ZERO,
-                  cs_GMP_FUNC_NAME_GMP_MOD);
+    raise_warning(cs_GMP_INVALID_VALUE_MUST_NOT_BE_ZERO, "gmp_mod");
     mpz_clear(gmpDataA);
     mpz_clear(gmpDataB);
     return false;
@@ -799,10 +788,10 @@ static Variant HHVM_FUNCTION(gmp_mul,
                              const Variant& dataB) {
   mpz_t gmpDataA, gmpDataB, gmpReturn;
 
-  if (!variantToGMPData(cs_GMP_FUNC_NAME_GMP_MUL, gmpDataA, dataA)) {
+  if (!variantToGMPData("gmp_mul", gmpDataA, dataA)) {
     return false;
   }
-  if (!variantToGMPData(cs_GMP_FUNC_NAME_GMP_MUL, gmpDataB, dataB)) {
+  if (!variantToGMPData("gmp_mul", gmpDataB, dataB)) {
     mpz_clear(gmpDataA);
     return false;
   }
@@ -824,7 +813,7 @@ static Variant HHVM_FUNCTION(gmp_neg,
                              const Variant& data) {
   mpz_t gmpReturn, gmpData;
 
-  if (!variantToGMPData(cs_GMP_FUNC_NAME_GMP_NEG, gmpData, data)) {
+  if (!variantToGMPData("gmp_neg", gmpData, data)) {
     return false;
   }
 
@@ -844,7 +833,7 @@ static Variant HHVM_FUNCTION(gmp_nextprime,
                              const Variant& data) {
   mpz_t gmpReturn, gmpData;
 
-  if (!variantToGMPData(cs_GMP_FUNC_NAME_GMP_NEXTPRIME, gmpData, data)) {
+  if (!variantToGMPData("gmp_nextprime", gmpData, data)) {
     return false;
   }
 
@@ -865,10 +854,10 @@ static Variant HHVM_FUNCTION(gmp_or,
                              const Variant& dataB) {
   mpz_t gmpDataA, gmpDataB, gmpReturn;
 
-  if (!variantToGMPData(cs_GMP_FUNC_NAME_GMP_OR, gmpDataA, dataA)) {
+  if (!variantToGMPData("gmp_or", gmpDataA, dataA)) {
     return false;
   }
-  if (!variantToGMPData(cs_GMP_FUNC_NAME_GMP_OR, gmpDataB, dataB)) {
+  if (!variantToGMPData("gmp_or", gmpDataB, dataB)) {
     mpz_clear(gmpDataA);
     return false;
   }
@@ -890,7 +879,7 @@ static bool HHVM_FUNCTION(gmp_perfect_square,
                           const Variant& data) {
   mpz_t gmpData;
 
-  if (!variantToGMPData(cs_GMP_FUNC_NAME_GMP_PERFECT_SQUARE, gmpData, data)) {
+  if (!variantToGMPData("gmp_perfect_square", gmpData, data)) {
     return false;
   }
 
@@ -906,7 +895,7 @@ static Variant HHVM_FUNCTION(gmp_popcount,
                              const Variant& data) {
   mpz_t gmpData;
 
-  if (!variantToGMPData(cs_GMP_FUNC_NAME_GMP_POPCOUNT, gmpData, data)) {
+  if (!variantToGMPData("gmp_popcount", gmpData, data)) {
     return false;
   }
 
@@ -923,12 +912,11 @@ static Variant HHVM_FUNCTION(gmp_pow,
   mpz_t gmpReturn, gmpData;
 
   if (exp < 0) {
-    raise_warning(cs_GMP_INVALID_EXPONENT_MUST_BE_POSITIVE,
-                  cs_GMP_FUNC_NAME_GMP_POW);
+    raise_warning(cs_GMP_INVALID_EXPONENT_MUST_BE_POSITIVE, "gmp_pow");
     return false;
   }
 
-  if (!variantToGMPData(cs_GMP_FUNC_NAME_GMP_POW, gmpData, data)) {
+  if (!variantToGMPData("gmp_pow", gmpData, data)) {
     return false;
   }
 
@@ -950,18 +938,17 @@ static Variant HHVM_FUNCTION(gmp_powm,
                              const Variant& dataC) {
   mpz_t gmpDataA, gmpDataB, gmpDataC, gmpReturn;
 
-  if (!variantToGMPData(cs_GMP_FUNC_NAME_GMP_POWM, gmpDataB, dataB)) {
+  if (!variantToGMPData("gmp_powm", gmpDataB, dataB)) {
     return false;
   }
   if (mpz_sgn(gmpDataB) < 0) {
     mpz_clear(gmpDataB);
 
-    raise_warning(cs_GMP_INVALID_EXPONENT_MUST_BE_POSITIVE,
-                  cs_GMP_FUNC_NAME_GMP_POWM);
+    raise_warning(cs_GMP_INVALID_EXPONENT_MUST_BE_POSITIVE, "gmp_powm");
     return false;
   }
 
-  if (!variantToGMPData(cs_GMP_FUNC_NAME_GMP_POWM, gmpDataC, dataC)) {
+  if (!variantToGMPData("gmp_powm", gmpDataC, dataC)) {
     mpz_clear(gmpDataB);
     return false;
   }
@@ -969,12 +956,11 @@ static Variant HHVM_FUNCTION(gmp_powm,
     mpz_clear(gmpDataB);
     mpz_clear(gmpDataC);
 
-    raise_warning(cs_GMP_INVALID_MODULUS_MUST_NOT_BE_ZERO,
-                  cs_GMP_FUNC_NAME_GMP_POWM);
+    raise_warning(cs_GMP_INVALID_MODULUS_MUST_NOT_BE_ZERO, "gmp_powm");
     return false;
   }
 
-  if (!variantToGMPData(cs_GMP_FUNC_NAME_GMP_POWM, gmpDataA, dataA)) {
+  if (!variantToGMPData("gmp_powm", gmpDataA, dataA)) {
     mpz_clear(gmpDataC);
     mpz_clear(gmpDataB);
     return false;
@@ -999,7 +985,7 @@ static Variant HHVM_FUNCTION(gmp_prob_prime,
                              int64_t reps = 10) {
   mpz_t gmpData;
 
-  if (!variantToGMPData(cs_GMP_FUNC_NAME_GMP_PROB_PRIME, gmpData, data)) {
+  if (!variantToGMPData("gmp_prob_prime", gmpData, data)) {
     return false;
   }
 
@@ -1013,7 +999,7 @@ static Variant HHVM_FUNCTION(gmp_prob_prime,
 
 static void HHVM_FUNCTION(gmp_random,
                           int64_t limiter) {
-  throw_not_implemented(cs_GMP_FUNC_NAME_GMP_RANDOM);
+  throw_not_implemented("gmp_random");
 }
 
 
@@ -1021,20 +1007,18 @@ static Variant HHVM_FUNCTION(gmp_root,
                              const Variant& data,
                              int64_t root) {
   if (root < 1) {
-    raise_warning(cs_GMP_INVALID_ROOT_MUST_BE_POSITIVE,
-                  cs_GMP_FUNC_NAME_GMP_ROOT);
+    raise_warning(cs_GMP_INVALID_ROOT_MUST_BE_POSITIVE, "gmp_root");
     return false;
   }
 
   mpz_t gmpData, gmpReturn;
-  if (!variantToGMPData(cs_GMP_FUNC_NAME_GMP_ROOT, gmpData, data)) {
+  if (!variantToGMPData("gmp_root", gmpData, data)) {
     return false;
   }
 
   if (root % 2 == 0 && mpz_sgn(gmpData) < 0) {
     mpz_clear(gmpData);
-    raise_warning(cs_GMP_ERROR_EVEN_ROOT_NEGATIVE_NUMBER,
-                  cs_GMP_FUNC_NAME_GMP_ROOT);
+    raise_warning(cs_GMP_ERROR_EVEN_ROOT_NEGATIVE_NUMBER, "gmp_root");
     return false;
   }
 
@@ -1054,20 +1038,18 @@ static Variant HHVM_FUNCTION(gmp_rootrem,
                              const Variant& data,
                              int64_t root) {
   if (root < 1) {
-    raise_warning(cs_GMP_INVALID_ROOT_MUST_BE_POSITIVE,
-                  cs_GMP_FUNC_NAME_GMP_ROOTREM);
+    raise_warning(cs_GMP_INVALID_ROOT_MUST_BE_POSITIVE, "gmp_rootrem");
     return false;
   }
 
   mpz_t gmpData, gmpReturn0, gmpReturn1;
-  if (!variantToGMPData(cs_GMP_FUNC_NAME_GMP_ROOTREM, gmpData, data)) {
+  if (!variantToGMPData("gmp_rootrem", gmpData, data)) {
     return false;
   }
 
   if (root % 2 == 0 && mpz_sgn(gmpData) < 0) {
     mpz_clear(gmpData);
-    raise_warning(cs_GMP_ERROR_EVEN_ROOT_NEGATIVE_NUMBER,
-                  cs_GMP_FUNC_NAME_GMP_ROOTREM);
+    raise_warning(cs_GMP_ERROR_EVEN_ROOT_NEGATIVE_NUMBER, "gmp_rootrem");
     return false;
   }
 
@@ -1092,13 +1074,12 @@ static Variant HHVM_FUNCTION(gmp_scan0,
                              const Variant& data,
                              int64_t start) {
   if (start < 0) {
-    raise_warning(cs_GMP_INVALID_STARTING_INDEX_IS_NEGATIVE,
-                  cs_GMP_FUNC_NAME_GMP_SCAN0);
+    raise_warning(cs_GMP_INVALID_STARTING_INDEX_IS_NEGATIVE, "gmp_scan0");
     return false;
   }
 
   mpz_t gmpData;
-  if (!variantToGMPData(cs_GMP_FUNC_NAME_GMP_SCAN0, gmpData, data)) {
+  if (!variantToGMPData("gmp_scan0", gmpData, data)) {
     return false;
   }
 
@@ -1114,13 +1095,12 @@ static Variant HHVM_FUNCTION(gmp_scan1,
                              const Variant& data,
                              int64_t start) {
   if (start < 0) {
-    raise_warning(cs_GMP_INVALID_STARTING_INDEX_IS_NEGATIVE,
-                  cs_GMP_FUNC_NAME_GMP_SCAN1);
+    raise_warning(cs_GMP_INVALID_STARTING_INDEX_IS_NEGATIVE, "gmp_scan1");
     return false;
   }
 
   mpz_t gmpData;
-  if (!variantToGMPData(cs_GMP_FUNC_NAME_GMP_SCAN1, gmpData, data)) {
+  if (!variantToGMPData("gmp_scan1", gmpData, data)) {
     return false;
   }
 
@@ -1137,20 +1117,19 @@ static void HHVM_FUNCTION(gmp_setbit,
                           int64_t index,
                           bool bitOn /* = true*/) {
   if (index < 0) {
-    raise_warning(cs_GMP_INVALID_INDEX_IS_NEGATIVE,
-                  cs_GMP_FUNC_NAME_GMP_SETBIT);
+    raise_warning(cs_GMP_INVALID_INDEX_IS_NEGATIVE, "gmp_setbit");
     return;
   }
 
   Object gmpObject = data.toObject();
   if (!gmpObject.instanceof(s_GMP_GMP)) {
-    raise_warning(cs_GMP_INVALID_OBJECT, cs_GMP_FUNC_NAME_GMP_SETBIT);
+    raise_warning(cs_GMP_INVALID_OBJECT, "gmp_setbit");
     return;
   }
 
   auto gmpData = Native::data<GMPData>(gmpObject);
   if (!gmpData) {
-    raise_warning(cs_GMP_INVALID_OBJECT, cs_GMP_FUNC_NAME_GMP_SETBIT);
+    raise_warning(cs_GMP_INVALID_OBJECT, "gmp_setbit");
     return;
   }
 
@@ -1166,7 +1145,7 @@ static Variant HHVM_FUNCTION(gmp_sign,
                              const Variant& data) {
   mpz_t gmpData;
 
-  if (!variantToGMPData(cs_GMP_FUNC_NAME_GMP_SIGN, gmpData, data)) {
+  if (!variantToGMPData("gmp_sign", gmpData, data)) {
     return false;
   }
 
@@ -1182,13 +1161,12 @@ static Variant HHVM_FUNCTION(gmp_sqrt,
                              const Variant& data) {
   mpz_t gmpReturn, gmpData;
 
-  if (!variantToGMPData(cs_GMP_FUNC_NAME_GMP_SQRT, gmpData, data)) {
+  if (!variantToGMPData("gmp_sqrt", gmpData, data)) {
     return false;
   }
 
   if (mpz_sgn(gmpData) < 0) {
-    raise_warning(cs_GMP_INVALID_NUMBER_IS_NEGATIVE,
-                  cs_GMP_FUNC_NAME_GMP_SQRT);
+    raise_warning(cs_GMP_INVALID_NUMBER_IS_NEGATIVE, "gmp_sqrt");
     return false;
   }
 
@@ -1208,13 +1186,12 @@ static Variant HHVM_FUNCTION(gmp_sqrtrem,
                              const Variant& data) {
   mpz_t gmpData, gmpSquareRoot, gmpRemainder;
 
-  if (!variantToGMPData(cs_GMP_FUNC_NAME_GMP_SQRTREM, gmpData, data)) {
+  if (!variantToGMPData("gmp_sqrtrem", gmpData, data)) {
     return false;
   }
 
   if (mpz_sgn(gmpData) < 0) {
-    raise_warning(cs_GMP_INVALID_NUMBER_IS_NEGATIVE,
-                  cs_GMP_FUNC_NAME_GMP_SQRTREM);
+    raise_warning(cs_GMP_INVALID_NUMBER_IS_NEGATIVE, "gmp_sqrtrem");
     return false;
   }
 
@@ -1241,14 +1218,11 @@ static Variant HHVM_FUNCTION(gmp_strval,
   mpz_t gmpData;
 
   if (base < GMP_MIN_BASE || (base > -2 && base < 2) || base > GMP_MAX_BASE) {
-    raise_warning(cs_GMP_INVALID_BASE_VALUE,
-                  cs_GMP_FUNC_NAME_GMP_STRVAL,
-                  base,
-                  GMP_MAX_BASE);
+    raise_warning(cs_GMP_INVALID_BASE_VALUE, "gmp_strval", base, GMP_MAX_BASE);
     return false;
   }
 
-  if (!variantToGMPData(cs_GMP_FUNC_NAME_GMP_STRVAL, gmpData, data)) {
+  if (!variantToGMPData("gmp_strval", gmpData, data)) {
     return false;
   }
 
@@ -1265,10 +1239,10 @@ static Variant HHVM_FUNCTION(gmp_sub,
                              const Variant& dataB) {
   mpz_t gmpDataA, gmpDataB, gmpReturn;
 
-  if (!variantToGMPData(cs_GMP_FUNC_NAME_GMP_SUB, gmpDataA, dataA)) {
+  if (!variantToGMPData("gmp_sub", gmpDataA, dataA)) {
     return false;
   }
-  if (!variantToGMPData(cs_GMP_FUNC_NAME_GMP_SUB, gmpDataB, dataB)) {
+  if (!variantToGMPData("gmp_sub", gmpDataB, dataB)) {
     mpz_clear(gmpDataA);
     return false;
   }
@@ -1292,12 +1266,11 @@ static bool HHVM_FUNCTION(gmp_testbit,
   mpz_t gmpData;
 
   if (index < 0) {
-    raise_warning(cs_GMP_INVALID_INDEX_IS_NEGATIVE,
-                  cs_GMP_FUNC_NAME_GMP_TESTBIT);
+    raise_warning(cs_GMP_INVALID_INDEX_IS_NEGATIVE, "gmp_testbit");
     return false;
   }
 
-  if (!variantToGMPData(cs_GMP_FUNC_NAME_GMP_TESTBIT, gmpData, data)) {
+  if (!variantToGMPData("gmp_testbit", gmpData, data)) {
     return false;
   }
 
@@ -1314,10 +1287,10 @@ static Variant HHVM_FUNCTION(gmp_xor,
                              const Variant& dataB) {
   mpz_t gmpDataA, gmpDataB, gmpReturn;
 
-  if (!variantToGMPData(cs_GMP_FUNC_NAME_GMP_XOR, gmpDataA, dataA)) {
+  if (!variantToGMPData("gmp_xor", gmpDataA, dataA)) {
     return false;
   }
-  if (!variantToGMPData(cs_GMP_FUNC_NAME_GMP_XOR, gmpDataB, dataB)) {
+  if (!variantToGMPData("gmp_xor", gmpDataB, dataB)) {
     mpz_clear(gmpDataA);
     return false;
   }
@@ -1367,14 +1340,14 @@ static void HHVM_METHOD(GMP, unserialize,
   // First value is a string (our number value)
   Variant num = unserializer.unserialize();
   if (!num.isString() || !setMpzFromString(gmpData, num.toString(), 10)) {
-    throw Exception(cs_GMP_COULD_NOT_UNSERIALIZE_NUMBER);
+    throw Exception("Could not unserialize number");
   }
 
   // Second value is an array of object properties optionally set by the user
   Variant props = unserializer.unserialize();
   if (!props.isArray()) {
     mpz_clear(gmpData);
-    throw Exception(cs_GMP_COULD_NOT_UNSERIALIZE_PROPERTIES);
+    throw Exception("Could not unserialize properties");
   }
 
   auto gmpObjectData = Native::data<GMPData>(this_);

--- a/hphp/runtime/ext/gmp/ext_gmp.h
+++ b/hphp/runtime/ext/gmp/ext_gmp.h
@@ -82,60 +82,10 @@ const char* const cs_GMP_INVALID_ROOT_MUST_BE_POSITIVE =
   "%s(): The root must be positive";
 const char* const cs_GMP_INVALID_ROUNDING_MODE =
   "%s(): Invalid rounding mode";
-const char* const cs_GMP_FAILED_TO_ALTER_BIT =
-  "%s(): Failed to alter bit";
 const char* const cs_GMP_INVALID_STARTING_INDEX_IS_NEGATIVE =
   "%s(): Starting index must be greater than or equal to zero";
-const char* const cs_GMP_COULD_NOT_UNSERIALIZE_NUMBER =
-  "Could not unserialize number";
-const char* const cs_GMP_COULD_NOT_UNSERIALIZE_PROPERTIES =
-  "Could not unserialize properties";
 const char* const cs_GMP_ERROR_EVEN_ROOT_NEGATIVE_NUMBER =
   "%s(): Can't take even root of negative number";
-
-// Function name strings
-const char* const cs_GMP_FUNC_NAME_GMP_ABS            = "gmp_abs";
-const char* const cs_GMP_FUNC_NAME_GMP_ADD            = "gmp_add";
-const char* const cs_GMP_FUNC_NAME_GMP_AND            = "gmp_add";
-const char* const cs_GMP_FUNC_NAME_GMP_CLRBIT         = "gmp_clrbit";
-const char* const cs_GMP_FUNC_NAME_GMP_CMP            = "gmp_cmp";
-const char* const cs_GMP_FUNC_NAME_GMP_COM            = "gmp_com";
-const char* const cs_GMP_FUNC_NAME_GMP_DIV_Q          = "gmp_div_q";
-const char* const cs_GMP_FUNC_NAME_GMP_DIV_R          = "gmp_div_r";
-const char* const cs_GMP_FUNC_NAME_GMP_DIV_QR         = "gmp_div_qr";
-const char* const cs_GMP_FUNC_NAME_GMP_DIVEXACT       = "gmp_divexact";
-const char* const cs_GMP_FUNC_NAME_GMP_FACT           = "gmp_fact";
-const char* const cs_GMP_FUNC_NAME_GMP_GCD            = "gmp_gcd";
-const char* const cs_GMP_FUNC_NAME_GMP_GCDEXCT        = "gmp_gcdexct";
-const char* const cs_GMP_FUNC_NAME_GMP_HAMDIST        = "gmp_hamdist";
-const char* const cs_GMP_FUNC_NAME_GMP_INIT           = "gmp_init";
-const char* const cs_GMP_FUNC_NAME_GMP_INTVAL         = "gmp_intval";
-const char* const cs_GMP_FUNC_NAME_GMP_INVERT         = "gmp_invert";
-const char* const cs_GMP_FUNC_NAME_GMP_JACOBI         = "gmp_jacobi";
-const char* const cs_GMP_FUNC_NAME_GMP_LEGENDRE       = "gmp_legendre";
-const char* const cs_GMP_FUNC_NAME_GMP_MOD            = "gmp_mod";
-const char* const cs_GMP_FUNC_NAME_GMP_MUL            = "gmp_mul";
-const char* const cs_GMP_FUNC_NAME_GMP_NEG            = "gmp_neg";
-const char* const cs_GMP_FUNC_NAME_GMP_NEXTPRIME      = "gmp_nextprime";
-const char* const cs_GMP_FUNC_NAME_GMP_OR             = "gmp_or";
-const char* const cs_GMP_FUNC_NAME_GMP_PERFECT_SQUARE = "gmp_perfect_square";
-const char* const cs_GMP_FUNC_NAME_GMP_POPCOUNT       = "gmp_popcount";
-const char* const cs_GMP_FUNC_NAME_GMP_POW            = "gmp_pow";
-const char* const cs_GMP_FUNC_NAME_GMP_POWM           = "gmp_powm";
-const char* const cs_GMP_FUNC_NAME_GMP_PROB_PRIME     = "gmp_prob_prime";
-const char* const cs_GMP_FUNC_NAME_GMP_RANDOM         = "gmp_random";
-const char* const cs_GMP_FUNC_NAME_GMP_ROOT           = "gmp_root";
-const char* const cs_GMP_FUNC_NAME_GMP_ROOTREM        = "gmp_rootrem";
-const char* const cs_GMP_FUNC_NAME_GMP_SCAN0          = "gmp_scan0";
-const char* const cs_GMP_FUNC_NAME_GMP_SCAN1          = "gmp_scan1";
-const char* const cs_GMP_FUNC_NAME_GMP_SETBIT         = "gmp_setbit";
-const char* const cs_GMP_FUNC_NAME_GMP_SIGN           = "gmp_sign";
-const char* const cs_GMP_FUNC_NAME_GMP_SQRT           = "gmp_sqrt";
-const char* const cs_GMP_FUNC_NAME_GMP_SQRTREM        = "gmp_sqrtrem";
-const char* const cs_GMP_FUNC_NAME_GMP_STRVAL         = "gmp_strval";
-const char* const cs_GMP_FUNC_NAME_GMP_SUB            = "gmp_sub";
-const char* const cs_GMP_FUNC_NAME_GMP_TESTBIT        = "gmp_testbit";
-const char* const cs_GMP_FUNC_NAME_GMP_XOR            = "gmp_xor";
 
 ///////////////////////////////////////////////////////////////////////////////
 // classes


### PR DESCRIPTION
They are pointlessly long, and, although they may be there in an attempt to prevent typos, even include a typo, as `cs_GMP_FUNC_NAME_GMP_AND` is set to `"gmp_add"`.
This just does a regex replace of `cs_GMP_FUNC_NAME_([A-Z_]+)` with `"\L\1"`. (For those who don't know, `\L` converts to lowercase in, at the very least, the regex engine used by Notepad++)

This also inlines a couple of the errors that are used in only one place, and are shorter than the name of the global.
This also removes `cs_GMP_FAILED_TO_ALTER_BIT`, which was never referenced anywhere.