### PR TITLE
Redo eb4a0cd without its transitive dependencies

### DIFF
--- a/hphp/hack/src/server/serverMain.mli
+++ b/hphp/hack/src/server/serverMain.mli
@@ -10,3 +10,5 @@
 
 val daemon_main: ServerArgs.options ->
   Unix.file_descr -> Unix.file_descr -> unit
+
+val run_once: ServerArgs.options -> 'a

--- a/hphp/hack/src/server/serverMonitor.ml
+++ b/hphp/hack/src/server/serverMonitor.ml
@@ -275,7 +275,9 @@ let monitor_daemon_main (options: ServerArgs.options) typechecker_entry =
   let www_root = (ServerArgs.root options) in
   ignore @@ Sys_utils.setsid ();
   let lock_file = ServerFiles.server_monitor_liveness_lock www_root in
-  if (Lock.grab lock_file) then
+  if ServerArgs.check_mode options then
+    ServerMain.run_once options
+  else if (Lock.grab lock_file) then
     Hh_logger.log "Starting monitor run loop"
   else
     (Hh_logger.log "Monitor daemon already running. Killing";


### PR DESCRIPTION
check mode runs typechecker in main process instead of daemon