### PR TITLE
Fix hf-prod-collect.sh for newer versions of perf

### DIFF
--- a/hphp/tools/hfsort/hf-prod-collect.sh
+++ b/hphp/tools/hfsort/hf-prod-collect.sh
@@ -16,7 +16,7 @@ fi
 
 perf record -ag -e instructions -o /tmp/perf.data -- sleep ${SLEEP_TIME:-200}
 
-perf script -i /tmp/perf.data -f comm,ip -chhvm | sed -ne '/^[^ 	]/,+2p' | $GZIP -c > $TMPDIR/perf.pds.gz
+perf script -i /tmp/perf.data --fields comm,ip -chhvm | sed -ne '/^[^ 	]/,+2p' | $GZIP -c > $TMPDIR/perf.pds.gz
 
 nm -S ${HHVM_BIN_PATH:-/proc/$HHVM_PID/exe} > $TMPDIR/hhvm.nm
 


### PR DESCRIPTION
Changed the perf script command to use "--fields" to be compatible with more versions of perf. The script was using "-f" which has been changed to "-F" in newer versions of perf. "--fields" means the same thing in both versions of perf.
