### PR TITLE
Fix the jsonc link.

### DIFF
--- a/hphp/runtime/ext/json/jsonc_parser.cpp
+++ b/hphp/runtime/ext/json/jsonc_parser.cpp
@@ -261,6 +261,14 @@ bool JSON_parser(Variant &return_value, const char *data, int data_len,
     return retval;
 }
 
+void json_parser_init() {
+    // Nop
+}
+
+void json_parser_scan(IMarker& imarker) {
+    // No-op for now?
+}
+
 }
 
 #endif /* HAVE_JSONC */


### PR DESCRIPTION
cmake -DUSE_JSONC . fails to link without these symbols defined.