### PR TITLE
Add stream_set_chunk_size() as no-op

### DIFF
--- a/hphp/runtime/base/file.cpp
+++ b/hphp/runtime/base/file.cpp
@@ -764,13 +764,9 @@ int64_t File::getChunkSize() const{
   return CHUNK_SIZE;
 }
 
-Variant File::setChunkSize(int64_t chunk_size) {
-  if (chunk_size > 0) {
-    //no-op currently, return the current chunk size
-    return getChunkSize();
-  } else {
-    return false;
-  }
+void File::setChunkSize(int64_t chunk_size) {
+  //no-op currently
+  assertx(chunk_size > 0);
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/hphp/runtime/base/file.cpp
+++ b/hphp/runtime/base/file.cpp
@@ -760,6 +760,19 @@ const String& File::o_getResourceName() const {
   return s_resource_name;
 }
 
+int64_t File::getChunkSize() const{
+  return CHUNK_SIZE;
+}
+
+Variant File::setChunkSize(int64_t chunk_size) {
+  if (chunk_size > 0) {
+    //no-op currently, return the current chunk size
+    return getChunkSize();
+  } else {
+    return false;
+  }
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 // csv functions
 

--- a/hphp/runtime/base/file.h
+++ b/hphp/runtime/base/file.h
@@ -255,7 +255,7 @@ struct File : SweepableResourceData {
   /**
    * Set the Chunk Size.
    */
-  Variant setChunkSize(int64_t chunk_size);
+  void setChunkSize(int64_t chunk_size);
 
   /**
    * Write one line of csv record.

--- a/hphp/runtime/base/file.h
+++ b/hphp/runtime/base/file.h
@@ -248,6 +248,16 @@ struct File : SweepableResourceData {
   int64_t printf(const String& format, const Array& args);
 
   /**
+   * Get the Chunk Size.
+   */
+  int64_t getChunkSize() const;
+
+  /**
+   * Set the Chunk Size.
+   */
+  Variant setChunkSize(int64_t chunk_size);
+
+  /**
    * Write one line of csv record.
    */
   int64_t writeCSV(const Array& fields, char delimiter = ',',

--- a/hphp/runtime/ext/stream/ext_stream.cpp
+++ b/hphp/runtime/ext/stream/ext_stream.cpp
@@ -471,10 +471,10 @@ int64_t HHVM_FUNCTION(stream_set_read_buffer,
 
 int64_t HHVM_FUNCTION(stream_set_chunk_size,
                       const Resource& stream,
-                      int chunk_size) {
-  if (isa<File>(stream) && chunk_size > 0 && chunk_size < k_PHP_INT_MAX) {
-    //for File CHUNK_SIZE is currently a constant, returns current chunk size
-    return File::CHUNK_SIZE;
+                      int64_t chunk_size) {
+  if (isa<File>(stream) && chunk_size > 0) {
+    auto file = cast<File>(stream);
+    return file->setChunkSize(chunk_size);
   }
   return false;
 }

--- a/hphp/runtime/ext/stream/ext_stream.cpp
+++ b/hphp/runtime/ext/stream/ext_stream.cpp
@@ -468,13 +468,15 @@ int64_t HHVM_FUNCTION(stream_set_read_buffer,
   } else {
     return -1;
   }
+}
 
-int64_t HHVM_FUNCTION(stream_set_chunk_size,
+Variant HHVM_FUNCTION(stream_set_chunk_size,
                       const Resource& stream,
                       int64_t chunk_size) {
   if (isa<File>(stream) && chunk_size > 0) {
     auto file = cast<File>(stream);
-    return file->setChunkSize(chunk_size);
+    file->setChunkSize(chunk_size);
+    return file->getChunkSize();
   }
   return false;
 }

--- a/hphp/runtime/ext/stream/ext_stream.cpp
+++ b/hphp/runtime/ext/stream/ext_stream.cpp
@@ -16,7 +16,7 @@
 */
 
 #include "hphp/runtime/ext/stream/ext_stream.h"
-
+#include "hphp/runtime/ext/std/ext_std_misc.h"
 #include "hphp/runtime/ext/sockets/ext_sockets.h"
 #include "hphp/runtime/ext/stream/ext_stream-user-filters.h"
 #include "hphp/runtime/base/array-init.h"
@@ -472,8 +472,9 @@ int64_t HHVM_FUNCTION(stream_set_read_buffer,
 int64_t HHVM_FUNCTION(stream_set_chunk_size,
                       const Resource& stream,
                       int chunk_size) {
-  if (isa<Resource>(stream) && chunk_size > 0 && chunk_size < sizeof(int64_t)) {
-    return chunk_size;
+  if (isa<File>(stream) && chunk_size > 0 && chunk_size < k_PHP_INT_MAX) {
+    //for File CHUNK_SIZE is currently a constant, returns current chunk size
+    return File::CHUNK_SIZE;
   }
   return false;
 }

--- a/hphp/runtime/ext/stream/ext_stream.cpp
+++ b/hphp/runtime/ext/stream/ext_stream.cpp
@@ -16,7 +16,7 @@
 */
 
 #include "hphp/runtime/ext/stream/ext_stream.h"
-#include "hphp/runtime/ext/std/ext_std_misc.h"
+
 #include "hphp/runtime/ext/sockets/ext_sockets.h"
 #include "hphp/runtime/ext/stream/ext_stream-user-filters.h"
 #include "hphp/runtime/base/array-init.h"

--- a/hphp/runtime/ext/stream/ext_stream.cpp
+++ b/hphp/runtime/ext/stream/ext_stream.cpp
@@ -176,6 +176,7 @@ static struct StreamExtension final : Extension {
     HHVM_FE(stream_await);
     HHVM_FE(stream_set_blocking);
     HHVM_FE(stream_set_read_buffer);
+    HHVM_FE(stream_set_chunk_size);
     HHVM_FE(stream_set_timeout);
     HHVM_FE(stream_set_write_buffer);
     HHVM_FE(set_file_buffer);
@@ -467,6 +468,11 @@ int64_t HHVM_FUNCTION(stream_set_read_buffer,
   } else {
     return -1;
   }
+
+int64_t HHVM_FUNCTION(stream_set_chunk_size,
+                      const Resource& stream,
+                      int chunk_size) {
+
 }
 
 const StaticString

--- a/hphp/runtime/ext/stream/ext_stream.cpp
+++ b/hphp/runtime/ext/stream/ext_stream.cpp
@@ -472,12 +472,10 @@ int64_t HHVM_FUNCTION(stream_set_read_buffer,
 int64_t HHVM_FUNCTION(stream_set_chunk_size,
                       const Resource& stream,
                       int chunk_size) {
-  if (isa<Socket>(stream)) {
-    //NOTE: This only sets the *recive* requested min chunk size in bytes.
-    return HHVM_FN(socket_set_option)
-      (stream, SOL_SOCKET, SO_RCVLOWAT, chunk_size);
+  if (isa<Resource>(stream) && chunk_size > 0 && chunk_size < sizeof(int64_t)) {
+    return chunk_size;
   }
-  return -1;
+  return false;
 }
 
 const StaticString

--- a/hphp/runtime/ext/stream/ext_stream.cpp
+++ b/hphp/runtime/ext/stream/ext_stream.cpp
@@ -472,7 +472,12 @@ int64_t HHVM_FUNCTION(stream_set_read_buffer,
 int64_t HHVM_FUNCTION(stream_set_chunk_size,
                       const Resource& stream,
                       int chunk_size) {
-
+  if (isa<Socket>(stream)) {
+    //NOTE: This only sets the *recive* requested min chunk size in bytes.
+    return HHVM_FN(socket_set_option)
+      (stream, SOL_SOCKET, SO_RCVLOWAT, chunk_size);
+  }
+  return -1;
 }
 
 const StaticString

--- a/hphp/runtime/ext/stream/ext_stream.h
+++ b/hphp/runtime/ext/stream/ext_stream.h
@@ -221,7 +221,7 @@ int64_t HHVM_FUNCTION(stream_set_read_buffer,
                       const Resource& stream,
                       int buffer);
 
-int64_t HHVM_FUNCTION(stream_set_chunk_size,
+Variant HHVM_FUNCTION(stream_set_chunk_size,
                       const Resource& stream,
                       int chunk_size);
 

--- a/hphp/runtime/ext/stream/ext_stream.h
+++ b/hphp/runtime/ext/stream/ext_stream.h
@@ -223,7 +223,7 @@ int64_t HHVM_FUNCTION(stream_set_read_buffer,
 
 Variant HHVM_FUNCTION(stream_set_chunk_size,
                       const Resource& stream,
-                      int chunk_size);
+                      int64_t chunk_size);
 
 bool HHVM_FUNCTION(stream_set_timeout,
                    const Resource& stream,

--- a/hphp/runtime/ext/stream/ext_stream.h
+++ b/hphp/runtime/ext/stream/ext_stream.h
@@ -221,6 +221,10 @@ int64_t HHVM_FUNCTION(stream_set_read_buffer,
                       const Resource& stream,
                       int buffer);
 
+int64_t HHVM_FUNCTION(stream_set_chunk_size,
+                      const Resource& stream,
+                      int chunk_size);
+
 bool HHVM_FUNCTION(stream_set_timeout,
                    const Resource& stream,
                    int seconds,

--- a/hphp/runtime/ext/stream/ext_stream.php
+++ b/hphp/runtime/ext/stream/ext_stream.php
@@ -378,7 +378,7 @@ function stream_set_read_buffer(resource $stream, int $buffer): int;
  * @param resource $stream - The target stream.
  * @param int $chunk_size - The desired new chunk size.
  *
- * @return int - Returns the pervious chunk size on success.
+ * @return int - Returns 0 on sucess, -1 on error.
  *
  */
 <<__Native>>

--- a/hphp/runtime/ext/stream/ext_stream.php
+++ b/hphp/runtime/ext/stream/ext_stream.php
@@ -373,6 +373,18 @@ function stream_set_blocking(resource $stream, int $mode): bool;
 function stream_set_read_buffer(resource $stream, int $buffer): int;
 
 /**
+ * Set the stream chunk size.
+ *
+ * @param resource $stream - The target stream.
+ * @param int $chunk_size - The desired new chunk size.
+ *
+ * @return int - Returns the pervious chunk size on success.
+ *
+ */
+<<__Native>>
+function stream_set_chunk_size(resource $stream, int $chunk_size): int;
+
+/**
  * Sets the timeout value on stream, expressed in the sum of seconds and
  *   microseconds.  When the stream times out, the 'timed_out' key of the array
  *   returned by stream_get_meta_data() is set to TRUE, although no

--- a/hphp/runtime/ext/stream/ext_stream.php
+++ b/hphp/runtime/ext/stream/ext_stream.php
@@ -378,11 +378,12 @@ function stream_set_read_buffer(resource $stream, int $buffer): int;
  * @param resource $stream - The target stream.
  * @param int $chunk_size - The desired new chunk size.
  *
- * @return int - Returns 0 on sucess, -1 on error.
+ * @return int - Returns the previous chunk size on success.  Will return FALSE
+ * if less than 1 or greater than PHP_INT_MAX.
  *
  */
 <<__Native>>
-function stream_set_chunk_size(resource $stream, int $chunk_size): int;
+function stream_set_chunk_size(resource $stream, int $chunk_size): mixed;
 
 /**
  * Sets the timeout value on stream, expressed in the sum of seconds and

--- a/hphp/test/slow/ext_stream/stream_set_chunk_size.php
+++ b/hphp/test/slow/ext_stream/stream_set_chunk_size.php
@@ -1,0 +1,5 @@
+<?php
+
+$fd = fopen(__DIR__.'/stream_set_chunk_size.php.sample', 'rb');
+var_dump(stream_set_chunk_size($fd, 256));
+fclose($fd);

--- a/hphp/test/slow/ext_stream/stream_set_chunk_size.php
+++ b/hphp/test/slow/ext_stream/stream_set_chunk_size.php
@@ -1,5 +1,7 @@
 <?php
 
 $fd = fopen(__DIR__.'/stream_set_chunk_size.php.sample', 'rb');
+var_dump(stream_set_chunk_size($fd, 8192));
 var_dump(stream_set_chunk_size($fd, 256));
+var_dump(stream_set_chunk_size($fd, 0));
 fclose($fd);

--- a/hphp/test/slow/ext_stream/stream_set_chunk_size.php.expect
+++ b/hphp/test/slow/ext_stream/stream_set_chunk_size.php.expect
@@ -1,0 +1,1 @@
+bool(false)

--- a/hphp/test/slow/ext_stream/stream_set_chunk_size.php.expect
+++ b/hphp/test/slow/ext_stream/stream_set_chunk_size.php.expect
@@ -1,1 +1,3 @@
 int(8192)
+int(8192)
+bool(false)

--- a/hphp/test/slow/ext_stream/stream_set_chunk_size.php.expect
+++ b/hphp/test/slow/ext_stream/stream_set_chunk_size.php.expect
@@ -1,1 +1,1 @@
-bool(false)
+int(8192)

--- a/hphp/test/slow/ext_stream/stream_set_chunk_size.php.sample
+++ b/hphp/test/slow/ext_stream/stream_set_chunk_size.php.sample
@@ -1,0 +1,2 @@
+hello
+world


### PR DESCRIPTION
Closes #6573 

Implements stream_set_chunk_size() as a call to the new File::setChunkSize() no-op.  This does properly return the current chunk size when appropriate, but won't change the Chunk Size as it's currently a constant.

Also adds a new File::getChunkSize() and tests for stream_set_chunk_size().