### PR TITLE
minor syntax update for apc_cache_info() to better match PHP

### DIFF
--- a/hphp/runtime/base/apc-stats.cpp
+++ b/hphp/runtime/base/apc-stats.cpp
@@ -246,7 +246,7 @@ std::string APCStats::getStatsInfo() const {
   return info + "\n";
 }
 
-const StaticString s_entries("entries");
+const StaticString s_num_entries("num_entries");
 const StaticString s_primedEntries("primed_entries");
 const StaticString s_primedLiveEntries("primed_live_entries");
 const StaticString s_valuesSize("values_size");
@@ -257,7 +257,7 @@ const StaticString s_pendingDeleteSize("pending_delete_size");
 
 void APCStats::collectStats(std::map<const StringData*, int64_t>& stats) const {
   stats.insert(
-      std::pair<const StringData*, int64_t>(s_entries.get(),
+      std::pair<const StringData*, int64_t>(s_num_entries.get(),
                                             m_entries->getValue()));
   stats.insert(
       std::pair<const StringData*, int64_t>(s_primedEntries.get(),

--- a/hphp/runtime/ext/apc/ext_apc.cpp
+++ b/hphp/runtime/ext/apc/ext_apc.cpp
@@ -473,7 +473,7 @@ const StaticString s_user("user");
 const StaticString s_start_time("start_time");
 const StaticString s_ttl("ttl");
 const StaticString s_cache_list("cache_list");
-const StaticString s_entry_name("entry_name");
+const StaticString s_info("info");
 const StaticString s_in_memory("in_memory");
 const StaticString s_mem_size("mem_size");
 const StaticString s_type("type");
@@ -507,7 +507,7 @@ Variant HHVM_FUNCTION(apc_cache_info,
     PackedArrayInit ents(entries.size());
     for (auto& entry : entries) {
       ArrayInit ent(kEntryInfoSize, ArrayInit::Map{});
-      ent.add(s_entry_name,
+      ent.add(s_info,
               Variant::attach(StringData::Make(entry.key.c_str())));
       ent.add(s_in_memory, entry.inMem);
       ent.add(s_ttl, entry.ttl);

--- a/hphp/system/php/apc/APCIterator.php
+++ b/hphp/system/php/apc/APCIterator.php
@@ -109,7 +109,7 @@ class APCIterator implements Iterator{
     if (!$this->valid()) {
       return false;
     }
-    return $this->getInfo()[$this->index]['entry_name'];
+    return $this->getInfo()[$this->index]['info'];
   }
 
   public function current() {
@@ -120,10 +120,10 @@ class APCIterator implements Iterator{
       $ret['type'] = ($info['type'] == 0) ? 'user' : 'file';
     }
     if ($this->format & APC_ITER_KEY) {
-      $ret['key'] = $info['entry_name'];
+      $ret['key'] = $info['info'];
     }
     if ($this->format & APC_ITER_VALUE) {
-      $ret['value'] = apc_fetch($info['entry_name']);
+      $ret['value'] = apc_fetch($info['info']);
     }
     if ($this->format & APC_ITER_MEM_SIZE) {
       $ret['mem_size'] = $info['mem_size'];
@@ -188,11 +188,11 @@ class APCIterator implements Iterator{
       if ($this->search !== null) {
         if (is_array($this->search)) {
           while (!$this->preg_match_recursive($this->search,
-                                              $list['entry_name'])) {
+                                              $list['info'])) {
             continue;
           }
         } else {
-          if (!preg_match($this->search, $list['entry_name'])) {
+          if (!preg_match($this->search, $list['info'])) {
             continue;
           }
         }
@@ -231,16 +231,16 @@ class APCIterator implements Iterator{
       if ($this->search !== null) {
         if (is_array($this->search)) {
           while (!$this->preg_match_recursive($this->search,
-                                              $key['entry_name'])) {
+                                              $key['info'])) {
             continue;
           }
         } else {
-          if (!preg_match($this->search, $key['entry_name'])) {
+          if (!preg_match($this->search, $key['info'])) {
             continue;
           }
         }
       }
-      apc_delete($key['entry_name']);
+      apc_delete($key['info']);
     }
     return true;
   }

--- a/hphp/test/slow/apc/cache_info.php
+++ b/hphp/test/slow/apc/cache_info.php
@@ -3,7 +3,7 @@
 echo "no key\n";
 $info = apc_cache_info('user');
 if (count($info) <= 1) echo "cache size error\n";
-if ($info['entries'] != 0) echo "entry count should be 0\n";
+if ($info['num_entries'] != 0) echo "entry count should be 0\n";
 
 apc_add('key', 1);
 echo "1 key\n";
@@ -57,8 +57,8 @@ function checkInfo($info, $valuesSize, $keysSize, $entriesCount, $checkList) {
            $info['values_size'], $valuesSize);
   }
   if ($info['keys_size'] < $keysSize) echo "keys size too small\n";
-  if ($info['entries'] != $entriesCount) echo "entries count wrong\n";
-  if ($checkList && count($info['cache_list']) != $info['entries']) {
+  if ($info['num_entries'] != $entriesCount) echo "entries count wrong\n";
+  if ($checkList && count($info['cache_list']) != $info['num_entries']) {
     echo "cache list wrong\n";
   }
   if (!$checkList && array_key_exists('cache_list')) {
@@ -69,6 +69,6 @@ function checkInfo($info, $valuesSize, $keysSize, $entriesCount, $checkList) {
 function dumpKeys($info) {
   $list = $info['cache_list'];
   foreach($list as $entry) {
-    var_dump($entry['entry_name']);
+    var_dump($entry['info']);
   }
 }


### PR DESCRIPTION
minor syntax update for apc_cache_info() to better match PHP

-rename ['cache_list'][0]['entry_name'] to 'info'
-rename 'entries' to 'num_entries'
-update related test/slow/apc as needed

I'm going to suggest this close #7064 as it does address the flagship issue.