### PR TITLE
Update TBB accessor in gdb script.

### DIFF
--- a/hphp/tools/gdb/idx.py
+++ b/hphp/tools/gdb/idx.py
@@ -92,7 +92,11 @@ def boost_flat_map_at(flat_map, key):
 # TBB accessors.
 
 def tbb_atomic_get(atomic):
-    return atomic['rep']['value']
+    try:
+        return atomic['rep']['value']
+    except gdb.error:
+        # atomic_impl representation since version 4.1 Update 2
+        return atomic['my_storage']['my_value']
 
 
 def tbb_chm_at(chm, key):


### PR DESCRIPTION
The TBB internal representation of atomic_impl changed in version 4.1 Update 2.
Keep old accessor for backward compatibility.