### PR TITLE
Inform vtune, gdb, and perf of additional generated code.

### DIFF
--- a/hphp/runtime/base/preg.cpp
+++ b/hphp/runtime/base/preg.cpp
@@ -746,14 +746,14 @@ pcre_get_compiled_regex_cache(PCRECache::Accessor& accessor,
       TCA end = start + size;
       std::string name = folly::sformat("HHVM::pcre_jit::{}", pattern);
 
-      if (!RuntimeOption::EvalJitNoGdb) {
+      if (!RuntimeOption::EvalJitNoGdb && jit::mcg) {
         jit::mcg->debugInfo()->recordStub(Debug::TCRange(start, end, false),
                                           name);
       }
       if (RuntimeOption::EvalJitUseVtuneAPI) {
         HPHP::jit::reportHelperToVtune(name.c_str(), start, end);
       }
-      if (RuntimeOption::EvalPerfPidMap) {
+      if (RuntimeOption::EvalPerfPidMap && jit::mcg) {
         jit::mcg->debugInfo()->recordPerfMap(Debug::TCRange(start, end, false),
                                              SrcKey{},
                                              nullptr,

--- a/hphp/runtime/base/preg.cpp
+++ b/hphp/runtime/base/preg.cpp
@@ -40,6 +40,8 @@
 #include "hphp/runtime/ext/string/ext_string.h"
 #include "hphp/runtime/vm/treadmill.h"
 #include "hphp/runtime/vm/vm-regs.h"
+#include "hphp/runtime/vm/jit/types.h"
+#include "hphp/runtime/vm/jit/vtune-jit.h"
 #include "hphp/util/logger.h"
 #include "hphp/util/concurrent-scalable-cache.h"
 
@@ -49,6 +51,8 @@
 #endif
 
 namespace HPHP {
+
+using jit::TCA;
 
 ///////////////////////////////////////////////////////////////////////////////
 // PCREglobals definition
@@ -730,6 +734,32 @@ pcre_get_compiled_regex_cache(PCRECache::Accessor& accessor,
       } catch (...) {
         pcre_free(re);
         throw;
+      }
+    }
+    if (!RuntimeOption::EvalJitNoGdb ||
+        RuntimeOption::EvalJitUseVtuneAPI ||
+        RuntimeOption::EvalPerfPidMap) {
+      unsigned int size;
+      pcre_fullinfo(re, extra, PCRE_INFO_JITSIZE, &size);
+
+      TCA start = *(TCA *)(extra->executable_jit);
+      TCA end = start + size;
+      std::string name = folly::sformat("HHVM::pcre_jit::{}", pattern);
+
+      if (!RuntimeOption::EvalJitNoGdb) {
+        jit::mcg->debugInfo()->recordStub(Debug::TCRange(start, end, false),
+                                          name);
+      }
+      if (RuntimeOption::EvalJitUseVtuneAPI) {
+        HPHP::jit::reportHelperToVtune(name.c_str(), start, end);
+      }
+      if (RuntimeOption::EvalPerfPidMap) {
+        jit::mcg->debugInfo()->recordPerfMap(Debug::TCRange(start, end, false),
+                                             SrcKey{},
+                                             nullptr,
+                                             false,
+                                             false,
+                                             name);
       }
     }
   }

--- a/hphp/runtime/vm/debug/debug.cpp
+++ b/hphp/runtime/vm/debug/debug.cpp
@@ -182,10 +182,12 @@ void DebugInfo::recordStub(TCRange range, const std::string& name) {
 }
 
 void DebugInfo::recordPerfMap(TCRange range, SrcKey sk, const Func* func,
-                              bool exit, bool inPrologue) {
+                              bool exit, bool inPrologue, std::string name) {
   if (!m_perfMap) return;
   if (RuntimeOption::EvalProfileBC) return;
-  std::string name = lookupFunction(func, exit, inPrologue, true);
+  if (name.empty()) {
+    name = lookupFunction(func, exit, inPrologue, true);
+  }
   fprintf(m_perfMap, "%lx %x %s\n",
     reinterpret_cast<uintptr_t>(range.begin()),
     range.size(),

--- a/hphp/runtime/vm/debug/debug.h
+++ b/hphp/runtime/vm/debug/debug.h
@@ -36,7 +36,7 @@ struct DebugInfo {
                       bool inPrologue);
   void recordStub(TCRange range, const std::string&);
   void recordPerfMap(TCRange range, SrcKey sk, const Func* func, bool exit,
-                     bool inPrologue);
+                     bool inPrologue, std::string stub = "");
   void recordBCInstr(TCRange range, uint32_t op);
 
   static void recordDataMap(const void* from, const void* to,

--- a/hphp/runtime/vm/jit/mc-generator.cpp
+++ b/hphp/runtime/vm/jit/mc-generator.cpp
@@ -755,6 +755,21 @@ TCA MCGenerator::getFuncBody(Func* func) {
     auto codeLock = mcg->lockCode();
     tca = genFuncBodyDispatch(func, dvs, m_code.view());
     func->setFuncBody(tca);
+    if (!RuntimeOption::EvalJitNoGdb) {
+      m_debugInfo.recordStub(
+        Debug::TCRange(tca, m_code.view().main().frontier(), false),
+        Debug::lookupFunction(func, false, false, true));
+    }
+    if (RuntimeOption::EvalJitUseVtuneAPI) {
+      reportHelperToVtune(func->fullName()->data(),
+                          tca,
+                          m_code.view().main().frontier());
+    }
+    if (RuntimeOption::EvalPerfPidMap) {
+      m_debugInfo.recordPerfMap(
+        Debug::TCRange(tca, m_code.view().main().frontier(), false),
+        SrcKey{}, func, false, false);
+    }
   } else {
     SrcKey sk(func, func->base(), false);
     tca = mcg->getTranslation(TransArgs{sk}).tca();

--- a/hphp/runtime/vm/jit/unique-stubs.cpp
+++ b/hphp/runtime/vm/jit/unique-stubs.cpp
@@ -1341,9 +1341,13 @@ void UniqueStubs::emitAll(CodeCache& code, Debug::DebugInfo& dbg) {
     return hotBlock.available() > 512 ? hotBlock : main;
   };
 
-#define ADD(name, stub) name = decltype(name)(add(#name, (stub), code, dbg))
+#define ADD(name, stub) name = add(#name, (stub), code, dbg)
   ADD(enterTCExit,   emitEnterTCExit(main, data, *this));
-  ADD(enterTCHelper, emitEnterTCHelper(main, data, *this));
+  enterTCHelper =
+    decltype(enterTCHelper)(add("enterTCHelper",
+                                emitEnterTCHelper(main, data, *this),
+                                code,
+                                dbg));
 
   // These guys are required by a number of other stubs.
   ADD(handleSRHelper, emitHandleSRHelper(cold, data));

--- a/hphp/runtime/vm/jit/vtune-jit.h
+++ b/hphp/runtime/vm/jit/vtune-jit.h
@@ -25,6 +25,9 @@ void reportTraceletToVtune(const Unit* unit,
                            const Func* func,
                            const TransRec& transRec);
 
+void reportHelperToVtune(const char *name,
+                         void *start,
+                         void *end);
 }}
 
 #endif


### PR DESCRIPTION
The unique stubs and pcre jitted code were not reported to any of the debugging or profiling tools, so addresses rather than symbolic names appeared. Now all executable addresses should be mapped to function names.
