### PR TITLE
Solve hack compilation issues on ppc64 platform

### DIFF
--- a/hphp/hack/src/_tags
+++ b/hphp/hack/src/_tags
@@ -1,4 +1,4 @@
-<**/*.ml*>: ocaml, warn_A, warn(-3-4-6-29-35-44-48-50), warn_error_A
+<**/*.ml*>: ocaml, warn_A, warn(-3-4-6-29-35-41-44-45-48-50-52), warn_error_A
 <*.ml*>: warn(-27)
 <client/*.ml*>: warn(-27)
 <deps/*.ml*>: warn(-27)


### PR DESCRIPTION
These warnings raise errors on ppc64 compilation. Solve it by ignoring them.