### PR TITLE
FIX: enable 'tls' to mean 'ssl' for stream_context

### DIFF
--- a/hphp/runtime/base/http-client.cpp
+++ b/hphp/runtime/base/http-client.cpp
@@ -106,6 +106,7 @@ int HttpClient::post(const char *url, const char *data, size_t size,
 
 const StaticString
   s_ssl("ssl"),
+  s_tls("tls"),
   s_verify_peer("verify_peer"),
   s_capath("capath"),
   s_cafile("cafile"),
@@ -225,8 +226,11 @@ int HttpClient::request(const char* verb,
     curl_easy_setopt(cp, CURLOPT_WRITEHEADER, (void*)this);
   }
 
-  if (m_stream_context_options[s_ssl].isArray()) {
-    const Array ssl = m_stream_context_options[s_ssl].toArray();
+  if (m_stream_context_options[s_ssl].isArray() || 
+      m_stream_context_options[s_tls].isArray()) {
+    const Array ssl = m_stream_context_options[s_ssl].isArray() ? \
+                      m_stream_context_options[s_ssl].toArray() : \
+                      m_stream_context_options[s_tls].toArray();
     if (ssl.exists(s_verify_peer)) {
       curl_easy_setopt(cp, CURLOPT_SSL_VERIFYPEER,
                        ssl[s_verify_peer].toBoolean());

--- a/hphp/test/slow/ext_stream/context_array.php
+++ b/hphp/test/slow/ext_stream/context_array.php
@@ -5,6 +5,9 @@ $opts = array(
     'header' => array(
       "Accept-Encoding: gzip",
       "User-Agent: Composer/source PHP 5.5.99)",
+    ),
+    'tls' => array(
+      "allow_self_signed"=>TRUE
     )
   )
 );

--- a/hphp/test/slow/ext_stream/context_array.php.expect
+++ b/hphp/test/slow/ext_stream/context_array.php.expect
@@ -2,13 +2,18 @@ array(1) {
   ["options"]=>
   array(1) {
     ["http"]=>
-    array(1) {
+    array(2) {
       ["header"]=>
       array(2) {
         [0]=>
         string(21) "Accept-Encoding: gzip"
         [1]=>
         string(39) "User-Agent: Composer/source PHP 5.5.99)"
+      }
+      ["tls"]=>
+      array(1) {
+        ["allow_self_signed"]=>
+        bool(true)
       }
     }
   }


### PR DESCRIPTION
- 'tls' array option will be considered the same as 'ssl' for stream_context options

Closes #6184

