### PR TITLE
FIX: remove orphan call to FindMemfd.cmake removed in <c168d42>

### DIFF
--- a/hphp/hack/CMakeLists.txt
+++ b/hphp/hack/CMakeLists.txt
@@ -3,7 +3,6 @@ CMAKE_MINIMUM_REQUIRED(VERSION 2.8.7 FATAL_ERROR)
 find_package(OCaml)
 find_package(LZ4)
 find_package(LibElf)
-find_package(Memfd)
 
 if (OCAMLC_FOUND)
   # This is totally the wrong way to do this, but I am tired of fighting with


### PR DESCRIPTION
Remove orphan call to FindMemfd.cmake which was removed in https://github.com/facebook/hhvm/commit/c168d42be61f7f13c15a3a6dcf572c7635869af5

