### PR TITLE
#5339 fix

### DIFF
--- a/hphp/system/php/spl/miscellaneous/ArrayObject.php
+++ b/hphp/system/php/spl/miscellaneous/ArrayObject.php
@@ -248,7 +248,7 @@ class ArrayObject implements IteratorAggregate, ArrayAccess,
    *
    * @return     mixed   The value at the specified index or NULL.
    */
-  public function offsetGet($index) {
+  public function &offsetGet($index) {
     if ($this->isArray()) {
       return $this->storage[$index];
     } else {

--- a/hphp/test/slow/array_object/array-obj-multidim-unset.php
+++ b/hphp/test/slow/array_object/array-obj-multidim-unset.php
@@ -1,0 +1,5 @@
+<?php
+
+$arrayobj = new ArrayObject(array('foo'=>array('bar' => 2)));
+unset($arrayObj['foo']['bar']);
+var_dump(isset($arrayObj['foo']['bar']));

--- a/hphp/test/slow/array_object/array-obj-multidim-unset.php.expect
+++ b/hphp/test/slow/array_object/array-obj-multidim-unset.php.expect
@@ -1,0 +1,1 @@
+bool(false)


### PR DESCRIPTION
OffsetGet in \ArrayObject should be returning reference. I could not get it tested because i've no access to any linux based system, but running implementation before fix on plain PHP (after removal of hhvm specific features) gives same result as described in issue, and returning reference fixes that so I believe that it will work.