### PR TITLE
If target is ARM, replaced push/pop calls with pushp/popp (pair)

### DIFF
--- a/hphp/runtime/vm/jit/phys-reg-saver.cpp
+++ b/hphp/runtime/vm/jit/phys-reg-saver.cpp
@@ -63,8 +63,6 @@ PhysRegSaver::PhysRegSaver(Vout& v, RegSet regs)
         }
       });
       break;
-    default:
-      always_assert(false);
   }
 
   if (m_adjust) {
@@ -99,8 +97,6 @@ PhysRegSaver::~PhysRegSaver() {
         }
       });
       break;
-    default:
-      always_assert(false);
   }
 
   if (!xmm.empty()) {

--- a/hphp/runtime/vm/jit/phys-reg-saver.cpp
+++ b/hphp/runtime/vm/jit/phys-reg-saver.cpp
@@ -47,7 +47,13 @@ PhysRegSaver::PhysRegSaver(Vout& v, RegSet regs)
     });
   }
 
-  switch(arch()) {
+  switch (arch()) {
+    case Arch::X64:
+    case Arch::PPC64:
+      gpr.forEach([&] (PhysReg r) {
+        v << push{r};
+      });
+      break;
     case Arch::ARM:
       gpr.forEachPair([&] (PhysReg r0, PhysReg r1) {
         if (r1 == InvalidReg) {
@@ -58,9 +64,7 @@ PhysRegSaver::PhysRegSaver(Vout& v, RegSet regs)
       });
       break;
     default:
-      gpr.forEach([&] (PhysReg r) {
-        v << push{r};
-      });
+      always_assert(false);
   }
 
   if (m_adjust) {
@@ -79,7 +83,13 @@ PhysRegSaver::~PhysRegSaver() {
   auto gpr = m_regs & abi().gp();
   auto xmm = m_regs & abi().simd();
 
-  switch(arch()) {
+  switch (arch()) {
+    case Arch::X64:
+    case Arch::PPC64:
+      gpr.forEachR([&] (PhysReg r) {
+        v << pop{r};
+      });
+      break;
     case Arch::ARM:
       gpr.forEachPairR([&] (PhysReg r0, PhysReg r1) {
         if (r1 == InvalidReg) {
@@ -90,9 +100,7 @@ PhysRegSaver::~PhysRegSaver() {
       });
       break;
     default:
-      gpr.forEachR([&] (PhysReg r) {
-        v << pop{r};
-      });
+      always_assert(false);
   }
 
   if (!xmm.empty()) {

--- a/hphp/runtime/vm/jit/phys-reg-saver.cpp
+++ b/hphp/runtime/vm/jit/phys-reg-saver.cpp
@@ -50,7 +50,7 @@ PhysRegSaver::PhysRegSaver(Vout& v, RegSet regs)
   switch(arch()) {
     case Arch::ARM:
       gpr.forEachPair([&] (PhysReg r0, PhysReg r1) {
-        if(r1 == InvalidReg) {
+        if (r1 == InvalidReg) {
           v << push{r0};
         } else {
           v << pushp{r1, r0};
@@ -82,7 +82,7 @@ PhysRegSaver::~PhysRegSaver() {
   switch(arch()) {
     case Arch::ARM:
       gpr.forEachPairR([&] (PhysReg r0, PhysReg r1) {
-        if(r1 == InvalidReg) {
+        if (r1 == InvalidReg) {
           v << pop{r0};
         } else {
           v << popp{r0, r1};

--- a/hphp/runtime/vm/jit/phys-reg-saver.cpp
+++ b/hphp/runtime/vm/jit/phys-reg-saver.cpp
@@ -16,6 +16,8 @@
 
 #include "hphp/runtime/vm/jit/phys-reg-saver.h"
 
+#include "hphp/runtime/base/arch.h"
+
 #include "hphp/runtime/vm/jit/abi.h"
 #include "hphp/runtime/vm/jit/phys-reg.h"
 #include "hphp/runtime/vm/jit/vasm-gen.h"
@@ -45,9 +47,21 @@ PhysRegSaver::PhysRegSaver(Vout& v, RegSet regs)
     });
   }
 
-  gpr.forEach([&] (PhysReg r) {
-    v << push{r};
-  });
+  switch(arch()) {
+    case Arch::ARM:
+      gpr.forEachPair([&] (PhysReg r0, PhysReg r1) {
+        if(r1 == InvalidReg) {
+          v << push{r0};
+        } else {
+          v << pushp{r1, r0};
+        }
+      });
+      break;
+    default:
+      gpr.forEach([&] (PhysReg r) {
+        v << push{r};
+      });
+  }
 
   if (m_adjust) {
     v << lea{sp[-m_adjust], sp};
@@ -65,9 +79,21 @@ PhysRegSaver::~PhysRegSaver() {
   auto gpr = m_regs & abi().gp();
   auto xmm = m_regs & abi().simd();
 
-  gpr.forEachR([&] (PhysReg r) {
-    v << pop{r};
-  });
+  switch(arch()) {
+    case Arch::ARM:
+      gpr.forEachPairR([&] (PhysReg r0, PhysReg r1) {
+        if(r1 == InvalidReg) {
+          v << pop{r0};
+        } else {
+          v << popp{r0, r1};
+        }
+      });
+      break;
+    default:
+      gpr.forEachR([&] (PhysReg r) {
+        v << pop{r};
+      });
+  }
 
   if (!xmm.empty()) {
     int offset = 0;


### PR DESCRIPTION
This will reduce the number of instructions for saving and restoring
the registers.