### PR TITLE
Fixing #6749 - filesize("") returns size of system root

### DIFF
--- a/hphp/hack/hhi/stdlib/builtins_file.hhi
+++ b/hphp/hack/hhi/stdlib/builtins_file.hhi
@@ -98,7 +98,7 @@ function tempnam($dir, $prefix);
 function tmpfile();
 function fileperms($filename);
 function fileinode($filename);
-function filesize($filename);
+function filesize(string $filename);
 function fileowner($filename);
 function filegroup($filename);
 function fileatime($filename);

--- a/hphp/runtime/ext/std/ext_std_file.cpp
+++ b/hphp/runtime/ext/std/ext_std_file.cpp
@@ -911,6 +911,9 @@ Variant HHVM_FUNCTION(fileinode,
 Variant HHVM_FUNCTION(filesize,
                       const String& filename) {
   CHECK_PATH(filename, 1);
+  if (filename.empty()) {
+    return false;
+  }
   if (StaticContentCache::TheFileCache) {
     int64_t size =
       StaticContentCache::TheFileCache->fileSize(filename.data(),


### PR DESCRIPTION
I could have tried to fix statSyscall(), but then I'd risk breaking all the other code that uses it.