### PR TITLE
Implement cvttsd2siq with X64 semantics on ARM64

### DIFF
--- a/hphp/runtime/vm/jit/vasm-dead.cpp
+++ b/hphp/runtime/vm/jit/vasm-dead.cpp
@@ -92,6 +92,7 @@ bool effectful(Vinstr& inst) {
     case Vinstr::fcmpo:
     case Vinstr::fcmpu:
     case Vinstr::fctidz:
+    case Vinstr::fcvtzs:
     case Vinstr::imul:
     case Vinstr::incl:
     case Vinstr::incq:
@@ -140,7 +141,6 @@ bool effectful(Vinstr& inst) {
     case Vinstr::movzbq:
     case Vinstr::movzlq:
     case Vinstr::mrs:
-    case Vinstr::msr:
     case Vinstr::mulsd:
     case Vinstr::neg:
     case Vinstr::nop:
@@ -238,6 +238,7 @@ bool effectful(Vinstr& inst) {
     case Vinstr::leavetc:
     case Vinstr::loadstubret:
     case Vinstr::mcprep:
+    case Vinstr::msr:
     case Vinstr::mtlr:
     case Vinstr::mtvsrd:
     case Vinstr::nothrow:

--- a/hphp/runtime/vm/jit/vasm-instr.h
+++ b/hphp/runtime/vm/jit/vasm-instr.h
@@ -291,6 +291,7 @@ struct Vunit;
   O(cmplims, I(s0), U(s1), D(sf))\
   O(cmpsds, I(pred), UA(s0) U(s1), D(d))\
   O(fabs, Inone, U(s), D(d))\
+  O(fcvtzs, Inone, U(s), D(d))\
   O(lslwi, I(s0), UH(s1,d), DH(d,s1))\
   O(lslwis, I(s0), U(s1) U(d), D(df) D(sf))\
   O(lslxi, I(s0), UH(s1,d), DH(d,s1))\
@@ -1124,6 +1125,7 @@ struct bln {};
 struct cmplims { Immed s0; Vptr s1; VregSF sf; };
 struct cmpsds { ComparisonPred pred; VregDbl s0, s1, d; VregSF sf; };
 struct fabs { VregDbl s, d; };
+struct fcvtzs { VregDbl s; Vreg64 d;};
 struct lslwi { Immed s0; Vreg32 s1, d; };
 struct lslwis { Immed s0; Vreg32 s1, d, df; VregSF sf; };
 struct lslxi { Immed s0; Vreg64 s1, d; };

--- a/hphp/vixl/a64/constants-a64.h
+++ b/hphp/vixl/a64/constants-a64.h
@@ -262,6 +262,11 @@ enum SystemRegister {
           (0x4 << CRn_offset) |
           (0x4 << CRm_offset) |
           (0x0 << SysOp2_offset)) >> ImmSystemRegister_offset,
+  FPSR = ((0x1 << SysO0_offset) |
+          (0x3 << SysOp1_offset) |
+          (0x4 << CRn_offset) |
+          (0x4 << CRm_offset) |
+          (0x1 << SysOp2_offset)) >> ImmSystemRegister_offset,
   TPIDR_EL0 = ((0x1 << SysO0_offset) |
                (0x3 << SysOp1_offset) |
                (0xd << CRn_offset) |


### PR DESCRIPTION
Summary:
'cvttsd2siq' VASM instruction follows X64 semantics of returning
special error code upon float to int conversion errors. Follow
the same convention for ARM64.

Changes:
- Marked 'msr' instruction 'effectful' to prevent it from being optimized by DCE.
- Added encoding for FPSR in vixl.
- Added 'fcvtzs' ARM instruction to be used in 'cvttsd2siq'.
- Implemented 'cvttsd2siq' to be consistent with X64 behaviour.