### PR TITLE
Fix the Redis client's scan family.

### DIFF
--- a/hphp/hack/hhi/stdlib/builtins_redis.hhi
+++ b/hphp/hack/hhi/stdlib/builtins_redis.hhi
@@ -32,10 +32,10 @@ class Redis {
   public function __construct() {}
   public function connect($host, $port = 6379, $timeout = 0.0) {}
   public function psetex($key, $ttl, $value) {}
-  public function sScan($key, $iterator, $pattern = '', $count = 0) {}
-  public function scan($iterator, $pattern = '', $count = 0) {}
-  public function zScan($key, $iterator, $pattern = '', $count = 0) {}
-  public function hScan($key, $iterator, $pattern = '', $count = 0) {}
+  public function sScan($key, &$iterator, $pattern = '', $count = 0) {}
+  public function scan(&$iterator, $pattern = '', $count = 0) {}
+  public function zScan($key, &$iterator, $pattern = '', $count = 0) {}
+  public function hScan($key, &$iterator, $pattern = '', $count = 0) {}
   public function client($command, $arg = '') {}
   public function slowlog($command) {}
   public function open($host, $port = 6379, $timeout = 0.0) {}

--- a/hphp/system/php/redis/Redis.php
+++ b/hphp/system/php/redis/Redis.php
@@ -54,8 +54,8 @@ class Redis {
 
   /* Scan retry settings. We essentially always retry, so this is
      just for PHP 5 compatibility. */
- const SCAN_RETRY = 0;
- const SCAN_NORETRY = 1;
+  const SCAN_RETRY = 0;
+  const SCAN_NORETRY = 1;
 
   /* Connection ---------------------------------------------------------- */
 
@@ -526,22 +526,22 @@ class Redis {
 
       $args = [];
       if ($cmd !== 'SCAN') {
-	$args[] = $this->_prefix($key);
+        $args[] = $this->_prefix($key);
       }
       $args[] = (int)$cursor;
       if ($pattern !== null) {
-	$args[] = 'MATCH';
-	$args[] = (string)$pattern;
+        $args[] = 'MATCH';
+        $args[] = (string)$pattern;
       }
       if ($count !== null) {
-	$args[] = 'COUNT';
-	$args[] = (int)$count;
+        $args[] = 'COUNT';
+        $args[] = (int)$count;
       }
       $this->processArrayCommand($cmd, $args);
       $resp = $this->processVariantResponse();
       if (!is_array($resp) || count($resp) != 2 || !is_array($resp[1])) {
-	throw new RedisException(
-	  sprintf("Invalid %s response: %s", $cmd, print_r($resp, true)));
+        throw new RedisException(
+          sprintf("Invalid %s response: %s", $cmd, print_r($resp, true)));
       }
       $cursor = (int)$resp[0];
       $results = $resp[1];

--- a/hphp/system/php/redis/Redis.php
+++ b/hphp/system/php/redis/Redis.php
@@ -42,6 +42,7 @@ class Redis {
   const OPT_SERIALIZER   = 1;
   const OPT_PREFIX       = 2;
   const OPT_READ_TIMEOUT = 3;
+  const OPT_SCAN         = 4;
 
   /* Type of serialization to use with values stored in redis */
   const SERIALIZER_NONE     = 0;
@@ -50,6 +51,11 @@ class Redis {
   /* Options used by lInsert and similar methods */
   const AFTER  = 'after';
   const BEFORE = 'before';
+
+  /* Scan retry settings. We essentially always retry, so this is
+     just for PHP 5 compatibility. */
+ const SCAN_RETRY = 0;
+ const SCAN_NORETRY = 1;
 
   /* Connection ---------------------------------------------------------- */
 
@@ -509,35 +515,68 @@ class Redis {
 
   /* Scan --------------------------------------------------------------- */
 
-  protected function scanImpl($cmd, $key, $cursor, $pattern, $count) {
-    $args = [];
-    if ($key !== null) {
-      $args[] = $this->_prefix($key);
+  protected function scanImpl($cmd, $key, &$cursor, $pattern, $count) {
+    if ($this->mode != self::ATOMIC) {
+      throw new RedisException("Can't call SCAN commands in multi or pipeline mode!");
     }
-    $args[] = (int)$cursor;
-    if ($pattern !== null) {
-      $args[] = 'MATCH';
-      if ($cmd === 'SCAN') {
-        $args[] = (string)$this->_prefix($pattern);
+
+    $results = false;
+    do {
+      if ($cursor === 0) return $results;
+
+      $args = [];
+      if ($cmd !== 'SCAN') {
+	$args[] = $this->_prefix($key);
       }
-      else {
-        $args[] = (string)$pattern;
+      $args[] = (int)$cursor;
+      if ($pattern !== null) {
+	$args[] = 'MATCH';
+	$args[] = (string)$pattern;
       }
-    }
-    if ($count !== null) {
-      $args[] = 'COUNT';
-      $args[] = (int)$count;
-    }
-    $this->processArrayCommand($cmd, $args);
-    return $this->processVariantResponse();
+      if ($count !== null) {
+	$args[] = 'COUNT';
+	$args[] = (int)$count;
+      }
+      $this->processArrayCommand($cmd, $args);
+      $resp = $this->processVariantResponse();
+      if (!is_array($resp) || count($resp) != 2 || !is_array($resp[1])) {
+	throw new RedisException(
+	  sprintf("Invalid %s response: %s", $cmd, print_r($resp, true)));
+      }
+      $cursor = (int)$resp[0];
+      $results = $resp[1];
+      // Provide SCAN_RETRY semantics by default. If iteration is done and
+      // there were no results, $cursor === 0 check at the top of the loop
+      // will pop us out.
+    } while(count($results) == 0);
+    return $results;
   }
 
-  public function scan($cursor, $pattern = null, $count = null) {
+  public function scan(&$cursor, $pattern = null, $count = null) {
     return $this->scanImpl('SCAN', null, $cursor, $pattern, $count);
-}
+  }
 
-  public function sScan($key, $cursor, $pattern = null, $count = null) {
+  public function sScan($key, &$cursor, $pattern = null, $count = null) {
     return $this->scanImpl('SSCAN', $key, $cursor, $pattern, $count);
+  }
+
+  public function hScan($key, &$cursor, $pattern = null, $count = null) {
+    return $this->scanImpl('HSCAN', $key, $cursor, $pattern, $count);
+  }
+
+  public function zScan($key, &$cursor, $pattern = null, $count = null) {
+    $flat = $this->scanImpl('ZSCAN', $key, $cursor, $pattern, $count);
+    if ($flat === false) return $flat;
+    /*
+     * ZScan behaves differently from the other *scan functions. The wire
+     * protocol returns names in even slots s, and the corresponding value
+     * in odd slot s + 1. The PHP client returns these as an array mapping
+     * keys to values.
+     */
+    assert(count($flat) % 2 == 0);
+    $ret = array();
+    for ($i = 0; $i < count($flat); $i += 2) $ret[$flat[$i]] = $flat[$i + 1];
+    return $ret;
   }
 
   /* Multi --------------------------------------------------------------- */

--- a/hphp/test/slow/ext_redis/scan.php
+++ b/hphp/test/slow/ext_redis/scan.php
@@ -3,17 +3,58 @@
 include (__DIR__ . '/redis.inc');
 
 $r = NewRedisTestInstance();
-$r->setOption(Redis::OPT_PREFIX, GetTestKeyName(__FILE__) . ':');
-$r->delete('scan');
-
-$r->mset(array('key:one' => 'one', 'key:two' => 'two',
+global $prefix;
+$prefix = GetTestKeyName(__FILE__) . ':';
+$r->setOption(Redis::OPT_PREFIX, $prefix);
+$r->setOption(Redis::OPT_SCAN, Redis::SCAN_RETRY);
+$ret = $r->delete('scan');
+$ret = $r->mset(array('key:one' => 'one', 'key:two' => 'two',
                'key:three' => 'three','key:four' => 'four'));
 
-var_dump($r->scan(0));
-var_dump($r->scan(0, 'key:t*'));
-var_dump($r->scan(0, 'nokey:t*'));
+/*
+ * The PHP5 extension we're patterning after doesn't try to turn
+ * OPT_PREFIX into a pattern when doing scan(), so scan returns
+ * global state. Filter it ourselves.
+ */
+function performScan($fn){
+	$cursor = null;
+	$returns = array();
+	while (($retval = $fn($cursor))){
+		foreach ($retval as $key){
+			global $prefix;
+			if (strstr($key, $prefix) !== false){
+				$returns []= substr($key, strlen($prefix));
+			}
+		}
+	}
+	// Normalize return order
+	sort($returns);
+	return $returns;
+}
 
-$r->delete('key:one');
-$r->delete('key:two');
-$r->delete('key:three');
-$r->delete('key:four');
+try {
+	$ret = performScan(function(&$cursor) use($r){
+		// Scan without patterns.
+		return $r->scan($cursor);
+	});
+	var_dump($ret);
+
+	$ret = performScan(function(&$cursor) use($r){
+		// catch key:two and key:three
+		global $prefix;
+		return $r->scan($cursor, $prefix . 'key:t*');
+	});
+	var_dump($ret);
+
+	$ret = performScan(function(&$cursor) use($r){
+		// nothing.
+		global $prefix;
+		return $r->scan($cursor, $prefix . 'nokey:t*');
+	});
+	var_dump($ret);
+} finally {
+	$r->delete('key:one');
+	$r->delete('key:two');
+	$r->delete('key:three');
+	$r->delete('key:four');
+}

--- a/hphp/test/slow/ext_redis/scan.php.expect
+++ b/hphp/test/slow/ext_redis/scan.php.expect
@@ -1,33 +1,18 @@
-array(2) {
+array(4) {
   [0]=>
-  string(1) "0"
+  string(8) "key:four"
   [1]=>
-  array(4) {
-    [0]=>
-    string(52) "REDIS_TEST:a994b47cc077764cbbb47943ee50fca1:key:four"
-    [1]=>
-    string(51) "REDIS_TEST:a994b47cc077764cbbb47943ee50fca1:key:one"
-    [2]=>
-    string(53) "REDIS_TEST:a994b47cc077764cbbb47943ee50fca1:key:three"
-    [3]=>
-    string(51) "REDIS_TEST:a994b47cc077764cbbb47943ee50fca1:key:two"
-  }
+  string(7) "key:one"
+  [2]=>
+  string(9) "key:three"
+  [3]=>
+  string(7) "key:two"
 }
 array(2) {
   [0]=>
-  string(1) "0"
+  string(9) "key:three"
   [1]=>
-  array(2) {
-    [0]=>
-    string(53) "REDIS_TEST:a994b47cc077764cbbb47943ee50fca1:key:three"
-    [1]=>
-    string(51) "REDIS_TEST:a994b47cc077764cbbb47943ee50fca1:key:two"
-  }
+  string(7) "key:two"
 }
-array(2) {
-  [0]=>
-  string(1) "0"
-  [1]=>
-  array(0) {
-  }
+array(0) {
 }

--- a/hphp/test/slow/ext_redis/sscan.php
+++ b/hphp/test/slow/ext_redis/sscan.php
@@ -4,12 +4,24 @@ include (__DIR__ . '/redis.inc');
 
 $r = NewRedisTestInstance();
 $r->setOption(Redis::OPT_PREFIX, GetTestKeyName(__FILE__) . ':');
+$r->setOption(Redis::OPT_SCAN, Redis::SCAN_RETRY);
 $r->delete('sscan');
 
 $r->sadd('sscan', 'member:one', 'member:two', 'member:three', 'member:four');
 
-var_dump($r->sscan('sscan', 0));
-var_dump($r->sscan('sscan', 0, 'member:t*'));
-var_dump($r->sscan('sscan', 0, 'nomember:*'));
+$cursor = null;
+$ret = $r->sscan('sscan', $cursor);
+sort($ret);
+var_dump($ret);
+
+$cursor = null;
+$ret = $r->sscan('sscan', $cursor, 'member:t*');
+sort($ret);
+var_dump($ret);
+
+$cursor = null;
+$ret = $r->sscan('sscan', $cursor, 'nomember:t*');
+sort($ret);
+var_dump($ret);
 
 $r->delete('sscan');

--- a/hphp/test/slow/ext_redis/sscan.php.expect
+++ b/hphp/test/slow/ext_redis/sscan.php.expect
@@ -1,33 +1,18 @@
-array(2) {
+array(4) {
   [0]=>
-  string(1) "0"
+  string(11) "member:four"
   [1]=>
-  array(4) {
-    [0]=>
-    string(11) "member:four"
-    [1]=>
-    string(12) "member:three"
-    [2]=>
-    string(10) "member:two"
-    [3]=>
-    string(10) "member:one"
-  }
+  string(10) "member:one"
+  [2]=>
+  string(12) "member:three"
+  [3]=>
+  string(10) "member:two"
 }
 array(2) {
   [0]=>
-  string(1) "0"
+  string(12) "member:three"
   [1]=>
-  array(2) {
-    [0]=>
-    string(12) "member:three"
-    [1]=>
-    string(10) "member:two"
-  }
+  string(10) "member:two"
 }
-array(2) {
-  [0]=>
-  string(1) "0"
-  [1]=>
-  array(0) {
-  }
+array(0) {
 }


### PR DESCRIPTION
The PECL Redis client wraps the *scan family of methods
in a less trivial way than most other methods. I've manually
verified that a Redis test suite agrees across PHP5 and HHVM
with these changes.