### PR TITLE
Add missing hhi definitions for the SessionHandler

### DIFF
--- a/hphp/hack/hhi/stdlib/builtins_session.hhi
+++ b/hphp/hack/hhi/stdlib/builtins_session.hhi
@@ -1,4 +1,4 @@
-<?hh     /* -*- php -*- */
+<?hh // decl /* -*- php -*- */
 /**
  * Copyright (c) 2014, Facebook, Inc.
  * All rights reserved.
@@ -8,6 +8,10 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  *
  */
+const int PHP_SESSION_DISABLED = 0;
+const int PHP_SESSION_NONE = 1;
+const int PHP_SESSION_ACTIVE = 2;
+
 function session_set_cookie_params($lifetime, $path = null, $domain = null, $secure = null, $httponly = null) { }
 function session_get_cookie_params() { }
 function session_name($newname = null) { }
@@ -26,5 +30,27 @@ function session_unset() { }
 function session_commit() { }
 function session_write_close() { }
 function session_register($var_names, ...) { }
-function session_unregister($varname) { }
+function session_register_shutdown() { }
 function session_is_registered($varname) { }
+function session_status() { }
+
+interface SessionHandlerInterface {
+
+  abstract public function close(): bool;
+  abstract public function destroy($session_id): bool;
+  abstract public function gc($maxlifetime): bool;
+  abstract public function open($save_path , $name): bool;
+  abstract public function read($session_id): string;
+  abstract public function write($session_id, $session_data): bool;
+}
+
+class SessionHandler implements SessionHandlerInterface {
+
+  public function close(): bool;
+  public function create_sid (): string;
+  public function destroy($session_id): bool;
+  public function gc($maxlifetime): bool;
+  public function open($save_path , $name): bool;
+  public function read($session_id): string;
+  public function write($session_id, $session_data): bool;
+}


### PR DESCRIPTION
Issue #6566 
Add missing hhi definitions for the SessionHandler and
SessionHandlerInterface. Remove deprecated and not implemented
session_unregister(). Using of session_unregister caused "Fatal error: Call to undefined function session_unregister() in ... on line ..."

Implementations of session_abort(), session_reset() are still missing.