### PR TITLE
Pulled in the support for following instructions from vixl master.

### DIFF
--- a/hphp/vixl/a64/assembler-a64.cc
+++ b/hphp/vixl/a64/assembler-a64.cc
@@ -534,6 +534,17 @@ void Assembler::adr(const Register& rd, Label* label) {
 }
 
 
+void Assembler::adrp(const Register& rd, int imm21) {
+  assert(rd.Is64Bits());
+  Emit(ADRP | ImmPCRelAddress(imm21) | Rd(rd));
+}
+
+
+void Assembler::adrp(const Register& rd, Label* label) {
+  adrp(rd, UpdateAndGetByteOffsetTo(label));
+}
+
+
 void Assembler::add(const Register& rd,
                     const Register& rn,
                     const Operand& operand,
@@ -1124,6 +1135,22 @@ void Assembler::ldr(const FPRegister& ft, double imm) {
 }
 
 
+void Assembler::ldxr(const Register& rt, const MemOperand& src) {
+  assert(src.IsImmediateOffset() && (src.offset() == 0));
+  LoadStoreExclusive op = rt.Is64Bits() ? LDXR_x : LDXR_w;
+  Emit(op | Rs_mask | Rt(rt) | Rt2_mask | RnSP(src.base()));
+}
+
+
+void Assembler::stxr(const Register& rs,
+                     const Register& rt,
+                     const MemOperand& dst) {
+  assert(dst.IsImmediateOffset() && (dst.offset() == 0));
+  LoadStoreExclusive op = rt.Is64Bits() ? STXR_x : STXR_w;
+  Emit(op | Rs(rs) | Rt(rt) | Rt2_mask | RnSP(dst.base()));
+}
+
+
 void Assembler::mov(const Register& rd, const Register& rm) {
   // Moves involving the stack pointer are encoded as add immediate with
   // second operand of zero. Otherwise, orr with first operand zr is
@@ -1267,6 +1294,20 @@ void Assembler::frintn(const FPRegister& fd,
                        const FPRegister& fn) {
   assert(fd.SizeInBits() == fn.SizeInBits());
   FPDataProcessing1Source(fd, fn, FRINTN);
+}
+
+
+void Assembler::frintm(const FPRegister& fd,
+                       const FPRegister& fn) {
+  assert(fd.SizeInBits() == fn.SizeInBits());
+  FPDataProcessing1Source(fd, fn, FRINTM);
+}
+
+
+void Assembler::frintp(const FPRegister& fd,
+                       const FPRegister& fn) {
+  assert(fd.SizeInBits() == fn.SizeInBits());
+  FPDataProcessing1Source(fd, fn, FRINTP);
 }
 
 

--- a/hphp/vixl/a64/assembler-a64.h
+++ b/hphp/vixl/a64/assembler-a64.h
@@ -692,6 +692,12 @@ class Assembler {
   // Calculate the address of a PC offset.
   void adr(const Register& rd, int imm21);
 
+  // Calculate the page address of a label.
+  void adrp(const Register& rd, Label* label);
+
+  // Calculate the page address of a PC offset.
+  void adrp(const Register& rd, int imm21);
+
   // Data Processing instructions.
   // Add.
   void add(const Register& rd,
@@ -1095,6 +1101,12 @@ class Assembler {
   // Load literal to FP register.
   void ldr(const FPRegister& ft, double imm);
 
+  // Load exclusive register.
+  void ldxr(const Register& rt, const MemOperand& src);
+
+  // Store exclusive register.
+  void stxr(const Register& rs, const Register& rt, const MemOperand& dst);
+
   // Move instructions. The default shift of -1 indicates that the move
   // instruction will calculate an appropriate 16-bit immediate and left shift
   // that is equal to the 64-bit immediate argument. If an explicit left shift
@@ -1197,6 +1209,12 @@ class Assembler {
 
   // FP round to integer (nearest with ties to even).
   void frintn(const FPRegister& fd, const FPRegister& fn);
+
+  // FP round to integer (towards -Inf)
+  void frintm(const FPRegister& fd, const FPRegister& fn);
+
+  // FP round to integer (towards +Inf)
+  void frintp(const FPRegister& fd, const FPRegister& fn);
 
   // FP round to integer (towards zero).
   void frintz(const FPRegister& fd, const FPRegister& fn);
@@ -1311,6 +1329,11 @@ class Assembler {
   static Instr Rt2(CPURegister rt2) {
     assert(rt2.code() != kSPRegInternalCode);
     return rt2.code() << Rt2_offset;
+  }
+
+  static Instr Rs(CPURegister rs) {
+    assert(rs.code() != kSPRegInternalCode);
+    return rs.code() << Rs_offset;
   }
 
   // These encoding functions allow the stack pointer to be encoded, and

--- a/hphp/vixl/a64/constants-a64.h
+++ b/hphp/vixl/a64/constants-a64.h
@@ -52,9 +52,9 @@ V_(Rd, 4, 0, Bits)                        /* Destination register.     */      \
 V_(Rn, 9, 5, Bits)                        /* First source register.    */      \
 V_(Rm, 20, 16, Bits)                      /* Second source register.   */      \
 V_(Ra, 14, 10, Bits)                      /* Third source register.    */      \
-V_(Rt, 4, 0, Bits)                        /* Load dest / store source. */      \
-V_(Rt2, 14, 10, Bits)                     /* Load second dest /        */      \
-                                         /* store second source.      */       \
+V_(Rt, 4, 0, Bits)                        /* Load/store register.      */      \
+V_(Rt2, 14, 10, Bits)                     /* Load/store 2nd register   */      \
+V_(Rs, 20, 16, Bits)                      /* Exclusive access status.  */      \
 V_(PrefetchMode, 4, 0, Bits)                                                   \
                                                                                \
 /* Common bits */                                                              \
@@ -738,6 +738,45 @@ enum LoadStoreRegisterOffset {
   #undef LOAD_STORE_REGISTER_OFFSET
 };
 
+// Load/store excusively
+enum LoadStoreExclusive {
+  LoadStoreExclusiveFixed = 0x08000000,
+  LoadStoreExclusiveFMask = 0x3F000000,
+  LoadStoreExclusiveMask  = 0xFFE08000,
+  STXRB_w  = LoadStoreExclusiveFixed | 0x00000000,
+  STXRH_w  = LoadStoreExclusiveFixed | 0x40000000,
+  STXR_w   = LoadStoreExclusiveFixed | 0x80000000,
+  STXR_x   = LoadStoreExclusiveFixed | 0xC0000000,
+  LDXRB_w  = LoadStoreExclusiveFixed | 0x00400000,
+  LDXRH_w  = LoadStoreExclusiveFixed | 0x40400000,
+  LDXR_w   = LoadStoreExclusiveFixed | 0x80400000,
+  LDXR_x   = LoadStoreExclusiveFixed | 0xC0400000,
+  STXP_w   = LoadStoreExclusiveFixed | 0x80200000,
+  STXP_x   = LoadStoreExclusiveFixed | 0xC0200000,
+  LDXP_w   = LoadStoreExclusiveFixed | 0x80600000,
+  LDXP_x   = LoadStoreExclusiveFixed | 0xC0600000,
+  STLXRB_w = LoadStoreExclusiveFixed | 0x00008000,
+  STLXRH_w = LoadStoreExclusiveFixed | 0x40008000,
+  STLXR_w  = LoadStoreExclusiveFixed | 0x80008000,
+  STLXR_x  = LoadStoreExclusiveFixed | 0xC0008000,
+  LDAXRB_w = LoadStoreExclusiveFixed | 0x00408000,
+  LDAXRH_w = LoadStoreExclusiveFixed | 0x40408000,
+  LDAXR_w  = LoadStoreExclusiveFixed | 0x80408000,
+  LDAXR_x  = LoadStoreExclusiveFixed | 0xC0408000,
+  STLXP_w  = LoadStoreExclusiveFixed | 0x80208000,
+  STLXP_x  = LoadStoreExclusiveFixed | 0xC0208000,
+  LDAXP_w  = LoadStoreExclusiveFixed | 0x80608000,
+  LDAXP_x  = LoadStoreExclusiveFixed | 0xC0608000,
+  STLRB_w  = LoadStoreExclusiveFixed | 0x00808000,
+  STLRH_w  = LoadStoreExclusiveFixed | 0x40808000,
+  STLR_w   = LoadStoreExclusiveFixed | 0x80808000,
+  STLR_x   = LoadStoreExclusiveFixed | 0xC0808000,
+  LDARB_w  = LoadStoreExclusiveFixed | 0x00C08000,
+  LDARH_w  = LoadStoreExclusiveFixed | 0x40C08000,
+  LDAR_w   = LoadStoreExclusiveFixed | 0x80C08000,
+  LDAR_x   = LoadStoreExclusiveFixed | 0xC0C08000
+};
+
 // Conditional compare.
 enum ConditionalCompareOp {
   ConditionalCompareMask = 0x60000000,
@@ -934,8 +973,10 @@ enum FPDataProcessing1SourceOp {
   FRINTN   = FRINTN_s,
   FRINTP_s = FPDataProcessing1SourceFixed | 0x00048000,
   FRINTP_d = FPDataProcessing1SourceFixed | FP64 | 0x00048000,
+  FRINTP   = FRINTP_s,
   FRINTM_s = FPDataProcessing1SourceFixed | 0x00050000,
   FRINTM_d = FPDataProcessing1SourceFixed | FP64 | 0x00050000,
+  FRINTM   = FRINTM_s,
   FRINTZ_s = FPDataProcessing1SourceFixed | 0x00058000,
   FRINTZ_d = FPDataProcessing1SourceFixed | FP64 | 0x00058000,
   FRINTZ   = FRINTZ_s,

--- a/hphp/vixl/a64/macro-assembler-a64.h
+++ b/hphp/vixl/a64/macro-assembler-a64.h
@@ -288,6 +288,11 @@ class MacroAssembler : public Assembler {
     assert(!rd.IsZero());
     adr(rd, label);
   }
+  void Adrp(const Register& rd, Label* label) {
+    assert(allow_macro_instructions_);
+    assert(!rd.IsZero());
+    adrp(rd, label);
+  }
   void Asr(const Register& rd, const Register& rn, unsigned shift) {
     assert(allow_macro_instructions_);
     assert(!rd.IsZero());


### PR DESCRIPTION
1.  adrp, Address of 4KB page at a PC-relative offset
2.  ldxr, Load register exclusively
3.  stxr, Store register exclusively
4.  frintp, Floating-point round to integral, toward positive infinity
5.  frintm, Floating-point round to integral, toward minus infinity