### PR TITLE
Fix typo for quoted-printable-decode

### DIFF
--- a/hphp/system/php/stream/default-filters.php
+++ b/hphp/system/php/stream/default-filters.php
@@ -72,7 +72,7 @@ namespace __SystemLib {
         case 'base64-encode':
         case 'base64-decode':
         case 'quoted-printable-encode':
-        case 'quoted-printable-encode':
+        case 'quoted-printable-decode':
           $this->filterFunction = str_replace('-', '_', $filterName);
           break;
         default:


### PR DESCRIPTION
'quoted-printable-encode' was repeated, which meant 'convert.quoted-printable-decode' wasn't actually working