### PR TITLE
Fix mysqli_use_result return type.

### DIFF
--- a/hphp/runtime/ext/mysql/ext_mysqli.php
+++ b/hphp/runtime/ext/mysql/ext_mysqli.php
@@ -2335,7 +2335,7 @@ function mysqli_thread_safe(): bool;
  * @return mysqli_result - Returns an unbuffered result object or FALSE
  *   if an error occurred.
  */
-function mysqli_use_result(mysqli $link): mysqli_result {
+function mysqli_use_result(mysqli $link): ?mixed {
   return $link->use_result();
 }
 


### PR DESCRIPTION
The type was just wrong as checked in. See the return type of the mysqli::use_result method we're returning. Actual use frequently hits this error.