### PR TITLE
FIX: correct object conversion error for floats

### DIFF
--- a/hphp/runtime/base/object-data-inl.h
+++ b/hphp/runtime/base/object-data-inl.h
@@ -227,7 +227,8 @@ inline double ObjectData::toDouble() const {
   if (UNLIKELY(getAttribute(CallToImpl) && !isCollection())) {
     return toDoubleImpl();
   }
-  return toInt64();
+  raiseObjToDoubleNotice(classname_cstr());
+  return 1;
 }
 
 inline const Func* ObjectData::methodNamed(const StringData* sd) const {

--- a/hphp/runtime/base/object-data.cpp
+++ b/hphp/runtime/base/object-data.cpp
@@ -1620,6 +1620,10 @@ void ObjectData::raiseObjToIntNotice(const char* clsName) {
   raise_notice("Object of class %s could not be converted to int", clsName);
 }
 
+void ObjectData::raiseObjToDoubleNotice(const char* clsName) {
+  raise_notice("Object of class %s could not be converted to float", clsName);
+}
+
 void ObjectData::raiseAbstractClassError(Class* cls) {
   Attr attrs = cls->attrs();
   raise_error("Cannot instantiate %s %s",

--- a/hphp/runtime/base/object-data.h
+++ b/hphp/runtime/base/object-data.h
@@ -415,6 +415,7 @@ struct ObjectData: type_scan::MarkCountable<ObjectData> {
   void unsetProp(Class* ctx, const StringData* key);
 
   static void raiseObjToIntNotice(const char*);
+  static void raiseObjToDoubleNotice(const char*);
   static void raiseAbstractClassError(Class*);
   void raiseUndefProp(const StringData*);
 

--- a/hphp/test/quick/cnvDbl.php.expectf
+++ b/hphp/test/quick/cnvDbl.php.expectf
@@ -6,7 +6,7 @@ float(1.1)
 float(0)
 float(1)
 
-Notice: Object of class C could not be converted to int in %s on line 4
+Notice: Object of class C could not be converted to float in %s on line 4
 float(1)
 float(0)
 float(0)
@@ -17,7 +17,7 @@ float(0)
 float(1.1)
 float(0)
 
-Notice: Object of class C could not be converted to int in %s on line 50
+Notice: Object of class C could not be converted to float in %s on line 50
 float(1)
 float(0)
 float(1)

--- a/hphp/test/quick/tobadtype.php.expectf
+++ b/hphp/test/quick/tobadtype.php.expectf
@@ -3,7 +3,7 @@ test int
 Notice: Object of class X could not be converted to int in %s on line 21
 test dbl
 
-Notice: Object of class X could not be converted to int in %s on line 25
+Notice: Object of class X could not be converted to float in %s on line 25
 test str
 
 Catchable fatal error: Object of class X could not be converted to string in %s on line 17

--- a/hphp/test/slow/comparisons/1054.php.expectf
+++ b/hphp/test/slow/comparisons/1054.php.expectf
@@ -3,9 +3,9 @@ Notice: Object of class stdClass could not be converted to int in %s/test/slow/c
 Notice: Object of class stdClass could not be converted to int in %s/test/slow/comparisons/1054.php on line 4
 bool(true)
 
-Notice: Object of class stdClass could not be converted to int in %s/test/slow/comparisons/1054.php on line 5
+Notice: Object of class stdClass could not be converted to float in %s/test/slow/comparisons/1054.php on line 5
 
-Notice: Object of class stdClass could not be converted to int in %s/test/slow/comparisons/1054.php on line 5
+Notice: Object of class stdClass could not be converted to float in %s/test/slow/comparisons/1054.php on line 5
 bool(true)
 
 Notice: Object of class stdClass could not be converted to int in %s/test/slow/comparisons/1054.php on line 6


### PR DESCRIPTION
correct object conversion error message for floats to name float instead of int

Closes #5408

