### PR TITLE
Stop constraining pseudo-main guards eagerly.

### DIFF
--- a/hphp/runtime/vm/jit/ir-builder.cpp
+++ b/hphp/runtime/vm/jit/ir-builder.cpp
@@ -169,13 +169,6 @@ void IRBuilder::appendInstruction(IRInstruction* inst) {
     if (inst->is(LdRef, CheckRefInner)) {
       constrainValue(inst->src(0), DataTypeSpecific);
     }
-
-    // In psuedomains we have to pre-constrain local guards, because we don't
-    // ever actually generate code that will constrain them otherwise.
-    // (Because of the LdLocPseudoMain stuff.)
-    if (inst->marker().func()->isPseudoMain() && inst->is(CheckLoc)) {
-      constrainGuard(inst, DataTypeSpecific);
-    }
   }
 
   auto where = m_curBlock->end();

--- a/hphp/runtime/vm/jit/region-tracelet.cpp
+++ b/hphp/runtime/vm/jit/region-tracelet.cpp
@@ -396,6 +396,7 @@ void recordDependencies(Env& env) {
   auto hintMap = std::map<Location,Type>{};
   auto catMap = std::map<Location,DataTypeCategory>{};
   const auto& guards = env.irgs.irb->guards()->guards;
+  auto predictionMap = std::map<Location,Type>{};
   visitGuards(unit, [&] (const IRInstruction* guard,
                          const Location& loc,
                          Type type, bool hint) {
@@ -404,6 +405,19 @@ void recordDependencies(Env& env) {
     if (type <= TCls) return;
     auto& whichMap = hint ? hintMap : guardMap;
     auto inret = whichMap.insert(std::make_pair(loc, type));
+    // Unconstrained pseudo-main guards will be relaxed to Gen by the guard
+    // relaxation pass. Since we don't allow loading TGen locals
+    // in pseudo-main, save the predicted type here.
+    if (guard->marker().func()->isPseudoMain()) {
+      auto ret = predictionMap.insert(std::make_pair(loc,type));
+      if (ret.second) {
+        FTRACE(1, "selectTracelet saving prediction for PseudoMain {}\n",
+            show(RegionDesc::TypedLocation {loc, type}));
+      } else {
+        auto& oldTy = ret.first->second;
+        oldTy &= type;
+      }
+    }
     if (inret.second) {
       if (!hint) {
         catMap[loc] = folly::get_default(guards, guard).category;
@@ -419,7 +433,6 @@ void recordDependencies(Env& env) {
     }
   });
 
-  std::vector<RegionDesc::TypedLocation> typePreds;
   for (auto& kv : guardMap) {
     auto const hint_it = hintMap.find(kv.first);
     // If we have a hinted type that's better than the guarded type, we want to
@@ -427,12 +440,9 @@ void recordDependencies(Env& env) {
     // Gen because we knew something was a BoxedCell statically, but we may
     // need to keep information about what inner type we were predicting.
     if (hint_it != end(hintMap) && hint_it->second < kv.second) {
-      auto const pred = RegionDesc::TypedLocation {
-        hint_it->first,
-        hint_it->second
-      };
-      FTRACE(1, "selectTracelet adding prediction {}\n", show(pred));
-      typePreds.push_back(pred);
+      FTRACE(1, "selectTracelet adding prediction {}\n",
+            show(RegionDesc::TypedLocation {hint_it->first, hint_it->second}));
+      predictionMap.insert(*hint_it);
     }
     if (kv.second == TGen) {
       // Guard was relaxed to Gen---don't record it.  But if there's a hint, we
@@ -447,16 +457,10 @@ void recordDependencies(Env& env) {
     firstBlock.addPreCondition(preCond);
   }
 
-  // Sort the predictions by location, so that we can simply compare
+  // Predictions are already sorted by location, so we can simply compare
   // the type-prediction vectors for different blocks later.
-  std::sort(typePreds.begin(), typePreds.end(),
-            [&](const RegionDesc::TypedLocation& tl1,
-                const RegionDesc::TypedLocation& tl2) {
-              return tl1.location < tl2.location;
-            });
-
-  for (auto& pred : typePreds) {
-    firstBlock.addPredicted(pred);
+  for (auto& pred : predictionMap) {
+    firstBlock.addPredicted(RegionDesc::TypedLocation{pred.first, pred.second});
   }
 }
 


### PR DESCRIPTION
Pre-constraining pseudo-main guards doesn't allow the guard relaxation pass to
    take effect. The result is that a lot of unnecessary type guards are left in
    pseudo-main. This diff stops constraining the guards eagerly and saves type
    information for unconstrained locals into RegionDesc as "type predictions". This
    decreases the total number of executed type guards for an oss-performance
    WordPress run by 40%.
