### PR TITLE
Add asm instructions for PPC64

### DIFF
--- a/hphp/hack/src/heap/hh_shared.c
+++ b/hphp/hack/src/heap/hh_shared.c
@@ -877,7 +877,7 @@ value hh_mem(value key) {
     // The data is currently in the process of being written, wait until it
     // actually is ready to be used before returning.
     while (hashtbl[slot].addr == (char*)1) {
-#ifdef __aarch64__
+#if defined(__aarch64__) || defined(__powerpc64__)
       asm volatile("yield" : : : "memory");
 #else
       asm volatile("pause" : : : "memory");

--- a/hphp/runtime/base/memory-manager-inl.h
+++ b/hphp/runtime/base/memory-manager-inl.h
@@ -130,6 +130,13 @@ inline uint32_t MemoryManager::bsr(uint32_t x) {
            : "r"(x)    // Inputs.
            );
   return ret;
+#elif defined(__powerpc64__)
+  uint32_t ret;
+  __asm__ ("cntlzw %0, %1"
+           : "=r"(ret) // Outputs.
+           : "r"(x)    // Inputs.
+           );
+  return 31 - ret;
 #else
   // Equivalent (but incompletely strength-reduced by gcc):
   return 31 - __builtin_clz(x);


### PR DESCRIPTION
yield instruction added for PPC64 to provides a hint that performance will
probably be improved if shared resources dedicated to the executing
processor are released for use by other  processors.
cntlzw instruction added for count leading zeros.