### PR TITLE
stream_set_chunk_size() now functional

### DIFF
--- a/hphp/runtime/base/file.cpp
+++ b/hphp/runtime/base/file.cpp
@@ -772,7 +772,7 @@ void File::setChunkSize(int64_t chunk_size) {
   m_data->m_chunkSize = chunk_size;
 
   if (m_data->m_buffer != nullptr && m_data->m_chunkSize > m_data->m_bufferSize) {
-    realloc(m_data->m_buffer, m_data->m_chunkSize);
+    m_data->m_buffer = realloc(m_data->m_buffer, m_data->m_chunkSize);
     m_data->m_bufferSize = m_data->m_chunkSize;
   }
 }

--- a/hphp/runtime/base/file.cpp
+++ b/hphp/runtime/base/file.cpp
@@ -69,7 +69,7 @@ StaticString File::s_resource_name("stream");
 
 int __thread s_pcloseRet;
 
-const int File::CHUNK_SIZE = FileData::CHUNK_SIZE;
+int File::CHUNK_SIZE = FileData::CHUNK_SIZE;
 const int File::USE_INCLUDE_PATH = 1;
 
 String File::TranslatePathKeepRelative(const char* filename, uint32_t size) {
@@ -765,8 +765,16 @@ int64_t File::getChunkSize() const{
 }
 
 void File::setChunkSize(int64_t chunk_size) {
-  //no-op currently
+
   assertx(chunk_size > 0);
+
+  CHUNK_SIZE = chunk_size;
+
+  if (m_data->m_buffer != nullptr) {
+    realloc(m_data->m_buffer, CHUNK_SIZE);
+    m_data->m_bufferSize = CHUNK_SIZE;
+  }
+
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/hphp/runtime/base/file.cpp
+++ b/hphp/runtime/base/file.cpp
@@ -46,7 +46,7 @@
 
 namespace HPHP {
 
-const int FileData::CHUNK_SIZE = 8192;
+const int FileData::DEFAULT_CHUNK_SIZE = 8192;
 
 FileData::FileData(bool nonblocking)
 : m_nonblocking(nonblocking)
@@ -69,7 +69,6 @@ StaticString File::s_resource_name("stream");
 
 int __thread s_pcloseRet;
 
-int File::CHUNK_SIZE = FileData::CHUNK_SIZE;
 const int File::USE_INCLUDE_PATH = 1;
 
 String File::TranslatePathKeepRelative(const char* filename, uint32_t size) {
@@ -261,8 +260,8 @@ String File::read() {
 
   while (!eof() || avail) {
     if (m_data->m_buffer == nullptr) {
-      m_data->m_buffer = (char *)malloc(CHUNK_SIZE);
-      m_data->m_bufferSize = CHUNK_SIZE;
+      m_data->m_buffer = (char *)malloc(m_data->m_chunk_size);
+      m_data->m_bufferSize = m_data->m_chunk_size;
     }
 
     if (avail > 0) {
@@ -300,8 +299,8 @@ String File::read(int64_t length) {
 
   while (avail < length && !eof()) {
     if (m_data->m_buffer == nullptr) {
-      m_data->m_buffer = (char *)malloc(CHUNK_SIZE);
-      m_data->m_bufferSize = CHUNK_SIZE;
+      m_data->m_buffer = (char *)malloc(m_data->m_chunk_size);
+      m_data->m_bufferSize = m_data->m_chunk_size;
     }
 
     if (avail > 0) {
@@ -336,7 +335,7 @@ String File::read(int64_t length) {
 }
 
 int64_t File::filteredReadToBuffer() {
-  int64_t bytes_read = readImpl(m_data->m_buffer, CHUNK_SIZE);
+  int64_t bytes_read = readImpl(m_data->m_buffer, m_data->m_chunk_size);
   if (LIKELY(m_readFilters.empty())) {
     return bytes_read;
   }
@@ -627,9 +626,10 @@ String File::readLine(int64_t maxlen /* = 0 */) {
       break;
     } else {
       if (m_data->m_buffer == nullptr) {
-        m_data->m_buffer = (char *)malloc(CHUNK_SIZE);
-        m_data->m_bufferSize = CHUNK_SIZE;
+        m_data->m_buffer = (char *)malloc(m_data->m_chunk_size);
+        m_data->m_bufferSize = m_data->m_chunk_size;
       }
+
       m_data->m_writepos = filteredReadToBuffer();
       m_data->m_readpos = 0;
       if (bufferedLen() == 0) {
@@ -652,29 +652,29 @@ Variant File::readRecord(const String& delimiter, int64_t maxlen /* = 0 */) {
     return false;
   }
 
-  if (maxlen <= 0 || maxlen > CHUNK_SIZE) {
-    maxlen = CHUNK_SIZE;
+  if (maxlen <= 0 || maxlen > m_data->m_chunk_size) {
+    maxlen = m_data->m_chunk_size;
   }
 
   int64_t avail = bufferedLen();
   if (m_data->m_buffer == nullptr) {
-    m_data->m_buffer = (char *)malloc(CHUNK_SIZE * 3);
-    m_data->m_bufferSize = CHUNK_SIZE * 3;
-  } else if (m_data->m_bufferSize < CHUNK_SIZE * 3) {
-    auto newbuf = malloc(CHUNK_SIZE * 3);
+    m_data->m_buffer = (char *)malloc(m_data->m_chunk_size * 3);
+    m_data->m_bufferSize = m_data->m_chunk_size * 3;
+  } else if (m_data->m_bufferSize < m_data->m_chunk_size * 3) {
+    auto newbuf = malloc(m_data->m_chunk_size * 3);
     memcpy(newbuf, m_data->m_buffer, m_data->m_bufferSize);
     free(m_data->m_buffer);
     m_data->m_buffer = (char*) newbuf;
-    m_data->m_bufferSize = CHUNK_SIZE * 3;
+    m_data->m_bufferSize = m_data->m_chunk_size * 3;
   }
 
   if (avail < maxlen && !eof()) {
-    assert(m_data->m_writepos + maxlen - avail <= CHUNK_SIZE * 3);
+    assert(m_data->m_writepos + maxlen - avail <= m_data->m_chunk_size * 3);
     m_data->m_writepos +=
       readImpl(m_data->m_buffer + m_data->m_writepos, maxlen - avail);
     maxlen = bufferedLen();
   }
-  if (m_data->m_readpos >= CHUNK_SIZE) {
+  if (m_data->m_readpos >= m_data->m_chunk_size) {
     memcpy(m_data->m_buffer,
            m_data->m_buffer + m_data->m_readpos,
            bufferedLen());
@@ -761,20 +761,19 @@ const String& File::o_getResourceName() const {
 }
 
 int64_t File::getChunkSize() const{
-  return CHUNK_SIZE;
+  return m_data->m_chunk_size;
 }
 
 void File::setChunkSize(int64_t chunk_size) {
 
   assertx(chunk_size > 0);
 
-  CHUNK_SIZE = chunk_size;
+  m_data->m_chunk_size = chunk_size;
 
-  if (m_data->m_buffer != nullptr) {
-    realloc(m_data->m_buffer, CHUNK_SIZE);
-    m_data->m_bufferSize = CHUNK_SIZE;
+  if (m_data->m_buffer == nullptr) {
+    realloc(m_data->m_buffer, m_data->m_chunk_size);
+    m_data->m_bufferSize = m_data->m_chunk_size;
   }
-
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/hphp/runtime/base/file.cpp
+++ b/hphp/runtime/base/file.cpp
@@ -771,7 +771,7 @@ void File::setChunkSize(int64_t chunk_size) {
 
   m_data->m_chunkSize = chunk_size;
 
-  if (m_data->m_buffer != nullptr) {
+  if (m_data->m_buffer != nullptr && m_data->m_chunkSize > m_data->m_bufferSize) {
     realloc(m_data->m_buffer, m_data->m_chunkSize);
     m_data->m_bufferSize = m_data->m_chunkSize;
   }

--- a/hphp/runtime/base/file.cpp
+++ b/hphp/runtime/base/file.cpp
@@ -772,7 +772,7 @@ void File::setChunkSize(int64_t chunk_size) {
   m_data->m_chunkSize = chunk_size;
 
   if (m_data->m_buffer != nullptr && m_data->m_chunkSize > m_data->m_bufferSize) {
-    m_data->m_buffer = realloc(m_data->m_buffer, m_data->m_chunkSize);
+    m_data->m_buffer = (char *)realloc(m_data->m_buffer, m_data->m_chunkSize);
     m_data->m_bufferSize = m_data->m_chunkSize;
   }
 }

--- a/hphp/runtime/base/file.cpp
+++ b/hphp/runtime/base/file.cpp
@@ -629,7 +629,6 @@ String File::readLine(int64_t maxlen /* = 0 */) {
         m_data->m_buffer = (char *)malloc(m_data->m_chunk_size);
         m_data->m_bufferSize = m_data->m_chunk_size;
       }
-
       m_data->m_writepos = filteredReadToBuffer();
       m_data->m_readpos = 0;
       if (bufferedLen() == 0) {

--- a/hphp/runtime/base/file.h
+++ b/hphp/runtime/base/file.h
@@ -48,7 +48,7 @@ extern int __thread s_pcloseRet;
 // FileData to add any persistent data members, e.g. see Socket.
 // Classes in the FileData hierarchy may not contain request-allocated data.
 struct FileData {
-  static const int CHUNK_SIZE;
+  static const int DEFAULT_CHUNK_SIZE;
 
   FileData() { }
   explicit FileData(bool nonblocking);
@@ -81,7 +81,9 @@ struct FileData {
   std::string m_mode;
 
   char *m_buffer{nullptr};
-  int64_t m_bufferSize{CHUNK_SIZE};
+  int64_t m_bufferSize{DEFAULT_CHUNK_SIZE};
+  int64_t m_chunk_size{DEFAULT_CHUNK_SIZE};
+
 };
 
 /**

--- a/hphp/runtime/base/file.h
+++ b/hphp/runtime/base/file.h
@@ -83,7 +83,6 @@ struct FileData {
   char *m_buffer{nullptr};
   int64_t m_bufferSize{DEFAULT_CHUNK_SIZE};
   int64_t m_chunk_size{DEFAULT_CHUNK_SIZE};
-
 };
 
 /**
@@ -93,8 +92,6 @@ struct FileData {
  * so they can share some minimal functionalities.
  */
 struct File : SweepableResourceData {
-  static int CHUNK_SIZE;
-
   static String TranslatePath(const String& filename);
   // Same as TranslatePath except doesn't make paths absolute
   static String TranslatePathKeepRelative(const char* fn, uint32_t len);

--- a/hphp/runtime/base/file.h
+++ b/hphp/runtime/base/file.h
@@ -91,7 +91,7 @@ struct FileData {
  * so they can share some minimal functionalities.
  */
 struct File : SweepableResourceData {
-  static const int CHUNK_SIZE;
+  static int CHUNK_SIZE;
 
   static String TranslatePath(const String& filename);
   // Same as TranslatePath except doesn't make paths absolute

--- a/hphp/runtime/base/file.h
+++ b/hphp/runtime/base/file.h
@@ -81,8 +81,8 @@ struct FileData {
   std::string m_mode;
 
   char *m_buffer{nullptr};
-  int64_t m_bufferSize{DEFAULT_CHUNK_SIZE};
-  int64_t m_chunk_size{DEFAULT_CHUNK_SIZE};
+  int64_t m_bufferSize{0};
+  int64_t m_chunkSize{DEFAULT_CHUNK_SIZE};
 };
 
 /**

--- a/hphp/runtime/ext/stream/ext_stream.cpp
+++ b/hphp/runtime/ext/stream/ext_stream.cpp
@@ -475,9 +475,10 @@ Variant HHVM_FUNCTION(stream_set_chunk_size,
                       const Resource& stream,
                       int64_t chunk_size) {
   if (isa<File>(stream) && chunk_size > 0) {
+    int64_t orig_chunk_size = file->getChunkSize();
     auto file = cast<File>(stream);
     file->setChunkSize(chunk_size);
-    return file->getChunkSize();
+    return orig_chunk_size;
   }
   return false;
 }

--- a/hphp/runtime/ext/stream/ext_stream.cpp
+++ b/hphp/runtime/ext/stream/ext_stream.cpp
@@ -330,7 +330,8 @@ Variant HHVM_FUNCTION(stream_copy_to_stream,
   if (maxlength == 0) maxlength = INT_MAX;
   while (cbytes < maxlength) {
     int remaining = maxlength - cbytes;
-    String buf = srcFile->read(std::min(remaining, File::CHUNK_SIZE));
+    int chunk_size = srcFile->getChunkSize();
+    String buf = srcFile->read(std::min(remaining, chunk_size));
     if (buf.size() == 0) break;
     if (destFile->write(buf) != buf.size()) {
       return false;

--- a/hphp/runtime/ext/stream/ext_stream.cpp
+++ b/hphp/runtime/ext/stream/ext_stream.cpp
@@ -330,7 +330,8 @@ Variant HHVM_FUNCTION(stream_copy_to_stream,
   if (maxlength == 0) maxlength = INT_MAX;
   while (cbytes < maxlength) {
     int remaining = maxlength - cbytes;
-    String buf = srcFile->read(std::min(remaining, static_cast<int>(srcFile->getChunkSize())));
+    auto chunkSize = srcFile->getChunkSize();
+    String buf = srcFile->read(std::min(remaining, chunkSize));
     if (buf.size() == 0) break;
     if (destFile->write(buf) != buf.size()) {
       return false;

--- a/hphp/runtime/ext/stream/ext_stream.cpp
+++ b/hphp/runtime/ext/stream/ext_stream.cpp
@@ -330,8 +330,7 @@ Variant HHVM_FUNCTION(stream_copy_to_stream,
   if (maxlength == 0) maxlength = INT_MAX;
   while (cbytes < maxlength) {
     int remaining = maxlength - cbytes;
-    int chunk_size = srcFile->getChunkSize();
-    String buf = srcFile->read(std::min(remaining, chunk_size));
+    String buf = srcFile->read(std::min(remaining, static_cast<int>(srcFile->getChunkSize())));
     if (buf.size() == 0) break;
     if (destFile->write(buf) != buf.size()) {
       return false;

--- a/hphp/runtime/ext/stream/ext_stream.cpp
+++ b/hphp/runtime/ext/stream/ext_stream.cpp
@@ -475,8 +475,8 @@ Variant HHVM_FUNCTION(stream_set_chunk_size,
                       const Resource& stream,
                       int64_t chunk_size) {
   if (isa<File>(stream) && chunk_size > 0) {
-    int64_t orig_chunk_size = file->getChunkSize();
     auto file = cast<File>(stream);
+    int64_t orig_chunk_size = file->getChunkSize();
     file->setChunkSize(chunk_size);
     return orig_chunk_size;
   }

--- a/hphp/runtime/ext/zlib/zip-file.cpp
+++ b/hphp/runtime/ext/zlib/zip-file.cpp
@@ -56,7 +56,7 @@ bool ZipFile::open(const String& filename, const String& mode) {
     }
     auto file = req::make<TempFile>();
     while (!m_innerFile->eof()) {
-      file->write(m_innerFile->read(File::CHUNK_SIZE));
+      file->write(m_innerFile->read(file->getChunkSize()));
     }
     file->rewind();
     m_tempFile = file;

--- a/hphp/test/slow/ext_stream/stream_set_chunk_size.php
+++ b/hphp/test/slow/ext_stream/stream_set_chunk_size.php
@@ -1,7 +1,7 @@
 <?php
 
 $fd = fopen(__DIR__.'/stream_set_chunk_size.php.sample', 'rb');
-var_dump(stream_set_chunk_size($fd, 8192));
 var_dump(stream_set_chunk_size($fd, 256));
+var_dump(stream_set_chunk_size($fd, 8192));
 var_dump(stream_set_chunk_size($fd, 0));
 fclose($fd);

--- a/hphp/test/slow/ext_stream/stream_set_chunk_size.php.expect
+++ b/hphp/test/slow/ext_stream/stream_set_chunk_size.php.expect
@@ -1,3 +1,3 @@
 int(8192)
-int(8192)
+int(256)
 bool(false)


### PR DESCRIPTION
FIX: stream_set_chunk_size() no longer a no-op

-File::setChunkSize() now implemented
-Moved the chunkSize into the m_data instance as m_chunkSize
-correct stream_set_chunk_size() to return the *previous* chunk size
-New DEFAULT_CHUNK_SIZE is set to 8k
-Updates/passes test/slow/stream

Closes #6573 
