### PR TITLE
Fix bug in Fsnotify on Windows.

### DIFF
--- a/hphp/hack/src/fsnotify_win/fsnotify_stubs.c
+++ b/hphp/hack/src/fsnotify_win/fsnotify_stubs.c
@@ -101,16 +101,12 @@ static value parse_events(struct events *events)
     wpath = caml_copy_string(events->wpath);
     for (;;) {
       // Forcefully null terminate the filename.
-      wchar_t oldMem = fileInfo->FileName[fileInfo->FileNameLength];
-      fileInfo->FileName[fileInfo->FileNameLength] = L'\0';
       char* modifiedFilename =
-        (char*)malloc(sizeof(wchar_t) * fileInfo->FileNameLength);
-      size_t filenameLen =
-        wcstombs_s(NULL, modifiedFilename,
-                   sizeof(wchar_t) * fileInfo->FileNameLength,
-                   fileInfo->FileName,
-                   (sizeof(wchar_t) * fileInfo->FileNameLength) - 1);
-      fileInfo->FileName[fileInfo->FileNameLength] = oldMem;
+        (char*)malloc(fileInfo->FileNameLength);
+      wcstombs_s(NULL, modifiedFilename,
+                 fileInfo->FileNameLength,
+                 fileInfo->FileName,
+                 fileInfo->FileNameLength / sizeof (wchar_t));
       // Allocate 'Fsnotify.events'
       ev = caml_alloc_tuple(2);
       Store_field(ev, 0, caml_copy_string(modifiedFilename));


### PR DESCRIPTION
An inversion about `filenameLength` unit (number of 'wide' character
vs. number of bytes) was leading to file name corruption.  This small
patch avoid this.