### PR TITLE
FIX: Prevent erroneous extern in *.tab.hpp with Bison >= 2.5.90 and YYDEBUG

### DIFF
--- a/hphp/parser/make-parser.sh
+++ b/hphp/parser/make-parser.sh
@@ -81,7 +81,7 @@ $SED -i "s#${TMP}#${INFILE}#g" "${OUTFILE7}"
 
 $SED -i \
      -e 's@int Compiler[57]parse.*@@' \
-     -e 's@int Compiler[57]debug.*@@' \
+     -e 's@.*int Compiler[57]debug.*@@' \
      -e "s@#ifndef YY_COMPILER[57]_.*@@g" \
      -e "s@# define YY_COMPILER[57]_.*@@g" \
      -e "s@#endif /\* !YY_COMPILER[57]_.*@@g" \


### PR DESCRIPTION
Prevents an erroneous extern being left in *.tab.hpp by maker-parser.sh with Bison >= 2.5.90 and YYDEBUG.

Noticed while attempting to enable bison's debug mode in hphp.y under CentOS 7 with bundled Bison 2.7 for issue #6992 

Relevant Bison change:
http://git.savannah.gnu.org/cgit/bison.git/commit/?id=56ca3d8fce0c9db2f2829d7a7a07a9ad06cdf6a8