### PR TITLE
FIX: fix behavior of parse_url for relative urls with ports

### DIFF
--- a/hphp/runtime/base/zend-url.cpp
+++ b/hphp/runtime/base/zend-url.cpp
@@ -136,6 +136,9 @@ bool url_parse(Url &output, const char *str, size_t length) {
       auto port = atoi(port_buf);
       if (port > 0 && port <= 65535) {
         output.port = port;
+        if (*s == '/' && *(s+1) == '/') { /* relative-scheme URL */
+          s += 2;
+        }
       } else {
         return false;
       }

--- a/hphp/test/slow/ext_url/parse_url.php
+++ b/hphp/test/slow/ext_url/parse_url.php
@@ -3,3 +3,4 @@ var_dump(parse_url('http://www.facebook.com'));
 var_dump(parse_url('https://lol:12345@www.facebook.com:14159/hhvmabcd'));
 var_dump(parse_url('irc://chat.freenode.net/#hhvm'));
 var_dump(parse_url('content/:/\*'));
+var_dump(parse_url("//example.org:8088/sites/default/files/drums.mp3"));

--- a/hphp/test/slow/ext_url/parse_url.php.expect
+++ b/hphp/test/slow/ext_url/parse_url.php.expect
@@ -32,3 +32,11 @@ array(1) {
   ["path"]=>
   string(12) "content/:/\*"
 }
+array(3) {
+  ["host"]=>
+  string(11) "example.org"
+  ["port"]=>
+  int(8088)
+  ["path"]=>
+  string(30) "/sites/default/files/drums.mp3"
+}


### PR DESCRIPTION
-resolve parse_url was returning bool(false) for valid relative urls with ports
-add test to confirm correct behavior

Closes #7136 
