### PR TITLE
Check the Phar has metadata before attempting to unserialize() it

### DIFF
--- a/hphp/system/php/archive_handler/PharArchiveHandler.ns.php
+++ b/hphp/system/php/archive_handler/PharArchiveHandler.ns.php
@@ -66,9 +66,11 @@ namespace __SystemLib {
       $alias_len = $this->bytesToInt($pos, 4);
       $this->alias = $this->substr($pos, $alias_len);
       $metadata_len = $this->bytesToInt($pos, 4);
-      $this->metadata = unserialize(
-        $this->substr($pos, $metadata_len)
-      );
+      if ($metadata_len > 0) {
+        $this->metadata = unserialize(
+          $this->substr($pos, $metadata_len)
+        );
+      }
       $this->parseFileInfo($count, $pos);
       if ($pos != $start + $len + 4) {
         throw new PharException(


### PR DESCRIPTION
Phar metadata is optional with the metadata length set to 0 if not present.  This confirms patch checks that the metadata length is greater than 0 before attempting to unserialize() it.
- https://secure.php.net/manual/en/phar.fileformat.phar.php

This is in response to the listed issue in #7178, however there are other outstanding/unrelated type checking warnings when running in PHP7 scalar mode (null instead of string).

