### PR TITLE
setting jit prefix to be the correct width

### DIFF
--- a/hphp/runtime/vm/debug/oprof-jitdump.h
+++ b/hphp/runtime/vm/debug/oprof-jitdump.h
@@ -55,7 +55,7 @@ struct JitHeader {
   uint64_t flags;       /* flags */
 };
 
-enum class JitRecordType : uint8_t {
+enum class JitRecordType : uint32_t {
   JIT_CODE_LOAD,
   JIT_CODE_MOVE,
   JIT_CODE_DEBUG_INFO,


### PR DESCRIPTION
based on http://lxr.free-electrons.com/source/tools/perf/util/jitdump.h#L57 this field should be 32 bits, not 8, this allows more complete perf analysis