### PR TITLE
Add two cotire header exclusions

### DIFF
--- a/hphp/CMakeLists.txt
+++ b/hphp/CMakeLists.txt
@@ -53,6 +53,7 @@ if (ENABLE_COTIRE)
       "${LIBC_INCLUDE_PATH}/libelf.h"
       "${LIBC_INCLUDE_PATH}/elf.h"
       "${LIBC_INCLUDE_PATH}/gelf.h"
+      "${LIBC_INCLUDE_PATH}/resolv.h"
       "${ARCH_INCLUDE_PATH}"
       "${CCLIENT_INCLUDE_PATH}"
       "${JEMALLOC_INCLUDE_DIR}/jemalloc"
@@ -63,6 +64,13 @@ if (ENABLE_COTIRE)
       "${LIBSQLITE3_INCLUDE_DIR}/sqlite3ext.h"
       "${CMAKE_SOURCE_DIR}"
       "${CMAKE_BINARY_DIR}")
+
+  # XED headers need to be wrapped in extern "C"
+  if (LibXed_INCLUDE_DIR)
+    set_property(DIRECTORY
+      APPEND PROPERTY COTIRE_PREFIX_HEADER_IGNORE_PATH
+        "${LibXed_INCLUDE_DIR}")
+  endif()
 endif()
 
 # Only thing to do directly in tools is install this one script. Tools also has


### PR DESCRIPTION
* Exclude resolv.h from the cotire prefix header. This fixes a compile
  error in thread-local.cpp due to resolv.h defining a p_type macro,
  which conflicts with the p_type member of ElfW(Phdr). Perhaps this
  conflict is the reason why elf.h was already excluded.
* Exclude the XED headers, since they need to be wrapped with extern "C"
  and cotire doesn't do that.