### PR TITLE
Imagick blurImage should default channel to CHANNEL_ALL

### DIFF
--- a/hphp/hack/hhi/imagick/Imagick.hhi
+++ b/hphp/hack/hhi/imagick/Imagick.hhi
@@ -501,7 +501,11 @@ class Imagick
   public function appendImages(bool $stack = false): Imagick;
   public function averageImages(): Imagick;
   public function blackThresholdImage($threshold): bool;
-  public function blurImage(float $radius, float $sigma, int $channel): bool;
+  public function blurImage(
+    float $radius,
+    float $sigma,
+    int $channel = \Imagick::CHANNEL_ALL,
+  ): bool;
   public function borderImage($bordercolor, int $width, int $height): bool;
   public function charcoalImage(float $radius, float $sigma): bool;
   public function chopImage(int $width, int $height, int $x, int $y): bool;

--- a/hphp/runtime/ext/imagick/ext_imagick.php
+++ b/hphp/runtime/ext/imagick/ext_imagick.php
@@ -232,7 +232,7 @@ class Imagick implements Countable, Iterator {
   <<__Native>>
   function blurImage(float $radius,
                      float $sigma,
-                     int $channel): bool;
+                     int $channel = Imagick::CHANNEL_ALL): bool;
 
   /**
    * Surrounds the image with a border


### PR DESCRIPTION
To maintain compatibility with the PHP runtime, the channel parameter on blurImage should default to Imagick::CHANNEL_ALL. Example incompatibility: Intervention/image#395