### PR TITLE
Fix compare double condition codes for arm64.

### DIFF
--- a/hphp/runtime/vm/jit/irlower-cmp.cpp
+++ b/hphp/runtime/vm/jit/irlower-cmp.cpp
@@ -194,12 +194,24 @@ void cgNeqDbl(IRLS& env, const IRInstruction* inst) {
  *
  * NB: This is clearly an x64-ism, and likely needs to be done differently for
  * other architectures.
+ *
+ * ARM has condition codes that test Gt, Gte, Lt, Lte without running into
+ * "unordered" ambiguity. We can just use those directly. See convertCC()
+ * in "abi-arm.h".
  */
+#if !defined(__aarch64__)
 #define CMP_DBL_OPS         \
   CDO(Gt,   CC_A,   false)  \
   CDO(Gte,  CC_AE,  false)  \
   CDO(Lt,   CC_A,   true)   \
   CDO(Lte,  CC_AE,  true)
+#else
+#define CMP_DBL_OPS         \
+  CDO(Gt,   CC_G,   false)  \
+  CDO(Gte,  CC_GE,  false)  \
+  CDO(Lt,   CC_B,   false)  \
+  CDO(Lte,  CC_BE,  false)
+#endif
 
 #define CDO(Inst, cc, invert) \
   void cg##Inst##Dbl(IRLS& env, const IRInstruction* inst) {  \


### PR DESCRIPTION
Summary:
When generating code for comparing floating points, use appropriate
condition codes for ARM to resolve ambiguity with "unordered"
comparisons.

Code generator that emits floating point comparisons for X64 uses only "A" (>) and "AE"(>=) 
condition codes. Inversion of these conditions are used to implement < and <=. This is done 
since other condition codes could be potentially set in "unordered" situation too.
 
However, ARM has condition codes that test >, >=, < and <= conditions without the 
"unordered" ambiguity. Also, the X64 approach used above leads to wrong results on ARM
since condition code conversion between X64 and ARM are not consistent across integer 
and floating point comparisons.

This PR fixes the ARM case by using CC_G, CC_GE, CC_B and CC_BE as these map to 
correct ARM conditions codes. (See ConvertCC() in abi-arm.h)