### PR TITLE
Fix flag's type from char to int8_t

### DIFF
--- a/hphp/runtime/base/intercept.cpp
+++ b/hphp/runtime/base/intercept.cpp
@@ -82,13 +82,13 @@ static Mutex s_mutex;
  * The vector contains a list of maybeIntercepted flags for functions
  * with this name.
  */
-typedef StringIMap<std::pair<bool,std::vector<char*>>> RegisteredFlagsMap;
+typedef StringIMap<std::pair<bool,std::vector<int8_t*>>> RegisteredFlagsMap;
 
 static RegisteredFlagsMap s_registered_flags;
 
 ///////////////////////////////////////////////////////////////////////////////
 
-static void flag_maybe_intercepted(std::vector<char*> &flags) {
+static void flag_maybe_intercepted(std::vector<int8_t*> &flags) {
   for (auto flag : flags) {
     *flag = 1;
   }
@@ -158,7 +158,7 @@ static Variant *get_enabled_intercept_handler(const String& name) {
   return handler;
 }
 
-Variant *get_intercept_handler(const String& name, char* flag) {
+Variant *get_intercept_handler(const String& name, int8_t* flag) {
   TRACE(1, "get_intercept_handler %s flag is %d\n",
         name.get()->data(), (int)*flag);
   if (*flag == -1) {
@@ -183,12 +183,12 @@ Variant *get_intercept_handler(const String& name, char* flag) {
   return handler;
 }
 
-void unregister_intercept_flag(const String& name, char *flag) {
+void unregister_intercept_flag(const String& name, int8_t *flag) {
   Lock lock(s_mutex);
   RegisteredFlagsMap::iterator iter =
     s_registered_flags.find(name);
   if (iter != s_registered_flags.end()) {
-    std::vector<char*> &flags = iter->second.second;
+    std::vector<int8_t*> &flags = iter->second.second;
     for (int i = flags.size(); i--; ) {
       if (flag == flags[i]) {
         flags.erase(flags.begin() + i);

--- a/hphp/runtime/base/intercept.h
+++ b/hphp/runtime/base/intercept.h
@@ -16,6 +16,8 @@
 #ifndef incl_HPHP_INTERCEPT_H_
 #define incl_HPHP_INTERCEPT_H_
 
+#include <stdint.h>
+
 namespace HPHP {
 
 struct Array;
@@ -35,7 +37,7 @@ bool register_intercept(const String& name, const Variant& callback, const Varia
 /**
  * Check to see if it is actually intercepted for current request.
  */
-Variant* get_intercept_handler(const String& name, char* flag);
+Variant* get_intercept_handler(const String& name, int8_t* flag);
 
 /**
  * Call intercept handler with original parameters.
@@ -46,7 +48,7 @@ bool handle_intercept(const Variant& handler, const String& name, const Array& p
 /**
  * Removes a previously registered flag.
  */
-void unregister_intercept_flag(const String& name, char* flag);
+void unregister_intercept_flag(const String& name, int8_t* flag);
 
 ///////////////////////////////////////////////////////////////////////////////
 // fb_rename_function()

--- a/hphp/runtime/vm/func-inl.h
+++ b/hphp/runtime/vm/func-inl.h
@@ -544,7 +544,7 @@ inline void Func::resetPrologues() {
 ///////////////////////////////////////////////////////////////////////////////
 // Other methods.
 
-inline char& Func::maybeIntercepted() const {
+inline int8_t& Func::maybeIntercepted() const {
   return m_maybeIntercepted;
 }
 

--- a/hphp/runtime/vm/func.h
+++ b/hphp/runtime/vm/func.h
@@ -971,7 +971,7 @@ struct Func {
   /*
    * Intercept hook flag.
    */
-  char& maybeIntercepted() const;
+  int8_t& maybeIntercepted() const;
 
   /*
    * Access to the global vector of funcs.  This maps FuncID's back to Func*'s.
@@ -1228,7 +1228,7 @@ private:
   };
   // Atomically-accessed intercept flag.  -1, 0, or 1.
   // TODO(#1114385) intercept should work via invalidation.
-  mutable char m_maybeIntercepted;
+  mutable int8_t m_maybeIntercepted;
   mutable ClonedFlag m_cloned;
   bool m_isPreFunc : 1;
   bool m_hasPrivateAncestor : 1;


### PR DESCRIPTION
The sign of a char type is not defined on C standard. On X64, the char expands to "signed char" however PPC64 expands it to "unsigned char", which is a common source of mistake found when porting applications.
The char type is designed to hold an ASCII character and arithmetic should be avoided.
In order to make the code platform independent, the type char was replaced to int8_t, which is explicit signed.