### PR TITLE
Read the CPU frequency from the /proc/cpuinfo usin

### DIFF
--- a/hphp/runtime/ext/hotprofiler/ext_hotprofiler.cpp
+++ b/hphp/runtime/ext/hotprofiler/ext_hotprofiler.cpp
@@ -155,7 +155,8 @@ static int64_t* get_cpu_frequency_from_file(const char *file, int ncpus)
       continue;
     }
     float freq;
-    if (sscanf(line, "cpu MHz : %f", &freq) == 1) {
+    if ((sscanf(line, "cpu MHz : %f", &freq) == 1) ||
+        (sscanf(line, "clock         : %f", &freq) == 1)) {
       if (processor != -1 && processor < ncpus) {
          freqs[processor] = nearbyint(freq);
          processor = -1;


### PR DESCRIPTION
HHVM is not able to detect PPC64 frequency. This patch adjust a
sscanf to match Intel and PPC64 clock frequency avoiding get_cpu_frequency()
call. This turns out to improve HHVM run time.