### PR TITLE
Added support for indirect results on ARM

### DIFF
--- a/hphp/runtime/vm/jit/abi-ppc64.h
+++ b/hphp/runtime/vm/jit/abi-ppc64.h
@@ -67,6 +67,7 @@ inline RegSet vm_regs_with_sp() { return vm_regs_no_sp() | rvmsp(); }
 
 PhysReg rret(size_t i = 0);
 PhysReg rret_simd(size_t i);
+constexpr PhysReg rret_indirect() { return ppc64_asm::reg::r3; };
 
 PhysReg rarg(size_t i);
 PhysReg rarg_simd(size_t i);

--- a/hphp/runtime/vm/jit/abi-x64.h
+++ b/hphp/runtime/vm/jit/abi-x64.h
@@ -46,6 +46,7 @@ inline RegSet vm_regs_with_sp() { return vm_regs_no_sp() | rvmsp(); }
 
 constexpr PhysReg rret_data() { return reg::rax; }
 constexpr PhysReg rret_type() { return reg::rdx; }
+constexpr PhysReg rret_indirect() { return reg::rax; }
 
 PhysReg rret(size_t i = 0);
 PhysReg rret_simd(size_t i);

--- a/hphp/runtime/vm/jit/abi.cpp
+++ b/hphp/runtime/vm/jit/abi.cpp
@@ -40,6 +40,7 @@ PhysReg rret_type() { return ARCH_SWITCH_CALL(rret_type); }
 
 PhysReg rret(size_t i) { return ARCH_SWITCH_CALL(rret, i); }
 PhysReg rret_simd(size_t i) { return ARCH_SWITCH_CALL(rret_simd, i); }
+PhysReg rret_indirect() { return ARCH_SWITCH_CALL(rret_indirect); }
 
 PhysReg rarg(size_t i) { return ARCH_SWITCH_CALL(rarg, i); }
 PhysReg rarg_simd(size_t i) { return ARCH_SWITCH_CALL(rarg_simd, i); }

--- a/hphp/runtime/vm/jit/abi.h
+++ b/hphp/runtime/vm/jit/abi.h
@@ -78,6 +78,7 @@ PhysReg rret_type();
  */
 PhysReg rret(size_t i = 0);
 PhysReg rret_simd(size_t i);
+PhysReg rret_indirect();
 
 /*
  * Native argument registers.

--- a/hphp/runtime/vm/jit/arg-group.h
+++ b/hphp/runtime/vm/jit/arg-group.h
@@ -243,7 +243,7 @@ private:
 private:
   const IRInstruction* m_inst;
   const StateVector<SSATmp,Vloc>& m_locs;
-  ArgVec* m_override{nullptr};// used to force args to go into a specific ArgVec
+  ArgVec* m_override{nullptr}; // used to force args to go into a specific ArgVec
   ArgVec m_gpArgs; // INTEGER class args
   ArgVec m_simdArgs; // SSE class args
   ArgVec m_stkArgs; // Overflow

--- a/hphp/runtime/vm/jit/arg-group.h
+++ b/hphp/runtime/vm/jit/arg-group.h
@@ -135,12 +135,13 @@ struct ArgGroup {
 
   explicit ArgGroup(const IRInstruction* inst,
                     const StateVector<SSATmp,Vloc>& locs)
-    : m_inst(inst), m_locs(locs), m_override(nullptr)
+    : m_inst(inst), m_locs(locs), m_override(nullptr), m_indirect(false)
   {}
 
   size_t numGpArgs() const { return m_gpArgs.size(); }
   size_t numSimdArgs() const { return m_simdArgs.size(); }
   size_t numStackArgs() const { return m_stkArgs.size(); }
+  bool isIndirect() const { return m_indirect; }
 
   ArgDesc& gpArg(size_t i) {
     assertx(i < m_gpArgs.size());
@@ -196,6 +197,11 @@ struct ArgGroup {
     return *this;
   }
 
+  ArgGroup& indirect(bool i) {
+    m_indirect = i;
+    return *this;
+  }
+
   /*
    * Pass tmp as a TypedValue passed by value.
    */
@@ -241,6 +247,7 @@ private:
   ArgVec m_gpArgs; // INTEGER class args
   ArgVec m_simdArgs; // SSE class args
   ArgVec m_stkArgs; // Overflow
+  bool m_indirect; // Indirect result
 };
 
 ArgGroup toArgGroup(const NativeCalls::CallInfo&,

--- a/hphp/runtime/vm/jit/arg-group.h
+++ b/hphp/runtime/vm/jit/arg-group.h
@@ -135,7 +135,7 @@ struct ArgGroup {
 
   explicit ArgGroup(const IRInstruction* inst,
                     const StateVector<SSATmp,Vloc>& locs)
-    : m_inst(inst), m_locs(locs), m_override(nullptr), m_indirect(false)
+    : m_inst(inst), m_locs(locs)
   {}
 
   size_t numGpArgs() const { return m_gpArgs.size(); }
@@ -243,11 +243,11 @@ private:
 private:
   const IRInstruction* m_inst;
   const StateVector<SSATmp,Vloc>& m_locs;
-  ArgVec* m_override; // used to force args to go into a specific ArgVec
+  ArgVec* m_override{nullptr};// used to force args to go into a specific ArgVec
   ArgVec m_gpArgs; // INTEGER class args
   ArgVec m_simdArgs; // SSE class args
   ArgVec m_stkArgs; // Overflow
-  bool m_indirect; // Indirect result
+  bool m_indirect{false}; // Indirect result
 };
 
 ArgGroup toArgGroup(const NativeCalls::CallInfo&,

--- a/hphp/runtime/vm/jit/code-gen-x64.cpp
+++ b/hphp/runtime/vm/jit/code-gen-x64.cpp
@@ -2921,6 +2921,8 @@ void CodeGenerator::cgCallBuiltin(IRInstruction* inst) {
     }
   }
 
+  callArgs.indirect(!returnByValue && isBuiltinByRef(funcReturnType));
+
   auto dest = [&] () -> CallDest {
     if (isBuiltinByRef(funcReturnType)) {
       if (returnByValue) {

--- a/hphp/runtime/vm/jit/irlower-call.cpp
+++ b/hphp/runtime/vm/jit/irlower-call.cpp
@@ -168,7 +168,8 @@ void cgCallHelper(Vout& v, IRLS& env, CallSpec call, const CallDest& dstInfo,
   auto const argsId = v.makeVcallArgs({
     std::move(vargs),
     std::move(vSimdArgs),
-    std::move(vStkArgs)
+    std::move(vStkArgs),
+    args.isIndirect()
   });
   auto const dstId = v.makeTuple(std::move(dstRegs));
 

--- a/hphp/runtime/vm/jit/vasm-lower.cpp
+++ b/hphp/runtime/vm/jit/vasm-lower.cpp
@@ -82,14 +82,12 @@ void lower_vcall(Vunit& unit, Inst& inst, Vlabel b, size_t i) {
                     v.makeTuple(std::move(argDests))};
     }
   };
-  switch(arch()) {
-  case Arch::X64:
-    {
+  switch (arch()) {
+    case Arch::X64:
+    case Arch::PPC64:
       doArgs(vargs.args, rarg);
-    }
-    break;
-  case Arch::ARM:
-    {
+      break;
+    case Arch::ARM:
       if (vargs.indirect) {
         if (vargs.args.size() > 0) {
           // First arg is pointer to storage for the return value
@@ -105,10 +103,9 @@ void lower_vcall(Vunit& unit, Inst& inst, Vlabel b, size_t i) {
         doArgs(vargs.args, rarg);
         needsCopy = false;
       }
-    }
-    break;
-  default:
-    always_assert(false);
+      break;
+    default:
+      always_assert(false);
   }
   doArgs(vargs.simdArgs, rarg_simd);
 

--- a/hphp/runtime/vm/jit/vasm-lower.cpp
+++ b/hphp/runtime/vm/jit/vasm-lower.cpp
@@ -139,9 +139,9 @@ void lower_vcall(Vunit& unit, Inst& inst, Vlabel b, size_t i) {
     v << nothrow{};
   }
 
-  // Copy back the indirect result pointer in case of ARM
-  if (arch() == Arch::ARM && needsCopy) {
-    v << copy{rret_indirect(), rarg(0)};
+  // Copy back the indirect result pointer into return register
+  if (needsCopy) {
+    v << copy{rret_indirect(), rret(0)};
   }
 
   // For vinvoke, `inst' is no longer valid after this point.

--- a/hphp/runtime/vm/jit/vasm-lower.cpp
+++ b/hphp/runtime/vm/jit/vasm-lower.cpp
@@ -91,8 +91,7 @@ void lower_vcall(Vunit& unit, Inst& inst, Vlabel b, size_t i) {
       if (vargs.indirect) {
         if (vargs.args.size() > 0) {
           // First arg is pointer to storage for the return value
-          auto const rreg = rret_indirect();
-          v << copy{vargs.args[0], rreg};
+          v << copy{vargs.args[0], rret_indirect()};
           VregList rem(vargs.args.begin() + 1, vargs.args.end());
           doArgs(rem, rarg);
           needsCopy = true;

--- a/hphp/runtime/vm/jit/vasm-lower.cpp
+++ b/hphp/runtime/vm/jit/vasm-lower.cpp
@@ -14,6 +14,8 @@
    +----------------------------------------------------------------------+
 */
 
+#include "hphp/runtime/base/arch.h"
+
 #include "hphp/runtime/vm/jit/vasm-lower.h"
 
 #include "hphp/runtime/vm/jit/types.h"
@@ -67,6 +69,7 @@ void lower_vcall(Vunit& unit, Inst& inst, Vlabel b, size_t i) {
 
   // Get the arguments in the proper registers.
   RegSet argRegs;
+  bool needsCopy;
   auto doArgs = [&] (const VregList& srcs, PhysReg (*r)(size_t)) {
     VregList argDests;
     for (size_t i = 0, n = srcs.size(); i < n; ++i) {
@@ -79,7 +82,34 @@ void lower_vcall(Vunit& unit, Inst& inst, Vlabel b, size_t i) {
                     v.makeTuple(std::move(argDests))};
     }
   };
-  doArgs(vargs.args, rarg);
+  switch(arch()) {
+  case Arch::X64:
+    {
+      doArgs(vargs.args, rarg);
+    }
+    break;
+  case Arch::ARM:
+    {
+      if (vargs.indirect) {
+        if (vargs.args.size() > 0) {
+          // First arg is pointer to storage for the return value
+          auto const rreg = rret_indirect();
+          v << copy{vargs.args[0], rreg};
+          VregList rem(vargs.args.begin() + 1, vargs.args.end());
+          doArgs(rem, rarg);
+          needsCopy = true;
+        } else {
+          needsCopy = false;
+        }
+      } else {
+        doArgs(vargs.args, rarg);
+        needsCopy = false;
+      }
+    }
+    break;
+  default:
+    always_assert(false);
+  }
   doArgs(vargs.simdArgs, rarg_simd);
 
   // Emit the appropriate call instruction sequence.
@@ -118,6 +148,12 @@ void lower_vcall(Vunit& unit, Inst& inst, Vlabel b, size_t i) {
   } else if (vcall.nothrow) {
     v << nothrow{};
   }
+
+  // Copy back the indirect result pointer in case of ARM
+  if (arch() == Arch::ARM && needsCopy) {
+    v << copy{rret_indirect(), rarg(0)};
+  }
+
   // For vinvoke, `inst' is no longer valid after this point.
 
   // Copy the call result to the destination register(s).

--- a/hphp/runtime/vm/jit/vasm-lower.cpp
+++ b/hphp/runtime/vm/jit/vasm-lower.cpp
@@ -14,9 +14,9 @@
    +----------------------------------------------------------------------+
 */
 
-#include "hphp/runtime/base/arch.h"
-
 #include "hphp/runtime/vm/jit/vasm-lower.h"
+
+#include "hphp/runtime/base/arch.h"
 
 #include "hphp/runtime/vm/jit/types.h"
 #include "hphp/runtime/vm/jit/abi.h"
@@ -69,7 +69,7 @@ void lower_vcall(Vunit& unit, Inst& inst, Vlabel b, size_t i) {
 
   // Get the arguments in the proper registers.
   RegSet argRegs;
-  bool needsCopy;
+  bool needsCopy = false;
   auto doArgs = [&] (const VregList& srcs, PhysReg (*r)(size_t)) {
     VregList argDests;
     for (size_t i = 0, n = srcs.size(); i < n; ++i) {
@@ -96,16 +96,10 @@ void lower_vcall(Vunit& unit, Inst& inst, Vlabel b, size_t i) {
           VregList rem(vargs.args.begin() + 1, vargs.args.end());
           doArgs(rem, rarg);
           needsCopy = true;
-        } else {
-          needsCopy = false;
         }
       } else {
         doArgs(vargs.args, rarg);
-        needsCopy = false;
       }
-      break;
-    default:
-      always_assert(false);
   }
   doArgs(vargs.simdArgs, rarg_simd);
 

--- a/hphp/runtime/vm/jit/vasm-unit.h
+++ b/hphp/runtime/vm/jit/vasm-unit.h
@@ -56,6 +56,7 @@ struct VcallArgs {
   VregList args;
   VregList simdArgs;
   VregList stkArgs;
+  bool indirect;
 };
 
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
On ARM, composite types by value are returned via indirect result
pointer in designated register 'x8' (on x86, it is first arg).
'indirect' field is added to ArgGroup{} and VcallArgs{} to notify
lower_vcall{} to copy the indirect result into appropriate register