### PR TITLE
Force hhvm_client_mode test avoid default php.ini

### DIFF
--- a/hphp/test/quick/hhvm_client_mode.php
+++ b/hphp/test/quick/hhvm_client_mode.php
@@ -2,6 +2,6 @@
 
 $hhvm = PHP_BINARY;
 $file = '/../../a/b/test.php';
-$cmd = "$hhvm $file";
+$cmd = "$hhvm --no-config $file";
 $out = exec($cmd);
 echo $out;


### PR DESCRIPTION
It is bad for test quick/hhvm_client_mode.php to relie on local config,
since it can contain, for instance, a ~E_NOTICE flag, that produces no
output to be match against the .expect file, failing the test.