### PR TITLE
Correctly set register arguments on lookupDestructor call

### DIFF
--- a/hphp/runtime/vm/jit/unique-stubs-x64.cpp
+++ b/hphp/runtime/vm/jit/unique-stubs-x64.cpp
@@ -168,7 +168,8 @@ static TCA emitDecRefHelper(CodeBlock& cb, PhysReg tv, PhysReg type,
       PhysRegSaver prs{v, live};
 
       // The refcount is exactly 1; release the value.
-      v << callm{lookupDestructor(v, type)};
+      // Avoid 'this' pointer overwriting by reserving it as an argument.
+      v << callm{lookupDestructor(v, type), arg_regs(1)};
 
       // Between where %rsp is now and the saved RIP of the call into the
       // freeLocalsHelpers stub, we have all the live regs we pushed, plus the


### PR DESCRIPTION
The 'this' pointer can be overwritten by the unique stub
emitFreeLocalsHelpers if registers need to be allocated.

There was no issue on X64 as no additional registers are needed on that
context at the moment but it was a dorment bug. If any other
architecture port is done by using X64 as base, this change is also
helpful.