### PR TITLE
Added support for indirect results on arm64 and fixed optimizations

### DIFF
--- a/hphp/runtime/vm/jit/code-gen-tls-inl.h
+++ b/hphp/runtime/vm/jit/code-gen-tls-inl.h
@@ -33,7 +33,6 @@ namespace HPHP { namespace jit {
 
 template<typename T>
 inline Vptr emitTLSAddr(Vout& v, TLSDatum<T> datum) {
-  if (arch() != Arch::X64) not_implemented();
   return x64::detail::emitTLSAddr(v, datum);
 }
 

--- a/hphp/runtime/vm/jit/code-gen-x64.cpp
+++ b/hphp/runtime/vm/jit/code-gen-x64.cpp
@@ -704,8 +704,9 @@ CallDest CodeGenerator::callDestDbl(const IRInstruction* inst) const {
 void CodeGenerator::cgCallHelper(Vout& v, CallSpec call,
                                  const CallDest& dstInfo,
                                  SyncOptions sync,
-                                 const ArgGroup& args) {
-  irlower::cgCallHelper(v, m_state, call, dstInfo, sync, args);
+                                 const ArgGroup& args,
+                                 bool indResult) {
+  irlower::cgCallHelper(v, m_state, call, dstInfo, sync, args, indResult);
 }
 
 void CodeGenerator::cgMov(IRInstruction* inst) {
@@ -2900,7 +2901,8 @@ void CodeGenerator::cgCallBuiltin(IRInstruction* inst) {
   }();
 
   cgCallHelper(v, CallSpec::direct(callee->nativeFuncPtr()),
-               dest, SyncOptions::Sync, callArgs);
+               dest, SyncOptions::Sync, callArgs,
+               !returnByValue && isBuiltinByRef(funcReturnType));
 
   // For primitive return types (int, bool, double), and returnByValue,
   // the return value is already in dstReg/dstType

--- a/hphp/runtime/vm/jit/code-gen-x64.h
+++ b/hphp/runtime/vm/jit/code-gen-x64.h
@@ -63,7 +63,8 @@ private:
   CallDest callDestDbl(const IRInstruction*) const;
 
   void cgCallHelper(Vout& v, CallSpec call, const CallDest& dstInfo,
-                    SyncOptions sync, const ArgGroup& args);
+                    SyncOptions sync, const ArgGroup& args,
+                    bool indResult = false);
   void cgInterpOneCommon(IRInstruction* inst);
 
   void emitTrashTV(Vreg, int32_t, char fillByte);

--- a/hphp/runtime/vm/jit/irlower-call.cpp
+++ b/hphp/runtime/vm/jit/irlower-call.cpp
@@ -104,7 +104,7 @@ Fixup makeFixup(const BCMarker& marker, SyncOptions sync) {
 }
 
 void cgCallHelper(Vout& v, IRLS& env, CallSpec call, const CallDest& dstInfo,
-                  SyncOptions sync, const ArgGroup& args) {
+                  SyncOptions sync, const ArgGroup& args, bool indResult) {
   auto const inst = args.inst();
   jit::vector<Vreg> vargs, vSimdArgs, vStkArgs;
 
@@ -174,11 +174,12 @@ void cgCallHelper(Vout& v, IRLS& env, CallSpec call, const CallDest& dstInfo,
 
   if (do_catch) {
     v << vinvoke{call, argsId, dstId, {targets[0], targets[1]},
-                 syncFixup, dstInfo.type};
+                 syncFixup, dstInfo.type, indResult};
     env.catch_calls[inst->taken()] = CatchCall::CPP;
     v = targets[0];
   } else {
-    v << vcall{call, argsId, dstId, syncFixup, dstInfo.type, nothrow};
+    v << vcall{call, argsId, dstId, syncFixup, dstInfo.type, nothrow,
+               indResult};
   }
 }
 

--- a/hphp/runtime/vm/jit/irlower-internal.h
+++ b/hphp/runtime/vm/jit/irlower-internal.h
@@ -88,7 +88,8 @@ Fixup makeFixup(const BCMarker& marker, SyncOptions sync = SyncOptions::Sync);
  * Native call helper.
  */
 void cgCallHelper(Vout& v, IRLS& env, CallSpec call, const CallDest& dstInfo,
-                  SyncOptions sync, const ArgGroup& args);
+                  SyncOptions sync, const ArgGroup& args,
+                  bool indResult = false);
 
 ///////////////////////////////////////////////////////////////////////////////
 

--- a/hphp/runtime/vm/jit/mc-generator.cpp
+++ b/hphp/runtime/vm/jit/mc-generator.cpp
@@ -62,6 +62,9 @@
 #include "hphp/util/timer.h"
 #include "hphp/util/trace.h"
 
+#include "hphp/vixl/a64/constants-a64.h"
+#include "hphp/vixl/a64/macro-assembler-a64.h"
+
 #include "hphp/runtime/base/arch.h"
 #include "hphp/runtime/base/execution-context.h"
 #include "hphp/runtime/base/rds.h"
@@ -1105,8 +1108,33 @@ MCGenerator::bindJmp(TCA toSmash, SrcKey destSk, ServiceRequest req,
     return tDest;
   }
 
-  x64::DecodedInstruction di(toSmash);
-  if (di.isBranch() && !di.isJmp()) {
+  bool isJcc;
+  switch (arch()) {
+    case Arch::X64: {
+        x64::DecodedInstruction di(toSmash);
+        isJcc = (di.isBranch() && !di.isJmp());
+        break;
+    }
+
+    case Arch::ARM: {
+        using namespace vixl;
+        struct JccDecoder : public Decoder {
+          void VisitConditionalBranch(Instruction* inst) override {
+            cc = (Condition)inst->ConditionBranch();
+          }
+          folly::Optional<Condition> cc;
+        };
+        JccDecoder decoder;
+        decoder.Decode(Instruction::Cast(toSmash));
+        isJcc = decoder.cc.hasValue();
+        break;
+      }
+
+    default: {
+      always_assert(false);
+    }
+  }
+  if (isJcc) {
     auto const target = smashableJccTarget(toSmash);
     assertx(target);
 

--- a/hphp/runtime/vm/jit/phys-reg-saver.cpp
+++ b/hphp/runtime/vm/jit/phys-reg-saver.cpp
@@ -16,6 +16,8 @@
 
 #include "hphp/runtime/vm/jit/phys-reg-saver.h"
 
+#include "hphp/runtime/base/arch.h"
+
 #include "hphp/runtime/vm/jit/abi.h"
 #include "hphp/runtime/vm/jit/phys-reg.h"
 #include "hphp/runtime/vm/jit/vasm-gen.h"
@@ -45,9 +47,21 @@ PhysRegSaver::PhysRegSaver(Vout& v, RegSet regs)
     });
   }
 
-  gpr.forEach([&] (PhysReg r) {
-    v << push{r};
-  });
+  switch(arch()) {
+    case Arch::ARM:
+      gpr.forEachPair([&] (PhysReg r0, PhysReg r1) {
+        if(r1 == InvalidReg) {
+          v << push{r0};
+        } else {
+          v << pushp{r1, r0};
+        }
+      });
+      break;
+    default:
+      gpr.forEach([&] (PhysReg r) {
+        v << push{r};
+      });
+  }
 
   if (m_adjust) {
     v << lea{sp[-m_adjust], sp};
@@ -65,9 +79,21 @@ PhysRegSaver::~PhysRegSaver() {
   auto gpr = m_regs & abi().gp();
   auto xmm = m_regs & abi().simd();
 
-  gpr.forEachR([&] (PhysReg r) {
-    v << pop{r};
-  });
+  switch(arch()) {
+    case Arch::ARM:
+      gpr.forEachPairR([&] (PhysReg r0, PhysReg r1) {
+        if(r1 == InvalidReg) {
+          v << pop{r0};
+        } else {
+          v << popp{r0, r1};
+        }
+      });
+      break;
+    default:
+      gpr.forEachR([&] (PhysReg r) {
+        v << pop{r};
+      });
+  }
 
   if (!xmm.empty()) {
     int offset = 0;

--- a/hphp/runtime/vm/jit/service-requests.cpp
+++ b/hphp/runtime/vm/jit/service-requests.cpp
@@ -222,6 +222,12 @@ namespace x64 {
   static constexpr int kLeaVmSpLen = 7;
 }
 
+namespace arm {
+  // 'lea' results in atmost 4 instructions (see vasm-arm.cpp)
+  static constexpr int kMovLen = 4 * 4;
+  static constexpr int kLeaVmSpLen = 4 * 4;
+}
+
 size_t stub_size() {
   // The extra args are the request type and the stub address.
   constexpr auto kTotalArgs = kMaxArgs + 2;
@@ -230,7 +236,7 @@ size_t stub_size() {
     case Arch::X64:
       return kTotalArgs * x64::kMovLen + x64::kLeaVmSpLen;
     case Arch::ARM:
-      not_implemented();
+      return kTotalArgs * arm::kMovLen + arm::kLeaVmSpLen;
     case Arch::PPC64:
       not_implemented();
   }
@@ -254,7 +260,44 @@ FPInvOffset extract_spoff(TCA stub) {
       }
 
     case Arch::ARM:
-      not_implemented();
+      {
+        struct Decoder : public vixl::Decoder {
+          void VisitAddSubImmediate(vixl::Instruction* inst) {
+            // For immediate operands, shift can be '0' or '12'
+            int64_t immed =
+              inst->ImmAddSub() << ((inst->ShiftAddSub() == 1) ? 12 : 0);
+            switch (inst->Mask(vixl::AddSubOpMask)) {
+              case vixl::ADD: offset = immed; break;
+              case vixl::SUB: offset = -immed; break;
+              default: break;
+            }
+          }
+          void VisitMoveWideImmediate(vixl::Instruction* inst) {
+            // For wide moves, shift can be 0, 16, 32 or 64
+            int64_t immed = safe_cast<int64_t>(
+              inst->ImmMoveWide() << (inst->ShiftMoveWide() << 4));
+            switch (inst->Mask(vixl::MoveWideImmediateMask)) {
+              case vixl::MOVN_w:
+              case vixl::MOVN_x:
+                immed = safe_cast<int64_t>(~immed);
+                break;
+            }
+            offset = immed;
+          }
+          folly::Optional<int32_t> offset;
+        };
+        Decoder decoder;
+        decoder.Decode((vixl::Instruction*)(stub));
+
+        // 'lea' becomes
+        //   a. 'add dst, base, #imm' or
+        //   b. 'mov r, #imm'
+        //      'add dst, base, r'
+        // FIXME: Return '0' if vasm optimizes 'lea' to 'mov'
+        if (!decoder.offset.hasValue()) return FPInvOffset{0};
+        always_assert(decoder.offset && (*decoder.offset % sizeof(Cell)) == 0);
+        return FPInvOffset{-(*decoder.offset / int32_t{sizeof(Cell)})};
+      }
 
     case Arch::PPC64:
       not_implemented();

--- a/hphp/runtime/vm/jit/target-cache.cpp
+++ b/hphp/runtime/vm/jit/target-cache.cpp
@@ -443,6 +443,9 @@ void handlePrimeCacheInit(Entry* mce,
 #if defined(__x86_64__)
   ActRec* framePtr;
   asm volatile("mov %%rbp, %0" : "=r" (framePtr) ::);
+#elif defined(__aarch64__)
+  ActRec* framePtr;
+  asm volatile("mov %0, x29" : "=r" (framePtr) ::);
 #else
   ActRec* framePtr = ar;
   always_assert(false);

--- a/hphp/runtime/vm/jit/translate-region.cpp
+++ b/hphp/runtime/vm/jit/translate-region.cpp
@@ -256,18 +256,7 @@ void emitPredictionsAndPreConditions(irgen::IRGS& irgs,
 
     // In the entry block, hhbc-translator gets a chance to emit some code
     // immediately after the initial checks on the first instruction.
-    switch (arch()) {
-      case Arch::X64:
-        irgen::prepareEntry(irgs);
-        break;
-      case Arch::ARM:
-        // Don't do this for ARM, because it can lead to interpOne on the
-        // first SrcKey in a translation, which isn't allowed.
-        break;
-      case Arch::PPC64:
-        not_implemented();
-        break;
-    }
+    irgen::prepareEntry(irgs);
   }
 }
 

--- a/hphp/runtime/vm/jit/vasm-fold-imms.cpp
+++ b/hphp/runtime/vm/jit/vasm-fold-imms.cpp
@@ -234,16 +234,18 @@ struct ImmFolder {
 
 namespace arm {
 struct ImmFolder {
+  jit::vector<bool> used;
   jit::vector<uint64_t> vals;
   boost::dynamic_bitset<> valid;
 
-  explicit ImmFolder(jit::vector<bool>&&) {}
+  explicit ImmFolder(jit::vector<bool>&& used_in)
+  : used(std::move(used_in)) { }
 
   bool arith_imm(Vreg r, int32_t& out) {
     if (!valid.test(r)) return false;
     auto imm64 = vals[r];
     if (!vixl::Assembler::IsImmArithmetic(imm64)) return false;
-    out = safe_cast<int32_t>(imm64);
+    out = imm64;
     return true;
   }
   bool logical_imm(Vreg r, int32_t& out) {
@@ -251,7 +253,7 @@ struct ImmFolder {
     auto imm64 = vals[r];
     if (!vixl::Assembler::IsImmLogical(imm64, vixl::kXRegSize)) return false;
     if (!deltaFits(imm64, sz::word)) return false;
-    out = safe_cast<int32_t>(imm64);
+    out = imm64;
     return true;
   }
   bool zero_imm(Vreg r) {


### PR DESCRIPTION
1.  Added 'indResult' for vcall and vinvoke to notify the target code that the result buffer should be provided indirectly
2.  Fixed emitTLSAddr for arm64
3.  Added arm64 instruction decoding code for jumps for lea
4.  Added arm64 limits in imm folding and copy propagation code
5.  Converted code gen to use pushp/popp instead of push/pop where possible