### PR TITLE
Minor corrections to Normalizer::isNormalized() & Normalizer::normalize()

### DIFF
--- a/hphp/runtime/ext/icu/ext_icu_normalizer.cpp
+++ b/hphp/runtime/ext/icu/ext_icu_normalizer.cpp
@@ -9,7 +9,7 @@ namespace HPHP { namespace Intl {
 
 const StaticString s_Normalizer("Normalizer");
 
-static Variant HHVM_STATIC_METHOD(Normalizer, isNormalized,
+static bool HHVM_STATIC_METHOD(Normalizer, isNormalized,
                                   const String& input, int64_t form) {
   s_intl_error->clearError();
   switch (form) {
@@ -22,7 +22,7 @@ static Variant HHVM_STATIC_METHOD(Normalizer, isNormalized,
       s_intl_error->setError(U_ILLEGAL_ARGUMENT_ERROR,
                              "normalizer_isnormalized: "
                              "illegal normalization form");
-      return init_null();
+      return false;
   }
 
   UErrorCode error = U_ZERO_ERROR;
@@ -33,9 +33,9 @@ static Variant HHVM_STATIC_METHOD(Normalizer, isNormalized,
   }
 
   error = U_ZERO_ERROR;
-  UBool ret = unorm_isNormalizedWithOptions(uinput.getBuffer(), uinput.length(),
+  bool ret = (unorm_isNormalizedWithOptions(uinput.getBuffer(), uinput.length(),
                                             (UNormalizationMode)form,
-                                            0, &error);
+                                            0, &error) == 1 ? true : false);
 
   if (U_FAILURE(error)) {
     s_intl_error->setError(error, "Error testing if string is the given "
@@ -64,7 +64,7 @@ static Variant HHVM_STATIC_METHOD(Normalizer, normalize,
       s_intl_error->setError(U_ILLEGAL_ARGUMENT_ERROR,
                              "normalizer_normalize: "
                              "illegal normalization form");
-      return init_null();
+      return false;
   }
 
   UErrorCode error = U_ZERO_ERROR;
@@ -85,7 +85,7 @@ static Variant HHVM_STATIC_METHOD(Normalizer, normalize,
   if (U_FAILURE(error) &&
       (error != U_BUFFER_OVERFLOW_ERROR) &&
       (error != U_STRING_NOT_TERMINATED_WARNING)) {
-    return init_null();
+    return false;
   }
 
   if (size_needed > capacity) {
@@ -97,7 +97,7 @@ static Variant HHVM_STATIC_METHOD(Normalizer, normalize,
                                   &error);
     if (U_FAILURE(error)) {
       s_intl_error->setError(error, "Error normalizing string");
-      return init_null();
+      return false;
     }
   }
   dest.releaseBuffer(size_needed);
@@ -107,7 +107,7 @@ static Variant HHVM_STATIC_METHOD(Normalizer, normalize,
   if (U_FAILURE(error)) {
     s_intl_error->setError(error, "normalizer_normalize: "
                                   "error converting normalized text UTF-8");
-    return init_null();
+    return false;
   }
   return ret;
 }

--- a/hphp/runtime/ext/icu/ext_icu_normalizer.php
+++ b/hphp/runtime/ext/icu/ext_icu_normalizer.php
@@ -23,23 +23,23 @@ class Normalizer {
    *
    *
    * @param string $input - The input string to normalize
-   * @param string $form - One of the normalization forms.
+   * @param int $form - One of the normalization forms.
    *
    * @return bool - TRUE if normalized, FALSE otherwise or if there an
    *   error
    */
   <<__Native>>
   public static function isNormalized(string $input,
-                                      int $form = Normalizer::FORM_C): mixed;
+                                      int $form = Normalizer::FORM_C): bool;
 
   /**
    * Normalizes the input provided and returns the normalized string
    *
    *
    * @param string $input - The input string to normalize
-   * @param string $form - One of the normalization forms.
+   * @param int $form - One of the normalization forms.
    *
-   * @return string - The normalized string or NULL if an error occurred.
+   * @return string - The normalized string or FALSE if an error occurred.
    */
   <<__Native>>
   public static function normalize(string $input,
@@ -53,13 +53,13 @@ class Normalizer {
  *
  *
  * @param string $input - The input string to normalize
- * @param string $form - One of the normalization forms.
+ * @param int $form - One of the normalization forms.
  *
  * @return bool - TRUE if normalized, FALSE otherwise or if there an
  *   error
  */
 function normalizer_is_normalized(string $input,
-                                  int $form = Normalizer::FORM_C): mixed {
+                                  int $form = Normalizer::FORM_C): bool {
   return Normalizer::isNormalized($input, $form);
 }
 
@@ -68,9 +68,9 @@ function normalizer_is_normalized(string $input,
  *
  *
  * @param string $input - The input string to normalize
- * @param string $form - One of the normalization forms.
+ * @param int $form - One of the normalization forms.
  *
- * @return string - The normalized string or NULL if an error occurred.
+ * @return string - The normalized string or FALSE if an error occurred.
  */
 function normalizer_normalize(string $input,
                               int $form = Normalizer::FORM_C): mixed {

--- a/hphp/test/slow/ext_intl/normalizer.php.expect
+++ b/hphp/test/slow/ext_intl/normalizer.php.expect
@@ -1,3 +1,3 @@
-int(1)
-int(0)
+bool(true)
+bool(false)
 bool(true)


### PR DESCRIPTION
Minor corrections to Normalizer::isNormalized() & Normalizer::normalize()
-Match PHP spec for returns types: https://secure.php.net/manual/en/normalizer.normalize.php
-Update relevant test

Closes #6668 
Closes #6667 
