### PR TITLE
Do not use Logger in mallctlHelper().

### DIFF
--- a/hphp/util/alloc.h
+++ b/hphp/util/alloc.h
@@ -282,7 +282,9 @@ int mallctlHelper(const char *cmd, T* out, T* in, bool errOk) {
   if (err != 0) {
     std::string errStr =
       folly::format("mallctl {}: {} ({})", cmd, strerror(err), err).str();
-    Logger::Warning(errStr);
+    if (!errOk) {
+      fprintf(stderr, "%s\n", errStr.c_str());
+    }
     always_assert(errOk || err == 0);
   }
   return err;

--- a/hphp/util/alloc.h
+++ b/hphp/util/alloc.h
@@ -280,9 +280,12 @@ int mallctlHelper(const char *cmd, T* out, T* in, bool errOk) {
   int err = ENOENT;
 #endif
   if (err != 0) {
-    std::string errStr =
-      folly::format("mallctl {}: {} ({})", cmd, strerror(err), err).str();
     if (!errOk) {
+      std::string errStr =
+        folly::format("mallctl {}: {} ({})", cmd, strerror(err), err).str();
+      // Do not use Logger here because JEMallocInitializer() calls this
+      // function and JEMallocInitializer has the highest constructor priority.
+      // The static variables in Logger are not initialized yet.
       fprintf(stderr, "%s\n", errStr.c_str());
     }
     always_assert(errOk || err == 0);


### PR DESCRIPTION
JEMallocInitializer() has the highest static constructor priority and calls
mallctlHelper(). The variables in Logger are not initialized yet and cause
crash.