### PR TITLE
Allow 0 as a connection timeout.

### DIFF
--- a/hphp/runtime/server/fastcgi/fastcgi-server.cpp
+++ b/hphp/runtime/server/fastcgi/fastcgi-server.cpp
@@ -86,7 +86,7 @@ FastCGIServer::FastCGIServer(const std::string &address,
   m_socketConfig.bindAddress = sock_addr;
   m_socketConfig.acceptBacklog = RuntimeOption::ServerBacklog;
   std::chrono::seconds timeout;
-  if (RuntimeOption::ConnectionTimeoutSeconds > 0) {
+  if (RuntimeOption::ConnectionTimeoutSeconds >= 0) {
     timeout = std::chrono::seconds(RuntimeOption::ConnectionTimeoutSeconds);
   } else {
     // default to 2 minutes


### PR DESCRIPTION
Wangle interprets 0 as meaning 'no timeout,' and since we manage some arbitrarily long downloads from PHP, we would like this behavior to be expressible.

BTW, counter to the apparent intention, wangle is not actually treating this number as an _idle_ timeout, but an absolute timeout. If you set up an fcgi server with a short php program that reads /dev/urandom, echos, flush(); @ob_flush();, you will see plenty of activity on the FCGI output socket (a client program gets bytes out at line rate), but wangle will still kill the connection after the number of seconds specified here.

Without this fix, it is impossible to specify no timeout. With this fix, the above program runs forever.