### PR TITLE
Updated required cmake version to 2.8.12.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-CMAKE_MINIMUM_REQUIRED(VERSION 2.8.7 FATAL_ERROR)
+CMAKE_MINIMUM_REQUIRED(VERSION 2.8.12 FATAL_ERROR)
 
 # This needs to be done before any languages are enabled or
 # projects are created.


### PR DESCRIPTION
The update of third-party/ragel to commit 534f472323e9b714e91508d51d5b5dc9dc25b040 means that cmake version 2.8.12 is now required (for add_compile_options support).
