### PR TITLE
Remove build-time from the Hack build-id

### DIFF
--- a/hphp/hack/src/utils/build_id.ml
+++ b/hphp/hack/src/utils/build_id.ml
@@ -9,9 +9,6 @@
  *)
 
 external get_build_revision : unit -> string = "hh_get_build_revision"
-external get_build_time : unit -> int = "hh_get_build_time"
-external get_build_time_string : unit -> string = "hh_get_build_time_string"
 
 let build_revision = get_build_revision ()
-let build_id_ohai = build_revision ^ " " ^ get_build_time_string ()
-let build_time = get_build_time ()
+let build_id_ohai = build_revision

--- a/hphp/hack/src/utils/get_build_id.c
+++ b/hphp/hack/src/utils/get_build_id.c
@@ -16,19 +16,16 @@
 #include <assert.h>
 #include <string.h>
 
-#include <time.h>
-
 extern const char* const BuildInfo_kRevision;
-const char* const build_time = __DATE__ " " __TIME__;
 
 /**
- * Export the constants provided by Facebook's build system to ocaml-land, since
+ * Export the constant provided by Facebook's build system to ocaml-land, since
  * their FFI only allows you to call functions, not reference variables. Doing
  * it this way makes sense for Facebook internally since our build system has
- * machinery for providing these two constants automatically (and no machinery
- * for doing codegen in a consistent way to build an ocaml file with them) but
- * is very roundabout for external users who have to have CMake codegen these
- * constants anyways. Sorry about that.
+ * machinery for providing this constant automatically (and no machinery for
+ * doing codegen in a consistent way to build an ocaml file with them) but is
+ * very roundabout for external users who have to have CMake codegen this
+ * constant anyways. Sorry about that.
  */
 value hh_get_build_revision(void) {
   CAMLparam0();
@@ -39,26 +36,4 @@ value hh_get_build_revision(void) {
 
   memcpy(String_val(result), BuildInfo_kRevision, len);
   CAMLreturn(result);
-}
-
-value hh_get_build_time_string(void) {
-  CAMLparam0();
-  CAMLlocal1(result);
-
-  size_t len = strlen(build_time);
-  result = caml_alloc_string(len);
-
-  memcpy(String_val(result), build_time, len);
-  CAMLreturn(result);
-}
-
-value hh_get_build_time(void) {
-#ifdef _WIN32
-  return Val_long(0);
-#else
-  struct tm tm;
-  char* success = strptime(build_time, "%b %d %Y %H:%M:%S", &tm);
-  assert(success != NULL && "Failed to parse build time");
-  return Val_long(mktime(&tm));
-#endif
 }


### PR DESCRIPTION
Embedding the build-time (__DATE__/__TIME__) into the Hack build-id
provides little value, especially given that the rest of the HHVM
doesn't include a similar ID.

Furthermore, embedding it actually has a downside: it renders the build
by definition unreproducible. More information about reproducible builds
and this problem in particular can be found at:
- https://reproducible-builds.org/
- https://reproducible-builds.org/docs/timestamps/