### PR TITLE
Fix quantity of registers on reg algorithms

### DIFF
--- a/hphp/runtime/vm/jit/phys-reg.h
+++ b/hphp/runtime/vm/jit/phys-reg.h
@@ -39,14 +39,6 @@ struct Vout;
  */
 struct PhysReg {
 private:
-  /*
-   * 48 GP regs + 64 SIMD regs + 1 SF reg + 15 empty == 128 regs.
-   *
-   * We can toggle these values, but they need sum to 128 so that RegSet can
-   * fit into two registers.
-   */
-  static constexpr auto kMaxRegs = 128;
-
   static constexpr auto kGPOffset = 0;
   static constexpr auto kNumGP = 48;
 
@@ -57,6 +49,14 @@ private:
   static constexpr auto kNumSF = 1;
 
 public:
+  /*
+   * 48 GP regs + 64 SIMD regs + 1 SF reg + 15 empty == 128 regs.
+   *
+   * We can toggle these values, but they need sum to 128 so that RegSet can
+   * fit into two registers.
+   */
+  static constexpr auto kMaxRegs = 128;
+
   enum Type {
     GP,
     SIMD,

--- a/hphp/runtime/vm/jit/reg-algorithms.cpp
+++ b/hphp/runtime/vm/jit/reg-algorithms.cpp
@@ -38,10 +38,9 @@ bool cycleHasSIMDReg(const CycleInfo& cycle, MovePlan& moves) {
 
 jit::vector<VMoveInfo>
 doVregMoves(Vunit& unit, MovePlan& moves) {
-  constexpr auto N = 128;
-  assertx(abi().all().size() <= N);
+  assertx(abi().all().size() <= PhysReg::kMaxRegs);
   jit::vector<VMoveInfo> howTo;
-  CycleInfo cycles[N];
+  CycleInfo cycles[PhysReg::kMaxRegs];
   size_t num_cycles = 0;
   PhysReg::Map<int> outDegree;
   PhysReg::Map<int> index;
@@ -60,7 +59,7 @@ doVregMoves(Vunit& unit, MovePlan& moves) {
 
     // Begin walking a path from reg.
     for (auto node = reg;;) {
-      assertx(nextIndex < N);
+      assertx(nextIndex < PhysReg::kMaxRegs);
       index[node] = nextIndex++;
       auto next = moves[node];
       if (next != InvalidReg) {
@@ -74,7 +73,7 @@ doVregMoves(Vunit& unit, MovePlan& moves) {
         // next already visited; check if next is on current path.
         if (index[next] >= index[reg]) {
           // found a cycle.
-          assert(num_cycles < N);
+          assert(num_cycles < PhysReg::kMaxRegs);
           cycles[num_cycles++] = { next, nextIndex - index[next] };
         }
       }
@@ -85,9 +84,11 @@ doVregMoves(Vunit& unit, MovePlan& moves) {
   // Handle all moves that aren't part of a cycle. Only nodes with outdegree
   // zero are put into the queue, which is how nodes in a cycle get excluded.
   {
-    PhysReg q[N];
+    PhysReg q[PhysReg::kMaxRegs];
     int qBack = 0;
-    auto enque = [&](PhysReg r) { assertx(qBack < N); q[qBack++] = r; };
+    auto enque = [&](PhysReg r) {
+      assertx(qBack < PhysReg::kMaxRegs); q[qBack++] = r;
+    };
     for (auto node : outDegree) {
       if (outDegree[node] == 0) enque(node);
     }
@@ -134,10 +135,9 @@ doVregMoves(Vunit& unit, MovePlan& moves) {
 }
 
 jit::vector<MoveInfo> doRegMoves(MovePlan& moves, PhysReg rTmp) {
-  constexpr auto N = 128;
-  assertx(abi().all().size() <= N);
+  assertx(abi().all().size() <= PhysReg::kMaxRegs);
   jit::vector<MoveInfo> howTo;
-  CycleInfo cycles[N];
+  CycleInfo cycles[PhysReg::kMaxRegs];
   size_t num_cycles = 0;
   PhysReg::Map<int> outDegree;
   PhysReg::Map<int> index;
@@ -157,7 +157,7 @@ jit::vector<MoveInfo> doRegMoves(MovePlan& moves, PhysReg rTmp) {
 
     // Begin walking a path from reg.
     for (auto node = reg;;) {
-      assertx(nextIndex < N);
+      assertx(nextIndex < PhysReg::kMaxRegs);
       index[node] = nextIndex++;
       auto next = moves[node];
       if (next != InvalidReg) {
@@ -171,7 +171,7 @@ jit::vector<MoveInfo> doRegMoves(MovePlan& moves, PhysReg rTmp) {
         // next already visited; check if next is on current path.
         if (index[next] >= index[reg]) {
           // found a cycle.
-          assert(num_cycles < N);
+          assert(num_cycles < PhysReg::kMaxRegs);
           cycles[num_cycles++] = { next, nextIndex - index[next] };
         }
       }
@@ -182,9 +182,11 @@ jit::vector<MoveInfo> doRegMoves(MovePlan& moves, PhysReg rTmp) {
   // Handle all moves that aren't part of a cycle. Only nodes with outdegree
   // zero are put into the queue, which is how nodes in a cycle get excluded.
   {
-    PhysReg q[N];
+    PhysReg q[PhysReg::kMaxRegs];
     int qBack = 0;
-    auto enque = [&](PhysReg r) { assertx(qBack < N); q[qBack++] = r; };
+    auto enque = [&](PhysReg r) {
+      assertx(qBack < PhysReg::kMaxRegs); q[qBack++] = r;
+    };
     for (auto node : outDegree) {
       if (outDegree[node] == 0) enque(node);
     }

--- a/hphp/runtime/vm/jit/reg-algorithms.cpp
+++ b/hphp/runtime/vm/jit/reg-algorithms.cpp
@@ -38,9 +38,10 @@ bool cycleHasSIMDReg(const CycleInfo& cycle, MovePlan& moves) {
 
 jit::vector<VMoveInfo>
 doVregMoves(Vunit& unit, MovePlan& moves) {
-  assertx(abi().all().size() <= PhysReg::kMaxRegs);
+  constexpr auto N = PhysReg::kMaxRegs;
+  assertx(abi().all().size() <= N);
   jit::vector<VMoveInfo> howTo;
-  CycleInfo cycles[PhysReg::kMaxRegs];
+  CycleInfo cycles[N];
   size_t num_cycles = 0;
   PhysReg::Map<int> outDegree;
   PhysReg::Map<int> index;
@@ -59,7 +60,7 @@ doVregMoves(Vunit& unit, MovePlan& moves) {
 
     // Begin walking a path from reg.
     for (auto node = reg;;) {
-      assertx(nextIndex < PhysReg::kMaxRegs);
+      assertx(nextIndex < N);
       index[node] = nextIndex++;
       auto next = moves[node];
       if (next != InvalidReg) {
@@ -73,7 +74,7 @@ doVregMoves(Vunit& unit, MovePlan& moves) {
         // next already visited; check if next is on current path.
         if (index[next] >= index[reg]) {
           // found a cycle.
-          assert(num_cycles < PhysReg::kMaxRegs);
+          assert(num_cycles < N);
           cycles[num_cycles++] = { next, nextIndex - index[next] };
         }
       }
@@ -84,11 +85,9 @@ doVregMoves(Vunit& unit, MovePlan& moves) {
   // Handle all moves that aren't part of a cycle. Only nodes with outdegree
   // zero are put into the queue, which is how nodes in a cycle get excluded.
   {
-    PhysReg q[PhysReg::kMaxRegs];
+    PhysReg q[N];
     int qBack = 0;
-    auto enque = [&](PhysReg r) {
-      assertx(qBack < PhysReg::kMaxRegs); q[qBack++] = r;
-    };
+    auto enque = [&](PhysReg r) { assertx(qBack < N); q[qBack++] = r; };
     for (auto node : outDegree) {
       if (outDegree[node] == 0) enque(node);
     }
@@ -135,9 +134,10 @@ doVregMoves(Vunit& unit, MovePlan& moves) {
 }
 
 jit::vector<MoveInfo> doRegMoves(MovePlan& moves, PhysReg rTmp) {
-  assertx(abi().all().size() <= PhysReg::kMaxRegs);
+  constexpr auto N = PhysReg::kMaxRegs;
+  assertx(abi().all().size() <= N);
   jit::vector<MoveInfo> howTo;
-  CycleInfo cycles[PhysReg::kMaxRegs];
+  CycleInfo cycles[N];
   size_t num_cycles = 0;
   PhysReg::Map<int> outDegree;
   PhysReg::Map<int> index;
@@ -157,7 +157,7 @@ jit::vector<MoveInfo> doRegMoves(MovePlan& moves, PhysReg rTmp) {
 
     // Begin walking a path from reg.
     for (auto node = reg;;) {
-      assertx(nextIndex < PhysReg::kMaxRegs);
+      assertx(nextIndex < N);
       index[node] = nextIndex++;
       auto next = moves[node];
       if (next != InvalidReg) {
@@ -171,7 +171,7 @@ jit::vector<MoveInfo> doRegMoves(MovePlan& moves, PhysReg rTmp) {
         // next already visited; check if next is on current path.
         if (index[next] >= index[reg]) {
           // found a cycle.
-          assert(num_cycles < PhysReg::kMaxRegs);
+          assert(num_cycles < N);
           cycles[num_cycles++] = { next, nextIndex - index[next] };
         }
       }
@@ -182,10 +182,11 @@ jit::vector<MoveInfo> doRegMoves(MovePlan& moves, PhysReg rTmp) {
   // Handle all moves that aren't part of a cycle. Only nodes with outdegree
   // zero are put into the queue, which is how nodes in a cycle get excluded.
   {
-    PhysReg q[PhysReg::kMaxRegs];
+    PhysReg q[N];
     int qBack = 0;
     auto enque = [&](PhysReg r) {
-      assertx(qBack < PhysReg::kMaxRegs); q[qBack++] = r;
+      assertx(qBack < N);
+      q[qBack++] = r; 
     };
     for (auto node : outDegree) {
       if (outDegree[node] == 0) enque(node);

--- a/hphp/runtime/vm/jit/reg-algorithms.cpp
+++ b/hphp/runtime/vm/jit/reg-algorithms.cpp
@@ -38,7 +38,7 @@ bool cycleHasSIMDReg(const CycleInfo& cycle, MovePlan& moves) {
 
 jit::vector<VMoveInfo>
 doVregMoves(Vunit& unit, MovePlan& moves) {
-  constexpr auto N = 64;
+  constexpr auto N = 128;
   assertx(abi().all().size() <= N);
   jit::vector<VMoveInfo> howTo;
   CycleInfo cycles[N];
@@ -134,7 +134,7 @@ doVregMoves(Vunit& unit, MovePlan& moves) {
 }
 
 jit::vector<MoveInfo> doRegMoves(MovePlan& moves, PhysReg rTmp) {
-  constexpr auto N = 64;
+  constexpr auto N = 128;
   assertx(abi().all().size() <= N);
   jit::vector<MoveInfo> howTo;
   CycleInfo cycles[N];

--- a/hphp/runtime/vm/jit/reg-algorithms.cpp
+++ b/hphp/runtime/vm/jit/reg-algorithms.cpp
@@ -186,7 +186,7 @@ jit::vector<MoveInfo> doRegMoves(MovePlan& moves, PhysReg rTmp) {
     int qBack = 0;
     auto enque = [&](PhysReg r) {
       assertx(qBack < N);
-      q[qBack++] = r; 
+      q[qBack++] = r;
     };
     for (auto node : outDegree) {
       if (outDegree[node] == 0) enque(node);

--- a/hphp/runtime/vm/jit/reg-algorithms.cpp
+++ b/hphp/runtime/vm/jit/reg-algorithms.cpp
@@ -184,10 +184,7 @@ jit::vector<MoveInfo> doRegMoves(MovePlan& moves, PhysReg rTmp) {
   {
     PhysReg q[N];
     int qBack = 0;
-    auto enque = [&](PhysReg r) {
-      assertx(qBack < N);
-      q[qBack++] = r;
-    };
+    auto enque = [&](PhysReg r) { assertx(qBack < N); q[qBack++] = r; };
     for (auto node : outDegree) {
       if (outDegree[node] == 0) enque(node);
     }


### PR DESCRIPTION
After the change that increases the number of possible registers in the
HHVM (from 64 to 128), the constants of this files got outdated. Changing
it to fit the current number of registers.