### PR TITLE
Add -gsplit-dwarf support to CMake build system

### DIFF
--- a/CMake/HPHPCompiler.cmake
+++ b/CMake/HPHPCompiler.cmake
@@ -182,18 +182,24 @@ if (${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang" OR ${CMAKE_CXX_COMPILER_ID} STREQU
     endif()
   endif()
 
+  if (ENABLE_SPLIT_DWARF)
+    set(GDB_SUBOPTION "split-dwarf")
+  else()
+    set(GDB_SUBOPTION "")
+  endif()
+
   # No optimizations for debug builds.
   # -Og enables some optimizations, but makes debugging harder by optimizing
   # away some functions and locals. -O0 is more debuggable.
   # -O0-ggdb was reputed to cause gdb to crash (github #4450)
-  set(CMAKE_C_FLAGS_DEBUG            "-O0 -g")
-  set(CMAKE_CXX_FLAGS_DEBUG          "-O0 -g")
+  set(CMAKE_C_FLAGS_DEBUG            "-O0 -g${GDB_SUBOPTION}")
+  set(CMAKE_CXX_FLAGS_DEBUG          "-O0 -g${GDB_SUBOPTION}")
   set(CMAKE_C_FLAGS_MINSIZEREL       "-Os -DNDEBUG")
   set(CMAKE_CXX_FLAGS_MINSIZEREL     "-Os -DNDEBUG")
   set(CMAKE_C_FLAGS_RELEASE          "-O3 -DNDEBUG")
   set(CMAKE_CXX_FLAGS_RELEASE        "-O3 -DNDEBUG")
-  set(CMAKE_C_FLAGS_RELWITHDEBINFO   "-O2 -g -DNDEBUG")
-  set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O2 -g -DNDEBUG")
+  set(CMAKE_C_FLAGS_RELWITHDEBINFO   "-O2 -g${GDB_SUBOPTION} -DNDEBUG")
+  set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O2 -g${GDB_SUBOPTION} -DNDEBUG")
   set(CMAKE_C_FLAGS                  "${CMAKE_C_FLAGS} -W -Werror=implicit-function-declaration -Wno-missing-field-initializers")
 
   foreach(opt ${DISABLED_NAMED_WARNINGS})

--- a/CMake/HPHPCompiler.cmake
+++ b/CMake/HPHPCompiler.cmake
@@ -52,6 +52,9 @@ if (${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang" OR ${CMAKE_CXX_COMPILER_ID} STREQU
   # Options to pass for release mode to the C++ compiler
   set(RELEASE_CXX_OPTIONS)
 
+  # Suboption of -g in debug mode
+  set(GDB_SUBOPTION)
+
   # Enable GCC/LLVM stack-smashing protection
   if(ENABLE_SSP)
     list(APPEND GENERAL_OPTIONS
@@ -180,12 +183,10 @@ if (${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang" OR ${CMAKE_CXX_COMPILER_ID} STREQU
     if(STATIC_CXX_LIB)
       set(CMAKE_EXE_LINKER_FLAGS "-static-libgcc -static-libstdc++")
     endif()
-  endif()
 
-  if (ENABLE_SPLIT_DWARF)
-    set(GDB_SUBOPTION "split-dwarf")
-  else()
-    set(GDB_SUBOPTION "")
+    if (ENABLE_SPLIT_DWARF)
+      set(GDB_SUBOPTION "split-dwarf")
+    endif()
   endif()
 
   # No optimizations for debug builds.

--- a/CMake/HPHPSetup.cmake
+++ b/CMake/HPHPSetup.cmake
@@ -1,5 +1,7 @@
 include(Options)
 
+set_property(GLOBAL PROPERTY DEBUG_CONFIGURATIONS Debug RelWithDebInfo)
+
 # Do this until cmake has a define for ARMv8
 INCLUDE(CheckCXXSourceCompiles)
 CHECK_CXX_SOURCE_COMPILES("

--- a/CMake/Options.cmake
+++ b/CMake/Options.cmake
@@ -34,6 +34,8 @@ option(ENABLE_ASYNC_MYSQL "Build the async_mysql extension" ON)
 option(ENABLE_MCROUTER "Build the mcrouter library and extension" ON)
 option(ENABLE_PROXYGEN_SERVER "Build the Proxygen HTTP server" ON)
 
+option(ENABLE_SPLIT_DWARF "Reduce linker memory usage by putting debugging information into .dwo files" OFF)
+
 IF (NOT DEFAULT_CONFIG_DIR)
   set(DEFAULT_CONFIG_DIR "/etc/hhvm/" CACHE STRING
     "Default directory to find php.ini")

--- a/hphp/hhvm/CMakeLists.txt
+++ b/hphp/hhvm/CMakeLists.txt
@@ -29,6 +29,14 @@ if (GOLD_FOUND AND ENABLE_LD_GOLD)
 endif()
 hphp_link(hhvm)
 
+if (ENABLE_SPLIT_DWARF)
+  if (NOT GOLD_FOUND)
+    message(FATAL_ERROR "ENABLE_SPLIT_DWARF was specified but the gold linker was not found")
+  endif()
+  message(STATUS "Enabled split DWARF files")
+  target_link_libraries(hhvm debug "-Wl,--gdb-index")
+endif()
+
 # cygwin has an issue with linking to crypt and intl
 # this is the only way the redirection stuff works
 if(CYGWIN)


### PR DESCRIPTION
Linking hhvm was causing an OOM on my 8GB laptop unless I closed all
open applications. So it's time for -gsplit-dwarf, a.k.a. Debug
Fission, which avoids the link-time overhead of debug symbols by
creating a .dwo file at compile time, which is then ignored by the
linker. This reduces both time and memory usage of the linker
substantially. This requires GCC 4.7+.

A future extension would be to package the .dwo files into a .dwp file
and install it. This should be optional, since packaging forgoes most of
the link time improvement, copying gigabytes of debug symbols. For
development, it's most efficient to just leave the .dwo files in the
build tree.