### PR TITLE
Fix for PHP5.6 compatibility of multiple arguments unpacking during function call

### DIFF
--- a/hphp/compiler/analysis/emitter.cpp
+++ b/hphp/compiler/analysis/emitter.cpp
@@ -2912,7 +2912,7 @@ void EmitterVisitor::emitCall(Emitter& e,
   auto const unpack = func->hasUnpack();
   if (!func->checkUnpackParams()) {
     throw IncludeTimeFatalException(
-      func, "Only the last parameter in a function call is allowed to use ...");
+      func, "Cannot use positional argument after argument unpacking");
   }
   {
     FPIRegionRecorder fpi(this, m_ue, m_evalStack, fpiStart);

--- a/hphp/compiler/expression/function_call.cpp
+++ b/hphp/compiler/expression/function_call.cpp
@@ -130,7 +130,7 @@ void FunctionCall::onParse(AnalysisResultConstPtr ar, FileScopePtr fs) {
     parseTimeFatal(
       fs,
       Compiler::NoError,
-      "Only the last parameter in a function call is allowed to use ...");
+      "Cannot use positional argument after argument unpacking");
   }
 }
 
@@ -140,18 +140,17 @@ bool FunctionCall::checkUnpackParams() {
   const auto numParams = params.getCount();
   if (!numParams) return true;
 
-  // when supporting multiple unpacks at the end of the param list, this
-  // will need to disallow transitions from unpack to non-unpack.
-  for (int i = 0; i < (numParams - 1); ++i) {
+  // Disallow non-unpack arguments after at least one unpack
+  bool unpackPresent = false;
+  for (int i = 0; i < numParams; ++i) {
     ExpressionPtr p = params[i];
     if (p->isUnpack()) {
+      unpackPresent = true;
+    } else if (unpackPresent) {
       return false;
     }
   }
 
-  // we don't get here if any parameter before the last has isUnpack()
-  // set, so the last one had better match containsUnpack().
-  assert(params.containsUnpack() == params[numParams - 1]->isUnpack());
   return true;
 }
 

--- a/hphp/test/slow/unpack_args/unpack_call_error.php.expectf
+++ b/hphp/test/slow/unpack_args/unpack_call_error.php.expectf
@@ -1,1 +1,1 @@
-Fatal error: Only the last parameter in a function call is allowed to use ... in %s/unpack_call_error.php on line 10
+Fatal error: Cannot use positional argument after argument unpacking in %s/unpack_call_error.php on line 10

--- a/hphp/test/slow/unpack_args/unpack_call_multi.php.expect
+++ b/hphp/test/slow/unpack_args/unpack_call_multi.php.expect
@@ -1,0 +1,11 @@
+f
+array(3) {
+  [0]=>
+  string(1) "a"
+  [1]=>
+  string(1) "b"
+  [2]=>
+  string(1) "c"
+}
+string(1) "a"
+string(1) "b"

--- a/hphp/test/slow/unpack_args/unpack_call_multi.php.expectf
+++ b/hphp/test/slow/unpack_args/unpack_call_multi.php.expectf
@@ -1,1 +1,0 @@
-Fatal error: Only the last parameter in a function call is allowed to use ... in %s/unpack_call_multi.php on line 10


### PR DESCRIPTION
Also corrected error message to match such in PHP
Fixes #7087