### PR TITLE
Add support to build Hack independently

### DIFF
--- a/hphp/hack/CMakeLists.txt
+++ b/hphp/hack/CMakeLists.txt
@@ -1,5 +1,7 @@
 CMAKE_MINIMUM_REQUIRED(VERSION 2.8.7 FATAL_ERROR)
 
+SET(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../CMake" ${CMAKE_MODULE_PATH})
+
 find_package(OCaml)
 find_package(LZ4)
 find_package(LibElf)


### PR DESCRIPTION
This change sets CMAKE_MODULE_PATH in hphp/hack/CMakeLists.txt. This is to allow Hack to be built independently from HHVM

Ref: hhvm/homebrew-hhvm#45