### PR TITLE
Confirm proper type support for mysqli_real_connect() & mysqli::real_connect() arguments host, passwd, & dbname

### DIFF
--- a/hphp/runtime/ext/mysql/ext_mysqli.php
+++ b/hphp/runtime/ext/mysql/ext_mysqli.php
@@ -561,10 +561,10 @@ class mysqli {
    *
    * @return bool -
    */
-  public function real_connect(?string $host = null,
+  public function real_connect(mixed $host = null,
                                ?string $username = null,
-                               ?string $passwd = null,
-                               ?string $dbname = null,
+                               mixed $passwd = null,
+                               mixed $dbname = null,
                                mixed $port = null,
                                ?string $socket = null,
                                ?int $flags = 0): bool {
@@ -608,8 +608,8 @@ class mysqli {
   <<__Native>>
   private function hh_real_connect(?string $server,
                                    ?string $username,
-                                   ?string $passwd,
-                                   ?string $dbname,
+                                   mixed $passwd,
+                                   mixed $dbname,
                                    ?int $flags): bool;
 
   /**
@@ -2050,10 +2050,10 @@ function mysqli_query(mysqli $link,
  * @return bool -
  */
 function mysqli_real_connect(mysqli $link,
-                             ?string $host = null,
+                             mixed $host = null,
                              ?string $username = null,
-                             ?string $passwd = null,
-                             ?string $dbname = null,
+                             mixed $passwd = null,
+                             mixed $dbname = null,
                              mixed $port = null,
                              ?string $socket = null,
                              ?int $flags = 0): bool {

--- a/hphp/runtime/ext/mysql/ext_mysqli.php
+++ b/hphp/runtime/ext/mysql/ext_mysqli.php
@@ -581,6 +581,13 @@ class mysqli {
       throw new Exception('Port is not numeric');
     }
 
+    if (!is_string($passwd) && !is_null($passwd)) {
+      throw new Exception('passwd must be string or NULL');
+    };
+    if (!is_string($dbname) && !is_null($dbname)) {
+      throw new Exception('dbname must be string or NULL');
+    };
+
     $server = null;
     if ($host) {
       $server = $host;

--- a/hphp/runtime/ext/mysql/ext_mysqli.php
+++ b/hphp/runtime/ext/mysql/ext_mysqli.php
@@ -561,10 +561,10 @@ class mysqli {
    *
    * @return bool -
    */
-  public function real_connect(mixed $host = null,
+  public function real_connect(?string $host = null,
                                ?string $username = null,
-                               mixed $passwd = null,
-                               mixed $dbname = null,
+                               ?string $passwd = null,
+                               ?string $dbname = null,
                                mixed $port = null,
                                ?string $socket = null,
                                ?int $flags = 0): bool {
@@ -608,8 +608,8 @@ class mysqli {
   <<__Native>>
   private function hh_real_connect(?string $server,
                                    ?string $username,
-                                   mixed $passwd,
-                                   mixed $dbname,
+                                   ?string $passwd,
+                                   ?string $dbname,
                                    ?int $flags): bool;
 
   /**
@@ -2050,10 +2050,10 @@ function mysqli_query(mysqli $link,
  * @return bool -
  */
 function mysqli_real_connect(mysqli $link,
-                             mixed $host = null,
+                             ?string $host = null,
                              ?string $username = null,
-                             mixed $passwd = null,
-                             mixed $dbname = null,
+                             ?string $passwd = null,
+                             ?string $dbname = null,
                              mixed $port = null,
                              ?string $socket = null,
                              ?int $flags = 0): bool {

--- a/hphp/runtime/ext/mysql/ext_mysqli.php
+++ b/hphp/runtime/ext/mysql/ext_mysqli.php
@@ -581,13 +581,6 @@ class mysqli {
       throw new Exception('Port is not numeric');
     }
 
-    if (!is_string($passwd) && !is_null($passwd)) {
-      throw new Exception('passwd must be string or NULL');
-    };
-    if (!is_string($dbname) && !is_null($dbname)) {
-      throw new Exception('dbname must be string or NULL');
-    };
-
     $server = null;
     if ($host) {
       $server = $host;

--- a/hphp/test/slow/ext_mysqli/test_mysqli.php
+++ b/hphp/test/slow/ext_mysqli/test_mysqli.php
@@ -12,3 +12,10 @@ if ($mysqli->connect_errno) {
 }
 $r = $mysqli->query("DROP TABLE IF EXISTS test");
 var_dump($r);
+
+//test null for host, passwd, & db
+$mysqlinull = new mysqli(null, $user, null, null, $port);
+if ($mysqlinull->connect_errno) {
+    echo "Failed to connect to MySQL: (" . $mysqlinull->connect_errno . ") " .
+         $mysqlinull->connect_error;
+}


### PR DESCRIPTION
The PHP documentation indicates that string or NULL type are allowed for mysqli_real_connect() & mysqli::real_connect() arguments host, passwd, & dbname - this adds a test to confirm proper NULL support.

NOTE: Unfortunately the PHP documentation does NOT list bool(false) as an allowed type for these arguments, therefore it is highly suggested to migrate to NULL for the same effect.

See: https://secure.php.net/manual/en/mysqli.real-connect.php
 
Closes #7078 
Closes #1817 
