### PR TITLE
php7 scalar type mode can't handle null as string in phpinfo call

### DIFF
--- a/hphp/runtime/ext/std/ext_std_options.php
+++ b/hphp/runtime/ext/std/ext_std_options.php
@@ -340,7 +340,7 @@ function phpinfo(int $what = 0): bool {
   \__SystemLib\phpinfo_tr('uname', php_uname());
   echo '</table>';
 
-  \__SystemLib\phpinfo_table('INI', ini_get_all(null, false));
+  \__SystemLib\phpinfo_table('INI', ini_get_all('', false));
 
   if (function_exists('getallheaders')) {
     \__SystemLib\phpinfo_table('Headers', getallheaders());


### PR DESCRIPTION
close: #6722