### PR TITLE
Properly qualify SlotState::default_type()

### DIFF
--- a/hphp/runtime/vm/jit/frame-state.h
+++ b/hphp/runtime/vm/jit/frame-state.h
@@ -86,7 +86,7 @@ struct LocationState {
    * However, whenever we have a value, the type of the SSATmp must match this
    * `type' field.
    */
-  Type type{default_type()};
+  Type type{LocationState::default_type()};
 
   /*
    * Prediction for the type at the location, if it's boxed or if we're in a
@@ -94,7 +94,7 @@ struct LocationState {
    *
    * @requires: predictedType <= type
    */
-  Type predictedType{default_type()};
+  Type predictedType{LocationState::default_type()};
 
   /*
    * The sources of the currently known type, which may be values.


### PR DESCRIPTION
When building hhvm with gcc 5.3, default_type() is not properly
resolved. Fully qualify it to fix the build.

[ 55%] Building CXX object hphp/runtime/CMakeFiles/hphp_runtime_static.dir/vm/jit/frame-state.cpp.o
In file included from /home/peter/hhvm/hphp/runtime/vm/jit/frame-state.cpp:17:0:
/home/peter/hhvm/hphp/runtime/vm/jit/frame-state.h: In member function ‘void HPHP::jit::irgen::FrameStateMgr::clearForUnprocessedPred()’:
/home/peter/hhvm/hphp/runtime/vm/jit/frame-state.h:89:25: error: ‘default_type’ was not declared in this scope
   Type type{default_type()};
                         ^
/home/peter/hhvm/hphp/runtime/vm/jit/frame-state.cpp:1055:24: error: could not convert ‘{<expression error>}’ from ‘<brace-enclosed initializer list>’ to ‘HPHP::jit::Type’
       stk = StackState{};
                        ^
/home/peter/hhvm/hphp/runtime/vm/jit/frame-state.cpp:1055:24: error: could not convert ‘{<expression error>}’ from ‘<brace-enclosed initializer list>’ to ‘HPHP::jit::Type’
hphp/runtime/CMakeFiles/hphp_runtime_static.dir/build.make:8516: recipe for target 'hphp/runtime/CMakeFiles/hphp_runtime_static.dir/vm/jit/frame-state.cpp.o' failed