### PR TITLE
Fix hardcoded value for memfd_create.

### DIFF
--- a/hphp/hack/src/heap/hh_shared.c
+++ b/hphp/hack/src/heap/hh_shared.c
@@ -130,9 +130,15 @@
  * appeared in Linux 3.17.
  ****************************************************************************/
 #if !defined __APPLE__ && !defined _WIN32
-  // Linux version must support syscall memfd_create
-  #ifndef __NR_memfd_create
-    #error "hh_shared.c requires a Linux version that supports memfd_create"
+  // Linux version for the architecture must support syscall memfd_create
+  #if defined(__x86_64__)
+    #define SYS_memfd_create 319
+  #elif defined(__powerpc64__)
+    #define SYS_memfd_create 360
+  #elif defined(__aarch64__)
+    #define SYS_memfd_create 385
+  #else
+    #error "hh_shared.c requires a architecture that supports memfd_create"
   #endif
 
   #define MEMFD_CREATE 1
@@ -145,7 +151,7 @@
    * kernel is < 3.17, and that's good enough.
    */
   static int memfd_create(const char *name, unsigned int flags) {
-    return syscall(__NR_memfd_create, name, flags);
+    return syscall(SYS_memfd_create, name, flags);
   }
 #endif
 

--- a/hphp/hack/src/heap/hh_shared.c
+++ b/hphp/hack/src/heap/hh_shared.c
@@ -130,9 +130,9 @@
  * appeared in Linux 3.17.
  ****************************************************************************/
 #if !defined __APPLE__ && !defined _WIN32
-  // We're assuming x86_64 linux here
-  #ifndef __x86_64__
-    #error "hh_shared.c requires Linux to be x86_64"
+  // Linux version must support syscall memfd_create
+  #ifndef __NR_memfd_create
+    #error "hh_shared.c requires a Linux version that supports memfd_create"
   #endif
 
   #define MEMFD_CREATE 1
@@ -142,11 +142,10 @@
    * kernel release version and make a decision based on whether
    * the kernel was >= 3.17 or not. However, syscall will return -1
    * with an strerr(errno) of "Function not implemented" if the
-   * kernel is < 3.17, and that's good enough. Also, I got the value
-   * of 319 from here: https://github.com/kernelslacker/trinity/blob/825b51cfe8fcbc7461c9a327411475ae481654c8/include/memfd.h
+   * kernel is < 3.17, and that's good enough.
    */
   static int memfd_create(const char *name, unsigned int flags) {
-    return syscall(319, name, flags);
+    return syscall(__NR_memfd_create, name, flags);
   }
 #endif
 


### PR DESCRIPTION
Summary:

After merge with upstream our build for PPC64 port brokes.
That's because an #ifndef x86_64 error called from hh_shared.

memfd_create syscall is 319 on x86_64, 360 on POWER and, 385 for
ARM. But we can call __NR_memfd_create defined on unistd.h
instead use a hardcoded  value and test if Linux version support
this syscall.

HHVM is currently being ported to architectures others architectures
(POWER and ARM) and must avoid introduces things "only for x86"
that breaks builds on those architectures.