### PR TITLE
Properly print repo schema when dumping TC.

### DIFF
--- a/hphp/runtime/vm/jit/mc-generator.cpp
+++ b/hphp/runtime/vm/jit/mc-generator.cpp
@@ -2116,7 +2116,7 @@ bool MCGenerator::dumpTCData() {
                 "acold.frontier   = %p\n"
                 "afrozen.base     = %p\n"
                 "afrozen.frontier = %p\n\n",
-                repoSchemaId(),
+                repoSchemaId().begin(),
                 m_code.hot().base(), m_code.hot().frontier(),
                 m_code.main().base(), m_code.main().frontier(),
                 m_code.prof().base(), m_code.prof().frontier(),


### PR DESCRIPTION
It was causing gzprintf to misbehave - all arguments after repoSchema() were
"shifted" to the right. Incorrect information in the gz archive was causing
tc-print to segfault.