### PR TITLE
Fix for auto-initialize on increment / decrement operations.

### DIFF
--- a/hphp/runtime/ext/memcached/ext_memcached.cpp
+++ b/hphp/runtime/ext/memcached/ext_memcached.cpp
@@ -507,7 +507,7 @@ struct MemcachedData {
 
   Variant incDecOp(bool isInc,
                    const StringData* server_key, const StringData* key,
-                   int64_t offset, const Variant* initial_value, int64_t expiry) {
+                   int64_t offset, const Variant& initial_value, int64_t expiry) {
     m_impl->rescode = q_Memcached$$RES_SUCCESS;
     if (key->empty() || strchr(key->data(), ' ')) {
       m_impl->rescode = q_Memcached$$RES_BAD_KEY_PROVIDED;

--- a/hphp/runtime/ext/memcached/ext_memcached.cpp
+++ b/hphp/runtime/ext/memcached/ext_memcached.cpp
@@ -523,7 +523,7 @@ struct MemcachedData {
     uint64_t value;
     memcached_return_t status;
 
-    bool use_initial = initial_value->isInteger();
+    bool use_initial = initial_value.isInteger();
     auto mc = &m_impl->memcached;
     if (use_initial) {
       if (!isBinaryProtocol()) {
@@ -536,22 +536,22 @@ struct MemcachedData {
           status = memcached_increment_with_initial_by_key(
             mc,
             server_key->data(), server_key->size(), key->data(), key->size(),
-            offset, initial_value->asInt64Val(), expiry, &value);
+            offset, initial_value.asInt64Val(), expiry, &value);
         } else {
           status = memcached_decrement_with_initial_by_key(
             mc,
             server_key->data(), server_key->size(), key->data(), key->size(),
-            offset, initial_value->asInt64Val(), expiry, &value);
+            offset, initial_value.asInt64Val(), expiry, &value);
         }
       } else {
         if (isInc) {
           status = memcached_increment_with_initial(
             mc, key->data(), key->size(),
-            offset, initial_value->asInt64Val(), expiry, &value);
+            offset, initial_value.asInt64Val(), expiry, &value);
         } else {
           status = memcached_decrement_with_initial(
             mc, key->data(), key->size(),
-            offset, initial_value->asInt64Val(), expiry, &value);
+            offset, initial_value.asInt64Val(), expiry, &value);
         }
       }
     } else {
@@ -886,7 +886,7 @@ Variant HHVM_METHOD(Memcached, deletemultibykey, const String& server_key,
 Variant HHVM_METHOD(Memcached, increment,
                     const String& key,
                     int64_t offset /* = 1 */,
-                    int64_t initial_value /* = 0 */,
+                    const Variant& initial_value /* = false */,
                     int64_t expiry /* = 0 */) {
   return Native::data<MemcachedData>(this_)->incDecOp(
     true, nullptr, key.get(), offset, initial_value, expiry);
@@ -896,7 +896,7 @@ Variant HHVM_METHOD(Memcached, incrementbykey,
                     const String& server_key,
                     const String& key,
                     int64_t offset /* = 1 */,
-                    int64_t initial_value /* = 0 */,
+                    const Variant& initial_value /* = false */,
                     int64_t expiry /* = 0 */) {
   return Native::data<MemcachedData>(this_)->incDecOp(
     true, server_key.get(), key.get(), offset, initial_value, expiry);
@@ -905,7 +905,7 @@ Variant HHVM_METHOD(Memcached, incrementbykey,
 Variant HHVM_METHOD(Memcached, decrement,
                     const String& key,
                     int64_t offset /* = 1 */,
-                    int64_t initial_value /* = 0 */,
+                    const Variant& initial_value /* = false */,
                     int64_t expiry /* = 0 */) {
   return Native::data<MemcachedData>(this_)->incDecOp(
     false, nullptr, key.get(), offset, initial_value, expiry);
@@ -915,7 +915,7 @@ Variant HHVM_METHOD(Memcached, decrementbykey,
                     const String& server_key,
                     const String& key,
                     int64_t offset /* = 1 */,
-                    int64_t initial_value /* = 0 */,
+                    const Variant& initial_value /* = false */,
                     int64_t expiry /* = 0 */) {
   return Native::data<MemcachedData>(this_)->incDecOp(
     false, server_key.get(), key.get(), offset, initial_value, expiry);

--- a/hphp/runtime/ext/memcached/ext_memcached.php
+++ b/hphp/runtime/ext/memcached/ext_memcached.php
@@ -200,16 +200,17 @@ class Memcached {
    * @param string $key - The key of the item to decrement.
    * @param int $offset - The amount by which to decrement the item's
    *   value.
-   * @param int $initial_value - The value to set the item to if it
-   *   doesn't currently exist.
+   * @param mixed $initial_value - The value to set the item to if it
+   *   doesn't currently exist. False to fail if the key does not exist
    * @param int $expiry - The expiry time to set on the item.
    *
-   * @return int - Returns item's new value on success.
+   * @return mixed - Returns item's new value on success. False if the key
+   *   doesn't exist and no initial_value was provided.
    */
   <<__Native>>
   public function decrement(string $key,
                             int $offset = 1,
-                            int $initial_value = 0,
+                            mixed $initial_value = false,
                             int $expiry = 0): mixed;
 
   /**
@@ -220,16 +221,17 @@ class Memcached {
    * @param int $offset - The amount by which to decrement the item's
    *   value.
    * @param int $initial_value - The value to set the item to if it
-   *   doesn't currently exist.
+   *   doesn't currently exist. False to fail if the key does not exist.
    * @param int $expiry - The expiry time to set on the item.
    *
-   * @return int - Returns item's new value on success.
+   * @return int - Returns item's new value on success. False if the key
+   *   doesn't exist and no initial_value was provided.
    */
   <<__Native>>
   public function decrementByKey(string $server_key,
                                  string $key,
                                  int $offset = 1,
-                                 int $initial_value = 0,
+                                 mixed $initial_value = false,
                                  int $expiry = 0): mixed;
 
   /**
@@ -506,16 +508,17 @@ class Memcached {
    * @param string $key - The key of the item to increment.
    * @param int $offset - The amount by which to increment the item's
    *   value.
-   * @param int $initial_value - The value to set the item to if it
-   *   doesn't currently exist.
+   * @param mixed $initial_value - The value to set the item to if it
+   *   doesn't currently exist. False to fail if the key does not exist.
    * @param int $expiry - The expiry time to set on the item.
    *
-   * @return int - Returns new item's value on success.
+   * @return mixed - Returns new item's value on success. False if the key
+   * doesn't exist.
    */
   <<__Native>>
   public function increment(string $key,
                             int $offset = 1,
-                            int $initial_value = 0,
+                            mixed $initial_value = false,
                             int $expiry = 0): mixed;
 
   /**
@@ -525,17 +528,18 @@ class Memcached {
    * @param string $key - The key of the item to increment.
    * @param int $offset - The amount by which to increment the item's
    *   value.
-   * @param int $initial_value - The value to set the item to if it
-   *   doesn't currently exist.
+   * @param mixed $initial_value - The value to set the item to if it
+   *   doesn't currently exist. False to fail if the key does not exist.
    * @param int $expiry - The expiry time to set on the item.
    *
-   * @return int - Returns new item's value on success.
+   * @return mixed - Returns new item's value on success. False if the key
+   *   doesn't exist and no initial_value was provided.
    */
   <<__Native>>
   public function incrementByKey(string $server_key,
                                  string $key,
                                  int $offset = 1,
-                                 int $initial_value = 0,
+                                 mixed $initial_value = false,
                                  int $expiry = 0): mixed;
 
   /**

--- a/hphp/test/slow/ext_memcached/inc_dec.php
+++ b/hphp/test/slow/ext_memcached/inc_dec.php
@@ -8,3 +8,19 @@ $mc->increment(key, 3);
 var_dump($mc->get( key));
 $mc->decrement(key, 1);
 var_dump($mc->get(key));
+
+//increment with initial value only works with binary protocol
+const non_existant_key = 'incr_decr_test_fail';
+
+$mc2 = new Memcached;
+$mc2->setOption(Memcached::OPT_BINARY_PROTOCOL, true);
+$mc2->addServer('127.0.0.1', 11211);
+
+var_dump($mc2->increment(non_existant_key, 3));
+var_dump($mc2->get_multi(array(non_existant_key)));
+var_dump($mc2->decrement(non_existant_key, 1));
+var_dump($mc2->get_multi(array(non_existant_key)));
+
+$mc2->increment(non_existant_key, 3, 1);
+$result = $mc2->get_multi(array(non_existant_key));
+var_dump($result[non_existant_key]);

--- a/hphp/test/slow/ext_memcached/inc_dec.php.expect
+++ b/hphp/test/slow/ext_memcached/inc_dec.php.expect
@@ -1,3 +1,8 @@
 int(0)
 int(3)
 int(2)
+bool(false)
+bool(false)
+bool(false)
+bool(false)
+int(1)


### PR DESCRIPTION
Made initial_value value optional on increment / decrement operations to make hhvm memcached extension behave in the same way than the same extension on php when using binary protocol.