### PR TITLE
Log parse errors during repo building

### DIFF
--- a/hphp/compiler/parser/parser.cpp
+++ b/hphp/compiler/parser/parser.cpp
@@ -216,8 +216,8 @@ bool Parser::parse() {
     }
     return true;
   } catch (const ParseTimeFatalException& e) {
-    Logger::Error("Error parsing %s:%d: %s", m_fileName, e.m_line,
-                  e.getMessage().c_str());
+    Logger::Verbose("Error parsing %s:%d: %s", m_fileName, e.m_line,
+                    e.getMessage().c_str());
 
     m_file->cleanupForError(m_ar);
     if (e.m_parseFatal) {

--- a/hphp/compiler/parser/parser.cpp
+++ b/hphp/compiler/parser/parser.cpp
@@ -216,6 +216,9 @@ bool Parser::parse() {
     }
     return true;
   } catch (const ParseTimeFatalException& e) {
+    Logger::Error("Error parsing %s:%d: %s", m_fileName, e.m_line,
+                  e.getMessage().c_str());
+
     m_file->cleanupForError(m_ar);
     if (e.m_parseFatal) {
       m_file->makeParseFatal(m_ar, e.getMessage(), e.m_line);


### PR DESCRIPTION
Add an error message during hhvm repo building for all encountered syntax errors.
This is only informative and compilation proceeds as usual, but this should help to identify problems as soon as possible.
This should also provide an alternative to hhvm -l syntax check - see #6979 for issues with it.