### PR TITLE
Pooled curl runtime management

### DIFF
--- a/hphp/runtime/ext/curl/curl-pool.cpp
+++ b/hphp/runtime/ext/curl/curl-pool.cpp
@@ -43,12 +43,14 @@ void PooledCurlHandle::resetHandle() {
 /////////////////////////////////////////////////////////////////////////////
 // CurlHandlePool
 
-CurlHandlePool::CurlHandlePool(int poolSize,
-                               int waitTimeout,
-                               int numConnReuses)
-: m_waitTimeout(waitTimeout) {
-  for (int i = 0; i < poolSize; i++) {
-    m_handleStack.push(new PooledCurlHandle(numConnReuses));
+CurlHandlePool::CurlHandlePool(int size,
+                               int connGetTimeout,
+                               int reuseLimit)
+: m_size(size),
+  m_connGetTimeout(connGetTimeout),
+  m_reuseLimit(reuseLimit) {
+  for (int i = 0; i < size; i++) {
+    m_handleStack.push(new PooledCurlHandle(reuseLimit));
   }
   pthread_cond_init(&m_cond, nullptr);
 }
@@ -63,23 +65,35 @@ CurlHandlePool::~CurlHandlePool() {
 }
 
 PooledCurlHandle* CurlHandlePool::fetch() {
-  Lock lock(m_mutex);
-
-  // wait until the user-specified timeout for an available handle
   struct timespec ts;
   gettime(CLOCK_REALTIME, &ts);
-  ts.tv_sec += m_waitTimeout / 1000;
-  ts.tv_nsec += 1000000 * (m_waitTimeout % 1000);
-  while (m_handleStack.empty()) {
-    if (ETIMEDOUT == pthread_cond_timedwait(&m_cond, &m_mutex.getRaw(), &ts)) {
-      SystemLib::throwRuntimeExceptionObject(
-        "Timeout reached waiting for an available pooled curl connection!");
-    }
+  ts.tv_sec += m_connGetTimeout / 1000;
+  ts.tv_nsec += 1000000 * (m_connGetTimeout % 1000);
+
+  Lock lock(m_mutex);
+  m_statsFetches += 1;
+  // wait until the user-specified timeout for an available handle
+  if (m_handleStack.empty()) {
+    m_statsEmpty += 1;
+    do {
+      if (ETIMEDOUT == pthread_cond_timedwait(&m_cond, &m_mutex.getRaw(), 
+                                              &ts)
+      ) {
+        m_statsFetchUs += m_connGetTimeout * 1000;
+        SystemLib::throwRuntimeExceptionObject(
+          "Timeout reached waiting for an available pooled curl connection!");
+      }
+    } while (m_handleStack.empty());
   }
 
   PooledCurlHandle* ret = m_handleStack.top();
   assertx(ret);
   m_handleStack.pop();
+
+  struct timespec after;
+  gettime(CLOCK_REALTIME, &after);
+  m_statsFetchUs += m_connGetTimeout * 1000 - gettime_diff_us(after, ts);
+
   return ret;
 }
 
@@ -90,7 +104,8 @@ void CurlHandlePool::store(PooledCurlHandle* handle) {
   pthread_cond_signal(&m_cond);
 }
 
-std::map<std::string, CurlHandlePool*> CurlHandlePool::namedPools;
+ReadWriteMutex CurlHandlePool::namedPoolsMutex;
+std::map<std::string, CurlHandlePoolPtr> CurlHandlePool::namedPools;
 
 /////////////////////////////////////////////////////////////////////////////
 }

--- a/hphp/runtime/ext/curl/curl-pool.h
+++ b/hphp/runtime/ext/curl/curl-pool.h
@@ -14,9 +14,9 @@ namespace HPHP {
 // Pooled Curl Handle
 
 /**
- *  * This is a helper class used to wrap Curl handles that are pooled.
- *   * Operations on this class are _NOT_ thread safe!
- *    */
+ * This is a helper class used to wrap Curl handles that are pooled.
+ * Operations on this class are _NOT_ thread safe!
+ */
 struct PooledCurlHandle {
   explicit PooledCurlHandle(int connRecycleAfter)
   : m_handle(nullptr), m_numUsages(0), m_connRecycleAfter(connRecycleAfter) { }
@@ -39,21 +39,36 @@ struct PooledCurlHandle {
  * hold connections open and cache SSL session ids over their lifetimes.
  * All operations on this class are thread safe.
  */
+struct CurlHandlePool;
+using CurlHandlePoolPtr = std::shared_ptr<CurlHandlePool>;
 struct CurlHandlePool {
   explicit CurlHandlePool(int poolSize, int waitTimeout, int numConnReuses);
   ~CurlHandlePool();
 
   PooledCurlHandle* fetch();
   void store(PooledCurlHandle* handle);
+  int size() { return m_size; }
+  int connGetTimeout() { return m_connGetTimeout; }
+  int reuseLimit() { return m_reuseLimit; }
+  unsigned long statsFetches() { return m_statsFetches; }
+  unsigned long statsEmpty() { return m_statsEmpty; }
+  unsigned long long statsFetchUs() { return m_statsFetchUs; }
 
-  static std::map<std::string, CurlHandlePool*> namedPools;
+  static ReadWriteMutex namedPoolsMutex;
+  static std::map<std::string, CurlHandlePoolPtr> namedPools;
 
 private:
   std::stack<PooledCurlHandle*> m_handleStack;
   Mutex m_mutex;
   pthread_cond_t m_cond;
-  int m_waitTimeout;
+  const int m_size;
+  const int m_connGetTimeout;
+  const int m_reuseLimit;
+  unsigned long m_statsFetches = 0;
+  unsigned long m_statsEmpty = 0;
+  unsigned long long m_statsFetchUs = 0;
 };
+
 
 /////////////////////////////////////////////////////////////////////////////
 }

--- a/hphp/runtime/ext/curl/curl-resource.cpp
+++ b/hphp/runtime/ext/curl/curl-resource.cpp
@@ -49,7 +49,7 @@ CurlResource::ToFree::~ToFree() {
 }
 
 CurlResource::CurlResource(const String& url,
-                           CurlHandlePool *pool /*=nullptr */)
+                           CurlHandlePoolPtr pool /*=nullptr */)
 : m_emptyPost(true), m_connPool(pool), m_pooledHandle(nullptr) {
   if (m_connPool) {
     m_pooledHandle = m_connPool->fetch();

--- a/hphp/runtime/ext/curl/curl-resource.h
+++ b/hphp/runtime/ext/curl/curl-resource.h
@@ -4,6 +4,7 @@
 #include "hphp/runtime/base/file.h"
 #include "hphp/runtime/base/string-buffer.h"
 #include "hphp/runtime/ext/extension.h"
+#include "hphp/runtime/ext/curl/curl-pool.h"
 
 #include "hphp/util/type-scan.h"
 
@@ -13,8 +14,6 @@ namespace HPHP {
 /////////////////////////////////////////////////////////////////////////////
 // CurlResource
 
-struct CurlHandlePool;
-struct PooledCurlHandle;
 
 struct CurlResource : SweepableResourceData {
   using ExceptionType = folly::Optional<boost::variant<Object,Exception*>>;
@@ -54,7 +53,7 @@ struct CurlResource : SweepableResourceData {
   DECLARE_RESOURCE_ALLOCATION(CurlResource)
   bool isInvalid() const override { return !m_cp; }
 
-  explicit CurlResource(const String& url, CurlHandlePool *pool = nullptr);
+  explicit CurlResource(const String& url, CurlHandlePoolPtr pool = nullptr);
   explicit CurlResource(req::ptr<CurlResource> src);
   ~CurlResource() { close(); }
 
@@ -143,7 +142,7 @@ struct CurlResource : SweepableResourceData {
   Variant      m_progress_callback;
 
   bool m_emptyPost;
-  CurlHandlePool* m_connPool;
+  CurlHandlePoolPtr m_connPool;
   PooledCurlHandle* m_pooledHandle;
 };
 

--- a/hphp/runtime/ext/curl/ext_curl.h
+++ b/hphp/runtime/ext/curl/ext_curl.h
@@ -31,6 +31,12 @@ namespace HPHP {
 Variant HHVM_FUNCTION(curl_init, const Variant& url = null_string);
 Variant HHVM_FUNCTION(curl_init_pooled, const String& poolName,
                               const Variant& url = null_string);
+void HHVM_FUNCTION(curl_create_pool, const String& poolName,
+                              const int size = 5,
+                              const int connGetTimeout = 5000,
+                              const int reuseLimit = 500);
+bool HHVM_FUNCTION(curl_destroy_pool, const String& poolName);
+Array HHVM_FUNCTION(curl_list_pools);
 Variant HHVM_FUNCTION(curl_copy_handle, const Resource& ch);
 Variant HHVM_FUNCTION(curl_version, int uversion = CURLVERSION_NOW);
 bool HHVM_FUNCTION(curl_setopt, const Resource& ch, int option, const Variant& value);

--- a/hphp/runtime/ext/curl/ext_curl.php
+++ b/hphp/runtime/ext/curl/ext_curl.php
@@ -133,9 +133,11 @@ function curl_init(?string $url = null): mixed;
  * is garbage collected, the curl handle will be saved for reuse later.
  * Pooled curl handles persist between requests.
  *
+ * @deprecated Use HH\curl_init_pooled instead
  * @param string $poolName - The name of the connection pool to use.
  *  Named connection pools are initialized via the 'curl.namedPools' ini
- *  setting, which is a comma separated list of named pools to create.
+ *  setting, which is a comma separated list of named pools to create,
+ *  or at runtime with curl_create_pool.
  * @param string $url - If provided, the CURLOPT_URL option will be set
  *   to its value. You can manually set this using the curl_setopt()
  *   function.    The file protocol is disabled by cURL if open_basedir is
@@ -143,8 +145,9 @@ function curl_init(?string $url = null): mixed;
  *
  * @return resource - Returns a cURL handle on success, FALSE on errors.
  */
-<<__Native, __HipHopSpecific>>
-function curl_init_pooled(string $poolName, ?string $url = null): mixed;
+function curl_init_pooled(string $poolName, ?string $url = null): mixed {
+    return HH\curl_init_pooled($poolName, $url);
+}
 
 /**
  * Add a normal cURL handle to a cURL multi handle
@@ -378,6 +381,66 @@ function fb_curl_multi_fdset(resource $mh, mixed &$read_fd_set,
                              ?int &$max_fd = null): mixed;
 
 } // root namespace
+
+namespace HH {
+
+/**
+ * Initialize a cURL session using a pooled curl handle. When this resource
+ * is garbage collected, the curl handle will be saved for reuse later.
+ * Pooled curl handles persist between requests.
+ *
+ * @param string $poolName - The name of the connection pool to use.
+ *  Named connection pools are initialized via the 'curl.namedPools' ini
+ *  setting, which is a comma separated list of named pools to create,
+ *  or at runtime with curl_create_pool.
+ * @param string $url - If provided, the CURLOPT_URL option will be set
+ *   to its value. You can manually set this using the curl_setopt()
+ *   function.    The file protocol is disabled by cURL if open_basedir is
+ *   set.
+ *
+ * @return resource - Returns a cURL handle on success, FALSE on errors.
+ */
+<<__Native, __HipHopSpecific>>
+function curl_init_pooled(string $poolName, ?string $url = null): mixed;
+
+/**
+ * Create a new cURL pool for use with curl_init_pooled. If a pool of
+ * this name already exists it will be replaced.
+ *
+ * @param string $poolName = The name of the connection pool to create.
+ * @param int $size - The number of connections the pool will hold
+ * @param int $connGetTimeout - The maximum time curl_init_pooled() will wait
+ *  for a connection to become available before throwing a RuntimeException
+ * @param int $reuseLimit - The number of times a connection will be reused
+ *  before being recycled.
+ */
+<<__Native, __HipHopSpecific>>
+function curl_create_pool(string $poolName, int $size = 5,
+                          int $connGetTimeout = 5000,
+                          int $reuseLimit = 500): void;
+
+/**
+ * Destroys a cURL connection pool. curl_init_pooled() calls that are
+ * already waiting on a handle will still complete, but no new calls
+ * will receive a pooled handle.
+ *
+ * @param string $poolName - The name of the connection pool to destroy.
+ * @return bool - Returns true on success, or false if the pool does not
+ *  exist.
+ */
+<<__Native, __HipHopSpecific>>
+function curl_destroy_pool(string $poolName): bool;
+
+/**
+ * Lists currently available cURL connection pools and their configuration.
+ *
+ * @return array
+ */
+<<__Native, __HipHopSpecific>>
+function curl_list_pools(): array;
+
+
+} // namespace HH
 
 namespace HH\Asio {
 

--- a/hphp/test/slow/ext_curl/curl_handles_are_reset_with_pooling.php
+++ b/hphp/test/slow/ext_curl/curl_handles_are_reset_with_pooling.php
@@ -1,5 +1,5 @@
 <?php
-$ch = curl_init_pooled('pool', 'foo.bar.com');
+$ch = HH\curl_init_pooled('pool', 'foo.bar.com');
 curl_close($ch);
-$ch = curl_init_pooled('pool', 'therighturl.com');
+$ch = HH\curl_init_pooled('pool', 'therighturl.com');
 var_dump(curl_getinfo($ch)['url']);

--- a/hphp/test/slow/ext_curl/curl_handles_in_different_pools_dont_interfere.php.disabled
+++ b/hphp/test/slow/ext_curl/curl_handles_in_different_pools_dont_interfere.php.disabled
@@ -1,9 +1,9 @@
 <?php
-$ch1 = curl_init_pooled('test', 'foo.com');
-$ch2 = curl_init_pooled('test2', 'bar.com');
+$ch1 = HH\curl_init_pooled('test', 'foo.com');
+$ch2 = HH\curl_init_pooled('test2', 'bar.com');
 var_dump(curl_getinfo($ch1)['url']);
 var_dump(curl_getinfo($ch2)['url']);
 curl_close($ch1);
 curl_close($ch2);
-$ch3 = curl_init_pooled('test', 'foo.com');
-$ch4 = curl_init_pooled('test', 'foo.com');
+$ch3 = HH\curl_init_pooled('test', 'foo.com');
+$ch4 = HH\curl_init_pooled('test', 'foo.com');

--- a/hphp/test/slow/ext_curl/get_pooled_curl_timeout_works.php.bad
+++ b/hphp/test/slow/ext_curl/get_pooled_curl_timeout_works.php.bad
@@ -1,4 +1,4 @@
 <?php
 // the curl pool is 1, so the second request will throw RuntimeException
-$ch = curl_init_pooled('test', 'foo.bar.com');
-$ch2 = curl_init_pooled('test', 'www.baz.com');
+$ch = HH\curl_init_pooled('test', 'foo.bar.com');
+$ch2 = HH\curl_init_pooled('test', 'www.baz.com');

--- a/hphp/test/slow/ext_curl/multiple_curl_handles_can_coexist_with_pooling.php
+++ b/hphp/test/slow/ext_curl/multiple_curl_handles_can_coexist_with_pooling.php
@@ -1,6 +1,6 @@
 <?php
-$ch = curl_init_pooled('test', 'foo.bar.com');
-$ch2 = curl_init_pooled('test', 'www.baz.com');
+$ch = HH\curl_init_pooled('test', 'foo.bar.com');
+$ch2 = HH\curl_init_pooled('test', 'www.baz.com');
 var_dump(curl_getinfo($ch)['url']);
 var_dump(curl_getinfo($ch2)['url']);
 curl_close($ch);

--- a/hphp/test/slow/ext_curl/pools_can_be_configured_independently.php
+++ b/hphp/test/slow/ext_curl/pools_can_be_configured_independently.php
@@ -1,6 +1,6 @@
 <?php
-$ch1 = curl_init_pooled('pool1', "foo.bar");
-$ch2 = curl_init_pooled('pool1', "foo.bar");
-$ch3 = curl_init_pooled('pool2', "foo.bar");
+$ch1 = HH\curl_init_pooled('pool1', "foo.bar");
+$ch2 = HH\curl_init_pooled('pool1', "foo.bar");
+$ch3 = HH\curl_init_pooled('pool2', "foo.bar");
 echo "here\n";
-$ch4 = curl_init_pooled('pool2', "foo.bar");
+$ch4 = HH\curl_init_pooled('pool2', "foo.bar");

--- a/hphp/test/slow/ext_curl/pools_can_be_initialized_at_runtime.php
+++ b/hphp/test/slow/ext_curl/pools_can_be_initialized_at_runtime.php
@@ -1,0 +1,9 @@
+<?php
+
+var_dump(HH\curl_list_pools());
+HH\curl_create_pool('unittest', 10, 20, 30);
+var_dump(HH\curl_list_pools());
+$ch1 = HH\curl_init_pooled('unittest');
+HH\curl_destroy_pool('unittest');
+var_dump(HH\curl_list_pools());
+

--- a/hphp/test/slow/ext_curl/pools_can_be_initialized_at_runtime.php.expect
+++ b/hphp/test/slow/ext_curl/pools_can_be_initialized_at_runtime.php.expect
@@ -1,0 +1,24 @@
+array(0) {
+}
+array(1) {
+  ["unittest"]=>
+  array(4) {
+    ["size"]=>
+    int(10)
+    ["connGetTimeout"]=>
+    int(20)
+    ["reuseLimit"]=>
+    int(30)
+    ["stats"]=>
+    array(3) {
+      ["fetches"]=>
+      int(0)
+      ["empty"]=>
+      int(0)
+      ["fetchMs"]=>
+      int(0)
+    }
+  }
+}
+array(0) {
+}

--- a/hphp/test/slow/ext_curl/pools_can_be_replaced.php
+++ b/hphp/test/slow/ext_curl/pools_can_be_replaced.php
@@ -1,0 +1,10 @@
+<?php
+
+HH\curl_create_pool('unittest', 1);
+$ch1 = HH\curl_init_pooled('unittest');
+HH\curl_create_pool('unittest', 1, 2, 3);
+// this is a new pool, so should succeed
+$ch2 = HH\curl_init_pooled('unittest');
+echo "here\n";
+// this one should fail
+$ch3 = HH\curl_init_pooled('unittest');

--- a/hphp/test/slow/ext_curl/pools_can_be_replaced.php.expectf
+++ b/hphp/test/slow/ext_curl/pools_can_be_replaced.php.expectf
@@ -1,0 +1,5 @@
+here
+
+Fatal error: Uncaught exception 'RuntimeException' with message 'Timeout reached waiting for an available pooled curl connection!' in %s/hphp/test/slow/ext_curl/pools_can_be_replaced.php:10
+Stack trace:
+#0 {main}

--- a/hphp/test/slow/ext_curl/pools_collect_usage_stats.php
+++ b/hphp/test/slow/ext_curl/pools_collect_usage_stats.php
@@ -1,0 +1,11 @@
+<?php
+
+HH\curl_create_pool('unittest', 1, 10);
+$ch1 = HH\curl_init_pooled('unittest');
+var_dump(HH\curl_list_pools()['unittest']['stats']);
+try {
+    $ch2 = HH\curl_init_pooled('unittest');
+} catch(RuntimeException $e) {
+    echo $e->getMessage(), "\n";
+}
+var_dump(HH\curl_list_pools()['unittest']['stats']);

--- a/hphp/test/slow/ext_curl/pools_collect_usage_stats.php.expect
+++ b/hphp/test/slow/ext_curl/pools_collect_usage_stats.php.expect
@@ -1,0 +1,17 @@
+array(3) {
+  ["fetches"]=>
+  int(1)
+  ["empty"]=>
+  int(0)
+  ["fetchMs"]=>
+  int(0)
+}
+Timeout reached waiting for an available pooled curl connection!
+array(3) {
+  ["fetches"]=>
+  int(2)
+  ["empty"]=>
+  int(1)
+  ["fetchMs"]=>
+  int(10)
+}

--- a/hphp/test/slow/ext_curl/using_uninit_pool_generates_warning.php
+++ b/hphp/test/slow/ext_curl/using_uninit_pool_generates_warning.php
@@ -1,4 +1,0 @@
-<?php
-$ch = curl_init_pooled('nonextantpool', 'foo.com');
-var_dump(curl_getinfo($ch)['url']);
-curl_close($ch);

--- a/hphp/test/slow/ext_curl/using_uninit_pool_generates_warning.php.expectf
+++ b/hphp/test/slow/ext_curl/using_uninit_pool_generates_warning.php.expectf
@@ -1,2 +1,0 @@
-Warning: Attempting to use connection pooling without specifying an existent connection pool! %s
-string(7) "foo.com"

--- a/hphp/test/slow/ext_curl/using_uninit_pool_generates_warning_and_returns_false.php
+++ b/hphp/test/slow/ext_curl/using_uninit_pool_generates_warning_and_returns_false.php
@@ -1,0 +1,3 @@
+<?php
+$ch = HH\curl_init_pooled('nonextantpool', 'foo.com');
+var_dump($ch);

--- a/hphp/test/slow/ext_curl/using_uninit_pool_generates_warning_and_returns_false.php.expectf
+++ b/hphp/test/slow/ext_curl/using_uninit_pool_generates_warning_and_returns_false.php.expectf
@@ -1,0 +1,3 @@
+
+Warning: Attempting to use connection pooling without specifying an existent connection pool! in %s/hphp/test/slow/ext_curl/using_uninit_pool_generates_warning_and_returns_false.php on line 2
+bool(false)


### PR DESCRIPTION
Includes a breaking change. Using curl_init_pooled to request
a handle from an unknown pool will now return false rather than an
unpooled handle. This gives the application the opportunity to create
the pool with appropriate settings.

* Adds three new methods, curl_create_pool, curl_destroy_pool,
  and curl_list_pools to allow the rutime configuration of
  connection pools.
* Required adding a ReadWriteMutex on all pool operations due to
  namedPools no longer being immutable.
* Changes curl_init_pooled to return false instead of an unpooled handle
  when the requested pool does not exist
* Adds stats collection for number of uses, number of times empty, and
  us spent waiting for pooled handles per pool.
* Renames a couple CurlHandlePool function arguments and members to
  provide consistent naming of the parameters from the ini and back
  through the code.
* Fix bug where the time spend waiting for per-pool lock was not
  included in the maximum time allowed waiting for an available handle.
