### PR TITLE
Remove zero length entries from mb_parse_str() results array

### DIFF
--- a/hphp/runtime/ext/mbstring/ext_mbstring.cpp
+++ b/hphp/runtime/ext/mbstring/ext_mbstring.cpp
@@ -2217,7 +2217,9 @@ static mbfl_encoding* _php_mb_encoding_handler_ex
     }
     n++;
 
-    arg.set(String(var, CopyString), String(val, val_len, CopyString));
+    if (val_len > 0) {
+      arg.set(String(var, CopyString), String(val, val_len, CopyString));
+    }
 
     if (convd != nullptr) {
       mbfl_string_clear(&resvar);

--- a/hphp/test/slow/ext_mb/mb_str.php
+++ b/hphp/test/slow/ext_mb/mb_str.php
@@ -6,6 +6,8 @@ var_dump($output['first']);
 var_dump($output['arr[]']); // bug in mb_parse_str not following PHP's
 mb_parse_str('', $output);
 var_dump($output); // should be empty array, not null
+mb_parse_str('[]', $output);
+var_dump($output);
 
 $date = "04/30/1973";
 $ret = mb_split("[/.-]", $date);

--- a/hphp/test/slow/ext_mb/mb_str.php.expect
+++ b/hphp/test/slow/ext_mb/mb_str.php.expect
@@ -3,6 +3,8 @@ string(5) "value"
 string(3) "baz"
 array(0) {
 }
+array(0) {
+}
 string(2) "04"
 string(2) "30"
 string(4) "1973"


### PR DESCRIPTION
The results array from mb_parse_str() no longer includes zero length entries to better match PHP's behavior.
- https://3v4l.org/plcYb#vhhvm-3100
- Includes new test case

Closes #7247 

