### PR TITLE
Fix a few typos all over the code

### DIFF
--- a/hphp/doc/options.compiler
+++ b/hphp/doc/options.compiler
@@ -207,7 +207,7 @@ a more precise partitioning.
 
 = GCCOptimization
 
-Default is disabled. This option allows to selectively decrease the compiler
+Default is disabled. This option allows one to selectively decrease the compiler
 optimization level for long functions. It is specified as:
 
   GCCOptimization {

--- a/hphp/hack/src/hh_matcher/hh_match_test_utils.ml
+++ b/hphp/hack/src/hh_matcher/hh_match_test_utils.ml
@@ -17,7 +17,7 @@ let pretty_print_test_output
     "%s\n\n=====\n\n"
     (Ast_code_extent.lexing_slice_to_string range code)
 
-(* This allows to fake having multiple files in one file. This
+(* This allows one to fake having multiple files in one file. This
  * is used only in unit test files.
  * This is necessary because we have to test matching a pattern
  * against a source file or patching a source file with a

--- a/hphp/hack/src/hh_single_type_check.ml
+++ b/hphp/hack/src/hh_single_type_check.ml
@@ -263,7 +263,7 @@ let suggest_and_print nenv fn { FileInfo.funs; classes; typedefs; consts; _ } =
       List.iter ~f: (ServerConvert.print_patch fn) l
     end
 
-(* This allows to fake having multiple files in one file. This
+(* This allows one to fake having multiple files in one file. This
  * is used only in unit test files.
  * Indeed, there are some features that require mutliple files to be tested.
  * For example, newtype has a different meaning depending on the file.

--- a/hphp/hack/test/typecheck/shape_remove_key5.php
+++ b/hphp/hack/test/typecheck/shape_remove_key5.php
@@ -1,7 +1,7 @@
 <?hh //strict
 
 /**
- * removeKey allows one to unset any key, but it still must be statically
+ * removeKey allows unsetting any key, but it still must be statically
  * known
  */
 type s = shape(

--- a/hphp/hack/test/typecheck/shape_remove_key5.php
+++ b/hphp/hack/test/typecheck/shape_remove_key5.php
@@ -1,7 +1,7 @@
 <?hh //strict
 
 /**
- * removeKey allows to unset any key, but it still must be statically
+ * removeKey allows one to unset any key, but it still must be statically
  * known
  */
 type s = shape(

--- a/hphp/hack/test/typecheck/shape_remove_key6.php
+++ b/hphp/hack/test/typecheck/shape_remove_key6.php
@@ -1,7 +1,7 @@
 <?hh
 
 /**
- * Removing optional field allows one to omit it even when fields are only
+ * Removing optional field allows omitting it even when fields are only
  * partially known.
  */
 type s = shape('x' => int);

--- a/hphp/hack/test/typecheck/shape_remove_key6.php
+++ b/hphp/hack/test/typecheck/shape_remove_key6.php
@@ -1,7 +1,7 @@
 <?hh
 
 /**
- * Removing optional field allows to omit it even when fields are only
+ * Removing optional field allows one to omit it even when fields are only
  * partially known.
  */
 type s = shape('x' => int);

--- a/hphp/neo/neo_hdf.c
+++ b/hphp/neo/neo_hdf.c
@@ -1190,7 +1190,7 @@ static NEOERR* parse_attr(char **str, HDF_ATTR **attr)
     if (*s == '\0' || k_l == 0)
     {
       _dealloc_hdf_attr(attr);
-      return nerr_raise(NERR_PARSE, "Misformed attribute specification: %s", *str);
+      return nerr_raise(NERR_PARSE, "Malformed attribute specification: %s", *str);
     }
     SKIPWS(s);
     if (*s == '=')
@@ -1245,7 +1245,7 @@ static NEOERR* parse_attr(char **str, HDF_ATTR **attr)
 	{
 	  _dealloc_hdf_attr(attr);
 	  string_clear(&buf);
-	  return nerr_raise(NERR_PARSE, "Misformed attribute specification: %s", *str);
+	  return nerr_raise(NERR_PARSE, "Malformed attribute specification: %s", *str);
 	}
 	s++;
 	v = buf.buf;
@@ -1258,7 +1258,7 @@ static NEOERR* parse_attr(char **str, HDF_ATTR **attr)
 	if (*s == '\0')
 	{
 	  _dealloc_hdf_attr(attr);
-	  return nerr_raise(NERR_PARSE, "Misformed attribute specification: %s", *str);
+	  return nerr_raise(NERR_PARSE, "Malformed attribute specification: %s", *str);
 	}
         v_l = s-v;
       }
@@ -1299,7 +1299,7 @@ static NEOERR* parse_attr(char **str, HDF_ATTR **attr)
   if (*s == '\0')
   {
     _dealloc_hdf_attr(attr);
-    return nerr_raise(NERR_PARSE, "Misformed attribute specification: %s", *str);
+    return nerr_raise(NERR_PARSE, "Malformed attribute specification: %s", *str);
   }
   *str = s+1;
   return STATUS_OK;

--- a/hphp/runtime/base/zend-pack.h
+++ b/hphp/runtime/base/zend-pack.h
@@ -67,7 +67,7 @@ private:
   // Mapping of byte from char (8bit) to int32 for machine endian
   int64_t byte_map[1];
 
-  // Mappings of bytes from int (machine dependant) to int for machine endian
+  // Mappings of bytes from int (machine dependent) to int for machine endian
   int64_t int_map[sizeof(int)];
 
   // Mappings of bytes from shorts (16bit) for all endian environments

--- a/hphp/runtime/ext/icu/ext_icu_rsrc_bundle.cpp
+++ b/hphp/runtime/ext/icu/ext_icu_rsrc_bundle.cpp
@@ -18,7 +18,7 @@ static Variant extractValue(ResourceBundle* data,
                             const icu::ResourceBundle& bundle) {
 #define EXTRACT_ERR(type) \
   if (U_FAILURE(error)) { \
-    data->setError(error, "Failed to retreive " #type " value"); \
+    data->setError(error, "Failed to retrieve " #type " value"); \
     return init_null(); \
   }
 

--- a/hphp/runtime/ext/std/ext_std_options.php
+++ b/hphp/runtime/ext/std/ext_std_options.php
@@ -372,8 +372,8 @@ function phpversion(string $extension = ""): mixed;
  * modify ANY environment variable!  The safe_mode_protected_env_vars
  * directive contains a comma-delimited list of environment variables, that
  * the end user won't be able to change using putenv(). These variables will
- * be protected even if safe_mode_allowed_env_vars is set to allow one to
- * change them.
+ * be protected even if safe_mode_allowed_env_vars is set to allow changing
+ * them.
  */
 <<__Native>>
 function putenv(string $setting): bool;

--- a/hphp/runtime/ext/std/ext_std_options.php
+++ b/hphp/runtime/ext/std/ext_std_options.php
@@ -372,8 +372,8 @@ function phpversion(string $extension = ""): mixed;
  * modify ANY environment variable!  The safe_mode_protected_env_vars
  * directive contains a comma-delimited list of environment variables, that
  * the end user won't be able to change using putenv(). These variables will
- * be protected even if safe_mode_allowed_env_vars is set to allow to change
- * them.
+ * be protected even if safe_mode_allowed_env_vars is set to allow one to
+ * change them.
  */
 <<__Native>>
 function putenv(string $setting): bool;

--- a/hphp/runtime/ext/stream/ext_stream.php
+++ b/hphp/runtime/ext/stream/ext_stream.php
@@ -242,7 +242,7 @@ function stream_wrapper_restore(string $protocol): bool;
 /**
  * Allows you to disable an already defined stream wrapper. Once the wrapper
  *   has been disabled you may override it with a user-defined wrapper using
- *   stream_wrapper_register() or reenable it later on with
+ *   stream_wrapper_register() or re-enable it later on with
  *   stream_wrapper_restore().
  *
  * @param string $protocol
@@ -517,7 +517,7 @@ function stream_socket_client(string $remote_socket,
  *   - STREAM_CRYPTO_SSLv23_SERVER
  *   - STREAM_CRYPTO_TLS_SERVER
  *
- *   When enabling crypto in HHVM, this parameter is requried as the
+ *   When enabling crypto in HHVM, this parameter is required as the
  *   session_stream parameter is not supported.
  *
  *   Under PHP, if omitted, the crypto_type context option on the stream's SSL

--- a/hphp/system/php/spl/iterators/ArrayIterator.php
+++ b/hphp/system/php/spl/iterators/ArrayIterator.php
@@ -4,7 +4,7 @@
 /**
  * ( excerpt from http://php.net/manual/en/class.arrayiterator.php )
  *
- * This iterator allows to unset and modify values and keys while
+ * This iterator allows one to unset and modify values and keys while
  * iterating over Arrays and Objects.
  *
  * When you want to iterate over the same array multiple times you need to

--- a/hphp/system/php/spl/iterators/ArrayIterator.php
+++ b/hphp/system/php/spl/iterators/ArrayIterator.php
@@ -4,7 +4,7 @@
 /**
  * ( excerpt from http://php.net/manual/en/class.arrayiterator.php )
  *
- * This iterator allows one to unset and modify values and keys while
+ * This iterator allows unsetting and modifying values and keys while
  * iterating over Arrays and Objects.
  *
  * When you want to iterate over the same array multiple times you need to

--- a/hphp/system/php/spl/iterators/RecursiveArrayIterator.php
+++ b/hphp/system/php/spl/iterators/RecursiveArrayIterator.php
@@ -5,7 +5,7 @@
  * ( excerpt from http://php.net/manual/en/class.recursivearrayiterator.php
  * )
  *
- * This iterator allows to unset and modify values and keys while
+ * This iterator allows one to unset and modify values and keys while
  * iterating over Arrays and Objects in the same way as the ArrayIterator.
  * Additionally it is possible to iterate over the current iterator entry.
  *

--- a/hphp/system/php/spl/iterators/RecursiveArrayIterator.php
+++ b/hphp/system/php/spl/iterators/RecursiveArrayIterator.php
@@ -5,7 +5,7 @@
  * ( excerpt from http://php.net/manual/en/class.recursivearrayiterator.php
  * )
  *
- * This iterator allows one to unset and modify values and keys while
+ * This iterator allows unsetting and modifying values and keys while
  * iterating over Arrays and Objects in the same way as the ArrayIterator.
  * Additionally it is possible to iterate over the current iterator entry.
  *


### PR DESCRIPTION
These are pretty trivial. Debian's lint tool (lintian) warns about those
in its verbose mode, and since we saw them when packaging for Debian, we
thought of fixing them and forwarding them upstream.