### PR TITLE
Use a recoverable fatal on curl_init_pooled

### DIFF
--- a/hphp/runtime/ext/curl/curl-pool.cpp
+++ b/hphp/runtime/ext/curl/curl-pool.cpp
@@ -1,6 +1,8 @@
 #include "hphp/runtime/ext/curl/curl-pool.h"
 
 #include "hphp/runtime/base/runtime-error.h"
+#include "hphp/runtime/vm/jit/translator-inline.h"
+#include "hphp/system/systemlib.h"
 #include "hphp/util/compatibility.h"
 #include "hphp/util/lock.h"
 
@@ -68,8 +70,8 @@ PooledCurlHandle* CurlHandlePool::fetch() {
   ts.tv_nsec += 1000000 * (m_waitTimeout % 1000);
   while (m_handleStack.empty()) {
     if (ETIMEDOUT == pthread_cond_timedwait(&m_cond, &m_mutex.getRaw(), &ts)) {
-      raise_error("Timeout reached waiting for an "
-                  "available pooled curl connection!");
+      SystemLib::throwRuntimeExceptionObject(
+        "Timeout reached waiting for an available pooled curl connection!");
     }
   }
 

--- a/hphp/test/slow/ext_curl/curl_handles_in_different_pools_dont_interfere.php.expectf
+++ b/hphp/test/slow/ext_curl/curl_handles_in_different_pools_dont_interfere.php.expectf
@@ -1,4 +1,6 @@
 string(7) "foo.com"
 string(7) "bar.com"
 
-Fatal error: Timeout reached waiting for an available pooled curl connection! %s
+Fatal error: Uncaught exception 'RuntimeException' with message 'Timeout reached waiting for an available pooled curl connection!' in %s/hphp/test/slow/ext_curl/curl_handles_in_different_pools_dont_interfere.php:9
+Stack trace:
+#0 {main}

--- a/hphp/test/slow/ext_curl/get_pooled_curl_timeout_works.php.bad
+++ b/hphp/test/slow/ext_curl/get_pooled_curl_timeout_works.php.bad
@@ -1,4 +1,4 @@
 <?php
-// the curl pool is 1, so the second request will fatal
+// the curl pool is 1, so the second request will throw RuntimeException
 $ch = curl_init_pooled('test', 'foo.bar.com');
 $ch2 = curl_init_pooled('test', 'www.baz.com');

--- a/hphp/test/slow/ext_curl/get_pooled_curl_timeout_works.php.expectf
+++ b/hphp/test/slow/ext_curl/get_pooled_curl_timeout_works.php.expectf
@@ -1,1 +1,4 @@
-Fatal error: Timeout reached waiting for an available pooled curl connection! %s
+
+Fatal error: Uncaught exception 'RuntimeException' with message 'Timeout reached waiting for an available pooled curl connection!' in %s/hphp/test/slow/ext_curl/get_pooled_curl_timeout_works.php:4
+Stack trace:
+#0 {main}

--- a/hphp/test/slow/ext_curl/pools_can_be_configured_independently.php.expectf
+++ b/hphp/test/slow/ext_curl/pools_can_be_configured_independently.php.expectf
@@ -1,3 +1,5 @@
 here
 
-Fatal error: Timeout reached waiting for an available pooled curl connection!%s
+Fatal error: Uncaught exception 'RuntimeException' with message 'Timeout reached waiting for an available pooled curl connection!' in %s/hphp/test/slow/ext_curl/pools_can_be_configured_independently.php:6
+Stack trace:
+#0 {main}


### PR DESCRIPTION
curl_init_pooled has an unfortunate failure mode, when the pool is
exhausted the entire request fatals. This prevents the application from
gracefully handling the failure. The application could disable the
feature rather than canceling the entire request. In general fatal
errors should be reserved for cases where it is impossible to continue
processing the request, not simply because something went wrong. This
switches the fatal to a RuntimeException.