### PR TITLE
Fix ext/soap find_encoder_by_type_name()

### DIFF
--- a/hphp/runtime/ext/soap/encoding.cpp
+++ b/hphp/runtime/ext/soap/encoding.cpp
@@ -451,9 +451,10 @@ void whiteSpace_collapse(xmlChar* str) {
 
 static encodePtr find_encoder_by_type_name(sdl *sdl, const char *type) {
   if (sdl) {
-    encodeMap::const_iterator iter = sdl->encoders.find(type);
-    if (iter != sdl->encoders.end()) {
-      return iter->second;
+    for (const auto& e : sdl->encoders) {
+      if (strcmp(e.second->details.type_str.c_str(), type) == 0) {
+        return e.second;
+      }
     }
   }
   return encodePtr();


### PR DESCRIPTION
This function is incorrectly comparing fully name spaced wsdl type names (e.g. urn:blah.thing.TypeName) to top level type names (e.g. just "TypeName").

Compare with the equivalent Zend function here: https://github.com/php/php-src/blob/master/ext/soap/php_encoding.c#L272

I'm not sure when this bug was introduced, but it seems like it's been around for a while.