### PR TITLE
Ignore changes to submodules. (They always diff anyway.)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "third-party"]
 	path = third-party
 	url = https://github.com/hhvm/hhvm-third-party.git
+	ignore = dirty


### PR DESCRIPTION
The third-party module always shows that it is dirty after doing a build; there's no point in showing that it's dirty since you would have to descend into the tree to see if you personally changed something anyway. This will also make git operations in the main project slightly faster.
