### PR TITLE
Allow null in $cwd parameter of proc_open()

### DIFF
--- a/hphp/runtime/ext/std/ext_std_process.cpp
+++ b/hphp/runtime/ext/std/ext_std_process.cpp
@@ -551,7 +551,7 @@ Variant HHVM_FUNCTION(proc_open,
                       const String& cmd,
                       const Array& descriptorspec,
                       VRefParam pipesParam,
-                      const Variant& cwd /* = null_string */,
+                      const Variant& cwd /* = null_variant */,
                       const Variant& env /* = null_variant */,
                       const Variant& other_options /* = null_variant */) {
   if (RuntimeOption::WhitelistExec && !check_cmd(cmd.data())) {
@@ -566,8 +566,8 @@ Variant HHVM_FUNCTION(proc_open,
   std::vector<DescriptorItem> items;
 
   std::string scwd = "";
-  if (!cwd.toString().empty()) {
-    scwd = cwd.toString().c_str();
+  if (!cwd.isNull() && cwd.isString() && !cwd.asCStrRef().empty()) {
+    scwd = cwd.asCStrRef().c_str();
   } else if (!g_context->getCwd().empty()) {
     scwd = g_context->getCwd().c_str();
   }

--- a/hphp/runtime/ext/std/ext_std_process.cpp
+++ b/hphp/runtime/ext/std/ext_std_process.cpp
@@ -551,7 +551,7 @@ Variant HHVM_FUNCTION(proc_open,
                       const String& cmd,
                       const Array& descriptorspec,
                       VRefParam pipesParam,
-                      const String& cwd /* = null_string */,
+                      const Variant& cwd /* = null_string */,
                       const Variant& env /* = null_variant */,
                       const Variant& other_options /* = null_variant */) {
   if (RuntimeOption::WhitelistExec && !check_cmd(cmd.data())) {
@@ -566,8 +566,8 @@ Variant HHVM_FUNCTION(proc_open,
   std::vector<DescriptorItem> items;
 
   std::string scwd = "";
-  if (!cwd.empty()) {
-    scwd = cwd.c_str();
+  if (!cwd.toString().empty()) {
+    scwd = cwd.toString().c_str();
   } else if (!g_context->getCwd().empty()) {
     scwd = g_context->getCwd().c_str();
   }

--- a/hphp/runtime/ext/std/ext_std_process.h
+++ b/hphp/runtime/ext/std/ext_std_process.h
@@ -43,7 +43,7 @@ Variant HHVM_FUNCTION(proc_open,
                       const String& cmd,
                       const Array& descriptorspec,
                       VRefParam pipes,
-                      const Variant& cwd = null_string,
+                      const Variant& cwd = null_variant,
                       const Variant& env = null_variant,
                       const Variant& other_options = null_variant);
 bool HHVM_FUNCTION(proc_terminate,

--- a/hphp/runtime/ext/std/ext_std_process.h
+++ b/hphp/runtime/ext/std/ext_std_process.h
@@ -43,7 +43,7 @@ Variant HHVM_FUNCTION(proc_open,
                       const String& cmd,
                       const Array& descriptorspec,
                       VRefParam pipes,
-                      const String& cwd = null_string,
+                      const Variant& cwd = null_string,
                       const Variant& env = null_variant,
                       const Variant& other_options = null_variant);
 bool HHVM_FUNCTION(proc_terminate,

--- a/hphp/runtime/ext/std/ext_std_process.php
+++ b/hphp/runtime/ext/std/ext_std_process.php
@@ -121,7 +121,7 @@ function system(string $command, mixed &$return_var = null): string;
 function proc_open(string $cmd,
                    array $descriptorspec,
                    mixed &$pipes,
-                   string $cwd = "",
+                   string $cwd = null,
                    mixed $env = null,
                    mixed $other_options = null): mixed;
 

--- a/hphp/runtime/ext/std/ext_std_process.php
+++ b/hphp/runtime/ext/std/ext_std_process.php
@@ -121,7 +121,7 @@ function system(string $command, mixed &$return_var = null): string;
 function proc_open(string $cmd,
                    array $descriptorspec,
                    mixed &$pipes,
-                   string $cwd = null,
+                   ?string $cwd = null,
                    mixed $env = null,
                    mixed $other_options = null): mixed;
 


### PR DESCRIPTION
PHP docs list `null` as acceptable in the `$cwd` parameter of `proc_open()`, but currently a warning is produced when php7 mode is enabled.

http://php.net/manual/en/function.proc-open.php

This should address #6885. 