### PR TITLE
Hack: build the HHI tarball reproducibly

### DIFF
--- a/hphp/hack/hhi/Makefile
+++ b/hphp/hack/hhi/Makefile
@@ -1,3 +1,9 @@
 .PHONY: hhi.tar.gz
 hhi.tar.gz:
-	tar czf ../bin/hhi.tar.gz .
+	# equivalent to tar -czf, but deterministic output
+	find . -print0 | LC_ALL=C sort -z | tar --null \
+		--mtime='1970-01-01 00:00Z' \
+		--owner=root --group=root \
+		--numeric-owner \
+		-T - --no-recursion \
+		-c | gzip -n > ../bin/hhi.tar.gz


### PR DESCRIPTION
The HHI tarball is currently built with "tar -czf" and then embedded
into hh_server as an ELF section. Unfortunately, neither tar nor gzip
are deterministic in their output by default and result into variance
being added into the build on every recompilation.

Modify the tar generation to:
- Embeded files with a static mtime, in UTC (epoch 0)
- Use stable file ordering, even across different locales
- Use stable (and numeric) owner/group (0/0) for all files
- Not embed a timestamp in the final gzip archive's metadata section

https://reproducible-builds.org/docs/archives/ explains some of those
methods in length.