### PR TITLE
Add switch options for PPC64

### DIFF
--- a/hphp/ppc64-asm/asm-ppc64.h
+++ b/hphp/ppc64-asm/asm-ppc64.h
@@ -50,9 +50,6 @@ namespace ppc64_asm {
 constexpr uint8_t min_frame_size            = 4 * 8;
 // Must be the same value of AROFF(_savedToc).
 constexpr uint8_t toc_position_on_frame     = 3 * 8;
-// exittc offset on our first native frame. (This position is requested as
-// reserved by ABI)
-constexpr uint8_t exittc_position_on_frame  = 1 * 8;
 
 // How many bytes a PPC64 instruction length is.
 constexpr uint8_t instr_size_in_bytes       = sizeof(PPC64Instr);

--- a/hphp/runtime/vm/jit/abi.cpp
+++ b/hphp/runtime/vm/jit/abi.cpp
@@ -19,8 +19,8 @@
 #include "hphp/util/arch.h"
 
 #include "hphp/runtime/vm/jit/abi-arm.h"
-#include "hphp/runtime/vm/jit/abi-x64.h"
 #include "hphp/runtime/vm/jit/abi-ppc64.h"
+#include "hphp/runtime/vm/jit/abi-x64.h"
 
 namespace HPHP { namespace jit {
 

--- a/hphp/runtime/vm/jit/abi.cpp
+++ b/hphp/runtime/vm/jit/abi.cpp
@@ -20,6 +20,7 @@
 
 #include "hphp/runtime/vm/jit/abi-arm.h"
 #include "hphp/runtime/vm/jit/abi-x64.h"
+#include "hphp/runtime/vm/jit/abi-ppc64.h"
 
 namespace HPHP { namespace jit {
 

--- a/hphp/runtime/vm/jit/align.cpp
+++ b/hphp/runtime/vm/jit/align.cpp
@@ -17,8 +17,8 @@
 #include "hphp/runtime/vm/jit/align.h"
 
 #include "hphp/runtime/vm/jit/align-arm.h"
-#include "hphp/runtime/vm/jit/align-x64.h"
 #include "hphp/runtime/vm/jit/align-ppc64.h"
+#include "hphp/runtime/vm/jit/align-x64.h"
 
 #include "hphp/util/arch.h"
 

--- a/hphp/runtime/vm/jit/align.cpp
+++ b/hphp/runtime/vm/jit/align.cpp
@@ -18,6 +18,7 @@
 
 #include "hphp/runtime/vm/jit/align-arm.h"
 #include "hphp/runtime/vm/jit/align-x64.h"
+#include "hphp/runtime/vm/jit/align-ppc64.h"
 
 #include "hphp/util/arch.h"
 

--- a/hphp/runtime/vm/jit/func-guard.cpp
+++ b/hphp/runtime/vm/jit/func-guard.cpp
@@ -21,6 +21,7 @@
 #include "hphp/runtime/vm/jit/code-cache.h"
 #include "hphp/runtime/vm/jit/func-guard-arm.h"
 #include "hphp/runtime/vm/jit/func-guard-x64.h"
+#include "hphp/runtime/vm/jit/func-guard-ppc64.h"
 #include "hphp/runtime/vm/jit/mc-generator.h"
 #include "hphp/runtime/vm/jit/vasm-gen.h"
 #include "hphp/runtime/vm/jit/vasm-instr.h"
@@ -37,26 +38,14 @@ void emitFuncGuard(const Func* func, CodeBlock& cb, CGMeta& fixups) {
 }
 
 TCA funcGuardFromPrologue(TCA prologue, const Func* func) {
-#if defined(__powerpc64__)
-  // Returning null since PPC64 specific code is under development
-  return nullptr;
-#endif
   return ARCH_SWITCH_CALL(funcGuardFromPrologue, prologue, func);
 }
 
 bool funcGuardMatches(TCA guard, const Func* func) {
-#if defined(__powerpc64__)
-  // Returning false since PPC64 specific code is under development
-  return false;
-#endif
   return ARCH_SWITCH_CALL(funcGuardMatches, guard, func);
 }
 
 void clobberFuncGuard(TCA guard, const Func* func) {
-#if defined(__powerpc64__)
-  // Returning since PPC64 specific code is under development
-  return;
-#endif
   return ARCH_SWITCH_CALL(clobberFuncGuard, guard, func);
 }
 

--- a/hphp/runtime/vm/jit/mc-generator.cpp
+++ b/hphp/runtime/vm/jit/mc-generator.cpp
@@ -1825,7 +1825,6 @@ MCGenerator::MCGenerator()
 
   s_jitMaturityCounter = ServiceData::createCounter("jit.maturity");
 
-  // Do not initialize JIT stubs for PPC64 - port under development
   m_ustubs.emitAll(m_code, m_debugInfo);
 
   // Write an .eh_frame section that covers the whole TC.

--- a/hphp/runtime/vm/jit/mc-generator.cpp
+++ b/hphp/runtime/vm/jit/mc-generator.cpp
@@ -1181,10 +1181,9 @@ MCGenerator::bindJmp(TCA toSmash, SrcKey destSk, ServiceRequest req,
         return decoder.cc;
       }
 
-      case Arch::PPC64: {
+      case Arch::PPC64:
         ppc64_asm::DecodedInstruction di(toSmash);
         return (di.isBranch() && !di.isJmp());
-      }
     }
     not_reached();
   }();

--- a/hphp/runtime/vm/jit/recycle-tc.cpp
+++ b/hphp/runtime/vm/jit/recycle-tc.cpp
@@ -30,6 +30,8 @@
 #include "hphp/util/asm-x64.h"
 #include "hphp/util/trace.h"
 
+#include "hphp/ppc64-asm/decoded-instr-ppc64.h"
+
 #include <folly/MoveWrapper.h>
 
 namespace HPHP { namespace jit {
@@ -94,7 +96,13 @@ void clearTCMaps(TCA start, TCA end) {
   auto& catchMap = mcg->catchTraceMap();
   auto const profData = jit::profData();
   while (start < end) {
-    x64::DecodedInstruction di (start);
+#if defined(__powerpc64__)
+    ppc64_asm::DecodedInstruction di(start);
+#elif defined(__x86_64__)
+    x64::DecodedInstruction di(start);
+#else
+    not_implemented();
+#endif
     if (profData && di.isBranch()) {
       profData->clearJmpTransID(start);
     }

--- a/hphp/runtime/vm/jit/reg-alloc.cpp
+++ b/hphp/runtime/vm/jit/reg-alloc.cpp
@@ -62,12 +62,7 @@ bool loadsCell(Opcode op) {
   case CGetElem:
   case VGetElem:
   case ArrayIdx:
-    switch (arch()) {
-    case Arch::X64: return true;
-    case Arch::ARM: return true;
-    case Arch::PPC64: return true;
-    }
-    not_reached();
+    return true;
 
   default:
     return false;
@@ -115,12 +110,7 @@ PhysReg forceAlloc(const SSATmp& tmp) {
   auto opc = inst->op();
 
   auto const forceStkPtrs = [&] {
-    switch (arch()) {
-    case Arch::X64: return false;
-    case Arch::ARM: return false;
-    case Arch::PPC64: return false;
-    }
-    not_reached();
+    return false;
   }();
 
   if (forceStkPtrs && tmp.isA(TStkPtr)) {
@@ -217,12 +207,6 @@ void getEffects(const Abi& abi, const Vinstr& i,
     case Vinstr::calls:
     case Vinstr::callstub:
       defs = abi.all() - (abi.calleeSaved | rvmfp());
-
-      switch (arch()) {
-        case Arch::ARM: break;
-        case Arch::X64: break;
-        case Arch::PPC64: break;
-      }
       break;
 
     case Vinstr::callfaststub:
@@ -231,21 +215,13 @@ void getEffects(const Abi& abi, const Vinstr& i,
 
     case Vinstr::callphp:
       defs = abi.all();
-      switch (arch()) {
-        case Arch::ARM: defs -= rvmtl(); break;
-        case Arch::X64: defs -= rvmtl(); break;
-        case Arch::PPC64: defs -= rvmtl(); break;
-      }
+      defs -= rvmtl();
       break;
 
     case Vinstr::callarray:
     case Vinstr::contenter:
       defs = abi.all() - RegSet(rvmfp());
-      switch (arch()) {
-        case Arch::ARM: defs -= rvmtl(); break;
-        case Arch::X64: defs -= rvmtl(); break;
-        case Arch::PPC64: defs -= rvmtl(); break;
-      }
+      defs -= rvmtl();
       break;
 
     case Vinstr::cqo:

--- a/hphp/runtime/vm/jit/reg-alloc.cpp
+++ b/hphp/runtime/vm/jit/reg-alloc.cpp
@@ -65,7 +65,7 @@ bool loadsCell(Opcode op) {
     switch (arch()) {
     case Arch::X64: return true;
     case Arch::ARM: return true;
-    case Arch::PPC64: not_implemented(); break;
+    case Arch::PPC64: return true;
     }
     not_reached();
 
@@ -83,7 +83,7 @@ bool storesCell(const IRInstruction& inst, uint32_t srcIdx) {
   switch (arch()) {
   case Arch::X64: break;
   case Arch::ARM: break;
-  case Arch::PPC64: not_implemented(); break;
+  case Arch::PPC64: return false;
   }
 
   // If this function returns true for an operand, then the register allocator
@@ -118,7 +118,7 @@ PhysReg forceAlloc(const SSATmp& tmp) {
     switch (arch()) {
     case Arch::X64: return false;
     case Arch::ARM: return false;
-    case Arch::PPC64: not_implemented(); break;
+    case Arch::PPC64: return false;
     }
     not_reached();
   }();
@@ -221,7 +221,7 @@ void getEffects(const Abi& abi, const Vinstr& i,
       switch (arch()) {
         case Arch::ARM: break;
         case Arch::X64: break;
-        case Arch::PPC64: not_implemented(); break;
+        case Arch::PPC64: break;
       }
       break;
 
@@ -234,7 +234,7 @@ void getEffects(const Abi& abi, const Vinstr& i,
       switch (arch()) {
         case Arch::ARM: defs -= rvmtl(); break;
         case Arch::X64: defs -= rvmtl(); break;
-        case Arch::PPC64: not_implemented(); break;
+        case Arch::PPC64: defs -= rvmtl(); break;
       }
       break;
 
@@ -244,7 +244,7 @@ void getEffects(const Abi& abi, const Vinstr& i,
       switch (arch()) {
         case Arch::ARM: defs -= rvmtl(); break;
         case Arch::X64: defs -= rvmtl(); break;
-        case Arch::PPC64: not_implemented(); break;
+        case Arch::PPC64: defs -= rvmtl(); break;
       }
       break;
 

--- a/hphp/runtime/vm/jit/service-requests.cpp
+++ b/hphp/runtime/vm/jit/service-requests.cpp
@@ -228,8 +228,8 @@ size_t stub_size() {
     case Arch::ARM:
       return kTotalArgs * arm::kMovLen + arm::kLeaVmSpLen;
     case Arch::PPC64:
-    // This calculus was based on the amount of emitted instructions in
-    // emit_svcreq.
+      // This calculus was based on the amount of emitted instructions in
+      // emit_svcreq.
       return (ppc64::kStdIns + ppc64::kLeaVMSpLen) * kTotalArgs +
           ppc64::kLeaVMSpLen + 3 * ppc64::kStdIns;
   }

--- a/hphp/runtime/vm/jit/unique-stubs-ppc64.cpp
+++ b/hphp/runtime/vm/jit/unique-stubs-ppc64.cpp
@@ -232,7 +232,8 @@ TCA emitCallToExit(CodeBlock& cb, DataBlock& data, const UniqueStubs& us) {
     vwrap(cb, data, [&] (Vout& v) {
       // Not doing it directly as rret(0) == rarg(0) on ppc64
       Vreg ret_addr = v.makeReg();
-      v << lea{rsp()[ppc64_asm::exittc_position_on_frame], ret_addr};
+      // exittc address pushed on calltc/resumetc.
+      v << lea{rsp()[0], ret_addr};
 
       // We need to spill the return registers around the assert call.
       v << push{rret(0)};
@@ -246,15 +247,20 @@ TCA emitCallToExit(CodeBlock& cb, DataBlock& data, const UniqueStubs& us) {
     });
   }
 
+  // Discard the exittc address pushed on calltc/resumetc for balancing the
+  // stack next.
+  a.addi(rsp(), rsp(), 8);
+
   // Reinitialize r1 for the external code found after enterTCExit's stubret
-  a.mr(ppc64_asm::reg::r1, rsp());
+  a.addi(ppc64_asm::reg::r1, rsp(), 8);
 
   // r31 should have the same value as caller's r1. Loading it soon on stubret.
   // (this corrupts the backchain, but it's not relevant as this frame will be
   // destroyed soon)
-  a.std(ppc64_asm::reg::r1, rsp()[0]);
+  a.std(ppc64_asm::reg::r1, rsp()[8]);
 
-  // Simply go to enterTCExit
+  // Emulate a ret to enterTCExit without actually doing one to avoid
+  // unbalancing the return stack buffer.
   a.branchAuto(TCA(mcg->ustubs().enterTCExit));
   return start;
 }

--- a/hphp/runtime/vm/jit/unique-stubs-ppc64.cpp
+++ b/hphp/runtime/vm/jit/unique-stubs-ppc64.cpp
@@ -232,8 +232,9 @@ TCA emitCallToExit(CodeBlock& cb, DataBlock& data, const UniqueStubs& us) {
     vwrap(cb, data, [&] (Vout& v) {
       // Not doing it directly as rret(0) == rarg(0) on ppc64
       Vreg ret_addr = v.makeReg();
+
       // exittc address pushed on calltc/resumetc.
-      v << lea{rsp()[0], ret_addr};
+      v << copy{rsp(), ret_addr};
 
       // We need to spill the return registers around the assert call.
       v << push{rret(0)};

--- a/hphp/runtime/vm/jit/unique-stubs.cpp
+++ b/hphp/runtime/vm/jit/unique-stubs.cpp
@@ -47,8 +47,8 @@
 #include "hphp/runtime/vm/jit/stack-overflow.h"
 #include "hphp/runtime/vm/jit/translator-inline.h"
 #include "hphp/runtime/vm/jit/unique-stubs-arm.h"
-#include "hphp/runtime/vm/jit/unique-stubs-x64.h"
 #include "hphp/runtime/vm/jit/unique-stubs-ppc64.h"
+#include "hphp/runtime/vm/jit/unique-stubs-x64.h"
 #include "hphp/runtime/vm/jit/unwind-itanium.h"
 #include "hphp/runtime/vm/jit/vasm-gen.h"
 #include "hphp/runtime/vm/jit/vasm-instr.h"
@@ -823,9 +823,6 @@ TCA emitBindCallStub(CodeBlock& cb, DataBlock& data) {
     v << subqi{callLen, savedRIP, args[1], v.makeReg()};
 
     v << copy{rvmfp(), args[2]};
-    // Promote bool type argument size to long in order to avoid issues on
-    // platforms that optimization might not ignore the higher bits of the
-    // register (e.g: ppc64)
     v << movb{v.cns(immutable), args[3]};
 
     auto const handler = reinterpret_cast<void (*)()>(

--- a/hphp/runtime/vm/jit/unique-stubs.cpp
+++ b/hphp/runtime/vm/jit/unique-stubs.cpp
@@ -1150,11 +1150,11 @@ TCA emitEnterTCHelper(CodeBlock& cb, DataBlock& data, UniqueStubs& us) {
 #endif
 
   return vwrap2(cb, cb, data, [&] (Vout& v, Vout& vc) {
-    // Architecture-specific setup to enter on TC.
-    v << inittc{};
-
     // Native func prologue.
     v << stublogue{true};
+
+    // Architecture-specific setup to enter on TC.
+    v << inittc{};
 
 #if defined(__CYGWIN__) || defined(__MINGW__) || defined(_MSC_VER)
     // Windows hates argument registers.

--- a/hphp/runtime/vm/jit/unique-stubs.cpp
+++ b/hphp/runtime/vm/jit/unique-stubs.cpp
@@ -1113,8 +1113,8 @@ TCA emitEnterTCHelper(CodeBlock& cb, DataBlock& data, UniqueStubs& us) {
     // Realign the native stack.
     switch (arch()) {
       case Arch::X64:
-        v << lea{rsp()[8], rsp()};
       case Arch::PPC64:
+        v << lea{rsp()[8], rsp()};
         break;
       case Arch::ARM:
         break;
@@ -1173,8 +1173,8 @@ TCA emitEnterTCHelper(CodeBlock& cb, DataBlock& data, UniqueStubs& us) {
     // Unalign the native stack.
     switch (arch()) {
       case Arch::X64:
-        v << lea{rsp()[-8], rsp()};
       case Arch::PPC64:
+        v << lea{rsp()[-8], rsp()};
         break;
       case Arch::ARM:
         break;

--- a/hphp/runtime/vm/jit/vasm-dead.cpp
+++ b/hphp/runtime/vm/jit/vasm-dead.cpp
@@ -135,6 +135,7 @@ bool effectful(Vinstr& inst) {
     case Vinstr::movtdb:
     case Vinstr::movtdq:
     case Vinstr::movtql:
+    case Vinstr::movw:
     case Vinstr::movzbw:
     case Vinstr::movzbl:
     case Vinstr::movzbq:

--- a/hphp/runtime/vm/jit/vasm-instr.cpp
+++ b/hphp/runtime/vm/jit/vasm-instr.cpp
@@ -253,6 +253,7 @@ Width width(Vinstr::Opcode op) {
     case Vinstr::cmpwm:
     case Vinstr::testwim:
     case Vinstr::loadw:
+    case Vinstr::movw:
     case Vinstr::storew:
     case Vinstr::storewi:
       return Width::Word;

--- a/hphp/runtime/vm/jit/vasm-instr.h
+++ b/hphp/runtime/vm/jit/vasm-instr.h
@@ -227,6 +227,7 @@ struct Vunit;
   /* copies */\
   O(movb, Inone, UH(s,d), DH(d,s))\
   O(movl, Inone, UH(s,d), DH(d,s))\
+  O(movw, Inone, UH(s,d), DH(d,s))\
   O(movzbw, Inone, UH(s,d), DH(d,s))\
   O(movzbl, Inone, UH(s,d), DH(d,s))\
   O(movzbq, Inone, UH(s,d), DH(d,s))\
@@ -1028,6 +1029,7 @@ struct lead { VdataPtr<void> s; Vreg64 d; };
 // moves
 struct movb { Vreg8 s, d; };
 struct movl { Vreg32 s, d; };
+struct movw { Vreg16 s, d; };
 // zero-extended s to d
 struct movzbw { Vreg8 s; Vreg16 d; };
 struct movzbl { Vreg8 s; Vreg32 d; };

--- a/hphp/runtime/vm/jit/vasm-ppc64.cpp
+++ b/hphp/runtime/vm/jit/vasm-ppc64.cpp
@@ -708,13 +708,6 @@ void Vgen::emit(const mcprep& i) {
 }
 
 void Vgen::emit(const inittc&) {
-  // workaround for avoiding the first useless stublogue: we don't need to
-  // create a frame here. X64 needs it as only the stublogue will complete a
-  // frame.
-  // TODO(rcardoso): as pointed to us maybe there is a better way to do this
-  // instead discard stublogue first frame.
-  a.addi(rsp(), ppc64_asm::reg::r1, min_frame_size);
-
   // initialize our rone register
   a.li(ppc64::rone(), 1);
 }

--- a/hphp/runtime/vm/jit/vasm-ppc64.cpp
+++ b/hphp/runtime/vm/jit/vasm-ppc64.cpp
@@ -730,7 +730,8 @@ void Vgen::emit(const inittc&) {
 }
 
 void Vgen::emit(const leavetc&) {
-  a.ld(rAsm, rsp()[AROFF(m_savedRip)]);
+  // should read enterTCExit address that was pushed by calltc/resumetc
+  emit(pop{rAsm});
   a.mtlr(rAsm);
   a.blr();
 }
@@ -742,7 +743,7 @@ void Vgen::emit(const calltc& i) {
 
   // this will be verified by emitCallToExit
   a.li64(rAsm, reinterpret_cast<int64_t>(i.exittc), false);
-  a.std(rAsm, rsp()[ppc64_asm::exittc_position_on_frame]);
+  emit(push{rAsm});
 
   // keep the return address as initialized by the vm frame
   a.ld(rfuncln(), i.fp[AROFF(m_savedRip)]);
@@ -761,7 +762,7 @@ void Vgen::emit(const resumetc& i) {
 
   // this will be verified by emitCallToExit
   a.li64(rAsm, reinterpret_cast<int64_t>(i.exittc), false);
-  a.std(rAsm, rsp()[ppc64_asm::exittc_position_on_frame]);
+  emit(push{rAsm});
 
   // and jump. When it returns, it'll be to enterTCExit
   a.mr(ppc64_asm::reg::r12, i.target.asReg());

--- a/hphp/runtime/vm/jit/vasm-ppc64.cpp
+++ b/hphp/runtime/vm/jit/vasm-ppc64.cpp
@@ -813,19 +813,22 @@ void Vgen::emit(const callphp& i) {
 }
 
 void Vgen::emit(const callarray& i) {
-  a.call(i.target);
+  // callarray target can indeed start with stublogue, therefore reuse callstub
+  // approach
+  emit(callstub{i.target});
 }
 
 void Vgen::emit(const callstub& i) {
-  // Build a minimal call frame in order to save the LR.
+  // Build a minimal call frame in order to save the LR but avoid writing to
+  // rsp() directly as there are stubs that are called that doesn't have a
+  // stublogue/stubret (e.g: freeLocalsHelpers)
   a.addi(ppc64_asm::reg::r1, rsp(), -min_frame_size);
   a.std(rvmfp(), ppc64_asm::reg::r1[AROFF(m_sfp)]);
   a.call(i.target);
 }
 
 void Vgen::emit(const callfaststub& i) {
-  // no frame being built
-  a.call(i.target);
+  emit(callstub{i.target});
   emit(syncpoint{i.fix});
 }
 
@@ -834,11 +837,11 @@ void Vgen::emit(const callfaststub& i) {
  * Stub function ABI
  */
 void Vgen::emit(const stublogue& i) {
-  // Save a complete frame
-  if (i.saveframe) a.stdu(rvmfp(), rsp()[-min_frame_size]);
-  else a.addi(rsp(), rsp(), -min_frame_size);
+  // Recover the frame created on callstub.
+  a.mr(rsp(), ppc64_asm::reg::r1);
+  if (i.saveframe) a.std(rvmfp(), rsp()[0]);
 
-  // save return address on this frame, just like phplogue does
+  // save return address on this frame
   a.mflr(rfuncln());
   a.std(rfuncln(), rsp()[AROFF(m_savedRip)]);
 }
@@ -861,7 +864,7 @@ void Vgen::emit(const tailcallstub& i) {
   // frame and undo stublogue allocation.
   a.ld(rfuncln(), rsp()[AROFF(m_savedRip)]);
   a.mtlr(rfuncln());
-  a.addi(rsp(), rsp(), min_frame_size);
+  a.mr(ppc64_asm::reg::r1, rsp());
   emit(jmpi{i.target, i.args});
 }
 

--- a/hphp/runtime/vm/jit/vasm-ppc64.cpp
+++ b/hphp/runtime/vm/jit/vasm-ppc64.cpp
@@ -626,20 +626,13 @@ void Vgen::emit(const loadqd& i) {
   a.ld(i.d, rAsm[0]);
 }
 
-void Vgen::emit(const callstub& i) {
-  a.call(i.target);
-}
-
-void Vgen::emit(const callfaststub& i) {
-  a.call(i.target);
-  emit(syncpoint{i.fix});
-}
 void Vgen::emit(const unwind& i) {
   // skip the "ld 2,24(1)" or "nop" emitted by "Assembler::call" at the end
   TCA saved_pc = a.frontier() - call_skip_bytes_for_ret;
   catches.push_back({saved_pc, i.targets[1]});
   emit(jmp{i.targets[0]});
 }
+
 void Vgen::emit(const jmp& i) {
   if (next == i.target) return;
   jmps.push_back({a.frontier(), i.target});
@@ -647,11 +640,13 @@ void Vgen::emit(const jmp& i) {
   // offset to be determined by a.patchBranch
   a.branchAuto(a.frontier());
 }
+
 void Vgen::emit(const jmpr& i) {
   a.mr(ppc64_asm::reg::r12, i.target.asReg());
   a.mtctr(ppc64_asm::reg::r12);
   a.bctr();
 }
+
 void Vgen::emit(const jcc& i) {
   if (i.targets[1] != i.targets[0]) {
     if (next == i.targets[1]) {
@@ -710,11 +705,6 @@ void Vgen::emit(const mcprep& i) {
   smashMovq(mov_addr, (imm << 1) | 1);
 
   env.meta.addressImmediates.insert(reinterpret_cast<TCA>(~imm));
-}
-
-void Vgen::emit(const callphp& i) {
-  emitSmashableCall(a.code(), env.meta, i.stub);
-  emit(unwind{{i.targets[0], i.targets[1]}});
 }
 
 void Vgen::emit(const inittc&) {
@@ -817,8 +807,26 @@ void Vgen::emit(const calls& i) {
   emitSmashableCall(a.code(), env.meta, i.target);
 }
 
+void Vgen::emit(const callphp& i) {
+  emitSmashableCall(a.code(), env.meta, i.stub);
+  emit(unwind{{i.targets[0], i.targets[1]}});
+}
+
 void Vgen::emit(const callarray& i) {
   a.call(i.target);
+}
+
+void Vgen::emit(const callstub& i) {
+  // Build a minimal call frame in order to save the LR.
+  a.addi(ppc64_asm::reg::r1, rsp(), -min_frame_size);
+  a.std(rvmfp(), ppc64_asm::reg::r1[AROFF(m_sfp)]);
+  a.call(i.target);
+}
+
+void Vgen::emit(const callfaststub& i) {
+  // no frame being built
+  a.call(i.target);
+  emit(syncpoint{i.fix});
 }
 
 /////////////////////////////////////////////////////////////////////////////

--- a/hphp/runtime/vm/jit/vasm-xls.cpp
+++ b/hphp/runtime/vm/jit/vasm-xls.cpp
@@ -17,6 +17,7 @@
 #include "hphp/runtime/vm/jit/vasm.h"
 
 #include "hphp/runtime/base/stats.h"
+#include "hphp/runtime/vm/jit/abi-ppc64.h"
 
 #include "hphp/runtime/vm/jit/abi.h"
 #include "hphp/runtime/vm/jit/mc-generator.h"
@@ -323,7 +324,7 @@ struct VxlsContext {
         tmp = vixl::x17; // also used as tmp1 by MacroAssembler
         break;
       case Arch::PPC64:
-        not_implemented();
+        tmp = ppc64_asm::reg::v29;
         break;
     }
     this->abi.simdUnreserved -= tmp;

--- a/hphp/runtime/vm/jit/vasm-xls.cpp
+++ b/hphp/runtime/vm/jit/vasm-xls.cpp
@@ -14,10 +14,11 @@
    +----------------------------------------------------------------------+
 */
 
+#include "hphp/ppc64-asm/asm-ppc64.h"
+
 #include "hphp/runtime/vm/jit/vasm.h"
 
 #include "hphp/runtime/base/stats.h"
-#include "hphp/runtime/vm/jit/abi-ppc64.h"
 
 #include "hphp/runtime/vm/jit/abi.h"
 #include "hphp/runtime/vm/jit/mc-generator.h"

--- a/hphp/runtime/vm/jit/vasm-xls.cpp
+++ b/hphp/runtime/vm/jit/vasm-xls.cpp
@@ -14,8 +14,6 @@
    +----------------------------------------------------------------------+
 */
 
-#include "hphp/ppc64-asm/asm-ppc64.h"
-
 #include "hphp/runtime/vm/jit/vasm.h"
 
 #include "hphp/runtime/base/stats.h"
@@ -37,6 +35,8 @@
 #include "hphp/util/assertions.h"
 #include "hphp/util/dataflow-worklist.h"
 #include "hphp/util/trace.h"
+
+#include "hphp/ppc64-asm/asm-ppc64.h"
 
 #include <boost/dynamic_bitset.hpp>
 #include <boost/range/adaptor/reversed.hpp>

--- a/hphp/util/arch.h
+++ b/hphp/util/arch.h
@@ -54,8 +54,7 @@ constexpr Arch arch() {
       case Arch::ARM:                                                 \
         return arm::MSVC_GLUE(func, (__VA_ARGS__));                   \
       case Arch::PPC64:                                               \
-        not_implemented();                                            \
-        break;                                                        \
+        return ppc64::MSVC_GLUE(func, (__VA_ARGS__));                 \
     }                                                                 \
     not_reached();                                                    \
   }())


### PR DESCRIPTION
Removed the call to "not_implemented()" from the architecture switches to
be able to call the PPC64 specific code.
Some minor fixes and "includes" added as well.