### PR TITLE
Fixed decode issues in arm64 cases

### DIFF
--- a/hphp/runtime/vm/jit/mc-generator.cpp
+++ b/hphp/runtime/vm/jit/mc-generator.cpp
@@ -62,6 +62,9 @@
 #include "hphp/util/timer.h"
 #include "hphp/util/trace.h"
 
+#include "hphp/vixl/a64/constants-a64.h"
+#include "hphp/vixl/a64/macro-assembler-a64.h"
+
 #include "hphp/runtime/base/arch.h"
 #include "hphp/runtime/base/execution-context.h"
 #include "hphp/runtime/base/rds.h"
@@ -1098,8 +1101,32 @@ MCGenerator::bindJmp(TCA toSmash, SrcKey destSk, ServiceRequest req,
     return tDest;
   }
 
-  x64::DecodedInstruction di(toSmash);
-  if (di.isBranch() && !di.isJmp()) {
+  bool isJcc;
+  switch (arch()) {
+  case Arch::X64:
+    {
+      DecodedInstruction di(toSmash);
+      isJcc = (di.isBranch() && !di.isJmp());
+    }
+    break;
+  case Arch::ARM:
+    {
+      using namespace vixl;
+      struct JccDecoder : public Decoder {
+        void VisitConditionalBranch(Instruction* inst) override {
+          cc = (Condition)inst->ConditionBranch();
+        }
+        folly::Optional<Condition> cc;
+      };
+      JccDecoder decoder;
+      decoder.Decode(Instruction::Cast(toSmash));
+      isJcc = decoder.cc.hasValue();
+    }
+    break;
+  default:
+    always_assert(false);
+  }
+  if (isJcc) {
     auto const target = smashableJccTarget(toSmash);
     assertx(target);
 

--- a/hphp/runtime/vm/jit/service-requests.cpp
+++ b/hphp/runtime/vm/jit/service-requests.cpp
@@ -222,6 +222,11 @@ namespace x64 {
   static constexpr int kLeaVmSpLen = 7;
 }
 
+namespace arm {
+  static constexpr int kMovLen = 16; // FIXME
+  static constexpr int kLeaVmSpLen = 16; // FIXME
+}
+
 size_t stub_size() {
   // The extra args are the request type and the stub address.
   constexpr auto kTotalArgs = kMaxArgs + 2;
@@ -230,7 +235,7 @@ size_t stub_size() {
     case Arch::X64:
       return kTotalArgs * x64::kMovLen + x64::kLeaVmSpLen;
     case Arch::ARM:
-      not_implemented();
+      return kTotalArgs * arm::kMovLen + arm::kLeaVmSpLen;
     case Arch::PPC64:
       not_implemented();
   }
@@ -254,7 +259,24 @@ FPInvOffset extract_spoff(TCA stub) {
       }
 
     case Arch::ARM:
-      not_implemented();
+      {
+        struct Decoder : public vixl::Decoder {
+          void VisitAddSubImmediate(vixl::Instruction* inst) {
+            int64_t immed =
+              inst->ImmAddSub() << ((inst->ShiftAddSub() == 1) ? 12 : 0);
+            switch (inst->Mask(vixl::AddSubOpMask)) {
+              case vixl::ADD: offset = immed; break;
+              case vixl::SUB: offset = -immed; break;
+              default: break;
+            }
+          }
+          folly::Optional<int32_t> offset;
+        };
+        Decoder decoder;
+        decoder.Decode((vixl::Instruction*)(stub));
+        always_assert(decoder.offset && (*decoder.offset % sizeof(Cell)) == 0);
+        return FPInvOffset{-(*decoder.offset / int32_t{sizeof(Cell)})};
+      }
 
     case Arch::PPC64:
       not_implemented();

--- a/hphp/runtime/vm/jit/service-requests.cpp
+++ b/hphp/runtime/vm/jit/service-requests.cpp
@@ -223,8 +223,9 @@ namespace x64 {
 }
 
 namespace arm {
-  static constexpr int kMovLen = 16; // FIXME
-  static constexpr int kLeaVmSpLen = 16; // FIXME
+  // 'lea' results in atmost 4 instructions (see vasm-arm.cpp)
+  static constexpr int kMovLen = 4 * 4;
+  static constexpr int kLeaVmSpLen = 4 * 4;
 }
 
 size_t stub_size() {
@@ -262,6 +263,7 @@ FPInvOffset extract_spoff(TCA stub) {
       {
         struct Decoder : public vixl::Decoder {
           void VisitAddSubImmediate(vixl::Instruction* inst) {
+            // For immediate operands, shift can be '0' or '12'
             int64_t immed =
               inst->ImmAddSub() << ((inst->ShiftAddSub() == 1) ? 12 : 0);
             switch (inst->Mask(vixl::AddSubOpMask)) {
@@ -270,10 +272,29 @@ FPInvOffset extract_spoff(TCA stub) {
               default: break;
             }
           }
+          void VisitMoveWideImmediate(vixl::Instruction* inst) {
+            // For wide moves, shift can be 0, 16, 32 or 64
+            int64_t immed = safe_cast<int64_t>(
+              inst->ImmMoveWide() << (inst->ShiftMoveWide() << 4));
+            switch (inst->Mask(vixl::MoveWideImmediateMask)) {
+              case vixl::MOVN_w:
+              case vixl::MOVN_x:
+                immed = safe_cast<int64_t>(~immed);
+                break;
+            }
+            offset = immed;
+          }
           folly::Optional<int32_t> offset;
         };
         Decoder decoder;
         decoder.Decode((vixl::Instruction*)(stub));
+
+        // 'lea' becomes
+        //   a. 'add dst, base, #imm' or
+        //   b. 'mov r, #imm'
+        //      'add dst, base, r'
+        // FIXME: Return '0' if vasm optimizes 'lea' to 'mov'
+        if (!decoder.offset.hasValue()) return FPInvOffset{0};
         always_assert(decoder.offset && (*decoder.offset % sizeof(Cell)) == 0);
         return FPInvOffset{-(*decoder.offset / int32_t{sizeof(Cell)})};
       }

--- a/hphp/runtime/vm/jit/target-cache.cpp
+++ b/hphp/runtime/vm/jit/target-cache.cpp
@@ -445,7 +445,7 @@ void handlePrimeCacheInit(Entry* mce,
   asm volatile("mov %%rbp, %0" : "=r" (framePtr) ::);
 #elif defined(__aarch64__)
   ActRec* framePtr;
-  asm volatile("str x29, %0" : "=m" (framePtr) ::);
+  asm volatile("mov %0, x29" : "=r" (framePtr) ::);
 #else
   ActRec* framePtr = ar;
   always_assert(false);

--- a/hphp/runtime/vm/jit/target-cache.cpp
+++ b/hphp/runtime/vm/jit/target-cache.cpp
@@ -443,6 +443,9 @@ void handlePrimeCacheInit(Entry* mce,
 #if defined(__x86_64__)
   ActRec* framePtr;
   asm volatile("mov %%rbp, %0" : "=r" (framePtr) ::);
+#elif defined(__aarch64__)
+  ActRec* framePtr;
+  asm volatile("str x29, %0" : "=m" (framePtr) ::);
 #else
   ActRec* framePtr = ar;
   always_assert(false);

--- a/hphp/runtime/vm/jit/translate-region.cpp
+++ b/hphp/runtime/vm/jit/translate-region.cpp
@@ -264,8 +264,7 @@ void emitPredictionsAndPreConditions(irgen::IRGS& irgs,
         irgen::prepareEntry(irgs);
         break;
       case Arch::ARM:
-        // Don't do this for ARM, because it can lead to interpOne on the
-        // first SrcKey in a translation, which isn't allowed.
+        irgen::prepareEntry(irgs);
         break;
       case Arch::PPC64:
         not_implemented();

--- a/hphp/runtime/vm/jit/translate-region.cpp
+++ b/hphp/runtime/vm/jit/translate-region.cpp
@@ -259,17 +259,7 @@ void emitPredictionsAndPreConditions(irgen::IRGS& irgs,
 
     // In the entry block, hhbc-translator gets a chance to emit some code
     // immediately after the initial checks on the first instruction.
-    switch (arch()) {
-      case Arch::X64:
-        irgen::prepareEntry(irgs);
-        break;
-      case Arch::ARM:
-        irgen::prepareEntry(irgs);
-        break;
-      case Arch::PPC64:
-        not_implemented();
-        break;
-    }
+    irgen::prepareEntry(irgs);
   }
 }
 


### PR DESCRIPTION
1.  Added arm64 jcc decoding in mc-generator.cpp
2.  Added arm64 framePtr save in target-cache.cpp
3.  Fixed stub_size and extract_spoff for arm64 in service-requests.cpp
4.  Fixed emitPredictionsAndPreConditions for arm64 in translate-region.cpp