### PR TITLE
Solve optimization issue on PPC64 by improving robustness

### DIFF
--- a/hphp/runtime/vm/jit/fixup.cpp
+++ b/hphp/runtime/vm/jit/fixup.cpp
@@ -158,8 +158,8 @@ void FixupMap::fixup(ExecutionContext* ec) const {
     DECLARE_FRAME_POINTER(framePtr);
     // In order to avoid tail call elimination optimization issues, grab the
     // parent frame pointer in order make sure this pointer is valid. The
-    // fixupWork function looks for a higher frame so there is no problem to
-    // skip this one.
+    // fixupWork() looks for a TC frame, and we never call fixup() directly
+    // from the TC, so skipping this frame isn't a problem.
     fixupWork(ec, framePtr->m_sfp);
   }
 }

--- a/hphp/runtime/vm/jit/fixup.cpp
+++ b/hphp/runtime/vm/jit/fixup.cpp
@@ -160,8 +160,7 @@ void FixupMap::fixup(ExecutionContext* ec) const {
     // parent frame pointer in order make sure this pointer is valid. The
     // fixupWork function looks for a higher frame so there is no problem to
     // skip this one.
-    framePtr = framePtr->m_sfp;
-    fixupWork(ec, framePtr);
+    fixupWork(ec, framePtr->m_sfp);
   }
 }
 

--- a/hphp/runtime/vm/jit/unique-stubs.cpp
+++ b/hphp/runtime/vm/jit/unique-stubs.cpp
@@ -545,10 +545,7 @@ TCA emitBindCallStub(CodeBlock& cb) {
     v << subqi{callLen, savedRIP, args[1], v.makeReg()};
 
     v << copy{rvmfp(), args[2]};
-    // Promote bool type argument size to long in order to avoid issues on
-    // platforms that optimization might not ignore the higher bits of the
-    // register (e.g: ppc64)
-    v << ldimml{immutable, args[3]};
+    v << movb{v.cns(immutable), args[3]};
 
     auto const handler = reinterpret_cast<void (*)()>(
       getMethodPtr(&MCGenerator::handleBindCall)

--- a/hphp/runtime/vm/jit/unique-stubs.cpp
+++ b/hphp/runtime/vm/jit/unique-stubs.cpp
@@ -545,7 +545,10 @@ TCA emitBindCallStub(CodeBlock& cb) {
     v << subqi{callLen, savedRIP, args[1], v.makeReg()};
 
     v << copy{rvmfp(), args[2]};
-    v << movb{v.cns(immutable), args[3]};
+    // Promote bool type argument size to long in order to avoid issues on
+    // platforms that optimization might not ignore the higher bits of the
+    // register (e.g: ppc64)
+    v << ldimml{immutable, args[3]};
 
     auto const handler = reinterpret_cast<void (*)()>(
       getMethodPtr(&MCGenerator::handleBindCall)


### PR DESCRIPTION
It's not a good idea to simply shut down optimizations if your code is
breaking because the compiler might change in the future. It's wiser
to make your code more robust in order to avoid falling in such cases
that optimization could break your code.

The fixup issue was already solved on upstream
(fa13910bd1f391f6110b1c07cd5a55d265e1b6be) but as discussed above, I
changed it to avoid the optimization issue by using a parent frame
(which tail call optimization doesn't eliminate). There is no drawback
as the called fixupWork will look for a VM frame, which is further back.

Thanks to @tuliom for discussing these decisions.