### PR TITLE
Correctly enclose regex when collecting statistics.

### DIFF
--- a/hphp/runtime/ext/mysql/mysql_common.cpp
+++ b/hphp/runtime/ext/mysql/mysql_common.cpp
@@ -1415,7 +1415,7 @@ MySQLQueryReturn php_mysql_do_query(const String& query, const Variant& link_id,
       if (RuntimeOption::EnableStats && RuntimeOption::EnableSQLTableStats) {
         MySqlStats::Record(verb, rconn->m_xaction_count, table);
         if (verb == "update") {
-          preg_match("([^\\s,]+)\\s*=\\s*([^\\s,]+)[\\+\\-]",
+          preg_match("/([^\\s,]+)\\s*=\\s*([^\\s,]+)[\\+\\-]/",
                      q, &matches);
           marray = matches.toArray();
           size = marray.size();


### PR DESCRIPTION
The current code lacks delimiters and will print an error when an UPDATE
query is ran and EnableSQLTableStats is enabled.