### PR TITLE
Exclude sqlite3ext.h from cotire

### DIFF
--- a/hphp/CMakeLists.txt
+++ b/hphp/CMakeLists.txt
@@ -57,6 +57,7 @@ if (ENABLE_COTIRE)
       "${ONIGURUMA_INCLUDE_DIR}/oniguruma.h"
       "${LIBPNG_INCLUDE_DIRS}/png.h"
       "${LDAP_INCLUDE_DIR}/ldap.h"
+      "${LIBSQLITE3_INCLUDE_DIR}/sqlite3ext.h"
       "${CMAKE_SOURCE_DIR}"
       "${CMAKE_BINARY_DIR}")
 endif()


### PR DESCRIPTION
[ 43%] Building CXX object hphp/util/CMakeFiles/hphp_util.dir/embedded-vfs.cpp.o
/home/peter/hhvm/hphp/util/embedded-vfs.cpp: In function ‘void HPHP::embeddedEnter()’:
/home/peter/hhvm/hphp/util/embedded-vfs.cpp:68:31: error: ‘sqlite3_api’ was not declared in this scope
 static void embeddedEnter() { sqlite3_mutex_enter(gEmbedded.pMutex); }
                               ^
/home/peter/hhvm/hphp/util/embedded-vfs.cpp: In function ‘void HPHP::embeddedLeave()’:
/home/peter/hhvm/hphp/util/embedded-vfs.cpp:69:31: error: ‘sqlite3_api’ was not declared in this scope
 static void embeddedLeave() { sqlite3_mutex_leave(gEmbedded.pMutex); }
                               ^
/home/peter/hhvm/hphp/util/embedded-vfs.cpp: In function ‘int HPHP::sqlite3_embedded_initialize(const char*, int)’:
/home/peter/hhvm/hphp/util/embedded-vfs.cpp:219:14: error: ‘sqlite3_api’ was not declared in this scope
   pOrigVfs = sqlite3_vfs_find(zOrigVfsName);
              ^
/home/peter/hhvm/hphp/util/embedded-vfs.cpp: In function ‘int HPHP::sqlite3_embedded_shutdown()’:
/home/peter/hhvm/hphp/util/embedded-vfs.cpp:269:3: error: ‘sqlite3_api’ was not declared in this scope
   sqlite3_mutex_free(gEmbedded.pMutex);
   ^
hphp/util/CMakeFiles/hphp_util.dir/build.make:508: recipe for target 'hphp/util/CMakeFiles/hphp_util.dir/embedded-vfs.cpp.o' failed