### PR TITLE
Pass LC_ALL=C to sort, when generating REPO_SCHEMA

### DIFF
--- a/hphp/util/generate-buildinfo.sh
+++ b/hphp/util/generate-buildinfo.sh
@@ -43,7 +43,7 @@ else
     else
         scm=""
         root=$DIR/../../
-        find_files='find hphp \( -type f -o -type l \) \! -iregex ".*\(~\|#.*\|\.swp\|/tags\|/.bash_history\|/out\)" | sort'
+        find_files='find hphp \( -type f -o -type l \) \! -iregex ".*\(~\|#.*\|\.swp\|/tags\|/.bash_history\|/out\)" | LC_ALL=C sort'
     fi
 fi
 


### PR DESCRIPTION
sort's output varies depending on the locale (LC_COLLATE in particular).
Since we rely on a stable output to generate REPO_SCHEMA and we don't
care in particular for what that sorting is (as we just end up SHA1-ing
all of it), call sort with LC_ALL=C.