### PR TITLE
Fix make-parser.sh's compatibility with Bison 3

### DIFF
--- a/hphp/parser/make-parser.sh
+++ b/hphp/parser/make-parser.sh
@@ -79,6 +79,14 @@ rm "${TMP}"
 $SED -i "s#${TMP}#${INFILE}#g" "${OUTFILE5}"
 $SED -i "s#${TMP}#${INFILE}#g" "${OUTFILE7}"
 
+$SED -i \
+     -e 's@int Compiler[57]parse.*@@' \
+     -e 's@int Compiler[57]debug.*@@' \
+     -e "s@#ifndef YY_COMPILER[57]_.*@@g" \
+     -e "s@# define YY_COMPILER[57]_.*@@g" \
+     -e "s@#endif /\* !YY_COMPILER[57]_.*@@g" \
+     "${OUTHEADER5}" "${OUTHEADER7}"
+
 cmp "${OUTHEADER5}" "${OUTHEADER7}"
 if [ $? -ne 0 ] ; then
   echo "PHP5 and PHP7 headers differ, must be the same tokens"
@@ -92,8 +100,6 @@ cp "${OUTHEADER5}" "${OUTHEADER}"
 $SED -i -r \
      -e 's/(T_\w+)\s+=\s+([0-9]+)\s*,?/YYTOKEN(\2, \1)/g' \
      -e "s/\s+enum\s+yytokentype/#ifndef YYTOKEN_MAP\n#define YYTOKEN_MAP enum yytokentype\n#define YYTOKEN(num, name) name = num,\n#endif\n   YYTOKEN_MAP/" \
-     -e "s/#ifndef YY_COMPILER_.*//g" \
-     -e "s/# define YY_COMPILER_.*//g" \
     "${OUTHEADER}"
 
 # remove the include guard's #endif (-e doesn't work for this)
@@ -109,11 +115,6 @@ grep "^\s\+YYTOKEN(" "${OUTHEADER}" | head -n 1 | \
     $SED -r -e 's/\s+YYTOKEN.([0-9]+).*/#ifndef YYTOKEN_MIN\n#define YYTOKEN_MIN \1\n#endif/' >> "${OUTHEADER}"
 grep "^\s\+YYTOKEN(" "${OUTHEADER}" | tail -n 1 | \
     $SED -r -e 's/\s+YYTOKEN.([0-9]+).*/#ifndef YYTOKEN_MAX\n#define YYTOKEN_MAX \1\n#endif/' >> "${OUTHEADER}"
-
-# Why this is in the .hpp in bison 3 is anybody's guess...
-$SED -i \
-     -e 's@int Compilerparse.*@@' \
-     "${OUTHEADER}"
 
 # Renaming some stuff in the cpp file
 $SED -i \


### PR DESCRIPTION
Since the PHP 5/7 parser split, make-parser.sh was broken (again) with
Bison 3. Bison 3 adds several extra statements based on the filename,
and creates extra churn that creates a diff between PHP 5 & 7 headers,
which subsequently raises a make-parser.sh error ("PHP5 and PHP7 headers
differ, must be the same tokens").

Some of this extra churn we were handling already, but below that check
in the script. Move those sed statements up and apply them in both
$OUTHEADER5 and $OUTHEADER7 and add a couple of more.

This eliminated the diff between the two and makes make-parser.sh work
again. Tested with Bison 3.0.4.

Fixes #6376.