### PR TITLE
Fix compiler warnings

### DIFF
--- a/hphp/neo/neo_hash.c
+++ b/hphp/neo/neo_hash.c
@@ -57,7 +57,7 @@ void ne_hash_destroy (NE_HASH **hash)
 
   my_hash = *hash;
 
-  for (x = 0; x < my_hash->size; x++)
+  for (x = 0; x < (int)my_hash->size; x++)
   {
     node = my_hash->nodes[x];
     while (node)
@@ -233,7 +233,7 @@ static NEOERR *_hash_resize(NE_HASH *hash)
   hash->size = hash->size*2;
 
   /* Initialize new parts */
-  for (x = orig_size; x < hash->size; x++)
+  for (x = orig_size; x < (int)hash->size; x++)
   {
     hash->nodes[x] = NULL;
   }
@@ -248,7 +248,7 @@ static NEOERR *_hash_resize(NE_HASH *hash)
 	 entry;
 	 entry = prev ? prev->next : hash->nodes[x])
     {
-      if ((entry->hashv & hash_mask) != x)
+      if ((int)(entry->hashv & hash_mask) != x)
       {
 	if (prev)
 	{

--- a/hphp/neo/neo_hdf.c
+++ b/hphp/neo/neo_hdf.c
@@ -270,7 +270,7 @@ static int _walk_hdf (HDF *hdf, const char *name, HDF **node)
 
   n = name;
   s = strchr (n, '.');
-  x = (s == NULL) ? strlen(n) : s - n;
+  x = (s == NULL) ? (int)strlen(n) : s - n;
 
   while (1)
   {
@@ -316,7 +316,7 @@ static int _walk_hdf (HDF *hdf, const char *name, HDF **node)
     }
     n = s + 1;
     s = strchr (n, '.');
-    x = (s == NULL) ? strlen(n) : s - n;
+    x = (s == NULL) ? (int)strlen(n) : s - n;
   }
   if (hp->link)
   {
@@ -519,7 +519,7 @@ static NEOERR* _set_value (HDF *hdf, const char *name, const char *value,
 
   n = name;
   s = strchr (n, '.');
-  x = (s != NULL) ? s - n : strlen(n);
+  x = (s != NULL) ? s - n : (int)strlen(n);
   if (x == 0)
   {
     return nerr_raise(NERR_ASSERT, "Unable to set Empty component %s", name);
@@ -692,7 +692,7 @@ skip_search:
     /* Otherwise, we need to find the next part of the namespace */
     n = s + 1;
     s = strchr (n, '.');
-    x = (s != NULL) ? s - n : strlen(n);
+    x = (s != NULL) ? s - n : (int)strlen(n);
     if (x == 0)
     {
       return nerr_raise(NERR_ASSERT, "Unable to set Empty component %s", name);
@@ -745,7 +745,7 @@ NEOERR* hdf_remove_tree (HDF *hdf, const char *name)
 
   n = name;
   s = strchr (n, '.');
-  x = (s == NULL) ? strlen(n) : s - n;
+  x = (s == NULL) ? (int)strlen(n) : s - n;
 
   while (1)
   {
@@ -772,7 +772,7 @@ NEOERR* hdf_remove_tree (HDF *hdf, const char *name)
     hp = hp->child;
     n = s + 1;
     s = strchr (n, '.');
-    x = (s == NULL) ? strlen(n) : s - n;
+    x = (s == NULL) ? (int)strlen(n) : s - n;
   }
 
   if (lp->hash != NULL)
@@ -1111,7 +1111,7 @@ static int _copy_line (const char **s, char *buf, size_t buf_len)
   int x = 0;
   const char *st = *s;
 
-  while (*st && x < buf_len-1)
+  while (*st && x < (int)buf_len-1)
   {
     buf[x++] = *st;
     if (*st++ == '\n') break;
@@ -1357,7 +1357,8 @@ static NEOERR* _hdf_read_string (HDF *hdf, const char **str, NEOSTRING *line,
           if (p == NULL) {
             char pwd[PATH_MAX];
             memset(pwd, 0, PATH_MAX);
-            getcwd(pwd, PATH_MAX);
+            if (getcwd(pwd, PATH_MAX) == NULL)
+              return nerr_raise(NERR_ASSERT, "Can't get current working dir");
             snprintf(fullpath, PATH_MAX, "%s/%s", pwd, name);
           } else {
             int dir_len = p - path + 1;


### PR DESCRIPTION
- signed vs unsigned comparison (int vs size_t)
- not using return value of getcwd.