### PR TITLE
Fixes compilation error due updates on Intel XED.

### DIFF
--- a/hphp/tools/tc-print/offline-x86-code.cpp
+++ b/hphp/tools/tc-print/offline-x86-code.cpp
@@ -24,7 +24,6 @@
 
 #include "hphp/tools/tc-print/tc-print.h"
 #include "hphp/tools/tc-print/offline-trans-data.h"
-#include "boost/algorithm/string.hpp"
 
 #define MAX_INSTR_ASM_LEN 128
 #define MAX_SYM_LEN       10240
@@ -52,26 +51,6 @@ static size_t fileSize(FILE* f) {
   struct stat st;
   fstat(fd, &st);
   return st.st_size;
-}
-
-// XED callback function to get a symbol from an address
-static int addressToSymbol(xed_uint64_t  address,
-                           char*         symbolBuffer,
-                           xed_uint32_t  bufferLength,
-                           xed_uint64_t* offset,
-                           void*         context) {
-  auto name = boost::trim_copy(getNativeFunctionName((void*)address));
-  if (boost::starts_with(name, "0x")) {
-    return 0;
-  }
-  auto pos = name.find_first_of('(');
-  auto copyLength = pos != std::string::npos
-    ? std::min(pos, size_t(bufferLength - 1))
-    : bufferLength - 1;
-  strncpy(symbolBuffer, name.c_str(), copyLength);
-  symbolBuffer[copyLength] = '\0';
-  *offset = 0;
-  return 1;
 }
 
 void OfflineX86Code::openFiles(TCA tcRegionBases[TCRCount]) {
@@ -262,7 +241,7 @@ void OfflineX86Code::disasm(FILE* file,
 
     // Get disassembled instruction in codeStr
     if (!xed_format_context(xed_syntax, &xedd, codeStr,
-                            MAX_INSTR_ASM_LEN, (uint64_t)ip, nullptr, addressToSymbol)) {
+                            MAX_INSTR_ASM_LEN, (uint64_t)ip, nullptr, 0)) {
       error("disasm error: xed_format_context failed");
     }
 

--- a/hphp/util/disasm.cpp
+++ b/hphp/util/disasm.cpp
@@ -56,7 +56,6 @@ Disasm::Disasm(const Disasm::Options& opts)
   xed_state_init(&m_xedState, XED_MACHINE_MODE_LONG_64,
                  XED_ADDRESS_WIDTH_64b, XED_ADDRESS_WIDTH_64b);
   xed_tables_init();
-  xed_register_disassembly_callback(addressToSymbol);
 #endif // HAVE_LIBXED
 }
 
@@ -98,7 +97,7 @@ void Disasm::disasm(std::ostream& out, uint8_t* codeStartAddr,
     auto const syntax = m_opts.m_forceAttSyntax ? XED_SYNTAX_ATT
                                                 : s_xed_syntax;
     if (!xed_format_context(syntax, &xedd, codeStr,
-                            MAX_INSTR_ASM_LEN, ip, nullptr)) {
+                            MAX_INSTR_ASM_LEN, ip, nullptr, addressToSymbol)) {
       out << folly::format("xed_format_context failed at address {}\n",
                            frontier);
       return;


### PR DESCRIPTION
Summary:

Dissasembler for x86_64 uses Intel XED to disasm code. At some point the interfaces has 
changed causes a compilation error with new versions of XED (2015-09-10). 
So i think it's time to drop the support to old versions.