### PR TITLE
Added arm specific restrictions in copy prop. and imm folding optimizations

### DIFF
--- a/hphp/runtime/vm/jit/vasm-fold-imms.cpp
+++ b/hphp/runtime/vm/jit/vasm-fold-imms.cpp
@@ -236,16 +236,18 @@ struct ImmFolder {
 
 namespace arm {
 struct ImmFolder {
+  jit::vector<bool> used;
   jit::vector<uint64_t> vals;
   boost::dynamic_bitset<> valid;
 
-  explicit ImmFolder(jit::vector<bool>&&) {}
+  explicit ImmFolder(jit::vector<bool>&& used_in)
+  : used(std::move(used_in)) { }
 
   bool arith_imm(Vreg r, int32_t& out) {
     if (!valid.test(r)) return false;
     auto imm64 = vals[r];
     if (!vixl::Assembler::IsImmArithmetic(imm64)) return false;
-    out = safe_cast<int32_t>(imm64);
+    out = imm64;
     return true;
   }
   bool logical_imm(Vreg r, int32_t& out) {
@@ -253,7 +255,7 @@ struct ImmFolder {
     auto imm64 = vals[r];
     if (!vixl::Assembler::IsImmLogical(imm64, vixl::kXRegSize)) return false;
     if (!deltaFits(imm64, sz::word)) return false;
-    out = safe_cast<int32_t>(imm64);
+    out = imm64;
     return true;
   }
   bool zero_imm(Vreg r) {


### PR DESCRIPTION
1.  After lowering, only [base, index lsl #scale] and [base, #imm] are
    allowed, where the range of #imm is [-256 .. 255]. So, if the Vptr
    is not in one of above two forms, avoided rewrite in vasm-copy
2.  Removed safe_cast<> in imm folding as IsImmArithmetic() and
    IsImmLogical() perform the checks on 64 bit value