### PR TITLE
Check pthread calls to prevent segfaults, such as /proc not mounted

### DIFF
--- a/hphp/hhvm/process-init.cpp
+++ b/hphp/hhvm/process-init.cpp
@@ -88,7 +88,8 @@ void ProcessInit() {
 
   if (slib.empty()) {
     // Die a horrible death.
-    Logger::Error("Unable to find/load systemlib.php");
+    Logger::Error("Unable to find/load systemlib.php, check /proc is mounted"
+                  " or export HHVM_SYSTEMLIB to your ENV");
     _exit(1);
   }
 

--- a/hphp/runtime/base/program-functions.cpp
+++ b/hphp/runtime/base/program-functions.cpp
@@ -1990,16 +1990,19 @@ void hphp_process_init() {
 // Linux+GNU extension
 #if defined(_GNU_SOURCE) && (defined(__linux__) || defined(__CYGWIN__))
   if (pthread_getattr_np(pthread_self(), &attr) != 0 ) {
-    raise_fatal_error("pthread_getattr_np failed while checking stack limits");
+    Logger::Error("pthread_getattr_np failed before checking stack limits");
+    _exit(1);
   }
 #else
   if (pthread_attr_init(&attr) != 0 ) {
-    raise_fatal_error("pthread_attr_init failed while checking stack limits");
+    Logger::Error("pthread_attr_init failed before checking stack limits");
+    _exit(1);
   }
 #endif
   init_stack_limits(&attr);
   if (pthread_attr_destroy(&attr) != 0 ) {
-    raise_fatal_error("pthread_attr_destroy failed while checking stack limits");
+    Logger::Error("pthread_attr_destroy failed after checking stack limits");
+    _exit(1);
   } 
   BootStats::mark("pthread_init");
 

--- a/hphp/runtime/base/program-functions.cpp
+++ b/hphp/runtime/base/program-functions.cpp
@@ -1989,12 +1989,18 @@ void hphp_process_init() {
   pthread_attr_t attr;
 // Linux+GNU extension
 #if defined(_GNU_SOURCE) && (defined(__linux__) || defined(__CYGWIN__))
-  pthread_getattr_np(pthread_self(), &attr);
+  if (pthread_getattr_np(pthread_self(), &attr) != 0 ) {
+    raise_fatal_error("pthread_getattr_np failed while checking stack limits");
+  }
 #else
-  pthread_attr_init(&attr);
+  if (pthread_attr_init(&attr) != 0 ) {
+    raise_fatal_error("pthread_attr_init failed while checking stack limits");
+  }
 #endif
   init_stack_limits(&attr);
-  pthread_attr_destroy(&attr);
+  if (pthread_attr_destroy(&attr) != 0 ) {
+    raise_fatal_error("pthread_attr_destroy failed while checking stack limits");
+  } 
   BootStats::mark("pthread_init");
 
   Process::InitProcessStatics();


### PR DESCRIPTION
Closes #6341 

-Check that the pthread calls while checking the stack limits return successful (!= 0) or raise a fatal error.  In this example because /proc is not mounted in a chroot.
-Also added some suggested resolution when unable to find/load systemlib.php as by default hhvm uses readlink /proc/self/exe to help set slib.
-I haven't added any new test cases, but I'm open to suggestions if needed.

BEFORE (chroot without /proc):
./php -r 'echo "hello";'
Core dumped: Segmentation fault
Stack trace in /tmp/stacktrace.20394.log
Segmentation fault

AFTER (chroot without /proc):
./php -r 'echo "hello";'
Uncaught exception: pthread_getattr_np failed while checking stack limits

AFTER (outside chroot with /proc):
./php -r 'echo "hello";'
hello