### PR TITLE
Fix calling convention when GP after FP is needed for PPC64

### DIFF
--- a/hphp/runtime/vm/jit/arg-group.h
+++ b/hphp/runtime/vm/jit/arg-group.h
@@ -16,6 +16,8 @@
 #ifndef incl_HPHP_JIT_ARG_GROUP_H
 #define incl_HPHP_JIT_ARG_GROUP_H
 
+#include "hphp/runtime/base/arch.h"
+
 #include "hphp/runtime/vm/jit/containers.h"
 #include "hphp/runtime/vm/jit/reg-alloc.h"
 #include "hphp/runtime/vm/jit/vasm-reg.h"
@@ -190,10 +192,10 @@ struct ArgGroup {
     ArgDesc arg(s, m_locs[s]);
     if (isFP) {
       push_SIMDarg(arg);
-#if defined(__powerpc64__)
-      // PPC64 ABIv2 compliant: reserve the aligned GP if FP is used
-      push_arg(ArgDesc(ArgDesc::Kind::Imm, 0)); // Push a dummy parameter
-#endif
+      if (arch() == Arch::PPC64) {
+        // PPC64 ABIv2 compliant: reserve the aligned GP if FP is used
+        push_arg(ArgDesc(ArgDesc::Kind::Imm, 0)); // Push a dummy parameter
+      }
     } else {
       push_arg(arg);
     }

--- a/hphp/runtime/vm/jit/arg-group.h
+++ b/hphp/runtime/vm/jit/arg-group.h
@@ -190,6 +190,10 @@ struct ArgGroup {
     ArgDesc arg(s, m_locs[s]);
     if (isFP) {
       push_SIMDarg(arg);
+#if defined(__powerpc64__)
+      // PPC64 ABIv2 compliant: reserve the aligned GP if FP is used
+      push_arg(ArgDesc(ArgDesc::Kind::Imm, 0)); // Push a dummy parameter
+#endif
     } else {
       push_arg(arg);
     }


### PR DESCRIPTION
Register allocation on ppc64 is not easy: If a fixed argument function
uses FP arguments, the aligned GP arg needs also to be reserved.

Here, the number_format function ("double, int, int, int" arguments,
with storage buffer) should use for it's first int argument the $r5, not
the $r4 how it was as $r3 is the storage buffer and $r4 is reserved due
to $f1 being used for the double.

I tried to make it nicely before by removing simdArgs from other places,
but then there was a lea trying to move a GP to FP, odd... this one is
neater despite wasting (possibly) a copy to an unused GP register
argument.