### PR TITLE
ARM64: Clear cache after emitting code directly

### DIFF
--- a/hphp/runtime/vm/jit/align-arm.cpp
+++ b/hphp/runtime/vm/jit/align-arm.cpp
@@ -42,6 +42,7 @@ struct AlignImpl {
 
   static void pad(CodeBlock& cb, AlignContext context, size_t bytes) {
     vixl::MacroAssembler a { cb };
+    auto start = cb.frontier();
 
     switch (context) {
       case AlignContext::Live:
@@ -49,6 +50,7 @@ struct AlignImpl {
         for (; bytes > 0; bytes -= 4) {
           a.Nop();
         }
+        __builtin___clear_cache(start, cb.frontier());
         return;
 
       case AlignContext::Dead:
@@ -56,6 +58,7 @@ struct AlignImpl {
           a.Brk();
           bytes -= 4;
         }
+        __builtin___clear_cache(start, cb.frontier());
         if (bytes > 0) pad(cb, AlignContext::Live, bytes);
         return;
     }

--- a/hphp/runtime/vm/jit/func-guard-arm.cpp
+++ b/hphp/runtime/vm/jit/func-guard-arm.cpp
@@ -60,6 +60,7 @@ void emitFuncGuard(const Func* func, CodeBlock& cb, CGMeta& fixups) {
   vixl::MacroAssembler a { cb };
   vixl::Label after_data;
   vixl::Label target_data;
+  auto start = cb.frontier();
 
   assertx(arm::abi(CodeKind::CrossTrace).gpUnreserved.contains(vixl::x0));
 
@@ -74,6 +75,8 @@ void emitFuncGuard(const Func* func, CodeBlock& cb, CGMeta& fixups) {
   a.  bind  (&target_data);
   a.  dc64  (mcg->ustubs().funcPrologueRedispatch);
   a.  bind  (&after_data);
+
+  __builtin___clear_cache(start, cb.frontier());
 }
 
 TCA funcGuardFromPrologue(TCA prologue, const Func* func) {

--- a/hphp/runtime/vm/jit/smashable-instr-arm.cpp
+++ b/hphp/runtime/vm/jit/smashable-instr-arm.cpp
@@ -58,6 +58,7 @@ TCA emitSmashableMovq(CodeBlock& cb, CGMeta& fixups, uint64_t imm,
   a.    dc64 (imm);
   a.    bind (&after_data);
 
+  __builtin___clear_cache(start, cb.frontier());
   return start;
 }
 
@@ -88,6 +89,7 @@ TCA emitSmashableCall(CodeBlock& cb, CGMeta& fixups, TCA target) {
   a.    Ldr  (rAsm, &target_data);
   a.    Blr  (rAsm);
 
+  __builtin___clear_cache(start, cb.frontier());
   return start;
 }
 
@@ -104,6 +106,7 @@ TCA emitSmashableJmpImpl(CodeBlock& cb, TCA target) {
   a.    bind (&target_data);
   a.    dc64 (target);
 
+  __builtin___clear_cache(start, cb.frontier());
   return start;
 }
 
@@ -130,6 +133,7 @@ TCA emitSmashableJccImpl(CodeBlock& cb, TCA target, ConditionCode cc) {
   emitSmashableJmpImpl(cb, target);
   a.    bind (&after_data);
 
+  __builtin___clear_cache(start, cb.frontier());
   return start;
 }
 

--- a/hphp/runtime/vm/jit/unique-stubs-arm.cpp
+++ b/hphp/runtime/vm/jit/unique-stubs-arm.cpp
@@ -217,6 +217,8 @@ TCA emitCallToExit(CodeBlock& cb, DataBlock& data, const UniqueStubs& us) {
   a.Br(rAsm);
   a.bind(&target_data);
   a.dc64(us.enterTCExit);
+
+  __builtin___clear_cache(start, cb.frontier());
   return start;
 }
 


### PR DESCRIPTION
Summary:
Fixes https://github.com/facebook/hhvm/issues/7223
Clear cache explicitly for code that is generated directly without going through 
VASM lowering. There are very few such instances:
  - align-arm.cpp (AlignImpl::pad())
  - func-guard-arm.cpp (emitFuncGuard())
  - smashable-instr-arm.cpp (emitSmashable*())
  - unique-stubs-arm.cpp (emitCallToExit())

Testing:
Quick tests run successfully on A57 core.