### PR TITLE
Extend support for linux tools perf for jitted code

### DIFF
--- a/hphp/runtime/base/runtime-option.h
+++ b/hphp/runtime/base/runtime-option.h
@@ -453,6 +453,7 @@ struct RuntimeOption {
   F(bool, SpinOnCrash,                 false)                           \
   F(uint32_t, DumpRingBufferOnCrash,   0)                               \
   F(bool, PerfPidMap,                  true)                            \
+  F(bool, PerfJitDump,                 false)                           \
   F(bool, PerfDataMap,                 false)                           \
   F(bool, KeepPerfPidMap,              false)                           \
   F(int32_t, PerfRelocate,             0)                               \

--- a/hphp/runtime/vm/debug/debug.h
+++ b/hphp/runtime/vm/debug/debug.h
@@ -37,6 +37,10 @@ struct DebugInfo {
   void recordStub(TCRange range, const std::string&);
   void recordPerfMap(TCRange range, const Func* func, bool exit,
                      bool inPrologue);
+  void recordPerfJitTracelet(TCRange range,
+                             const Func* func,
+                             bool exit,
+                             bool inPrologue);
   void recordBCInstr(TCRange range, uint32_t op);
 
   static void recordDataMap(void* from, void* to, const std::string& desc);
@@ -50,9 +54,15 @@ struct DebugInfo {
     pidMapOverlayStart = from;
     pidMapOverlayEnd = to;
   }
+
  private:
   void generatePidMapOverlay();
-
+  void initPerfJitDump();
+  void closePerfJitDump();
+  int perfJitDumpTrace(const void* startAddr, 
+                       const unsigned int size, 
+                       const char* symName); 
+  
   /* maintain separate dwarf info for a and acold, so that we
    * don't emit dwarf info for the two in the same ELF file.
    * gdb tends to get confused when it sees dwarf info for
@@ -66,7 +76,20 @@ struct DebugInfo {
    */
   FILE* m_perfMap{nullptr};
   std::string m_perfMapName;
-
+  
+  /*
+   * jitdump file will store the generated code in /tmp/jit-<pid>.dump 
+   * perf record will create perf.data 
+   * perf inject will read jitdump file and generate a corresponding 
+   * jitted-<pid>-<id>.so ELF file every trace compiled, it will then insert
+   * a PERF_RECORD_MMAP2 mmap event for every ELF file created into perf.data
+   * perf report will be able to read these ELF files and provide information
+   * on the samples collected on generated code. 
+   */ 
+  FILE* m_perfJitDump{nullptr}; 
+  std::string m_perfJitDumpName;  
+  void* m_perfMmapMarker{nullptr}; 
+  
   /*
    * Similar to perfMap, but for data addresses. Perf doesn't use
    * it directly, but we can write tools based on perf script that

--- a/hphp/runtime/vm/debug/oprof-jitdump.h
+++ b/hphp/runtime/vm/debug/oprof-jitdump.h
@@ -1,0 +1,125 @@
+/*
+   +----------------------------------------------------------------------+
+   | HipHop for PHP                                                       |
+   +----------------------------------------------------------------------+
+   | Copyright (c) 2010-2016 Facebook, Inc. (http://www.facebook.com)     |
+   +----------------------------------------------------------------------+
+   | This source file is subject to version 3.01 of the PHP license,      |
+   | that is bundled with this package in the file LICENSE, and is        |
+   | available through the world-wide-web at the following url:           |
+   | http://www.php.net/license/3_01.txt                                  |
+   | If you did not receive a copy of the PHP license and are unable to   |
+   | obtain it through the world-wide-web, please send a note to          |
+   | license@php.net so we can mail you a copy immediately.               |
+   +----------------------------------------------------------------------+
+
+ * oprof-jitdump.h: jitted code info; encapsulation file format
+ *
+ * Adapted from the Oprofile code in jitdump.h
+ * Copyright 2007 OProfile authors
+ * Jens Wilke
+ * Daniel Hansel
+ * Copyright IBM Corporation 2007
+ */
+#ifndef JITDUMP_H
+#define JITDUMP_H
+
+#include <sys/time.h>
+#include <time.h>
+#include <stdint.h>
+
+/* JiTD */
+#define JITHEADER_MAGIC         0x4A695444
+#define JITHEADER_MAGIC_SW      0x4454694A
+
+#define PADDING_8ALIGNED(x) ((((x) + 7) & 7) ^ 7)
+
+#define JITHEADER_VERSION 1
+
+enum jitdump_flags_bits {
+  JITDUMP_FLAGS_ARCH_TIMESTAMP_BIT,
+  JITDUMP_FLAGS_MAX_BIT,
+};
+
+#define JITDUMP_FLAGS_ARCH_TIMESTAMP  (1ULL << JITDUMP_FLAGS_ARCH_TIMESTAMP_BIT)
+
+#define JITDUMP_FLAGS_RESERVED (JITDUMP_FLAGS_MAX_BIT < 64 ? \
+                               (~((1ULL << JITDUMP_FLAGS_MAX_BIT) - 1)) : 0)
+
+struct jitheader {
+  uint32_t magic;       /* characters "jItD" */
+  uint32_t version;     /* header version */
+  uint32_t total_size;  /* total size of header */
+  uint32_t elf_mach;    /* elf mach target */
+  uint32_t pad1;        /* reserved */
+  uint32_t pid;         /* JIT process id */
+  uint64_t timestamp;   /* timestamp */
+  uint64_t flags;       /* flags */
+};
+
+enum jit_record_type {
+  JIT_CODE_LOAD        = 0,
+  JIT_CODE_MOVE        = 1,
+  JIT_CODE_DEBUG_INFO  = 2,
+  JIT_CODE_CLOSE       = 3,
+  JIT_CODE_MAX
+};
+
+/* record prefix (mandatory in each record) */
+struct jr_prefix {
+  uint32_t id;
+  uint32_t total_size;
+  uint64_t timestamp;
+};
+
+struct jr_code_load {
+  struct jr_prefix p;
+
+  uint32_t pid;
+  uint32_t tid;
+  uint64_t vma;
+  uint64_t code_addr;
+  uint64_t code_size;
+  uint64_t code_index;
+};
+
+struct jr_code_close {
+  struct jr_prefix p;
+};
+
+struct jr_code_move {
+  struct jr_prefix p;
+
+  uint32_t pid;
+  uint32_t tid;
+  uint64_t vma;
+  uint64_t old_code_addr;
+  uint64_t new_code_addr;
+  uint64_t code_size;
+  uint64_t code_index;
+};
+
+struct debug_entry {
+  uint64_t addr;
+  int lineno;      /* source line number starting at 1 */
+  int discrim;      /* column discriminator, 0 is default */
+  const char name[0]; /* null terminated filename, \xff\0 if same as previous entry */
+};
+
+struct jr_code_debug_info {
+  struct jr_prefix p;
+
+  uint64_t code_addr;
+  uint64_t nr_entry;
+  struct debug_entry entries[0];
+};
+
+union jr_entry {
+  struct jr_code_debug_info info;
+  struct jr_code_close close;
+  struct jr_code_load load;
+  struct jr_code_move move;
+  struct jr_prefix prefix;
+};
+
+#endif /* !JITDUMP_H */

--- a/hphp/runtime/vm/debug/perf-jitdump.cpp
+++ b/hphp/runtime/vm/debug/perf-jitdump.cpp
@@ -1,0 +1,278 @@
+/*
+   +----------------------------------------------------------------------+
+   | HipHop for PHP                                                       |
+   +----------------------------------------------------------------------+
+   | Copyright (c) 2010-2016 Facebook, Inc. (http://www.facebook.com)     |
+   +----------------------------------------------------------------------+
+   | This source file is subject to version 3.01 of the PHP license,      |
+   | that is bundled with this package in the file LICENSE, and is        |
+   | available through the world-wide-web at the following url:           |
+   | http://www.php.net/license/3_01.txt                                  |
+   | If you did not receive a copy of the PHP license and are unable to   |
+   | obtain it through the world-wide-web, please send a note to          |
+   | license@php.net so we can mail you a copy immediately.               |
+   +----------------------------------------------------------------------+
+
+ * perf-jitdump.c: perf agent to dump generated code into jit-<pid>.dump
+ *
+ * Adapted from the Oprofile code in opagent.c
+ * Copyright 2007 OProfile authors
+ * Jens Wilke
+ * Daniel Hansel
+ * Copyright IBM Corporation 2007
+ */
+
+#include "hphp/runtime/vm/debug/debug.h"
+#include "hphp/runtime/vm/debug/oprof-jitdump.h"
+
+#include <sys/types.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+#include <errno.h>
+#include <boost/filesystem/operations.hpp>
+#include <boost/filesystem/path.hpp>
+
+using namespace HPHP::jit;
+
+const char padding_bytes[7] = {'\0', '\0', '\0', '\0', '\0', '\0', '\0'};
+
+namespace HPHP {
+namespace Debug {
+
+static int getEMachine(struct jitheader *hdr)  {
+  char id[16];
+  int fd;
+  struct {
+    uint16_t e_type;
+    uint16_t e_machine;
+  } info;
+
+  fd = open("/proc/self/exe", O_RDONLY);
+  if (fd == -1)
+    return -1;
+
+  read(fd, id, sizeof(id));
+  
+  /* check ELF signature */
+  if (id[0] != 0x7f || id[1] != 'E' || id[2] != 'L' || id[3] != 'F') {
+    close(fd);
+    return -1;
+  }
+
+  read(fd, &info, sizeof(info));
+
+  if (info.e_machine < 0)  
+    hdr->elf_mach = 0; /* ELF EM_NONE */
+
+  close(fd);
+  return 0;
+}
+
+static int use_arch_timestamp;
+
+static inline uint64_t getArchTimestamp(void)  {
+#if defined(__i386__) || defined(__x86_64__)
+  unsigned int low, high;
+
+  asm volatile("rdtsc" : "=a" (low), "=d" (high));
+  return low | ((uint64_t)high) << 32;
+#else
+  return 0;
+#endif
+}
+
+#define CLOCK_MONOTONIC 1 
+#define NSEC_PER_SEC    1000000000
+static int perf_clk_id = CLOCK_MONOTONIC;
+
+static inline uint64_t timespec_to_ns(const struct timespec *ts)  {
+  return ((uint64_t) ts->tv_sec * NSEC_PER_SEC) + ts->tv_nsec;
+}
+
+static inline uint64_t perfGetTimestamp(void) {
+  struct timespec ts;
+
+  if (use_arch_timestamp)
+    return getArchTimestamp();
+
+  if(clock_gettime(perf_clk_id, &ts))
+    return 0;
+
+  return timespec_to_ns(&ts);
+}
+
+static bool createJitdumpDir(const char* dirName) {
+  /* create the directory if it does not exist, else use /tmp if it fails */ 
+  if(!dirName || !strlen(dirName)) {
+    return false;
+  }
+  
+  namespace bfs = boost::filesystem; 
+  boost::system::error_code ec;
+  
+  bfs::path dirPath(dirName); 
+  if(!boost::filesystem::is_directory(dirPath, ec)) {
+    if(!bfs::create_directories(dirPath)) {
+      return false;
+    }
+  } 
+  return true; 
+}
+
+void DebugInfo::initPerfJitDump() {
+  /* create and open the jitdump file*/
+  auto const jitdump_dir = getenv("JITDUMPDIR");
+
+  if(createJitdumpDir(jitdump_dir)) {
+    m_perfJitDumpName = folly::sformat("{}/jit-{}.dump", jitdump_dir, getpid());
+  } else {
+    m_perfJitDumpName = folly::sformat("/tmp/jit-{}.dump", getpid());
+  }
+    
+  /* env variable JITDUMP_USE_ARCH_TIMESTAMP is used in the perf tools    
+   * framework as well, in order to collect Intel PT processor trace 
+   * this must be set to 1. 
+   * If use perf in sampling mode, there's 2 clock sources available
+   * Monotonic clock : perf record -k mono ..
+   *                 : perf record -k 1 ..
+   * ARCH clock: perf record .. 
+   * The policy used here, defaults to ARCH clock unless the env variable 
+   * is explicitly set to 0. 
+   */
+  use_arch_timestamp = 1; 
+  
+  const char* str = getenv("JITDUMP_USE_ARCH_TIMESTAMP");
+  if(str && *str == '0')  use_arch_timestamp = 0;
+ 
+
+  /* check if perf_clk_id is supported else exit 
+   * jitdump records need to be timestamp'd 
+   */ 
+  if(!perfGetTimestamp()) {
+    if(use_arch_timestamp) {
+      fprintf(stderr, "system arch timestamp not supported\n"); 
+    } else {
+      fprintf(stderr, "kernel does not support (monotonic) %d clk_id\n", perf_clk_id);
+    }
+    fprintf(stderr, "Cannot create %s \n", m_perfJitDumpName.c_str());
+    return;  
+  }
+ 
+  int fd = open(m_perfJitDumpName.c_str(), O_CREAT|O_TRUNC|O_RDWR, 0666);
+  m_perfMmapMarker = mmap(NULL, sysconf(_SC_PAGESIZE), PROT_READ|PROT_EXEC, MAP_PRIVATE, fd, 0); 
+  
+  if(m_perfMmapMarker == MAP_FAILED) {
+    fprintf(stderr, "Failed to create mmap marker file for perf\n");
+    close(fd);
+    return;
+  } 
+
+  m_perfJitDump = fdopen(fd, "w+");
+  if(!m_perfJitDump) {
+    fprintf(stderr, "Failed to create the file %s for perf\n", m_perfJitDumpName.c_str());
+    return; 
+  }
+  /*
+   * Init the jitdump header and write to the file
+   */
+  struct jitheader header; 
+  memset(&header, 0, sizeof(header));
+ 
+  if (getEMachine(&header)) {
+    fprintf(stderr, "failed to get machine ELF information\n");
+    fclose(m_perfJitDump);
+  }
+
+  header.magic      = JITHEADER_MAGIC;
+  header.version    = JITHEADER_VERSION;
+  header.total_size = sizeof(header);
+  header.pid        = getpid();
+
+  int padding_count;
+  /* calculate amount of padding '\0' */
+  padding_count = PADDING_8ALIGNED(header.total_size);
+  header.total_size += padding_count;
+
+  header.timestamp = perfGetTimestamp();
+
+  if (use_arch_timestamp)
+      header.flags |= JITDUMP_FLAGS_ARCH_TIMESTAMP;
+
+  fwrite(&header, sizeof(header), 1, m_perfJitDump);
+ 
+  /* write padding '\0' if necessary */
+  if (padding_count)  
+    fwrite(padding_bytes, padding_count, 1, m_perfJitDump);
+  
+  fflush(m_perfJitDump); 
+}
+
+void DebugInfo::closePerfJitDump() {
+  if (!m_perfJitDump)  return;
+
+  struct jr_code_close rec;
+
+  rec.p.id = JIT_CODE_CLOSE;
+  rec.p.total_size = sizeof(rec);
+  rec.p.timestamp = perfGetTimestamp();
+
+  fwrite(&rec, sizeof(rec), 1, m_perfJitDump);
+  fflush(m_perfJitDump);
+  fclose(m_perfJitDump);
+
+  m_perfJitDump = NULL;
+  if(!m_perfMmapMarker) {
+    munmap(m_perfMmapMarker, sysconf(_SC_PAGESIZE));
+  }
+}
+
+/*
+ * This is invoked from MCGenerator::recordGdbTranslation() 
+ * it holds the write lease, hence there is no need to acquire 
+ * the lock when writing to jit-<pid>.dump 
+ */
+int DebugInfo::perfJitDumpTrace(const void* startAddr, 
+                                const unsigned int size, 
+                                const char* symName)  {
+
+  if(!startAddr || !size) return -1; 
+  
+  static int code_generation = 1;
+  struct jr_code_load rec;  
+  size_t padding_count;
+  
+  uint64_t vma = reinterpret_cast<uintptr_t>(startAddr);  
+  
+  rec.p.id           = JIT_CODE_LOAD;
+  rec.p.total_size   = sizeof(rec) + strlen(symName) + 1;
+  padding_count      = PADDING_8ALIGNED(rec.p.total_size);
+  rec.p.total_size  += padding_count;
+  rec.p.timestamp    = perfGetTimestamp();
+
+  rec.code_size     = size;
+  rec.vma           = vma;
+  rec.code_addr     = vma;
+  rec.pid           = getpid();
+  rec.tid           = (pid_t)syscall(__NR_gettid);
+  rec.p.total_size += size;
+
+  rec.code_index = code_generation++;
+
+  /* write the name of the function and the jitdump record  */
+  fwrite(&rec, sizeof(rec), 1, m_perfJitDump);
+  fwrite(symName, (strlen(symName)+1), 1, m_perfJitDump);
+  
+  /* write padding '\0' if necessary */
+  if (padding_count)
+    fwrite(padding_bytes, padding_count, 1, m_perfJitDump);
+  
+  /* write the code generated for the tracelet */
+  fwrite(startAddr, size, 1, m_perfJitDump);
+
+  fflush(m_perfJitDump);
+  return 0;
+}
+
+} // namespace Debug
+} // namespace HPHP

--- a/hphp/runtime/vm/jit/mc-generator.cpp
+++ b/hphp/runtime/vm/jit/mc-generator.cpp
@@ -1982,6 +1982,10 @@ void MCGenerator::recordGdbTranslation(SrcKey sk,
       m_debugInfo.recordPerfMap(rangeFrom(cb, start, &cb == &m_code.cold()),
                                 srcFunc, exit, inPrologue);
     }
+    if(RuntimeOption::EvalPerfJitDump) {
+      m_debugInfo.recordPerfJitTracelet(rangeFrom(cb, start, &cb == &m_code.cold()),
+                                srcFunc, exit, inPrologue);
+    }
   }
 }
 


### PR DESCRIPTION
Summary: This patch provides better support for two of the perf tools infra

(a) perf record/report/annotate supported limited profiling of
    jitted code. Function/ DSO view worked however assembly profile view
    of jitted code was not supported.
    With this patch and the latest version of perf tools from
    https://git.kernel.org/cgit/linux/kernel/git/tip/tip.git/
    jitted code profile can be viewed at the assembly level.

    It works by generating /tmp/perf-<pid>.dump for perf to read jitted code.
There's two choices for clock source to be used for profiling
(.1) use arch_timestamp; perf tooling requires the env variable
     JITDUMP_USE_ARCH_TIMESTAMP=1 to be set.
     run perf record
(.2) use MONOTONIC_CLOCK;
     run perf record -k 1/mono

     perf inject --jit -i perf.data -o perf.jitted.data
     will inject jit records into perf.data. This will generate an ELF
     file for every trace recorded in perf-<pid>.dump. "PERF_RECORD_MMAP2"
     entry in inserted into perf.data for each one of these ELF files
     created in /tmp.
     By default they will be in /tmp unless specified via
     env variable JITDUMPDIR.

perf report -i perf.jitted.data will generate the results.

The patch defaults to using arch_timestamp unless
env variable is set to JITDUMP_USE_ARCH_TIMESTAMP=0

(b) It extends support for jitted code for
    perf event "intel_pt//" ;PT processor trace recording.
    perf record -e intel_pt//u -p <pid>
    perf inject --jit -i perf.data -o perf.jitted.data
    perf script --itrace=i0ns -F.. -i perf.jitted.data
    will produce a trace of the workload.

This requires 4.1+ version of kernel and the latest version of perf.
 --itrace option of 0ns is supported only in the latest version.

The env var JITDUMP_USE_ARCH_TIMESTAMP=1 must be set and is used by the
linux perf tools infra.