### PR TITLE
Fix cmp to test vasm simplication for PPC64

### DIFF
--- a/hphp/runtime/vm/jit/vasm-ppc64.cpp
+++ b/hphp/runtime/vm/jit/vasm-ppc64.cpp
@@ -1581,8 +1581,10 @@ void optimizePPC64(Vunit& unit, const Abi& abi, bool regalloc) {
   lowerForPPC64(unit);
 
   simplify(unit);
-
   optimizeCopies(unit, abi);
+
+  // 2nd lower call to affect new vasms
+  lowerForPPC64(unit);
 
   if (unit.needsRegAlloc()) {
     removeDeadCode(unit);

--- a/hphp/runtime/vm/jit/vasm-simplify.cpp
+++ b/hphp/runtime/vm/jit/vasm-simplify.cpp
@@ -282,10 +282,9 @@ bool cmp_zero_impl(Env& env, const In& inst, Reg r, Vlabel b, size_t i) {
   if (env.use_counts[inst.sf] != 1) return false;
 
   auto const suitable_use = [&]{
-    // This "cmp zero -> test" simplification is architecture specific. On
-    // PPC64, test vasms are lowered so this simplification (which is
-    // post-vasm-lower) is not desirable.
-    if (arch() == Arch::PPC64) return false;
+    // "cmp zero -> test" simplification is arch specific so it's considered an
+    // opt-in optimization.
+    if (arch() != Arch::X64) return false;
 
     auto const& code = env.unit.blocks[b].code;
     if (i + 1 >= code.size()) return false;

--- a/hphp/runtime/vm/jit/vasm-simplify.cpp
+++ b/hphp/runtime/vm/jit/vasm-simplify.cpp
@@ -282,6 +282,11 @@ bool cmp_zero_impl(Env& env, const In& inst, Reg r, Vlabel b, size_t i) {
   if (env.use_counts[inst.sf] != 1) return false;
 
   auto const suitable_use = [&]{
+    // This "cmp zero -> test" simplification is architecture specific. On
+    // PPC64, test vasms are lowered so this simplification (which is
+    // post-vasm-lower) is not desirable.
+    if (arch() == Arch::PPC64) return false;
+
     auto const& code = env.unit.blocks[b].code;
     if (i + 1 >= code.size()) return false;
     CmpUseChecker c{inst.sf};


### PR DESCRIPTION
The improvement implemented on fa442471676c9550691c28fe31c9fee2edda0a05 is
arch-specific as a test may not be better than a cmp on every arch. So it
should actually be opt-in for other archs to make use of it.

Moreover PPC64 couldn't handle the test vasm after it's lower phase, therefore
a second call to lower was added to guarantee that the vasms emitted by
simplify and optimizeCopies are actually handled by PPC64 emitter. 

No significant overhead was noticed.