### PR TITLE
Fix DatePeriod::constuctor arguments

### DIFF
--- a/hphp/hack/hhi/stdlib/builtins_datetime.hhi
+++ b/hphp/hack/hhi/stdlib/builtins_datetime.hhi
@@ -196,7 +196,7 @@ class DatePeriod implements Iterator<DateTime> {
 
   public function __construct(
     /* DateTimeInterface */ $start, // date string converts
-    ?DateInterval $interval = null,
+    DateInterval $interval,
     /* ?DateTimeInterface */ $end = null, // date string converts
     int $options = 0,
   );

--- a/hphp/system/php/date/dateperiod.php
+++ b/hphp/system/php/date/dateperiod.php
@@ -37,7 +37,7 @@ class DatePeriod implements Iterator {
       throw new Exception(
         "DatePeriod::__construct(): This constructor accepts either " .
         "(DateTimeInterface, DateInterval, int) OR (DateTimeInterface, ".
-        "DateInterval, DateTime)"
+        "DateInterval, DateTime) as arguments."
       );
     }
 

--- a/hphp/system/php/date/dateperiod.php
+++ b/hphp/system/php/date/dateperiod.php
@@ -15,7 +15,7 @@ class DatePeriod implements Iterator {
 
   public function __construct(
     DateTimeInterface $start,
-    DateInterval $interval = null,
+    DateInterval $interval,
     mixed $end = null,
     int $options = null) {
 
@@ -31,8 +31,14 @@ class DatePeriod implements Iterator {
         $end_date->add($interval);
       }
       $this->end = $end_date;
-    } else {
+    } else if ($end instanceof DateTimeInterface) {
       $this->end = $end;
+    } else {
+      throw new Exception(
+        "DatePeriod::__construct(): This constructor accepts either " .
+        "(DateTimeInterface, DateInterval, int) OR (DateTimeInterface, ".
+        "DateInterval, DateTime)"
+      );
     }
 
     $this->options = $options;

--- a/hphp/system/php/date/dateperiod.php
+++ b/hphp/system/php/date/dateperiod.php
@@ -32,7 +32,7 @@ class DatePeriod implements Iterator {
       }
       $this->end = $end_date;
     } else if ($end instanceof DateTimeInterface) {
-      $this->end = $end;
+      $this->end = clone $end;
     } else {
       throw new Exception(
         "DatePeriod::__construct(): This constructor accepts either " .

--- a/hphp/test/slow/ext_datetime/dateperiod_ctor_wrongarg.php
+++ b/hphp/test/slow/ext_datetime/dateperiod_ctor_wrongarg.php
@@ -1,0 +1,7 @@
+<?php
+
+try {
+  new DatePeriod(new DateTime("now"));
+} catch (Exception $e) {
+  var_dump($e->getMessage());
+}

--- a/hphp/test/slow/ext_datetime/dateperiod_ctor_wrongarg.php
+++ b/hphp/test/slow/ext_datetime/dateperiod_ctor_wrongarg.php
@@ -1,7 +1,7 @@
 <?php
 
 try {
-  new DatePeriod(new DateTime("now"));
+  new DatePeriod(new DateTime("now"), new DateInterval("P2Y4DT6H8M"), "wrong");
 } catch (Exception $e) {
   var_dump($e->getMessage());
 }

--- a/hphp/test/slow/ext_datetime/dateperiod_ctor_wrongarg.php.expect
+++ b/hphp/test/slow/ext_datetime/dateperiod_ctor_wrongarg.php.expect
@@ -1,1 +1,1 @@
-string(170) "DatePeriod::__construct(): This constructor accepts either (DateTimeInterface, DateInterval, int) OR (DateTimeInterface, DateInterval, DateTime) as arguments."
+string(158) "DatePeriod::__construct(): This constructor accepts either (DateTimeInterface, DateInterval, int) OR (DateTimeInterface, DateInterval, DateTime) as arguments."

--- a/hphp/test/slow/ext_datetime/dateperiod_ctor_wrongarg.php.expect
+++ b/hphp/test/slow/ext_datetime/dateperiod_ctor_wrongarg.php.expect
@@ -1,0 +1,1 @@
+string(170) "DatePeriod::__construct(): This constructor accepts either (DateTimeInterface, DateInterval, int) OR (DateTimeInterface, DateInterval, DateTime) as arguments."


### PR DESCRIPTION
partially... DatePeriod also allows creating from iso string, which we don't
do currently.

However with the current implementation, passing null to the interval
is always wrong, because it tries to clone the object we passed.