### PR TITLE
Do not use folly::Optional on iterator in store-elim.

### DIFF
--- a/hphp/runtime/vm/jit/store-elim.cpp
+++ b/hphp/runtime/vm/jit/store-elim.cpp
@@ -584,7 +584,7 @@ void visit(Local& env, IRInstruction& inst) {
 
 void block_visit(Local& env, Block* block) {
   FTRACE(2, "  visiting B{}\n", block->id());
-  if (block->instrs().empty()) return;
+  assertx(!block->instrs().empty());
 
   auto prev = std::prev(block->instrs().end());
   for (;;) {

--- a/hphp/runtime/vm/jit/store-elim.cpp
+++ b/hphp/runtime/vm/jit/store-elim.cpp
@@ -584,16 +584,18 @@ void visit(Local& env, IRInstruction& inst) {
 
 void block_visit(Local& env, Block* block) {
   FTRACE(2, "  visiting B{}\n", block->id());
-  auto it = block->instrs().end();
-  --it;
+  if (block->instrs().empty()) return;
+
+  auto prev = std::prev(block->instrs().end());
   for (;;) {
-    folly::Optional<Block::iterator> prev;
+    auto it = prev;
     if (it != block->instrs().begin()) {
       prev = std::prev(it);
+      visit(env, *it);
+    } else {
+      visit(env, *it);
+      break;
     }
-    visit(env, *it);
-    if (!prev) break;
-    it = *prev;
   }
 }
 


### PR DESCRIPTION
Clang 3.6 and 3.7 on mac crash with assertion "move constructor should not be
deleted".

https://github.com/llvm-mirror/clang/blob/e1d7b3bd4c2f9d0866ca7eaa4178a0c06815b607/include/clang/AST/DeclCXX.h#L919-L924