### PR TITLE
Fix ppc64 interpreter mode

### DIFF
--- a/hphp/runtime/vm/jit/mc-generator.cpp
+++ b/hphp/runtime/vm/jit/mc-generator.cpp
@@ -2063,7 +2063,10 @@ MCGenerator::MCGenerator()
 
   s_jitMaturityCounter = ServiceData::createCounter("jit.maturity");
 
+  // Do not initialize JIT stubs for PPC64 - port under development
+#if !defined(__powerpc64__)
   m_ustubs.emitAll(m_code, m_debugInfo);
+#endif
 
   // Write an .eh_frame section that covers the whole TC.
   EHFrameWriter ehfw;


### PR DESCRIPTION
As there are no unique stubs for ppc64, hhvm tries to initialize them
and dies:
Assertion failure: hphp/runtime/vm/jit/align.cpp:34:
HPHP::jit::align(HPHP::CodeBlock&, HPHP::jit::CGMeta*,
HPHP::jit::Alignment, HPHP::jit::AlignContext)::<lambda()>: assertion
`0' failed.