### PR TITLE
Added missing vasm to arm64 routines

### DIFF
--- a/hphp/runtime/vm/jit/reg-alloc.cpp
+++ b/hphp/runtime/vm/jit/reg-alloc.cpp
@@ -65,7 +65,7 @@ bool loadsCell(Opcode op) {
   case ArrayIdx:
     switch (arch()) {
     case Arch::X64: return true;
-    case Arch::ARM: return false;
+    case Arch::ARM: return true;
     case Arch::PPC64: not_implemented(); break;
     }
     not_reached();
@@ -83,7 +83,7 @@ bool loadsCell(Opcode op) {
 bool storesCell(const IRInstruction& inst, uint32_t srcIdx) {
   switch (arch()) {
   case Arch::X64: break;
-  case Arch::ARM: return false;
+  case Arch::ARM: break;
   case Arch::PPC64: not_implemented(); break;
   }
 
@@ -118,7 +118,7 @@ PhysReg forceAlloc(const SSATmp& tmp) {
   auto const forceStkPtrs = [&] {
     switch (arch()) {
     case Arch::X64: return false;
-    case Arch::ARM: return true;
+    case Arch::ARM: return false;
     case Arch::PPC64: not_implemented(); break;
     }
     not_reached();
@@ -220,7 +220,7 @@ void getEffects(const Abi& abi, const Vinstr& i,
       defs = abi.all() - (abi.calleeSaved | rvmfp());
 
       switch (arch()) {
-        case Arch::ARM: defs |= PhysReg(arm::rLinkReg); break;
+        case Arch::ARM: break;
         case Arch::X64: break;
         case Arch::PPC64: not_implemented(); break;
       }
@@ -233,7 +233,7 @@ void getEffects(const Abi& abi, const Vinstr& i,
     case Vinstr::callphp:
       defs = abi.all();
       switch (arch()) {
-        case Arch::ARM: break;
+        case Arch::ARM: defs -= rvmtl(); break;
         case Arch::X64: defs -= rvmtl(); break;
         case Arch::PPC64: not_implemented(); break;
       }
@@ -243,7 +243,7 @@ void getEffects(const Abi& abi, const Vinstr& i,
     case Vinstr::contenter:
       defs = abi.all() - RegSet(rvmfp());
       switch (arch()) {
-        case Arch::ARM: break;
+        case Arch::ARM: defs -= rvmtl(); break;
         case Arch::X64: defs -= rvmtl(); break;
         case Arch::PPC64: not_implemented(); break;
       }
@@ -259,12 +259,6 @@ void getEffects(const Abi& abi, const Vinstr& i,
     case Vinstr::shlq:
     case Vinstr::sarq:
       across = RegSet(reg::rcx);
-      break;
-
-    // arm instrs
-    case Vinstr::hostcall:
-      defs = (abi.all() - abi.calleeSaved) |
-             RegSet(PhysReg(arm::rHostCallReg));
       break;
 
     case Vinstr::vcall:

--- a/hphp/runtime/vm/jit/vasm-arm.cpp
+++ b/hphp/runtime/vm/jit/vasm-arm.cpp
@@ -50,7 +50,22 @@ namespace {
 
 const TCA kEndOfTargetChain = reinterpret_cast<TCA>(0xf00ffeeffaaff11f);
 
+vixl::Register X(Vreg64 r) {
+  PhysReg pr(r.asReg());
+  return x2a(pr);
+}
+
+vixl::Register W(Vreg64 r) {
+  PhysReg pr(r.asReg());
+  return x2a(pr).W();
+}
+
 vixl::Register W(Vreg32 r) {
+  PhysReg pr(r.asReg());
+  return x2a(pr).W();
+}
+
+vixl::Register W(Vreg16 r) {
   PhysReg pr(r.asReg());
   return x2a(pr).W();
 }
@@ -60,19 +75,37 @@ vixl::Register W(Vreg8 r) {
   return x2a(pr).W();
 }
 
-vixl::Register X(Vreg64 r) {
-  PhysReg pr(r.asReg());
-  return x2a(pr);
-}
-
 vixl::FPRegister D(Vreg r) {
   return x2simd(r);
 }
 
-// convert Vptr to MemOperand
-vixl::MemOperand M(Vptr p) {
-  assertx(p.base.isValid() && !p.index.isValid());
-  return X(p.base)[p.disp];
+/*
+ * Convert a Vptr to a MemOperand.
+ *
+ * If the Vptr is too fancy, this will emit instructions.
+ *
+ * FIXME: Following can be optimized as load/store take index+shift
+ *
+ */
+vixl::MemOperand M(vixl::MacroAssembler* a, Vptr p) {
+  auto shift = p.scale == 2 ? 1 :
+               p.scale == 4 ? 2 :
+               p.scale == 8 ? 3 : 0;
+  if (p.base.isValid()) {
+    if (!p.index.isValid()) return X(p.base)[p.disp];
+    a->Lsl(rAsm2, X(p.index), shift);
+    if (!p.disp) return X(p.base)[rAsm2];
+    a->Add(rAsm2, X(p.base), rAsm2 /* Don't set flags */);
+    return rAsm2[p.disp];
+  }
+  // no base, but index,scale,disp can be valid
+  if (p.index.isValid()) {
+    a->Lsl(rAsm2, X(p.index), shift);
+    return rAsm2[p.disp];
+  }
+  // no base, no index.
+  a->Mov(rAsm2, p.disp);
+  return rAsm2[0];
 }
 
 vixl::Condition C(ConditionCode cc) {
@@ -110,68 +143,181 @@ struct Vgen {
   void emit(const copy& i);
   void emit(const copy2& i);
   void emit(const debugtrap& i) { a->Brk(0); }
-  void emit(const hostcall& i) { a->HostCall(i.argc); }
-  void emit(const ldimmq& i);
-  void emit(const ldimml& i);
+  void emit(const fallthru& i) {}
   void emit(const ldimmb& i);
-  void emit(const ldimmqs& i) { not_implemented(); }
+  void emit(const ldimml& i);
+  void emit(const ldimmq& i);
+  void emit(const ldimmqs& i);
+  void emit(const ldimmw& i);
   void emit(const load& i);
   void emit(const store& i);
+  void emit(const mcprep& i);
 
-  // functions
+  // native function abi
+  void emit(const call& i);
+  void emit(const callm& i);
   void emit(const callr& i) { a->Blr(X(i.target)); }
+  void emit(const calls& i);
   void emit(const ret& i) { a->Ret(); }
+
+  // stub function abi
+  void emit(const stublogue& i);
+  void emit(const stubret& i);
+  void emit(const callstub& i);
+  void emit(const callfaststub& i);
+  void emit(const tailcallstub& i);
+
+  // php function abi
+  void emit(const phplogue& i);
+  void emit(const phpret& i);
   void emit(const callphp& i);
+  void emit(const tailcallphp& i);
+  void emit(const callarray& i);
+  void emit(const contenter& i);
+  void emit(const leavetc&) { a->Ret(); }
 
   // exceptions
+  void emit(const landingpad& i) {}
   void emit(const nothrow& i);
   void emit(const syncpoint& i);
   void emit(const unwind& i);
 
+  // intrinsics
+  void emit(const absdbl& i) { a->Fabs(D(i.d), D(i.s)); }
+  void emit(const sar& i) { a->Asr(X(i.d), X(i.s1), X(i.s0)); }
+  void emit(const shl& i) { a->Lsl(X(i.d), X(i.s1), X(i.s0)); }
+  void emit(const srem& i);
+  void emit(const divint& i) { a->Sdiv(X(i.d), X(i.s0), X(i.s1)); }
+
   // instructions
+  void emit(const addl& i) { a->Add(W(i.d), W(i.s1), W(i.s0), SetFlags); }
   void emit(const addli& i) { a->Add(W(i.d), W(i.s1), i.s0.l(), SetFlags); }
+  void emit(const addlm& i);
+  void emit(const addlim& i);
   void emit(const addq& i) { a->Add(X(i.d), X(i.s1), X(i.s0), SetFlags); }
-  void emit(const addqi& i) { a->Add(X(i.d), X(i.s1), i.s0.l(), SetFlags); }
-  void emit(const andq& i) { a->And(X(i.d), X(i.s1), X(i.s0) /* flags? */); }
-  void emit(const andqi& i) { a->And(X(i.d), X(i.s1), i.s0.l() /* flags? */); }
-  void emit(const sar& i) { a->asrv(X(i.d), X(i.s0), X(i.s1)); }
-  void emit(const brk& i) { a->Brk(i.code); }
-  void emit(cbcc i);
+  void emit(const addqi& i) { a->Add(X(i.d), X(i.s1), i.s0.q(), SetFlags); }
+  void emit(const addqim& i);
+  void emit(const addsd i) { a->Fadd(D(i.d), D(i.s1), D(i.s0)); }
+  void emit(const andb& i) { a->And(W(i.d), W(i.s1), W(i.s0), SetFlags); }
+  void emit(const andbi& i);
+  void emit(const andbim& i);
+  void emit(const andl& i) { a->And(W(i.d), W(i.s1), W(i.s0), SetFlags); }
+  void emit(const andli& i) { a->And(W(i.d), W(i.s1), i.s0.l(), SetFlags); }
+  void emit(const andq& i) { a->And(X(i.d), X(i.s1), X(i.s0), SetFlags); }
+  void emit(const andqi& i) { a->And(X(i.d), X(i.s1), i.s0.q(), SetFlags); }
+  void emit(const cloadq& i);
+  void emit(const cmovq& i);
+  void emit(const cmpwim& i);
   void emit(const cmpl& i) { a->Cmp(W(i.s1), W(i.s0)); }
   void emit(const cmpli& i) { a->Cmp(W(i.s1), i.s0.l()); }
+  void emit(const cmplim& i);
+  void emit(const cmplm& i);
   void emit(const cmpq& i) { a->Cmp(X(i.s1), X(i.s0)); }
   void emit(const cmpqi& i) { a->Cmp(X(i.s1), i.s0.l()); }
-  void emit(const decq& i) { a->Sub(X(i.d), X(i.s), 1LL, SetFlags); }
+  void emit(const cmpqim& i);
+  void emit(const cmpqm& i);
+  void emit(const cmpsd& i);
+  void emit(const cqo& i);
+  void emit(const cvttsd2siq& i);
+  void emit(const cvtsi2sd& i);
+  void emit(const cvtsi2sdm& i);
+  void emit(const decl& i) { a->Sub(W(i.d), W(i.s), 1, SetFlags); }
+  void emit(const declm& i);
+  void emit(const decq& i) { a->Sub(X(i.d), X(i.s), 1, SetFlags); }
+  void emit(const decqm& i);
+  void emit(const divsd i) { a->Fdiv(D(i.d), D(i.s1), D(i.s0)); }
+  void emit(const idiv& i);
+  void emit(const imul& i);
+  void emit(const incl& i) { a->Add(W(i.d), W(i.s), 1LL, SetFlags); }
+  void emit(const inclm& i);
   void emit(const incq& i) { a->Add(X(i.d), X(i.s), 1LL, SetFlags); }
-  void emit(jcc i);
-  void emit(jmp i);
+  void emit(const incqm& i);
+  void emit(const incqmlock& i);
+  void emit(const incw& i) { a->Add(W(i.d), W(i.s), 1LL, SetFlags); }
+  void emit(const incwm& i);
+  void emit(const jcc i);
+  void emit(const jcci& i);
+  void emit(const jmp i);
+  void emit(const jmpr& i) { a->Br(X(i.target)); }
+  void emit(const jmpm& i);
+  void emit(const jmpi i);
   void emit(const lea& i);
-  void emit(const loadl& i) { a->Ldr(W(i.d), M(i.s)); /* 0-extends? */ }
-  void emit(const loadzbl& i) { a->Ldrb(W(i.d), M(i.s)); }
-  void emit(const shl& i) { a->lslv(X(i.d), X(i.s0), X(i.s1)); }
+  void emit(const leap& i);
+  void emit(const loadups& i);
+  void emit(const loadtqb& i) { a->Ldrsb(W(i.d), M(a, i.s)); }
+  void emit(const loadb& i) { a->Ldrsb(W(i.d), M(a, i.s)); }
+  void emit(const loadl& i) { a->Ldr(W(i.d), M(a, i.s)); }
+  void emit(const loadqp& i);
+  void emit(const loadsd& i);
+  void emit(const loadzbl& i) { a->Ldrb(W(i.d), M(a, i.s)); }
+  void emit(const loadzbq& i) { a->Ldrb(W(i.d), M(a, i.s)); /* FIXME */ }
+  void emit(const loadzlq& i) { a->Ldr(W(i.d), M(a, i.s)); /* FIXME */ }
+  void emit(const movb& i) { a->Mov(W(i.d), W(i.s)); }
+  void emit(const movl& i) { a->Mov(W(i.d), W(i.s)); }
   void emit(const movzbl& i) { a->Uxtb(W(i.d), W(i.s)); }
-  void emit(const movzbq& i) { a->Uxtb(W(Vreg32(size_t(i.d))), W(i.s)); }
-  void emit(const imul& i) { a->Mul(X(i.d), X(i.s0), X(i.s1)); }
-  void emit(const neg& i) { a->Neg(X(i.d), X(i.s), vixl::SetFlags); }
+  void emit(const movzbq& i) { a->Uxtb(X(i.d), W(i.s).X()); }
+  void emit(const movtqb& i);
+  void emit(const movtql& i);
+  void emit(const mulsd& i);
+  void emit(const neg& i) { a->Neg(X(i.d), X(i.s), SetFlags); }
+  void emit(const nop& i) { a->Nop(); }
   void emit(const not& i) { a->Mvn(X(i.d), X(i.s)); }
-  void emit(const orq& i) { a->Orr(X(i.d), X(i.s1), X(i.s0) /* flags? */); }
-  void emit(const orqi& i) { a->Orr(X(i.d), X(i.s1), i.s0.l() /* flags? */); }
-  void emit(const storeb& i) { a->Strb(W(i.s), M(i.m)); }
-  void emit(const storel& i) { a->Str(W(i.s), M(i.m)); }
-  void emit(const setcc& i) { PhysReg r(i.d.asReg()); a->Cset(X(r), C(i.cc)); }
+  void emit(const notb& i) { a->Mvn(W(i.d), W(i.s)); }
+  void emit(const orbim& i);
+  void emit(const orwim& i);
+  void emit(const orq& i) { a->Orr(X(i.d), X(i.s1), X(i.s0)); /* FIXME: */ }
+  void emit(const orqi& i) { a->Orr(X(i.d), X(i.s1), i.s0.l()); /* FIXME */ }
+  void emit(const orqim& i);
+  void emit(const pop& i);
+  void emit(const popm& i);
+  void emit(const psllq& i);
+  void emit(const psrlq& i);
+  void emit(const push& i);
+  void emit(const pushm& i);
+  void emit(const roundsd& i);
+  void emit(const setcc& i);
+  void emit(const sarq& i);
+  void emit(const sarqi& i);
+  void emit(const shlli& i);
+  void emit(const shlq& i);
+  void emit(const shlqi& i);
+  void emit(const shrli& i) { a->Lsr(W(i.d), W(i.s1), i.s0.l()); /* FIXME */ }
+  void emit(const shrqi& i);
+  void emit(const sqrtsd& i);
+  void emit(const storeb& i) { a->Strb(W(i.s), M(a, i.m)); }
+  void emit(const storebi& i);
+  void emit(const storeups& i);
+  void emit(const storel& i) { a->Str(W(i.s), M(a, i.m)); }
+  void emit(const storeli& i);
+  void emit(const storeqi& i);
+  void emit(const storesd& i);
+  void emit(const storew& i) { a->Str(W(i.s), M(a, i.m)); }
+  void emit(const storewi& i);
+  void emit(const subbi& i) { a->Sub(W(i.d), W(i.s1), i.s0.l(), SetFlags); }
+  void emit(const subl& i) { a->Sub(W(i.d), W(i.s1), W(i.s0), SetFlags); }
   void emit(const subli& i) { a->Sub(W(i.d), W(i.s1), i.s0.l(), SetFlags); }
   void emit(const subq& i) { a->Sub(X(i.d), X(i.s1), X(i.s0), SetFlags); }
-  void emit(const subqi& i) { a->Sub(X(i.d), X(i.s1), i.s0.l(), SetFlags); }
-  void emit(tbcc i);
+  void emit(const subqi& i) { a->Sub(X(i.d), X(i.s1), i.s0.q(), SetFlags); }
+  void emit(const subsd& i) { a->Fsub(D(i.d), D(i.s1), D(i.s0)); }
+  void emit(const testb& i) { a->Tst(W(i.s1), W(i.s0)); }
+  void emit(const testbi& i) { a->Tst(W(i.s1), i.s0.l()); }
+  void emit(const testbim&);
+  void emit(const testwim&);
   void emit(const testl& i) { a->Tst(W(i.s1), W(i.s0)); }
   void emit(const testli& i) { a->Tst(W(i.s1), i.s0.l()); }
+  void emit(const testlim&);
+  void emit(const testq& i) { a->Tst(X(i.s1), X(i.s0)); }
+  void emit(const testqi& i) { a->Tst(X(i.s1), i.s0.q()); }
+  void emit(const testqm&);
+  void emit(const testqim&);
+  void emit(const ucomisd& i) { a->Fcmp(D(i.s0), D(i.s1)); }
   void emit(const ud2& i) { a->Brk(1); }
-  void emit(const xorq& i) { a->Eor(X(i.d), X(i.s1), X(i.s0) /* flags? */); }
-  void emit(const xorqi& i) { a->Eor(X(i.d), X(i.s1), i.s0.l() /* flags? */); }
-  void emit(const conjure& i) { always_assert(false); }
-  void emit(const conjureuse& i) { always_assert(false); }
-
-  void emit_nop() { not_implemented(); }
+  void emit(const unpcklpd&);
+  void emit(const xorb& i) { a->Eor(W(i.d), W(i.s1), W(i.s0)); /* FIXME */ }
+  void emit(const xorbi& i) { a->Eor(W(i.d), W(i.s1), i.s0.l()); /* FIXME */ }
+  void emit(const xorl& i) { a->Eor(W(i.d), W(i.s1), W(i.s0)); /* FIXME */ }
+  void emit(const xorq& i) { a->Eor(X(i.d), X(i.s1), X(i.s0)); /* FIXME */ }
+  void emit(const xorqi& i) { a->Eor(X(i.d), X(i.s1), i.s0.l()); /* FIXME */ }
 
 private:
   CodeBlock& frozen() { return text.frozen().code; }
@@ -196,11 +342,11 @@ private:
 void Vgen::patch(Venv& env) {
   for (auto& p : env.jmps) {
     assertx(env.addrs[p.target]);
-    smashJmp(p.instr, env.addrs[p.target]);
+    *reinterpret_cast<TCA*>(p.instr + 8) = env.addrs[p.target];
   }
   for (auto& p : env.jccs) {
     assertx(env.addrs[p.target]);
-    smashJcc(p.instr, env.addrs[p.target]);
+    *reinterpret_cast<TCA*>(p.instr + 16) = env.addrs[p.target];
   }
   for (auto& p : env.bccs) {
     assertx(env.addrs[p.target]);
@@ -210,10 +356,6 @@ void Vgen::patch(Venv& env) {
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-
-void Vgen::emit(const callphp& i) {
-  emitSmashableCall(*codeBlock, env.meta, i.stub);
-}
 
 void Vgen::emit(const copy& i) {
   if (i.s.isGP() && i.d.isGP()) {
@@ -247,10 +389,40 @@ void Vgen::emit(const copy2& i) {
   }
 }
 
+void emitSimdImmInt(vixl::MacroAssembler* a, int64_t val, Vreg d) {
+  // FIXME: Same Fmov() for all 'ldimm[bwl]' instructions below
+  if (val == 0) {
+    a->Fmov(D(d), vixl::xzr);
+  } else {
+    union { double dval; int64_t ival; };
+    ival = val;
+    a->Fmov(D(d), dval);
+  }
+}
+
+void Vgen::emit(const ldimmb& i) {
+  if (i.d.isSIMD()) {
+    emitSimdImmInt(a, i.s.b(), i.d);
+  } else {
+    Vreg8 d = i.d;
+    a->Mov(W(d), i.s.l());
+  }
+}
+
+void Vgen::emit(const ldimml& i) {
+  if (i.d.isSIMD()) {
+    emitSimdImmInt(a, i.s.l(), i.d);
+  } else {
+    Vreg32 d = i.d;
+    a->Mov(W(d), i.s.l());
+  }
+}
+
 void Vgen::emit(const ldimmq& i) {
   union { double dval; int64_t ival; };
   ival = i.s.q();
   if (i.d.isSIMD()) {
+    // FIXME:
     // Assembler::fmov (which you'd think shouldn't be a macro instruction)
     // will emit a ldr from a literal pool if IsImmFP64 is false. vixl's
     // literal pools don't work well with our codegen pattern, so if that
@@ -262,7 +434,7 @@ void Vgen::emit(const ldimmq& i) {
       // 0.0 is not encodeable as an immediate to Fmov, but this works.
       a->Fmov(D(i.d), vixl::xzr);
     } else {
-      a->Mov(rAsm, ival); // XXX avoid scratch register somehow.
+      a->Mov(rAsm, ival);
       a->Fmov(D(i.d), rAsm);
     }
   } else {
@@ -270,59 +442,157 @@ void Vgen::emit(const ldimmq& i) {
   }
 }
 
-void emitSimdImmInt(vixl::MacroAssembler* a, int64_t val, Vreg d) {
-  if (val == 0) {
-    a->Fmov(D(d), vixl::xzr);
-  } else {
-    a->Mov(rAsm, val); // XXX avoid scratch register somehow.
-    a->Fmov(D(d), rAsm);
-  }
+void Vgen::emit(const ldimmqs& i) {
+  emitSmashableMovq(*codeBlock, i.s.q(), i.d);
 }
 
-void Vgen::emit(const ldimml& i) {
+void Vgen::emit(const ldimmw& i) {
   if (i.d.isSIMD()) {
-    emitSimdImmInt(a, i.s.q(), i.d);
+    emitSimdImmInt(a, i.s.l(), i.d);
   } else {
-    Vreg32 d = i.d;
-    a->Mov(W(d), i.s.l());
-  }
-}
-
-void Vgen::emit(const ldimmb& i) {
-  if (i.d.isSIMD()) {
-    emitSimdImmInt(a, i.s.q(), i.d);
-  } else {
-    Vreg8 d = i.d;
-    a->Mov(W(d), i.s.b());
+    a->movk(W(i.d), i.s.l(), 0);
   }
 }
 
 void Vgen::emit(const load& i) {
   if (i.d.isGP()) {
-    a->Ldr(X(i.d), M(i.s));
+    a->Ldr(X(i.d), M(a, i.s));
   } else {
-    a->Ldr(D(i.d), M(i.s));
+    a->Ldr(D(i.d), M(a, i.s));
   }
 }
 
 void Vgen::emit(const store& i) {
   if (i.s.isGP()) {
-    a->Str(X(i.s), M(i.d));
+    a->Str(X(i.s), M(a, i.d));
   } else {
-    a->Str(D(i.s), M(i.d));
+    a->Str(D(i.s), M(a, i.d));
   }
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 
+void Vgen::emit(const mcprep& i) {
+  /*
+   * Initially, we set the cache to hold (addr << 1) | 1 (where `addr' is the
+   * address of the movq) so that we can find the movq from the handler.
+   *
+   * We set the low bit for two reasons: the Class* will never be a valid
+   * Class*, so we'll always miss the inline check before it's smashed, and
+   * handlePrimeCacheInit can tell it's not been smashed yet
+   */
+  auto const mov_addr = emitSmashableMovq(*codeBlock, 0, r64(i.d));
+  auto const imm = reinterpret_cast<uint64_t>(mov_addr);
+  smashMovq(mov_addr, (imm << 1) | 1);
+
+  mcg->cgFixups().addressImmediates.insert(reinterpret_cast<TCA>(~imm));
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+void Vgen::emit(const call& i) {
+  a->Mov(rAsm, reinterpret_cast<uint64_t>(i.target));
+  a->Blr(rAsm);
+}
+
+void Vgen::emit(const callm& i) {
+  a->Ldr(rAsm, M(a, i.target));
+  a->Blr(rAsm);
+}
+
+void Vgen::emit(const calls& i) {
+  emitSmashableCall(*codeBlock, i.target);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+void Vgen::emit(const stublogue& i) {
+  // Save x29 and x30 always, regardless of i.saveframe (makes sp 16B aligned)
+  a->Stp(x29, x30, MemOperand(sp, -16, PreIndex));
+}
+
+void Vgen::emit(const stubret& i) {
+  if(i.saveframe)
+    a->Ldp(x29, x30, MemOperand(sp, 16, PostIndex));
+  else
+    a->Ldp(rAsm, x30, MemOperand(sp, 16, PostIndex));
+  a->Ret();
+}
+
+void Vgen::emit(const callstub& i) {
+  emit(call{i.target, i.args});
+}
+
+void Vgen::emit(const callfaststub& i) {
+  emit(call{i.target, i.args});
+  emit(syncpoint{i.fix});
+}
+
+void Vgen::emit(const tailcallstub& i) {
+  // sp is already aligned, just jmp
+  emit(jmpi{i.target, i.args});
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+void Vgen::emit(const phplogue& i) {
+  // Save link register in m_savedRip on the current VM frame pointed by 'i.fp'
+  a->Str(rLinkReg, X(i.fp)[AROFF(m_savedRip)]);
+}
+
+void Vgen::emit(const phpret& i) {
+  a->Ldr(rLinkReg, X(i.fp)[AROFF(m_savedRip)]);
+  if (!i.noframe) {
+    a->Ldr(X(i.d), X(i.fp)[AROFF(m_sfp)]);
+  }
+  a->Ret();
+}
+
+void Vgen::emit(const callphp& i) {
+  emitSmashableCall(*codeBlock, i.stub);
+  emit(unwind{{i.targets[0], i.targets[1]}});
+}
+
+void Vgen::emit(const tailcallphp& i) {
+  // To make callee's return as caller's return, load the return address at
+  // i.fp[AROFF(m_savedRip)] into link register and jmp to target
+  a->Ldr(rLinkReg, X(i.fp)[AROFF(m_savedRip)]);
+  emit(jmpr{i.target, i.args});
+}
+
+void Vgen::emit(const callarray& i) {
+  emit(call{i.target, i.args});
+}
+
+void Vgen::emit(const contenter& i) {
+  // FIXME: Mimicking x64. Verify
+  vixl::Label Stub, End;
+
+  a->B(&End);
+  a->bind(&Stub);
+
+  // FIXME: x64 has pop() here. Needs sp adjustment?
+  a->Ldr(rAsm, sp[0]);
+  a->Str(rAsm, X(i.fp)[AROFF(m_savedRip)]);
+
+  a->Br(X(i.target));
+  a->bind(&End);
+  a->Ldr(rAsm, &Stub);
+  a->Blr(rAsm);
+  // m_savedRip will point here.
+  emit(unwind{{i.targets[0], i.targets[1]}});
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
 void Vgen::emit(const nothrow& i) {
-  env.meta.catches.emplace_back(a->frontier(), nullptr);
+  mcg->registerCatchBlock(a->frontier(), nullptr);
 }
 
 void Vgen::emit(const syncpoint& i) {
   FTRACE(5, "IR recordSyncPoint: {} {} {}\n", a->frontier(),
          i.fix.pcOffset, i.fix.spOffset);
-  env.meta.fixups.emplace_back(a->frontier(), i.fix);
+  mcg->recordSyncPoint(a->frontier(), i.fix);
 }
 
 void Vgen::emit(const unwind& i) {
@@ -332,69 +602,430 @@ void Vgen::emit(const unwind& i) {
 
 ///////////////////////////////////////////////////////////////////////////////
 
+void Vgen::emit(const srem& i) {
+  a->Sdiv(rAsm, X(i.s0), X(i.s1));
+  a->Msub(X(i.d), rAsm, X(i.s1), X(i.s0));
+}
+
+void Vgen::emit(const addlm& i) {
+  auto adr = M(a, i.m);
+  a->Ldr(rAsm.W(), adr);
+  a->Add(rAsm.W(), rAsm.W(), W(i.s0), SetFlags);
+  a->Str(rAsm.W(), adr);
+}
+
+void Vgen::emit(const addlim& i) {
+  auto adr = M(a, i.m);
+  a->Ldr(rAsm.W(), adr);
+  a->Add(rAsm.W(), rAsm.W(), i.s0.l(), SetFlags);
+  a->Str(rAsm.W(), adr);
+}
+
+void Vgen::emit(const addqim& i) {
+  auto adr = M(a, i.m);
+  a->Ldr(rAsm, adr);
+  a->Add(rAsm, rAsm, i.s0.q(), SetFlags);
+  a->Str(rAsm, adr);
+}
+
+void Vgen::emit(const andbi& i) {
+  a->Mov(rAsm.W(), i.s0.l());
+  a->And(W(i.d), W(i.s1), rAsm.W(), SetFlags);
+}
+
+void Vgen::emit(const andbim& i) {
+  auto adr = M(a, i.m);
+  a->Ldrsb(rAsm.W(), adr);
+  a->And(rAsm.W(), rAsm.W(), i.s.l(), SetFlags);
+  a->Strb(rAsm.W(), adr);
+}
+
+void Vgen::emit(const cloadq& i) {
+  a->Ldr(rAsm, M(a, i.t));
+  a->Csel(X(i.d), rAsm, X(i.f), C(i.cc));
+}
+
+void Vgen::emit(const cmovq& i) {
+  a->Csel(X(i.d), X(i.t), X(i.f), C(i.cc));
+}
+
+void Vgen::emit(const cmpwim& i) {
+  a->Ldrsh(rAsm.W(), M(a, i.s1));
+  a->Cmp(rAsm.W(), i.s0.l());
+}
+
+void Vgen::emit(const cmplim& i) {
+  a->Ldr(rAsm.W(), M(a, i.s1));
+  a->Cmp(rAsm.W(), i.s0.l());
+}
+
+void Vgen::emit(const cmplm& i) {
+  a->Ldr(rAsm.W(), M(a, i.s1));
+  a->Cmp(rAsm.W(), W(i.s0));
+}
+
+void Vgen::emit(const cmpqim& i) {
+  a->Ldr(rAsm, M(a, i.s1));
+  a->Cmp(rAsm, i.s0.q());
+}
+
+void Vgen::emit(const cmpqm& i) {
+  a->Ldr(rAsm, M(a, i.s1));
+  a->Cmp(rAsm, X(i.s0));
+}
+
+void Vgen::emit(const cmpsd& i) {
+  // FIXME: Mimicking x64 'cmpsd' (flags are modified). change ir->vasm?
+  a->Fcmp(D(i.s0), D(i.s1));
+  switch(i.pred) {
+  case ComparisonPred::eq_ord:
+    a->Csetm(rAsm, C(jit::CC_E));
+    break;
+  case ComparisonPred::ne_unord:
+    a->Csetm(rAsm, C(jit::CC_NE));
+    break;
+  default:
+    always_assert(false);
+  }
+  a->Fmov(D(i.d), rAsm);
+}
+
+void Vgen::emit(const cqo& i) {
+  // FIXME: Sign-Extend RAX
+  not_implemented();
+}
+
+void Vgen::emit(const cvttsd2siq& i) {
+  a->Fcvtzs(X(i.d), D(i.s));
+}
+
+void Vgen::emit(const cvtsi2sd& i) {
+  a->Scvtf(D(i.d), X(i.s));
+}
+
+void Vgen::emit(const cvtsi2sdm& i) {
+  a->Ldr(rAsm, M(a, i.s));
+  a->Scvtf(D(i.d), rAsm);
+}
+
+void Vgen::emit(const declm& i) {
+  auto adr = M(a, i.m);
+  a->Ldr(rAsm.W(), adr);
+  a->Sub(rAsm.W(), rAsm.W(), 1, SetFlags);
+  a->Str(rAsm.W(), adr);
+}
+
+void Vgen::emit(const decqm& i) {
+  auto adr = M(a, i.m);
+  a->Ldr(rAsm, adr);
+  a->Sub(rAsm, rAsm, 1, SetFlags);
+  a->Str(rAsm, adr);
+}
+
+void Vgen::emit(const idiv& i) {
+  // FIXME: (rdx:rax)/i.s
+  not_implemented();
+}
+
+void Vgen::emit(const imul& i) {
+  // FIXME: SetFlags?
+  a->Mul(X(i.d), X(i.s0), X(i.s1));
+}
+
+void Vgen::emit(const inclm& i) {
+  auto adr = M(a, i.m);
+  a->Ldr(rAsm.W(), adr);
+  a->Add(rAsm.W(), rAsm.W(), 1, SetFlags);
+  a->Str(rAsm.W(), adr);
+}
+
+void Vgen::emit(const incqm& i) {
+  auto adr = M(a, i.m);
+  a->Ldr(rAsm, adr);
+  a->Add(rAsm, rAsm, 1, SetFlags);
+  a->Str(rAsm, adr);
+}
+
+void Vgen::emit(const incqmlock& i) {
+  auto adr = M(a, i.m);
+  vixl::Label again;
+  a->bind(&again);
+  a->ldxr(rAsm, adr);
+  a->Add(rAsm, rAsm, 1, SetFlags);
+  a->stxr(rAsm.W(), rAsm, adr);
+  a->Cbnz(rAsm.W(), &again);
+}
+
+void Vgen::emit(const incwm& i) {
+  auto adr = M(a, i.m);
+  a->Ldrh(rAsm.W(), adr);
+  a->Add(rAsm.W(), rAsm.W(), 1, SetFlags);
+  a->Strh(rAsm.W(), adr);
+}
+
+void Vgen::emit(const jcc i) {
+  if (i.targets[1] != i.targets[0]) {
+    if (next == i.targets[1]) {
+      return emit(jcc{ccNegate(i.cc), i.sf, {i.targets[1], i.targets[0]}});
+    }
+    auto taken = i.targets[1];
+    jccs.push_back({a->frontier(), taken});
+    vixl::Label truecase, falsecase, data;
+    // Vgen::patch() should work for all 'jcc{,i,s}' instructions. So, using
+    // 4 instructions though it can be done in 3 as jccs needs 4
+    a->B(&truecase, C(i.cc));
+    a->B(&falsecase);
+    a->bind(&truecase);
+    a->Ldr(rAsm, &data);
+    a->Br(rAsm);
+    a->bind(&data);
+    a->dc64(reinterpret_cast<int64_t>(a->frontier()));
+    a->bind(&falsecase);
+  }
+  emit(jmp{i.targets[0]});
+}
+
+void Vgen::emit(const jcci& i) {
+  vixl::Label truecase, falsecase, data;
+
+  // Vgen::patch() should work for all 'jcc{,i,s}' instructions. So, using
+  // 4 instructions though it can be done in 3 as jccs needs 4
+  a->B(&truecase, C(i.cc));
+  a->B(&falsecase);
+  a->bind(&truecase);
+  a->Ldr(rAsm, &data);
+  a->Br(rAsm);
+  a->bind(&data);
+  a->dc64(reinterpret_cast<int64_t>(i.taken));
+  a->bind(&falsecase);
+  emit(jmp{i.target});
+}
+
 void Vgen::emit(jmp i) {
   if (next == i.target) return;
   jmps.push_back({a->frontier(), i.target});
-  // B range is +/- 128MB but this uses BR
-  emitSmashableJmp(*codeBlock, env.meta, kEndOfTargetChain);
+  vixl::Label data;
+  a->Ldr(rAsm, &data);
+  a->Br(rAsm);
+  a->bind(&data);
+  a->dc64(reinterpret_cast<int64_t>(a->frontier()));
 }
 
-void Vgen::emit(jcc i) {
-  assertx(i.cc != CC_None);
-  if (i.targets[1] != i.targets[0]) {
-    if (next == i.targets[1]) {
-      // the taken branch is the fall-through block, invert the branch.
-      i = jcc{ccNegate(i.cc), i.sf, {i.targets[1], i.targets[0]}};
-    }
-    jccs.push_back({a->frontier(), i.targets[1]});
-    // B.cond range is +/- 1MB but this uses BR
-    emitSmashableJcc(*codeBlock, env.meta, kEndOfTargetChain, i.cc);
-  }
-  emit(jmp{i.targets[0]});
+void Vgen::emit(const jmpm& i) {
+  a->Ldr(rAsm, M(a, i.target));
+  a->Br(rAsm);
+}
+
+void Vgen::emit(const jmpi i) {
+  vixl::Label data;
+  a->Ldr(rAsm, &data);
+  a->Br(rAsm);
+  a->bind(&data);
+  a->dc64(reinterpret_cast<int64_t>(i.target));
 }
 
 void Vgen::emit(const lea& i) {
-  assertx(!i.s.index.isValid());
-  assertx(i.s.scale == 1);
-  a->Add(X(i.d), X(i.s.base), i.s.disp);
+  auto adr = M(a, i.s);
+  auto offset = reinterpret_cast<int64_t>(adr.offset());
+  a->Add(X(i.d), adr.base(), offset /* Don't set flags */);
 }
 
-void Vgen::emit(cbcc i) {
-  assertx(i.cc == vixl::ne || i.cc == vixl::eq);
-  if (i.targets[1] != i.targets[0]) {
-    if (next == i.targets[1]) {
-      // the taken branch is the fall-through block, invert the branch.
-      i = cbcc{i.cc == vixl::ne ? vixl::eq : vixl::ne, i.s,
-               {i.targets[1], i.targets[0]}};
-    }
-    bccs.push_back({a->frontier(), i.targets[1]});
-    // offset range +/- 1MB
-    if (i.cc == vixl::ne) {
-      a->cbnz(X(i.s), 0);
-    } else {
-      a->cbz(X(i.s), 0);
-    }
-  }
-  emit(jmp{i.targets[0]});
+void Vgen::emit(const leap& i) {
+  // FIXME: PC relative?
+  a->Mov(X(i.d), i.s.r.disp);
 }
 
-void Vgen::emit(tbcc i) {
-  assertx(i.cc == vixl::ne || i.cc == vixl::eq);
-  if (i.targets[1] != i.targets[0]) {
-    if (next == i.targets[1]) {
-      // the taken branch is the fall-through block, invert the branch.
-      i = tbcc{i.cc == vixl::ne ? vixl::eq : vixl::ne, i.bit, i.s,
-               {i.targets[1], i.targets[0]}};
-    }
-    bccs.push_back({a->frontier(), i.targets[1]});
-    // offset range +/- 32KB
-    if (i.cc == vixl::ne) {
-      a->tbnz(X(i.s), i.bit, 0);
-    } else {
-      a->tbz(X(i.s), i.bit, 0);
-    }
+void Vgen::emit(const loadups& i) {
+  // FIXME: Needs simd support in vixl
+  not_implemented();
+}
+
+void Vgen::emit(const loadqp& i) {
+  // FIXME: PC relative?
+  a->Mov(X(i.d), i.s.r.disp);
+  a->Ldr(X(i.d), X(i.d)[0]);
+}
+
+void Vgen::emit(const loadsd& i) {
+  a->Ldr(rAsm, M(a, i.s));
+  a->Fmov(D(i.d), rAsm);
+}
+
+void Vgen::emit(const movtqb& i) {
+  a->Mov(W(i.d), X(i.s));
+}
+
+void Vgen::emit(const movtql& i) {
+  a->Mov(W(i.d), X(i.s));
+}
+
+void Vgen::emit(const mulsd& i) {
+  a->Fmul(D(i.d), D(i.s0), D(i.s1));
+}
+
+void Vgen::emit(const orbim& i) {
+  // FIXME: SetFlags?
+  a->Ldrsb(rAsm.W(), M(a, i.m));
+  a->Orr(rAsm.W(), rAsm.W(), i.s0.l());
+  a->Strb(rAsm.W(), M(a, i.m));
+}
+
+void Vgen::emit(const orwim& i) {
+  // FIXME: SetFlags?
+  a->Ldrsh(rAsm.W(), M(a, i.m));
+  a->Orr(rAsm.W(), rAsm.W(), i.s0.l());
+  a->Strh(rAsm.W(), M(a, i.m));
+}
+
+void Vgen::emit(const orqim& i) {
+  // FIXME: SetFlags?
+  a->Ldr(rAsm, M(a, i.m));
+  a->Orr(rAsm, rAsm, i.s0.q());
+  a->Str(rAsm, M(a, i.m));
+}
+
+void Vgen::emit(const pop& i) {
+  a->Ldr(X(i.d), MemOperand(sp, 8, PostIndex));
+}
+
+void Vgen::emit(const popm& i) {
+  a->Ldr(rAsm, MemOperand(sp, 8, PostIndex));
+  a->Str(rAsm, M(a, i.d));
+}
+
+void Vgen::emit(const psllq& i) {
+  // FIXME: Needs simd support in vixl
+  not_implemented();
+}
+
+void Vgen::emit(const psrlq& i) {
+  // FIXME: Needs simd support in vixl
+  not_implemented();
+}
+
+void Vgen::emit(const push& i) {
+  a->Str(X(i.s), MemOperand(sp, -8, PreIndex));
+}
+
+void Vgen::emit(const pushm& i) {
+  a->Ldr(rAsm, M(a, i.s));
+  a->Str(rAsm, MemOperand(sp, -8, PreIndex));
+}
+
+void Vgen::emit(const roundsd& i) {
+  switch(i.dir) {
+  case RoundDirection::nearest:
+    a->frintn(D(i.d), D(i.s));
+    break;
+  case RoundDirection::floor:
+    a->frintm(D(i.d), D(i.s));
+    break;
+  case RoundDirection:: ceil:
+    a->frintp(D(i.d), D(i.s));
+    break;
+  default:
+    assertx(i.dir == RoundDirection::truncate);
+    a->frintz(D(i.d), D(i.s));
   }
-  emit(jmp{i.targets[0]});
+}
+
+void Vgen::emit(const setcc& i) {
+  PhysReg r(i.d.asReg());
+  a->Cset(X(r), C(i.cc));
+}
+
+void Vgen::emit(const sarq& i) {
+  // FIXME: SetFlags?
+  a->Asr(X(i.d), X(i.s), 1);
+}
+
+void Vgen::emit(const sarqi& i) {
+  // FIXME: SetFlags?
+  a->Asr(X(i.d), X(i.s1), i.s0.l());
+}
+
+void Vgen::emit(const shlli& i) {
+  // FIXME: SetFlags?
+  a->Lsl(W(i.d), W(i.s1), i.s0.l());
+}
+
+void Vgen::emit(const shlq& i) {
+  // FIXME: SetFlags?
+  a->Lsl(X(i.d), X(i.s), 1);
+}
+
+void Vgen::emit(const shlqi& i) {
+  // FIXME: SetFlags?
+  a->Lsl(X(i.d), X(i.s1), i.s0.l());
+}
+
+void Vgen::emit(const shrqi& i) {
+  // FIXME: SetFlags?
+  a->Lsr(X(i.d), X(i.s1), i.s0.l());
+}
+
+void Vgen::emit(const sqrtsd& i) {
+  a->Fsqrt(D(i.d), D(i.s));
+}
+
+void Vgen::emit(const storebi& i) {
+  a->Mov(rAsm.W(), i.s.l());
+  a->Strb(rAsm.W(), M(a, i.m));
+}
+
+void Vgen::emit(const storeups& i) {
+  // FIXME: Needs simd support in vixl
+  not_implemented();
+}
+
+void Vgen::emit(const storeli& i) {
+  a->Mov(rAsm.W(), i.s.l());
+  a->Str(rAsm.W(), M(a, i.m));
+}
+
+void Vgen::emit(const storeqi& i) {
+  a->Mov(rAsm, i.s.q());
+  a->Str(rAsm, M(a, i.m));
+}
+
+void Vgen::emit(const storesd& i) {
+  a->Fmov(rAsm, D(i.s));
+  a->Str(rAsm, M(a, i.m));
+}
+
+void Vgen::emit(const storewi& i) {
+  a->Mov(rAsm.W(), i.s.w());
+  a->Strh(rAsm.W(), M(a, i.m));
+}
+
+void Vgen::emit(const testbim& i) {
+  a->Ldrsb(rAsm.W(), M(a, i.s1));
+  a->Tst(rAsm.W(), i.s0.l());
+}
+
+void Vgen::emit(const testwim& i) {
+  a->Ldrsh(rAsm.W(), M(a, i.s1));
+  a->Tst(rAsm.W(), i.s0.l());
+}
+
+void Vgen::emit(const testlim& i) {
+  a->Ldr(rAsm.W(), M(a, i.s1));
+  a->Tst(rAsm.W(), i.s0.l());
+}
+
+void Vgen::emit(const testqm& i) {
+  a->Ldr(rAsm, M(a, i.s1));
+  a->Tst(X(i.s0), rAsm);
+}
+
+void Vgen::emit(const testqim& i) {
+  a->Ldr(rAsm, M(a, i.s1));
+  a->Tst(rAsm, i.s0.q());
+}
+
+void Vgen::emit(const unpcklpd& i) {
+  // FIXME: Needs simd support in vixl
+  not_implemented();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -409,28 +1040,45 @@ void lower(Inst& i, Vout& v) {
   v << i;
 }
 
+void lower(countbytecode& i, Vout& v) {
+  v << incqm{i.base[g_bytecodesVasm.handle()], i.sf};
+}
+
+void lower(stubtophp& i, Vout& v) {
+  v << addqi{8, reg::rsp, reg::rsp, v.makeReg()};
+  v << popm{i.fp[AROFF(m_savedRip)]};
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+void lower(cmpb& i, Vout& v) {
+  auto s0 = v.makeReg();
+  auto s1 = v.makeReg();
+  v << movzbl{i.s0, s0};
+  v << movzbl{i.s1, s1};
+  v << cmpl{s0, s1, i.sf};
+}
+
+void lower(cmpbi& i, Vout& v) {
+  auto s1 = v.makeReg();
+  v << movzbl{i.s1, s1};
+  v << cmpli{i.s0, s1, i.sf};
+}
+
 void lower(cmpbim& i, Vout& v) {
   auto scratch = v.makeReg();
   v << loadzbl{i.s1, scratch};
   v << cmpli{i.s0, scratch, i.sf};
 }
 
-void lower(cmplim& i, Vout& v) {
-  auto scratch = v.makeReg();
-  v << loadl{i.s1, scratch};
-  v << cmpli{i.s0, scratch, i.sf};
-}
-
-void lower(cmpqm& i, Vout& v) {
-  auto scratch = v.makeReg();
-  v << load{i.s1, scratch};
-  v << cmpq{i.s0, scratch, i.sf};
-}
-
 void lower(testbim& i, Vout& v) {
   auto scratch = v.makeReg();
   v << loadzbl{i.s1, scratch};
   v << testli{i.s0, scratch, i.sf};
+}
+
+void lower(call& i, Vout& v) {
+  v << callr{v.cns(i.target), i.args};
 }
 
 void lowerForARM(Vunit& unit) {
@@ -465,16 +1113,25 @@ void lowerForARM(Vunit& unit) {
 ///////////////////////////////////////////////////////////////////////////////
 }
 
-void optimizeARM(Vunit& unit, const Abi& abi, bool regalloc) {
+void finishARM(Vunit& unit, Vtext& text, CGMeta& fixups,
+               const Abi& abi, AsmInfo* asmInfo) {
   Timer timer(Timer::vasm_optimize);
 
+  removeTrivialNops(unit);
+  optimizePhis(unit);
+  fuseBranches(unit);
+  optimizeJmps(unit);
   optimizeExits(unit);
+  vlower(unit);
+  lowerForARM(unit);
   simplify(unit);
   if (!unit.constToReg.empty()) {
     foldImms<arm::ImmFolder>(unit);
   }
-  vlower(unit);
-  lowerForARM(unit);
+  {
+    Timer timer(Timer::vasm_copy);
+    optimizeCopies(unit, abi);
+  }
   if (unit.needsRegAlloc()) {
     removeDeadCode(unit);
     if (regalloc) allocateRegisters(unit, abi);

--- a/hphp/runtime/vm/jit/vasm-check.cpp
+++ b/hphp/runtime/vm/jit/vasm-check.cpp
@@ -126,7 +126,6 @@ checkCalls(const Vunit& unit, const jit::vector<Vlabel>& blocks) {
         case Vinstr::callstub:
         case Vinstr::callarray:
         case Vinstr::contenter:
-        case Vinstr::hostcall:
           sync_valid = unwind_valid = nothrow_valid = true;
           break;
         case Vinstr::syncpoint:

--- a/hphp/runtime/vm/jit/vasm-dead.cpp
+++ b/hphp/runtime/vm/jit/vasm-dead.cpp
@@ -42,19 +42,22 @@ bool effectful(Vinstr& inst) {
     case Vinstr::addq:
     case Vinstr::addqi:
     case Vinstr::addsd:
+    case Vinstr::addxi:
     case Vinstr::andb:
     case Vinstr::andbi:
     case Vinstr::andl:
     case Vinstr::andli:
     case Vinstr::andq:
     case Vinstr::andqi:
+    case Vinstr::asrxi:
+    case Vinstr::asrxis:
+    case Vinstr::blrn:
     case Vinstr::cloadq:
     case Vinstr::cmovb:
     case Vinstr::cmovq:
     case Vinstr::cmpb:
     case Vinstr::cmpbi:
     case Vinstr::cmpbim:
-    case Vinstr::cmpwim:
     case Vinstr::cmpl:
     case Vinstr::cmpli:
     case Vinstr::cmplim:
@@ -64,8 +67,10 @@ bool effectful(Vinstr& inst) {
     case Vinstr::cmpqim:
     case Vinstr::cmpqm:
     case Vinstr::cmpsd:
-    case Vinstr::copy2:
+    case Vinstr::cmpsds:
+    case Vinstr::cmpwim:
     case Vinstr::copy:
+    case Vinstr::copy2:
     case Vinstr::copyargs:
     case Vinstr::cvtsi2sd:
     case Vinstr::cvtsi2sdm:
@@ -84,26 +89,36 @@ bool effectful(Vinstr& inst) {
     case Vinstr::incl:
     case Vinstr::incq:
     case Vinstr::incw:
-    case Vinstr::ldimmq:
-    case Vinstr::ldimml:
-    case Vinstr::ldimmw:
     case Vinstr::ldimmb:
+    case Vinstr::ldimml:
+    case Vinstr::ldimmq:
     case Vinstr::ldimmqs:
+    case Vinstr::ldimmw:
     case Vinstr::lea:
+    case Vinstr::lead:
     case Vinstr::leap:
     case Vinstr::lead:
     case Vinstr::load:
-    case Vinstr::loadups:
     case Vinstr::loadb:
     case Vinstr::loadl:
+    case Vinstr::loadqd:
     case Vinstr::loadqp:
     case Vinstr::loadqd:
     case Vinstr::loadsd:
-    case Vinstr::loadw:
     case Vinstr::loadtqb:
+    case Vinstr::loadups:
+    case Vinstr::loadw:
     case Vinstr::loadzbl:
     case Vinstr::loadzbq:
     case Vinstr::loadzlq:
+    case Vinstr::lslwi:
+    case Vinstr::lslwis:
+    case Vinstr::lslxi:
+    case Vinstr::lslxis:
+    case Vinstr::lsrwi:
+    case Vinstr::lsrwis:
+    case Vinstr::lsrxi:
+    case Vinstr::lsrxis:
     case Vinstr::mfcr:
     case Vinstr::mflr:
     case Vinstr::mfvsrd:
@@ -115,11 +130,14 @@ bool effectful(Vinstr& inst) {
     case Vinstr::movzbl:
     case Vinstr::movzbq:
     case Vinstr::movzlq:
+    case Vinstr::mrs:
+    case Vinstr::msr:
     case Vinstr::mulsd:
     case Vinstr::neg:
     case Vinstr::nop:
     case Vinstr::not:
     case Vinstr::notb:
+    case Vinstr::orswi:
     case Vinstr::orq:
     case Vinstr::orqi:
     case Vinstr::psllq:
@@ -183,6 +201,7 @@ bool effectful(Vinstr& inst) {
     case Vinstr::callr:
     case Vinstr::calls:
     case Vinstr::callstub:
+    case Vinstr::calltc:
     case Vinstr::contenter:
     case Vinstr::cqo:
     case Vinstr::debugtrap:
@@ -219,8 +238,10 @@ bool effectful(Vinstr& inst) {
     case Vinstr::phpret:
     case Vinstr::pop:
     case Vinstr::popm:
+    case Vinstr::popp:
     case Vinstr::push:
     case Vinstr::pushm:
+    case Vinstr::pushp:
     case Vinstr::resumetc:
     case Vinstr::ret:
     case Vinstr::retransopt:

--- a/hphp/runtime/vm/jit/vasm-dead.cpp
+++ b/hphp/runtime/vm/jit/vasm-dead.cpp
@@ -175,7 +175,6 @@ bool effectful(Vinstr& inst) {
     case Vinstr::bindjcc1st:
     case Vinstr::bindjcc:
     case Vinstr::bindjmp:
-    case Vinstr::brk:
     case Vinstr::call:
     case Vinstr::callarray:
     case Vinstr::callfaststub:
@@ -184,8 +183,6 @@ bool effectful(Vinstr& inst) {
     case Vinstr::callr:
     case Vinstr::calls:
     case Vinstr::callstub:
-    case Vinstr::calltc:
-    case Vinstr::cbcc:
     case Vinstr::contenter:
     case Vinstr::cqo:
     case Vinstr::debugtrap:
@@ -195,7 +192,6 @@ bool effectful(Vinstr& inst) {
     case Vinstr::fallback:
     case Vinstr::fallbackcc:
     case Vinstr::fallthru:
-    case Vinstr::hostcall:
     case Vinstr::idiv:
     case Vinstr::inclm:
     case Vinstr::incqm:
@@ -247,7 +243,6 @@ bool effectful(Vinstr& inst) {
     case Vinstr::syncvmsp:
     case Vinstr::tailcallphp:
     case Vinstr::tailcallstub:
-    case Vinstr::tbcc:
     case Vinstr::ud2:
     case Vinstr::unwind:
     case Vinstr::vcall:

--- a/hphp/runtime/vm/jit/vasm-dead.cpp
+++ b/hphp/runtime/vm/jit/vasm-dead.cpp
@@ -83,6 +83,7 @@ bool effectful(Vinstr& inst) {
     case Vinstr::divsd:
     case Vinstr::extsb:
     case Vinstr::extsw:
+    case Vinstr::fabs:
     case Vinstr::fcmpo:
     case Vinstr::fcmpu:
     case Vinstr::imul:
@@ -97,13 +98,11 @@ bool effectful(Vinstr& inst) {
     case Vinstr::lea:
     case Vinstr::lead:
     case Vinstr::leap:
-    case Vinstr::lead:
     case Vinstr::load:
     case Vinstr::loadb:
     case Vinstr::loadl:
     case Vinstr::loadqd:
     case Vinstr::loadqp:
-    case Vinstr::loadqd:
     case Vinstr::loadsd:
     case Vinstr::loadtqb:
     case Vinstr::loadups:
@@ -137,6 +136,7 @@ bool effectful(Vinstr& inst) {
     case Vinstr::nop:
     case Vinstr::not:
     case Vinstr::notb:
+    case Vinstr::orsw:
     case Vinstr::orswi:
     case Vinstr::orq:
     case Vinstr::orqi:
@@ -160,6 +160,7 @@ bool effectful(Vinstr& inst) {
     case Vinstr::subli:
     case Vinstr::subq:
     case Vinstr::subqi:
+    case Vinstr::subsb:
     case Vinstr::subsd:
     case Vinstr::testb:
     case Vinstr::testbi:

--- a/hphp/runtime/vm/jit/vasm-instr.cpp
+++ b/hphp/runtime/vm/jit/vasm-instr.cpp
@@ -84,6 +84,8 @@ Width width(Vinstr::Opcode op) {
     case Vinstr::fallbackcc:
     case Vinstr::retransopt:
     // vasm intrinsics
+    case Vinstr::conjure:
+    case Vinstr::conjureuse:
     case Vinstr::copy:
     case Vinstr::copy2:
     case Vinstr::copyargs:
@@ -178,6 +180,7 @@ Width width(Vinstr::Opcode op) {
     case Vinstr::asrxis:
     case Vinstr::blrn:
     case Vinstr::cmpsds:
+    case Vinstr::fabs:
     case Vinstr::lslwi:
     case Vinstr::lslwis:
     case Vinstr::lslxi:
@@ -188,9 +191,11 @@ Width width(Vinstr::Opcode op) {
     case Vinstr::lsrxis:
     case Vinstr::mrs:
     case Vinstr::msr:
+    case Vinstr::orsw:
     case Vinstr::orswi:
     case Vinstr::popp:
     case Vinstr::pushp:
+    case Vinstr::subsb:
     // ppc64 instructions
     case Vinstr::extsb:
     case Vinstr::extsw:

--- a/hphp/runtime/vm/jit/vasm-instr.cpp
+++ b/hphp/runtime/vm/jit/vasm-instr.cpp
@@ -84,8 +84,6 @@ Width width(Vinstr::Opcode op) {
     case Vinstr::fallbackcc:
     case Vinstr::retransopt:
     // vasm intrinsics
-    case Vinstr::conjure:
-    case Vinstr::conjureuse:
     case Vinstr::copy:
     case Vinstr::copy2:
     case Vinstr::copyargs:
@@ -175,10 +173,24 @@ Width width(Vinstr::Opcode op) {
     case Vinstr::sarq:
     case Vinstr::shlq:
     // arm instructions
-    case Vinstr::brk:
-    case Vinstr::cbcc:
-    case Vinstr::hostcall:
-    case Vinstr::tbcc:
+    case Vinstr::addxi:
+    case Vinstr::asrxi:
+    case Vinstr::asrxis:
+    case Vinstr::blrn:
+    case Vinstr::cmpsds:
+    case Vinstr::lslwi:
+    case Vinstr::lslwis:
+    case Vinstr::lslxi:
+    case Vinstr::lslxis:
+    case Vinstr::lsrwi:
+    case Vinstr::lsrwis:
+    case Vinstr::lsrxi:
+    case Vinstr::lsrxis:
+    case Vinstr::mrs:
+    case Vinstr::msr:
+    case Vinstr::orswi:
+    case Vinstr::popp:
+    case Vinstr::pushp:
     // ppc64 instructions
     case Vinstr::extsb:
     case Vinstr::extsw:

--- a/hphp/runtime/vm/jit/vasm-instr.cpp
+++ b/hphp/runtime/vm/jit/vasm-instr.cpp
@@ -67,10 +67,6 @@ bool isBlockEnd(const Vinstr& inst) {
     case Vinstr::phpret:
     case Vinstr::leavetc:
     case Vinstr::fallthru:
-    // arm specific
-    case Vinstr::cbcc:
-    case Vinstr::tbcc:
-    case Vinstr::brk:
       return true;
     default:
       return false;

--- a/hphp/runtime/vm/jit/vasm-instr.h
+++ b/hphp/runtime/vm/jit/vasm-instr.h
@@ -281,6 +281,7 @@ struct Vunit;
   O(asrxis, I(s0), U(s1) U(d), D(df) D(sf))\
   O(blrn, Inone, Un, Dn)\
   O(cmpsds, I(pred), UA(s0) U(s1), D(d))\
+  O(fabs, Inone, U(s), D(d))\
   O(lslwi, I(s0), UH(s1,d), DH(d,s1))\
   O(lslwis, I(s0), U(s1) U(d), D(df) D(sf))\
   O(lslxi, I(s0), UH(s1,d), DH(d,s1))\
@@ -292,8 +293,10 @@ struct Vunit;
   O(mrs, I(s), Un, D(r))\
   O(msr, I(s), U(r), Dn)\
   O(orswi, I(s0), UH(s1,d), DH(d,s1) D(sf))\
+  O(orsw, Inone, U(s0) U(s1), D(d) D(sf)) \
   O(popp, Inone, U(s0) U(s1), Dn)\
   O(pushp, Inone, U(s0) U(s1), Dn)\
+  O(subsb, Inone, UA(s0) U(s1), D(d) D(sf))\
   /* ppc64 instructions */\
   O(extsb, Inone, UH(s,d), DH(d,s) D(sf))\
   O(extsw, Inone, UH(s,d), DH(d,s) D(sf))\
@@ -1100,6 +1103,7 @@ struct asrxi { Immed s0; Vreg64 s1, d; };
 struct asrxis { Immed s0; Vreg64 s1, d, df; VregSF sf; };
 struct blrn {};
 struct cmpsds { ComparisonPred pred; VregDbl s0, s1, d; VregSF sf; };
+struct fabs { VregDbl s, d; };
 struct lslwi { Immed s0; Vreg32 s1, d; };
 struct lslwis { Immed s0; Vreg32 s1, d, df; VregSF sf; };
 struct lslxi { Immed s0; Vreg64 s1, d; };
@@ -1111,8 +1115,10 @@ struct lsrxis { Immed s0; Vreg64 s1, d, df; VregSF sf; };
 struct mrs { Immed s; Vreg64 r; };
 struct msr { Vreg64 r; Immed s; };
 struct orswi { Immed s0; Vreg32 s1, d; VregSF sf; };
+struct orsw { Vreg32 s0, s1, d; VregSF sf; };
 struct popp { Vreg64 s0, s1; };
 struct pushp { Vreg64 s0, s1; };
+struct subsb { Vreg8 s0, s1, d; VregSF sf; };
 
 /*
  * ppc64 intrinsics.

--- a/hphp/runtime/vm/jit/vasm-instr.h
+++ b/hphp/runtime/vm/jit/vasm-instr.h
@@ -124,9 +124,6 @@ struct Vunit;
   O(absdbl, Inone, U(s), D(d))\
   O(srem, Inone, U(s0) U(s1), D(d))\
   O(divint, Inone, U(s0) U(s1), D(d))\
-  /* nop and trap */\
-  O(nop, Inone, Un, Dn)\
-  O(ud2, Inone, Un, Dn)\
   /* arithmetic instructions */\
   O(addl, Inone, U(s0) U(s1), D(d) D(sf)) \
   O(addli, I(s0), UH(s1,d), DH(d,s1) D(sf)) \
@@ -858,17 +855,6 @@ struct srem { Vreg s0, s1, d; };
 struct divint { Vreg s0, s1, d; };
 
 ///////////////////////////////////////////////////////////////////////////////
-
-/*
- * Unless specifically noted otherwise, instructions with Vreg{8,16,32} dsts
- * can do whatever they please with the upper bits.
- */
-
-/*
- * Nop and trap.
- */
-struct nop {};
-struct ud2 {};
 
 /*
  * Arithmetic instructions.

--- a/hphp/runtime/vm/jit/vasm.cpp
+++ b/hphp/runtime/vm/jit/vasm.cpp
@@ -39,8 +39,6 @@ folly::Range<Vlabel*> succs(Vinstr& inst) {
     case Vinstr::unwind:      return {inst.unwind_.targets, 2};
     case Vinstr::vcallarray:  return {inst.vcallarray_.targets, 2};
     case Vinstr::vinvoke:     return {inst.vinvoke_.targets, 2};
-    case Vinstr::cbcc:        return {inst.cbcc_.targets, 2};
-    case Vinstr::tbcc:        return {inst.tbcc_.targets, 2};
     default:                  return {nullptr, nullptr};
   }
 }


### PR DESCRIPTION
Note:
  Reused code at https://github.com/edwinsmith/hhvm-armjit partially.

1.  Removed unnecessary arm specific vasm codes (hostcall,cbcc,tbcc etc.)
2.  Fixed/Added remaining vasm to arm64 conversion routines
3.  SIMD is pending