### PR TITLE
ADD: creation_time and mtime to apc_cache_info()

### DIFF
--- a/hphp/runtime/base/concurrent-shared-store.cpp
+++ b/hphp/runtime/base/concurrent-shared-store.cpp
@@ -817,6 +817,8 @@ bool ConcurrentTableSharedStore::storeImpl(const String& key,
 
     sval->set(svar.handle, adjustedTtl);
     sval->dataSize = svar.size;
+    if (sval->creation_time == 0) sval->creation_time = time(nullptr);
+    sval->mtime = time(nullptr);
     expiry = sval->expire;
     if (expiry) {
       auto ikey = intptr_t(acc->first);
@@ -997,7 +999,8 @@ EntryInfo ConcurrentTableSharedStore::makeEntryInfo(const char* key,
     if (ttl == 0) ttl = 1; // don't want to confuse with primed keys
   }
 
-  return EntryInfo(key, inMem, size, ttl, type);
+  return EntryInfo(key, inMem, size, ttl, type, sval->creation_time, 
+                   sval->mtime);
 }
 
 std::vector<EntryInfo> ConcurrentTableSharedStore::getEntriesInfo() {

--- a/hphp/runtime/base/concurrent-shared-store.cpp
+++ b/hphp/runtime/base/concurrent-shared-store.cpp
@@ -817,7 +817,7 @@ bool ConcurrentTableSharedStore::storeImpl(const String& key,
 
     sval->set(svar.handle, adjustedTtl);
     sval->dataSize = svar.size;
-    if (sval->creation_time == 0) sval->creation_time = time(nullptr);
+    if (sval->c_time == 0) sval->c_time = time(nullptr);
     sval->mtime = time(nullptr);
     expiry = sval->expire;
     if (expiry) {
@@ -999,8 +999,7 @@ EntryInfo ConcurrentTableSharedStore::makeEntryInfo(const char* key,
     if (ttl == 0) ttl = 1; // don't want to confuse with primed keys
   }
 
-  return EntryInfo(key, inMem, size, ttl, type, sval->creation_time, 
-                   sval->mtime);
+  return EntryInfo(key, inMem, size, ttl, type, sval->c_time, sval->mtime);
 }
 
 std::vector<EntryInfo> ConcurrentTableSharedStore::getEntriesInfo() {

--- a/hphp/runtime/base/concurrent-shared-store.cpp
+++ b/hphp/runtime/base/concurrent-shared-store.cpp
@@ -60,7 +60,9 @@ bool check_noTTL(const char* key, size_t keyLen) {
 
 void StoreValue::set(APCHandle* v, int64_t ttl) {
   setHandle(v);
-  expire = ttl ? time(nullptr) + ttl : 0;
+  mtime = time(nullptr);
+  if (c_time == 0)  c_time = mtime;
+  expire = ttl ? mtime + ttl : 0;
 }
 
 bool StoreValue::expired() const {
@@ -817,8 +819,6 @@ bool ConcurrentTableSharedStore::storeImpl(const String& key,
 
     sval->set(svar.handle, adjustedTtl);
     sval->dataSize = svar.size;
-    if (sval->c_time == 0) sval->c_time = time(nullptr);
-    sval->mtime = time(nullptr);
     expiry = sval->expire;
     if (expiry) {
       auto ikey = intptr_t(acc->first);

--- a/hphp/runtime/base/concurrent-shared-store.h
+++ b/hphp/runtime/base/concurrent-shared-store.h
@@ -56,6 +56,8 @@ struct StoreValue {
     , expire{o.expire}
     , dataSize{o.dataSize}
     , kind(o.kind)
+    , creation_time{o.creation_time}
+    , mtime{o.mtime}
     // Copy everything except the lock
   {
     hotIndex.store(o.hotIndex.load(std::memory_order_relaxed),
@@ -109,7 +111,9 @@ struct StoreValue {
   // Reference to any HotCache entry to be cleared if the value is treadmilled.
   mutable std::atomic<HotCacheIdx> hotIndex{kHotCacheUnknown};
   APCKind kind;  // Only valid if data is an APCHandle*.
-  char padding[19];  // Make APCMap nodes cache-line sized (it static_asserts).
+  uint32_t creation_time{0};
+  uint32_t mtime{0};
+  char padding[3];  // Make APCMap nodes cache-line sized (it static_asserts).
 };
 
 //////////////////////////////////////////////////////////////////////
@@ -135,12 +139,16 @@ struct EntryInfo {
             bool inMem,
             int32_t size,
             int64_t ttl,
-            Type type)
+            Type type,
+            int64_t creation_time,
+            int64_t mtime)
     : key(apckey)
     , inMem(inMem)
     , size(size)
     , ttl(ttl)
     , type(type)
+    , creation_time(creation_time)
+    , mtime(mtime)
   {}
 
   static Type getAPCType(const APCHandle* handle);
@@ -150,6 +158,8 @@ struct EntryInfo {
   int32_t size;
   int64_t ttl;
   Type type;
+  int64_t creation_time;
+  int64_t mtime;
 };
 
 //////////////////////////////////////////////////////////////////////

--- a/hphp/runtime/base/concurrent-shared-store.h
+++ b/hphp/runtime/base/concurrent-shared-store.h
@@ -102,7 +102,8 @@ struct StoreValue {
    * lock during their initial file-data-to-APCHandle conversion, so these two
    * fields are unioned.
    *
-   * Note: expiration times are stored in 32-bits as seconds since the Epoch.
+   * Note: expiration, creation, and modification times are stored unsigned 
+   * in 32-bits as seconds since the Epoch to save cache-line space.
    * HHVM might get confused after 2106 :)
    */
   mutable Either<APCHandle*,char*,either_policy::high_bit> data;
@@ -111,9 +112,9 @@ struct StoreValue {
   // Reference to any HotCache entry to be cleared if the value is treadmilled.
   mutable std::atomic<HotCacheIdx> hotIndex{kHotCacheUnknown};
   APCKind kind;  // Only valid if data is an APCHandle*.
-  char padding[3];  // Make APCMap nodes cache-line sized (it static_asserts).
-  int64_t c_time{0}; //modification time
-  int64_t mtime{0}; //creation time
+  char padding[11];  // Make APCMap nodes cache-line sized (it static_asserts).
+  uint32_t c_time{0}; // Modification time
+  uint32_t mtime{0}; // Creation time
 };
 
 //////////////////////////////////////////////////////////////////////

--- a/hphp/runtime/base/concurrent-shared-store.h
+++ b/hphp/runtime/base/concurrent-shared-store.h
@@ -56,7 +56,7 @@ struct StoreValue {
     , expire{o.expire}
     , dataSize{o.dataSize}
     , kind(o.kind)
-    , creation_time{o.creation_time}
+    , c_time{o.c_time}
     , mtime{o.mtime}
     // Copy everything except the lock
   {
@@ -111,9 +111,9 @@ struct StoreValue {
   // Reference to any HotCache entry to be cleared if the value is treadmilled.
   mutable std::atomic<HotCacheIdx> hotIndex{kHotCacheUnknown};
   APCKind kind;  // Only valid if data is an APCHandle*.
-  uint32_t creation_time{0};
-  uint32_t mtime{0};
   char padding[3];  // Make APCMap nodes cache-line sized (it static_asserts).
+  int64_t c_time{0}; //modification time
+  int64_t mtime{0}; //creation time
 };
 
 //////////////////////////////////////////////////////////////////////
@@ -140,14 +140,14 @@ struct EntryInfo {
             int32_t size,
             int64_t ttl,
             Type type,
-            int64_t creation_time,
+            int64_t c_time,
             int64_t mtime)
     : key(apckey)
     , inMem(inMem)
     , size(size)
     , ttl(ttl)
     , type(type)
-    , creation_time(creation_time)
+    , c_time(c_time)
     , mtime(mtime)
   {}
 
@@ -158,7 +158,7 @@ struct EntryInfo {
   int32_t size;
   int64_t ttl;
   Type type;
-  int64_t creation_time;
+  int64_t c_time;
   int64_t mtime;
 };
 

--- a/hphp/runtime/ext/apc/ext_apc.cpp
+++ b/hphp/runtime/ext/apc/ext_apc.cpp
@@ -478,7 +478,7 @@ const StaticString s_info("info");
 const StaticString s_in_memory("in_memory");
 const StaticString s_mem_size("mem_size");
 const StaticString s_type("type");
-const StaticString s_creation_time("creation_time");
+const StaticString s_c_time("creation_time");
 const StaticString s_mtime("mtime");
 
 // This is a guess to the size of the info array. It is significantly
@@ -516,7 +516,7 @@ Variant HHVM_FUNCTION(apc_cache_info,
       ent.add(s_ttl, entry.ttl);
       ent.add(s_mem_size, entry.size);
       ent.add(s_type, static_cast<int64_t>(entry.type));
-      ent.add(s_creation_time, entry.creation_time);
+      ent.add(s_c_time, entry.c_time);
       ent.add(s_mtime, entry.mtime);
       ents.append(ent.toArray());
     }

--- a/hphp/runtime/ext/apc/ext_apc.cpp
+++ b/hphp/runtime/ext/apc/ext_apc.cpp
@@ -478,6 +478,8 @@ const StaticString s_info("info");
 const StaticString s_in_memory("in_memory");
 const StaticString s_mem_size("mem_size");
 const StaticString s_type("type");
+const StaticString s_creation_time("creation_time");
+const StaticString s_mtime("mtime");
 
 // This is a guess to the size of the info array. It is significantly
 // bigger than what we need but hard to control all the info that we
@@ -485,7 +487,7 @@ const StaticString s_type("type");
 // Try to keep it such that we do not have to resize the array
 const uint32_t kCacheInfoSize = 40;
 // Number of elements in the entry array
-const int32_t kEntryInfoSize = 5;
+const int32_t kEntryInfoSize = 7;
 
 Variant HHVM_FUNCTION(apc_cache_info,
                       const String& cache_type,
@@ -514,6 +516,8 @@ Variant HHVM_FUNCTION(apc_cache_info,
       ent.add(s_ttl, entry.ttl);
       ent.add(s_mem_size, entry.size);
       ent.add(s_type, static_cast<int64_t>(entry.type));
+      ent.add(s_creation_time, entry.creation_time);
+      ent.add(s_mtime, entry.mtime);
       ents.append(ent.toArray());
     }
     info.add(s_cache_list, ents.toArray(), false);


### PR DESCRIPTION
Adds creation_time and mtime to apc_cache_info()'s return
- In the APCMap node they are stored as unit32_t to save cache-line space for future use.

Closes #7064 

NOTE: Documentation is limited on creation_time and mtime, in particular I've assumed that mtime is modification time (the time the entry was more recently modified).

