### PR TITLE
Use specific emitTLSAddr for powerpc64

### DIFF
--- a/hphp/runtime/vm/jit/code-gen-tls-inl.h
+++ b/hphp/runtime/vm/jit/code-gen-tls-inl.h
@@ -39,8 +39,6 @@ inline Vptr emitTLSAddr(Vout& v, TLSDatum<T> datum) {
       return x64::detail::emitTLSAddr(v, datum);
     case Arch::PPC64:
       return ppc64::detail::emitTLSAddr(v, datum);
-    default:
-      not_implemented();
   }
 }
 

--- a/hphp/runtime/vm/jit/code-gen-tls-inl.h
+++ b/hphp/runtime/vm/jit/code-gen-tls-inl.h
@@ -33,8 +33,10 @@ namespace HPHP { namespace jit {
 
 template<typename T>
 inline Vptr emitTLSAddr(Vout& v, TLSDatum<T> datum) {
-  if (arch() != Arch::X64 && arch() != Arch::ARM) not_implemented();
-  return x64::detail::emitTLSAddr(v, datum);
+  if (arch() == Arch::X64 || arch() == Arch::ARM)
+    return x64::detail::emitTLSAddr(v, datum);
+  else if (arch() == Arch::PPC64) return ppc64::detail::emitTLSAddr(v, datum);
+  else not_implemented();
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/hphp/runtime/vm/jit/code-gen-tls-inl.h
+++ b/hphp/runtime/vm/jit/code-gen-tls-inl.h
@@ -40,6 +40,7 @@ inline Vptr emitTLSAddr(Vout& v, TLSDatum<T> datum) {
     case Arch::PPC64:
       return ppc64::detail::emitTLSAddr(v, datum);
   }
+  not_reached();
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/hphp/runtime/vm/jit/code-gen-tls-inl.h
+++ b/hphp/runtime/vm/jit/code-gen-tls-inl.h
@@ -33,10 +33,15 @@ namespace HPHP { namespace jit {
 
 template<typename T>
 inline Vptr emitTLSAddr(Vout& v, TLSDatum<T> datum) {
-  if (arch() == Arch::X64 || arch() == Arch::ARM)
-    return x64::detail::emitTLSAddr(v, datum);
-  else if (arch() == Arch::PPC64) return ppc64::detail::emitTLSAddr(v, datum);
-  else not_implemented();
+  switch (arch()) {
+    case Arch::X64:
+    case Arch::ARM:
+      return x64::detail::emitTLSAddr(v, datum);
+    case Arch::PPC64:
+      return ppc64::detail::emitTLSAddr(v, datum);
+    default:
+      not_implemented();
+  }
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/hphp/runtime/vm/jit/code-gen-tls-ppc64.h
+++ b/hphp/runtime/vm/jit/code-gen-tls-ppc64.h
@@ -1,0 +1,46 @@
+/*
+   +----------------------------------------------------------------------+
+   | HipHop for PHP                                                       |
+   +----------------------------------------------------------------------+
+   | Copyright (c) 2010-2016 Facebook, Inc. (http://www.facebook.com)     |
+   +----------------------------------------------------------------------+
+   | This source file is subject to version 3.01 of the PHP license,      |
+   | that is bundled with this package in the file LICENSE, and is        |
+   | available through the world-wide-web at the following url:           |
+   | http://www.php.net/license/3_01.txt                                  |
+   | If you did not receive a copy of the PHP license and are unable to   |
+   | obtain it through the world-wide-web, please send a note to          |
+   | license@php.net so we can mail you a copy immediately.               |
+   +----------------------------------------------------------------------+
+*/
+
+#ifndef incl_HPHP_VM_CODE_GEN_TLS_PPC64_H_
+#define incl_HPHP_VM_CODE_GEN_TLS_PPC64_H_
+
+#include "hphp/runtime/vm/jit/vasm-gen.h"
+#include "hphp/runtime/vm/jit/vasm-instr.h"
+#include "hphp/runtime/vm/jit/vasm-reg.h"
+
+#include "hphp/runtime/vm/jit/abi-ppc64.h"
+#include "hphp/util/thread-local.h"
+
+namespace HPHP { namespace jit { namespace ppc64 { namespace detail {
+
+///////////////////////////////////////////////////////////////////////////////
+
+/*
+ * Same implementation as x64 but uses r13 as thread local storage pointer.
+ *
+ * No segmented memory exists, just need to use relative addressing to r13,
+ * therefore no FS segment was specified.
+ */
+template<typename T>
+Vptr emitTLSAddr(Vout& v, TLSDatum<T> datum) {
+
+  uintptr_t vaddr = uintptr_t(datum.tls) - tlsBase();
+  return Vptr{MemoryRef(DispReg(rthreadptr(),vaddr))};
+}
+
+}}}}
+
+#endif

--- a/hphp/runtime/vm/jit/code-gen-tls-ppc64.h
+++ b/hphp/runtime/vm/jit/code-gen-tls-ppc64.h
@@ -36,9 +36,8 @@ namespace HPHP { namespace jit { namespace ppc64 { namespace detail {
  */
 template<typename T>
 Vptr emitTLSAddr(Vout& v, TLSDatum<T> datum) {
-
   uintptr_t vaddr = uintptr_t(datum.tls) - tlsBase();
-  return Vptr{MemoryRef(DispReg(rthreadptr(),vaddr))};
+  return rthreadptr()[vaddr];
 }
 
 }}}}

--- a/hphp/runtime/vm/jit/code-gen-tls.h
+++ b/hphp/runtime/vm/jit/code-gen-tls.h
@@ -85,6 +85,7 @@ void emitTLSLoad(Vout& v, TLSDatum<ThreadLocalNoCheck<T>> datum, Vreg d);
 }}
 
 #include "hphp/runtime/vm/jit/code-gen-tls-x64.h"
+#include "hphp/runtime/vm/jit/code-gen-tls-ppc64.h"
 
 // This has to follow all the arch-specific includes.
 #include "hphp/runtime/vm/jit/code-gen-tls-inl.h"

--- a/hphp/runtime/vm/jit/unwind-itanium.cpp
+++ b/hphp/runtime/vm/jit/unwind-itanium.cpp
@@ -346,7 +346,7 @@ void write_tc_cie(EHFrameWriter& ehfw) {
   ehfw.offset_extended_sf(dw_reg::FP, (record_size - AROFF(m_sfp)) / 8);
 
 #if defined(__powerpc64__)
-  ehfw.offset_extended_sf(dw_reg::TOC, (record_size - 24) / 8);
+  ehfw.offset_extended_sf(dw_reg::TOC, (record_size - AROFF(m_savedToc)) / 8);
 #endif
 
   // This is an artifact of a time when we did not spill registers onto the

--- a/hphp/runtime/vm/jit/unwind-itanium.cpp
+++ b/hphp/runtime/vm/jit/unwind-itanium.cpp
@@ -346,7 +346,7 @@ void write_tc_cie(EHFrameWriter& ehfw) {
   ehfw.offset_extended_sf(dw_reg::FP, (record_size - AROFF(m_sfp)) / 8);
 
 #if defined(__powerpc64__)
-  ehfw.offset_extended_sf(dw_reg::TOC, (record_size - AROFF(m_savedToc)) / 8);
+  ehfw.offset_extended_sf(dw_reg::TOC, (record_size - 24) / 8);
 #endif
 
   // This is an artifact of a time when we did not spill registers onto the


### PR DESCRIPTION
For ppc64, there is no fs register. To refer to a thread content,
the ppc64-abi uses a displacement relative to r13 (thread pointer).