### PR TITLE
Correct behavior of timezone_open() to match PHP spec

### DIFF
--- a/hphp/runtime/ext/datetime/ext_datetime.php
+++ b/hphp/runtime/ext/datetime/ext_datetime.php
@@ -876,8 +876,16 @@ function timezone_name_get(DateTimeZone $timezone): string {
 }
 
 <<__ParamCoerceModeFalse>>
-function timezone_open(string $timezone): DateTimeZone {
-  return new DateTimeZone($timezone);
+function timezone_open(string $timezone): mixed {
+  try { 
+    return new DateTimeZone($timezone); 
+  }
+  catch (Exception $e) { 
+    $msg = str_replace("DateTimeZone::__construct", "timezone_open",
+                       $e->getMessage());
+    trigger_error($msg, E_WARNING);
+    return false; 
+  }
 }
 
 function timezone_transitions_get(DateTimeZone $timezone,

--- a/hphp/test/slow/ext_datetime/date_timezone.php
+++ b/hphp/test/slow/ext_datetime/date_timezone.php
@@ -54,3 +54,5 @@ $tz = timezone_open("CHAST");
 var_dump(timezone_name_get($tz));
 
 var_dump((bool)timezone_version_get());
+
+var_dump(timezone_open('sdf'));

--- a/hphp/test/slow/ext_datetime/date_timezone.php.expectf
+++ b/hphp/test/slow/ext_datetime/date_timezone.php.expectf
@@ -20,3 +20,6 @@ string(16) "America/New_York"
 string(19) "America/Los_Angeles"
 string(15) "Pacific/Chatham"
 bool(true)
+
+Warning: timezone_open(): Unknown or bad timezone (sdf) in %s
+bool(false)


### PR DESCRIPTION
Correct behavior of timezone_open() to match PHP spec
-returns bool false and warning instead of exception
-add new test for this behavior

Example:
https://3v4l.org/qKNug
https://secure.php.net/manual/en/datetimezone.construct.php

Closes #6632 