### PR TITLE
Added arm64 support to the following routines.

### DIFF
--- a/hphp/hack/src/heap/hh_shared.c
+++ b/hphp/hack/src/heap/hh_shared.c
@@ -864,7 +864,11 @@ value hh_mem(value key) {
     // The data is currently in the process of being written, wait until it
     // actually is ready to be used before returning.
     while (hashtbl[slot].addr == (char*)1) {
+#ifdef __aarch64__
+      asm volatile("yield" : : : "memory");
+#else
       asm volatile("pause" : : : "memory");
+#endif
     }
     return Val_bool(1);
   }

--- a/hphp/runtime/base/arch.h
+++ b/hphp/runtime/base/arch.h
@@ -18,6 +18,8 @@
 
 #include "hphp/runtime/base/runtime-option.h"
 
+#include "hphp/util/assertions.h"
+
 #include <boost/type_traits.hpp>
 
 namespace HPHP {
@@ -29,6 +31,8 @@ enum class Arch { X64, ARM, PPC64, };
 constexpr Arch arch() {
 #if defined(__powerpc64__)
   return Arch::PPC64;
+#elif defined(__aarch64__)
+  return Arch::ARM;
 #else
   return Arch::X64;
 #endif

--- a/hphp/util/atomic.h
+++ b/hphp/util/atomic.h
@@ -46,7 +46,7 @@ inline void assert_address_is_atomically_accessible(T* address) {
   assert(((uintptr_t(address) + sizeof(T) - 1) & ~63ul) ==
          ( uintptr_t(address)                  & ~63ul) &&
         "Atomically accessed addresses may not span cache lines");
-#elif __AARCH64EL__ || __powerpc64__
+#elif __aarch64__ || __powerpc64__
   // N-byte accesses must be N-byte aligned
   assert((uintptr_t(address) & (sizeof(T) - 1)) == 0);
 #else

--- a/hphp/util/bitops.h
+++ b/hphp/util/bitops.h
@@ -17,7 +17,7 @@
 #ifndef incl_HPHP_BITOPS_H_
 #define incl_HPHP_BITOPS_H_
 
-#if !defined(__x86_64__) && !defined(__AARCH64EL__)
+#if !defined(__x86_64__) && !defined(__aarch64__)
 #include <folly/Bits.h>
 #endif
 
@@ -38,7 +38,7 @@ inline bool ffs64(I64 input, I64 &out) {
     "r"(input):
     "cc"
   );
-#elif defined(__AARCH64EL__)
+#elif defined(__aarch64__)
   asm volatile (
     "rbit  %2, %2\n\t"  // reverse bits
     "clz   %1, %2\n\t"  // count leading zeros
@@ -66,7 +66,7 @@ inline bool fls64(I64 input, I64 &out) {
     "r"(input):
     "cc"
   );
-#elif defined(__AARCH64EL__)
+#elif defined(__aarch64__)
   asm volatile (
     "clz   %1, %2\n\t"      // count leading zeros
     "neg   %1, %1\n\t"

--- a/hphp/util/compact-tagged-ptrs.h
+++ b/hphp/util/compact-tagged-ptrs.h
@@ -38,7 +38,8 @@ namespace HPHP {
 
 //////////////////////////////////////////////////////////////////////
 
-#if defined(__x86_64__) || defined(_M_X64) || defined(__powerpc64__)
+#if defined(__x86_64__) || defined(_M_X64) || defined(__powerpc64__) || \
+    defined(__aarch64__)
 
 template<class T, class TagType = uint32_t>
 struct CompactTaggedPtr {

--- a/hphp/util/cycles.h
+++ b/hphp/util/cycles.h
@@ -17,6 +17,8 @@
 #ifndef incl_HPHP_TSC_H_
 #define incl_HPHP_TSC_H_
 
+#include <folly/portability/Asm.h>
+
 #include "hphp/util/assertions.h"
 #ifdef _MSC_VER
 #include <intrin.h>
@@ -41,17 +43,19 @@ inline uint64_t cpuCycles() {
   return tb;
 #elif _MSC_VER
   return (uint64_t)__rdtsc();
+#elif __aarch64__
+  // FIXME: This returns the virtual timer which is not exactly
+  // the core cycles but has a different frequency.
+  uint64_t tb;
+  asm volatile("mrs %0, cntvct_el0" : "=r" (tb));
+  return tb;
 #else
   not_implemented();
 #endif
 }
 
 inline void cpuRelax() {
-#ifdef __x86_64__
-  asm volatile("pause");
-#elif __powerpc64__
-  asm volatile("or 31,31,31");
-#endif
+  folly::asm_volatile_pause();
 }
 
 inline void cycleDelay(uint32_t numCycles) {

--- a/hphp/util/dwarf-reg.h
+++ b/hphp/util/dwarf-reg.h
@@ -34,11 +34,20 @@ enum class ppc64 : uint8_t {
   R28, R29, R30, FP,  LR = 65
 };
 
+enum class arm : uint8_t {
+  X0,  X1,  X2,  X3,  X4,  X5,  X6,  X7,
+  X8,  X9,  X10, X11, X12, X13, X14, X15,
+  X16, X17, X18, X19, X20, X21, X22, X23,
+  X24, X25, X26, X27, X28, X29, X30, SP
+};
+
 constexpr auto FP = static_cast<uint8_t>(
 #if defined(__x86_64__)
   x64::RBP
 #elif defined(__powerpc64__)
   ppc64::FP
+#elif defined(__aarch64__)
+  arm::X29
 #else
   0
 #endif
@@ -49,6 +58,8 @@ constexpr auto SP = static_cast<uint8_t>(
   x64::RSP
 #elif defined(__powerpc64__)
   ppc64::SP
+#elif defined(__aarch64__)
+  arm::SP
 #else
   0
 #endif
@@ -59,6 +70,8 @@ constexpr auto IP = static_cast<uint8_t>(
   x64::RIP
 #elif defined(__powerpc64__)
   ppc64::LR
+#elif defined(__aarch64__)
+  arm::X30
 #else
   0
 #endif


### PR DESCRIPTION
1. cpuRelax()
2. cpuCycles()
3. arch()
4. hh_mem()
5. CompactTaggedPtr definition