### PR TITLE
Hack: make the HHI tarball generation umask-agnostic

### DIFF
--- a/hphp/hack/hhi/Makefile
+++ b/hphp/hack/hhi/Makefile
@@ -5,5 +5,6 @@ hhi.tar.gz:
 		--mtime='1970-01-01 00:00Z' \
 		--owner=root --group=root \
 		--numeric-owner \
+		--mode="u=rwX,go=rX" \
 		-T - --no-recursion \
 		-c | gzip -n > ../bin/hhi.tar.gz


### PR DESCRIPTION
This is a follow-up to D2834659, which aimed to make the HHI tarball
generation deterministic/reproducible. That commit unfortunately didn't
catch the case of a varying umask, which results in the tarball having
different modes for files/directories depending on the builder's umask.
Pass --mode to tar, to force the mode to a static one.