### PR TITLE
Expose HHVM_API_VERSION to hhvm --version

### DIFF
--- a/hphp/runtime/base/program-functions.cpp
+++ b/hphp/runtime/base/program-functions.cpp
@@ -1444,6 +1444,7 @@ static int execute_program_impl(int argc, char** argv) {
     cout << " (" << (debug ? "dbg" : "rel") << ")\n";
     cout << "Compiler: " << kCompilerId << "\n";
     cout << "Repo schema: " << kRepoSchemaId << "\n";
+    cout << "Extension API: " << std::to_string(HHVM_API_VERSION) << "\n";
     return 0;
   }
   if (vm.count("modules")) {


### PR DESCRIPTION
Expose the constant HHVM_API_VERSION to hhvm --version. We've been using
that in the Debian packages to create Debian metadata for HHVM extension
packages that may rely on the API/ABI.