### PR TITLE
Refactor relocation to support multiple architectures

### DIFF
--- a/hphp/ppc64-asm/asm-ppc64.h
+++ b/hphp/ppc64-asm/asm-ppc64.h
@@ -2152,8 +2152,12 @@ struct Assembler {
 
   void emitNop(int nbytes) {
     assert((nbytes % 4 == 0) && "This arch supports only 4 bytes alignment");
-    for (; nbytes > 0; nbytes -= 4)
-      nop();
+    for (; nbytes > 0; nbytes -= 4) nop();
+  }
+
+  void emitExceptions(int nbytes) {
+    assert((nbytes % 4 == 0) && "This arch supports only 4 bytes alignment");
+    for (; nbytes > 0; nbytes -= 4) trap();
   }
 
   // Secure high level instruction emitter

--- a/hphp/ppc64-asm/asm-ppc64.h
+++ b/hphp/ppc64-asm/asm-ppc64.h
@@ -2155,13 +2155,6 @@ struct Assembler {
     for (; nbytes > 0; nbytes -= 4) nop();
   }
 
-  /*
-   * Emit exception traps until the end of the codeblock.
-   */
-  void emitTrap() {
-    for (size_t nbytes = available(); nbytes > 0; nbytes -= 4) trap();
-  }
-
   // Secure high level instruction emitter
   void Emit(PPC64Instr instruction){
     assert(codeBlock.canEmit(sizeof(instruction)));

--- a/hphp/ppc64-asm/asm-ppc64.h
+++ b/hphp/ppc64-asm/asm-ppc64.h
@@ -2155,9 +2155,11 @@ struct Assembler {
     for (; nbytes > 0; nbytes -= 4) nop();
   }
 
-  void emitTrap(int nbytes) {
-    assert((nbytes % 4 == 0) && "This arch supports only 4 bytes alignment");
-    for (; nbytes > 0; nbytes -= 4) trap();
+  /*
+   * Emit exception traps until the end of the codeblock.
+   */
+  void emitTrap() {
+    for (size_t nbytes = available(); nbytes > 0; nbytes -= 4) trap();
   }
 
   // Secure high level instruction emitter

--- a/hphp/ppc64-asm/asm-ppc64.h
+++ b/hphp/ppc64-asm/asm-ppc64.h
@@ -2155,7 +2155,7 @@ struct Assembler {
     for (; nbytes > 0; nbytes -= 4) nop();
   }
 
-  void emitExceptions(int nbytes) {
+  void emitTrap(int nbytes) {
     assert((nbytes % 4 == 0) && "This arch supports only 4 bytes alignment");
     for (; nbytes > 0; nbytes -= 4) trap();
   }

--- a/hphp/runtime/vm/jit/relocation-arm.h
+++ b/hphp/runtime/vm/jit/relocation-arm.h
@@ -13,8 +13,9 @@
    | license@php.net so we can mail you a copy immediately.               |
    +----------------------------------------------------------------------+
 */
-#ifndef incl_HPHP_CODE_RELOCATION_ARM_H_
-#define incl_HPHP_CODE_RELOCATION_ARM_H_
+
+#ifndef incl_HPHP_RUNTIME_VM_JIT_RELOCATION_ARM_H_
+#define incl_HPHP_RUNTIME_VM_JIT_RELOCATION_ARM_H_
 
 #include "hphp/runtime/vm/jit/relocation.h"
 

--- a/hphp/runtime/vm/jit/relocation-arm.h
+++ b/hphp/runtime/vm/jit/relocation-arm.h
@@ -1,0 +1,45 @@
+/*
+   +----------------------------------------------------------------------+
+   | HipHop for PHP                                                       |
+   +----------------------------------------------------------------------+
+   | Copyright (c) 2010-2016 Facebook, Inc. (http://www.facebook.com)     |
+   +----------------------------------------------------------------------+
+   | This source file is subject to version 3.01 of the PHP license,      |
+   | that is bundled with this package in the file LICENSE, and is        |
+   | available through the world-wide-web at the following url:           |
+   | http://www.php.net/license/3_01.txt                                  |
+   | If you did not receive a copy of the PHP license and are unable to   |
+   | obtain it through the world-wide-web, please send a note to          |
+   | license@php.net so we can mail you a copy immediately.               |
+   +----------------------------------------------------------------------+
+*/
+#ifndef incl_HPHP_CODE_RELOCATION_ARM_H_
+#define incl_HPHP_CODE_RELOCATION_ARM_H_
+
+#include "hphp/runtime/vm/jit/relocation.h"
+
+namespace HPHP { namespace jit { namespace arm {
+
+void adjustForRelocation(RelocationInfo&) {
+  not_implemented();
+}
+void adjustForRelocation(RelocationInfo& rel, TCA srcStart, TCA srcEnd) {
+  not_implemented();
+}
+void adjustCodeForRelocation(RelocationInfo& rel, CGMeta& fixups) {
+  not_implemented();
+}
+void adjustMetaDataForRelocation(RelocationInfo&, AsmInfo*, CGMeta&) {
+  not_implemented();
+}
+void findFixups(TCA start, TCA end, CGMeta& fixups) {
+  not_implemented();
+}
+size_t relocate(RelocationInfo&, CodeBlock&, TCA, TCA, CGMeta&, TCA*) {
+  not_implemented();
+  return 0;
+}
+
+}}}
+
+#endif

--- a/hphp/runtime/vm/jit/relocation-ppc64.h
+++ b/hphp/runtime/vm/jit/relocation-ppc64.h
@@ -13,8 +13,9 @@
    | license@php.net so we can mail you a copy immediately.               |
    +----------------------------------------------------------------------+
 */
-#ifndef incl_HPHP_CODE_RELOCATION_PPC64_H_
-#define incl_HPHP_CODE_RELOCATION_PPC64_H_
+
+#ifndef incl_HPHP_RUNTIME_VM_JIT_RELOCATION_PPC64_H_
+#define incl_HPHP_RUNTIME_VM_JIT_RELOCATION_PPC64_H_
 
 #include "hphp/runtime/vm/jit/relocation.h"
 

--- a/hphp/runtime/vm/jit/relocation-ppc64.h
+++ b/hphp/runtime/vm/jit/relocation-ppc64.h
@@ -1,0 +1,45 @@
+/*
+   +----------------------------------------------------------------------+
+   | HipHop for PHP                                                       |
+   +----------------------------------------------------------------------+
+   | Copyright (c) 2010-2016 Facebook, Inc. (http://www.facebook.com)     |
+   +----------------------------------------------------------------------+
+   | This source file is subject to version 3.01 of the PHP license,      |
+   | that is bundled with this package in the file LICENSE, and is        |
+   | available through the world-wide-web at the following url:           |
+   | http://www.php.net/license/3_01.txt                                  |
+   | If you did not receive a copy of the PHP license and are unable to   |
+   | obtain it through the world-wide-web, please send a note to          |
+   | license@php.net so we can mail you a copy immediately.               |
+   +----------------------------------------------------------------------+
+*/
+#ifndef incl_HPHP_CODE_RELOCATION_PPC64_H_
+#define incl_HPHP_CODE_RELOCATION_PPC64_H_
+
+#include "hphp/runtime/vm/jit/relocation.h"
+
+namespace HPHP { namespace jit { namespace ppc64 {
+
+void adjustForRelocation(RelocationInfo&) {
+  not_implemented();
+}
+void adjustForRelocation(RelocationInfo& rel, TCA srcStart, TCA srcEnd) {
+  not_implemented();
+}
+void adjustCodeForRelocation(RelocationInfo& rel, CGMeta& fixups) {
+  not_implemented();
+}
+void adjustMetaDataForRelocation(RelocationInfo&, AsmInfo*, CGMeta&) {
+  not_implemented();
+}
+void findFixups(TCA start, TCA end, CGMeta& fixups) {
+  not_implemented();
+}
+size_t relocate(RelocationInfo&, CodeBlock&, TCA, TCA, CGMeta&, TCA*) {
+  not_implemented();
+  return 0;
+}
+
+}}}
+
+#endif

--- a/hphp/runtime/vm/jit/relocation-x64.h
+++ b/hphp/runtime/vm/jit/relocation-x64.h
@@ -13,12 +13,11 @@
    | license@php.net so we can mail you a copy immediately.               |
    +----------------------------------------------------------------------+
 */
-#ifndef incl_HPHP_CODE_RELOCATION_X64_H_
-#define incl_HPHP_CODE_RELOCATION_X64_H_
+
+#ifndef incl_HPHP_RUNTIME_VM_JIT_RELOCATION_X64_H_
+#define incl_HPHP_RUNTIME_VM_JIT_RELOCATION_X64_H_
 
 #include "hphp/runtime/vm/jit/relocation.h"
-
-#include "hphp/util/asm-x64.h"
 
 namespace HPHP { namespace jit { namespace x64 {
 

--- a/hphp/runtime/vm/jit/relocation-x64.h
+++ b/hphp/runtime/vm/jit/relocation-x64.h
@@ -1,0 +1,34 @@
+/*
+   +----------------------------------------------------------------------+
+   | HipHop for PHP                                                       |
+   +----------------------------------------------------------------------+
+   | Copyright (c) 2010-2016 Facebook, Inc. (http://www.facebook.com)     |
+   +----------------------------------------------------------------------+
+   | This source file is subject to version 3.01 of the PHP license,      |
+   | that is bundled with this package in the file LICENSE, and is        |
+   | available through the world-wide-web at the following url:           |
+   | http://www.php.net/license/3_01.txt                                  |
+   | If you did not receive a copy of the PHP license and are unable to   |
+   | obtain it through the world-wide-web, please send a note to          |
+   | license@php.net so we can mail you a copy immediately.               |
+   +----------------------------------------------------------------------+
+*/
+#ifndef incl_HPHP_CODE_RELOCATION_X64_H_
+#define incl_HPHP_CODE_RELOCATION_X64_H_
+
+#include "hphp/runtime/vm/jit/relocation.h"
+
+#include "hphp/util/asm-x64.h"
+
+namespace HPHP { namespace jit { namespace x64 {
+
+void adjustForRelocation(RelocationInfo&);
+void adjustForRelocation(RelocationInfo& rel, TCA srcStart, TCA srcEnd);
+void adjustCodeForRelocation(RelocationInfo& rel, CGMeta& fixups);
+void adjustMetaDataForRelocation(RelocationInfo&, AsmInfo*, CGMeta&);
+void findFixups(TCA start, TCA end, CGMeta& fixups);
+size_t relocate(RelocationInfo&, CodeBlock&, TCA, TCA, CGMeta&, TCA*);
+
+}}}
+
+#endif

--- a/hphp/runtime/vm/jit/relocation.cpp
+++ b/hphp/runtime/vm/jit/relocation.cpp
@@ -15,6 +15,8 @@
 */
 
 #include "hphp/runtime/vm/jit/relocation.h"
+#include "hphp/runtime/vm/jit/relocation-arm.h"
+#include "hphp/runtime/vm/jit/relocation-ppc64.h"
 #include "hphp/runtime/vm/jit/relocation-x64.h"
 
 #include "hphp/util/arch.h"
@@ -83,76 +85,33 @@ void RelocationInfo::rewind(TCA start, TCA end) {
 //////////////////////////////////////////////////////////////////////
 
 /*
- * Wrappers. Not using ARCH_SWITCH_CALL as not all platforms implemented
- * relocation.
+ * Wrappers.
  */
 
 void adjustForRelocation(RelocationInfo& rel) {
-  switch (arch()) {
-  case Arch::X64:
-    x64::adjustForRelocation(rel);
-    break;
-  case Arch::PPC64:
-  case Arch::ARM:
-    break;
-  }
+  return ARCH_SWITCH_CALL(adjustForRelocation, rel);
 }
 void adjustForRelocation(RelocationInfo& rel, TCA srcStart, TCA srcEnd) {
-  switch (arch()) {
-  case Arch::X64:
-    x64::adjustForRelocation(rel, srcStart, srcEnd);
-    break;
-  case Arch::PPC64:
-  case Arch::ARM:
-    break;
-  }
+  return ARCH_SWITCH_CALL(adjustForRelocation, rel, srcStart, srcEnd);
 }
 void adjustCodeForRelocation(RelocationInfo& rel, CGMeta& fixups) {
-  switch (arch()) {
-  case Arch::X64:
-    x64::adjustCodeForRelocation(rel, fixups);
-    break;
-  case Arch::PPC64:
-  case Arch::ARM:
-    break;
-  }
+  return ARCH_SWITCH_CALL(adjustCodeForRelocation, rel, fixups);
 }
 void adjustMetaDataForRelocation(RelocationInfo& rel,
                                  AsmInfo* asmInfo,
                                  CGMeta& fixups) {
-  switch (arch()) {
-  case Arch::X64:
-    x64::adjustMetaDataForRelocation(rel, asmInfo, fixups);
-    break;
-  case Arch::PPC64:
-  case Arch::ARM:
-    break;
-  }
+  return ARCH_SWITCH_CALL(adjustMetaDataForRelocation, rel, asmInfo, fixups);
 }
 void findFixups(TCA start, TCA end, CGMeta& fixups) {
-  switch (arch()) {
-  case Arch::X64:
-    x64::findFixups(start, end, fixups);
-    break;
-  case Arch::PPC64:
-  case Arch::ARM:
-    break;
-  }
+  return ARCH_SWITCH_CALL(findFixups, start, end, fixups);
 }
 size_t relocate(RelocationInfo& rel,
                 CodeBlock& destBlock,
                 TCA start, TCA end,
                 CGMeta& fixups,
                 TCA* exitAddr) {
-  switch (arch()) {
-  case Arch::X64:
-    return x64::relocate(rel, destBlock, start, end, fixups, exitAddr);
-    break;
-  case Arch::PPC64:
-  case Arch::ARM:
-    return 0;
-  }
-  not_reached();
+  return ARCH_SWITCH_CALL(relocate, rel, destBlock, start, end, fixups,
+      exitAddr);
 }
 
 //////////////////////////////////////////////////////////////////////

--- a/hphp/runtime/vm/jit/relocation.cpp
+++ b/hphp/runtime/vm/jit/relocation.cpp
@@ -15,6 +15,9 @@
 */
 
 #include "hphp/runtime/vm/jit/relocation.h"
+#include "hphp/runtime/vm/jit/relocation-x64.h"
+
+#include "hphp/util/arch.h"
 
 namespace HPHP { namespace jit {
 
@@ -76,5 +79,82 @@ void RelocationInfo::rewind(TCA start, TCA end) {
     }
   }
 }
+
+//////////////////////////////////////////////////////////////////////
+
+/*
+ * Wrappers. Not using ARCH_SWITCH_CALL as not all platforms implemented
+ * relocation.
+ */
+
+void adjustForRelocation(RelocationInfo& rel) {
+  switch (arch()) {
+  case Arch::X64:
+    x64::adjustForRelocation(rel);
+    break;
+  case Arch::PPC64:
+  case Arch::ARM:
+    break;
+  }
+}
+void adjustForRelocation(RelocationInfo& rel, TCA srcStart, TCA srcEnd) {
+  switch (arch()) {
+  case Arch::X64:
+    x64::adjustForRelocation(rel, srcStart, srcEnd);
+    break;
+  case Arch::PPC64:
+  case Arch::ARM:
+    break;
+  }
+}
+void adjustCodeForRelocation(RelocationInfo& rel, CGMeta& fixups) {
+  switch (arch()) {
+  case Arch::X64:
+    x64::adjustCodeForRelocation(rel, fixups);
+    break;
+  case Arch::PPC64:
+  case Arch::ARM:
+    break;
+  }
+}
+void adjustMetaDataForRelocation(RelocationInfo& rel,
+                                 AsmInfo* asmInfo,
+                                 CGMeta& fixups) {
+  switch (arch()) {
+  case Arch::X64:
+    x64::adjustMetaDataForRelocation(rel, asmInfo, fixups);
+    break;
+  case Arch::PPC64:
+  case Arch::ARM:
+    break;
+  }
+}
+void findFixups(TCA start, TCA end, CGMeta& fixups) {
+  switch (arch()) {
+  case Arch::X64:
+    x64::findFixups(start, end, fixups);
+    break;
+  case Arch::PPC64:
+  case Arch::ARM:
+    break;
+  }
+}
+size_t relocate(RelocationInfo& rel,
+                CodeBlock& destBlock,
+                TCA start, TCA end,
+                CGMeta& fixups,
+                TCA* exitAddr) {
+  switch (arch()) {
+  case Arch::X64:
+    return x64::relocate(rel, destBlock, start, end, fixups, exitAddr);
+    break;
+  case Arch::PPC64:
+  case Arch::ARM:
+    return 0;
+  }
+  not_reached();
+}
+
+//////////////////////////////////////////////////////////////////////
 
 }}

--- a/hphp/runtime/vm/jit/relocation.h
+++ b/hphp/runtime/vm/jit/relocation.h
@@ -66,22 +66,16 @@ struct RelocationInfo {
   std::set<TCA> addressImmediates;
 };
 
-namespace x64 {
-
+/*
+ * Wrappers
+ */
 void adjustForRelocation(RelocationInfo&);
 void adjustForRelocation(RelocationInfo& rel, TCA srcStart, TCA srcEnd);
 void adjustCodeForRelocation(RelocationInfo& rel, CGMeta& fixups);
-void adjustMetaDataForRelocation(RelocationInfo& rel,
-                                 AsmInfo* asmInfo,
-                                 CGMeta& fixups);
+void adjustMetaDataForRelocation(RelocationInfo&, AsmInfo*, CGMeta&);
 void findFixups(TCA start, TCA end, CGMeta& fixups);
-size_t relocate(RelocationInfo& rel,
-                CodeBlock& destBlock,
-                TCA start, TCA end,
-                CGMeta& fixups,
-                TCA* exitAddr);
+size_t relocate(RelocationInfo&, CodeBlock&, TCA, TCA, CGMeta&, TCA*);
 
-}}}
-
+}}
 
 #endif

--- a/hphp/runtime/vm/jit/relocation.h
+++ b/hphp/runtime/vm/jit/relocation.h
@@ -66,15 +66,18 @@ struct RelocationInfo {
   std::set<TCA> addressImmediates;
 };
 
-/*
- * Wrappers
- */
 void adjustForRelocation(RelocationInfo&);
 void adjustForRelocation(RelocationInfo& rel, TCA srcStart, TCA srcEnd);
 void adjustCodeForRelocation(RelocationInfo& rel, CGMeta& fixups);
-void adjustMetaDataForRelocation(RelocationInfo&, AsmInfo*, CGMeta&);
+void adjustMetaDataForRelocation(RelocationInfo& rel,
+                                 AsmInfo* asmInfo,
+                                 CGMeta& fixups);
 void findFixups(TCA start, TCA end, CGMeta& fixups);
-size_t relocate(RelocationInfo&, CodeBlock&, TCA, TCA, CGMeta&, TCA*);
+size_t relocate(RelocationInfo& rel,
+                CodeBlock& destBlock,
+                TCA start, TCA end,
+                CGMeta& fixups,
+                TCA* exitAddr);
 
 }}
 

--- a/hphp/runtime/vm/jit/tc-recycle.cpp
+++ b/hphp/runtime/vm/jit/tc-recycle.cpp
@@ -213,11 +213,11 @@ void reclaimTranslation(TransLoc loc) {
       switch (arch()) {
         case Arch::PPC64: {
           ppc64_asm::Assembler a{cb};
-          a.emitTrap(cb.available());
+          a.emitTrap();
         }
         case Arch::X64: {
           X64Assembler a{cb};
-          a.emitTrap(cb.available());
+          a.emitTrap();
         }
         case Arch::ARM:
           not_implemented();

--- a/hphp/runtime/vm/jit/tc-recycle.cpp
+++ b/hphp/runtime/vm/jit/tc-recycle.cpp
@@ -214,13 +214,16 @@ void reclaimTranslation(TransLoc loc) {
         case Arch::PPC64: {
           ppc64_asm::Assembler a{cb};
           a.emitTrap();
+          break;
         }
         case Arch::X64: {
           X64Assembler a{cb};
           a.emitTrap();
+          break;
         }
         case Arch::ARM:
           not_implemented();
+          break;
       }
       always_assert(!cb.available());
     };

--- a/hphp/runtime/vm/jit/tc-recycle.cpp
+++ b/hphp/runtime/vm/jit/tc-recycle.cpp
@@ -211,10 +211,12 @@ void reclaimTranslation(TransLoc loc) {
     // Ensure no one calls into the function
     ITRACE(1, "Overwriting function\n");
     auto clearBlock = [] (CodeBlock& cb) {
+      CGMeta fixups;
+      SCOPE_EXIT { assert(fixups.empty()); };
+
       DataBlock db;
-      vwrap(cb, db, [] (Vout& v) {
-        v << ud2{};
-      });
+      Vauto vasm { cb, cb, db, fixups };
+      vasm.unit().padding = true;
     };
 
     CodeBlock main, cold, frozen;

--- a/hphp/runtime/vm/jit/tc-recycle.cpp
+++ b/hphp/runtime/vm/jit/tc-recycle.cpp
@@ -213,11 +213,11 @@ void reclaimTranslation(TransLoc loc) {
       switch (arch()) {
         case Arch::PPC64: {
           ppc64_asm::Assembler a{cb};
-          a.emitExceptions(cb.available());
+          a.emitTrap(cb.available());
         }
         case Arch::X64: {
           X64Assembler a{cb};
-          a.emitExceptions(cb.available());
+          a.emitTrap(cb.available());
         }
         case Arch::ARM:
           not_implemented();

--- a/hphp/runtime/vm/jit/tc-relocate.cpp
+++ b/hphp/runtime/vm/jit/tc-relocate.cpp
@@ -93,12 +93,12 @@ struct CodeSmasher {
       switch (arch()) {
         case Arch::PPC64: {
           ppc64_asm::Assembler a{cb};
-          a.emitExceptions(cb.available());
+          a.emitTrap(cb.available());
           break;
         }
         case Arch::X64: {
           X64Assembler a{cb};
-          a.emitExceptions(cb.available());
+          a.emitTrap(cb.available());
           break;
         }
         case Arch::ARM:
@@ -543,12 +543,12 @@ bool relocateNewTranslation(TransLoc& loc, CodeCache::View cache,
       switch (arch()) {
         case Arch::PPC64: {
           ppc64_asm::Assembler a{cb};
-          a.emitExceptions(cb.available());
+          a.emitTrap(cb.available());
           break;
         }
         case Arch::X64: {
           X64Assembler a{cb};
-          a.emitExceptions(cb.available());
+          a.emitTrap(cb.available());
           break;
         }
         case Arch::ARM:

--- a/hphp/runtime/vm/jit/tc-relocate.cpp
+++ b/hphp/runtime/vm/jit/tc-relocate.cpp
@@ -93,12 +93,12 @@ struct CodeSmasher {
       switch (arch()) {
         case Arch::PPC64: {
           ppc64_asm::Assembler a{cb};
-          a.emitTrap(cb.available());
+          a.emitTrap();
           break;
         }
         case Arch::X64: {
           X64Assembler a{cb};
-          a.emitTrap(cb.available());
+          a.emitTrap();
           break;
         }
         case Arch::ARM:
@@ -543,12 +543,12 @@ bool relocateNewTranslation(TransLoc& loc, CodeCache::View cache,
       switch (arch()) {
         case Arch::PPC64: {
           ppc64_asm::Assembler a{cb};
-          a.emitTrap(cb.available());
+          a.emitTrap();
           break;
         }
         case Arch::X64: {
           X64Assembler a{cb};
-          a.emitTrap(cb.available());
+          a.emitTrap();
           break;
         }
         case Arch::ARM:

--- a/hphp/runtime/vm/jit/tc-relocate.cpp
+++ b/hphp/runtime/vm/jit/tc-relocate.cpp
@@ -34,8 +34,11 @@
 #include "hphp/tools/hfsort/jitsort.h"
 
 #include "hphp/util/arch.h"
+#include "hphp/util/asm-x64.h"
 #include "hphp/util/logger.h"
 #include "hphp/util/trace.h"
+
+#include "hphp/ppc64-asm/asm-ppc64.h"
 
 #include <algorithm>
 #include <cstdio>
@@ -87,11 +90,21 @@ struct CodeSmasher {
     for (auto& e : entries) {
       CodeBlock cb;
       cb.init(e.first, e.second - e.first, "relocated");
-      X64Assembler a { cb };
-      while (a.canEmit(2)) {
-        a.ud2();
+      switch (arch()) {
+        case Arch::PPC64: {
+          ppc64_asm::Assembler a{cb};
+          a.emitExceptions(cb.available());
+          break;
+        }
+        case Arch::X64: {
+          X64Assembler a{cb};
+          a.emitExceptions(cb.available());
+          break;
+        }
+        case Arch::ARM:
+          not_implemented();
+          break;
       }
-      if (a.canEmit(1)) a.int3();
     }
     okToRelocate = true;
   }
@@ -110,7 +123,7 @@ void postProcess(TransRelocInfo&& tri, void* paramPtr) {
   auto relocMap = param.relocMap;
 
   if (!rel.adjustedAddressAfter(tri.start)) {
-    x64::adjustForRelocation(rel, tri.start, tri.end);
+    adjustForRelocation(rel, tri.start, tri.end);
     auto coldStart = tri.coldStart;
     if (&code().blockFor(coldStart) == &code().frozen()) {
       /*
@@ -122,12 +135,12 @@ void postProcess(TransRelocInfo&& tri, void* paramPtr) {
        */
       auto it = deadStubs.lower_bound(tri.coldStart);
       while (it != deadStubs.end() && *it < tri.coldEnd) {
-        x64::adjustForRelocation(rel, coldStart, *it);
+        adjustForRelocation(rel, coldStart, *it);
         coldStart = *it + svcreq::stub_size();
         ++it;
       }
     }
-    x64::adjustForRelocation(rel, coldStart, tri.coldEnd);
+    adjustForRelocation(rel, coldStart, tri.coldEnd);
   }
   auto adjustAfter = [&rel](TCA& addr) {
     if (auto adj = rel.adjustedAddressAfter(addr)) addr = adj;
@@ -146,7 +159,7 @@ void postProcess(TransRelocInfo&& tri, void* paramPtr) {
       ib.adjust(adjusted);
     }
   }
-  x64::adjustMetaDataForRelocation(rel, nullptr, tri.fixups);
+  adjustMetaDataForRelocation(rel, nullptr, tri.fixups);
 
   auto data = perfRelocMapInfo(
     tri.start, tri.end,
@@ -232,7 +245,7 @@ void relocateStubs(TransLoc& loc, TCA frozenStart, TCA frozenEnd,
 
     CodeBlock dest;
     dest.init(cache.frozen().frontier(), stubSize, "New Stub");
-    x64::relocate(rel, dest, addr, addr + stubSize, fixups, nullptr);
+    relocate(rel, dest, addr, addr + stubSize, fixups, nullptr);
     cache.frozen().skip(stubSize);
     if (addr != frozenStart) {
       rel.recordRange(frozenStart, addr, frozenStart, addr);
@@ -243,9 +256,9 @@ void relocateStubs(TransLoc& loc, TCA frozenStart, TCA frozenEnd,
     rel.recordRange(frozenStart, frozenEnd, frozenStart, frozenEnd);
   }
 
-  x64::adjustForRelocation(rel);
-  x64::adjustMetaDataForRelocation(rel, nullptr, fixups);
-  x64::adjustCodeForRelocation(rel, fixups);
+  adjustForRelocation(rel);
+  adjustMetaDataForRelocation(rel, nullptr, fixups);
+  adjustCodeForRelocation(rel, fixups);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -285,7 +298,7 @@ void readRelocations(
       TransRelocInfo tri(trih.toTRI(code()));
       tri.start = reinterpret_cast<TCA>(addr);
       tri.end = reinterpret_cast<TCA>(end);
-      x64::findFixups(tri.start, tri.end, tri.fixups);
+      findFixups(tri.start, tri.end, tri.fixups);
 
       callback(std::move(tri), data);
     }
@@ -327,7 +340,7 @@ void relocate(std::vector<TransRelocInfo>& relocs, CodeBlock& dest,
     if (ignoreEntry(reloc.sk)) continue;
     auto start DEBUG_ONLY = dest.frontier();
     try {
-      x64::relocate(rel, dest,
+      relocate(rel, dest,
                     reloc.start, reloc.end, reloc.fixups, nullptr);
     } catch (const DataBlockFull& dbf) {
       break;
@@ -342,11 +355,11 @@ void relocate(std::vector<TransRelocInfo>& relocs, CodeBlock& dest,
   swap_trick(fixups.alignments);
   assert(fixups.empty());
 
-  x64::adjustForRelocation(rel);
+  adjustForRelocation(rel);
 
   for (size_t i = 0; i < num; i++) {
     if (!ignoreEntry(relocs[i].sk)) {
-      x64::adjustMetaDataForRelocation(rel, nullptr, relocs[i].fixups);
+      adjustMetaDataForRelocation(rel, nullptr, relocs[i].fixups);
     }
   }
 
@@ -378,12 +391,12 @@ void relocate(std::vector<TransRelocInfo>& relocs, CodeBlock& dest,
     if (!reloc.sk.valid()) continue;
     auto f = const_cast<Func*>(reloc.sk.func());
 
-    x64::adjustCodeForRelocation(rel, reloc.fixups);
+    adjustCodeForRelocation(rel, reloc.fixups);
     reloc.fixups.clear();
 
     // fixup code references in the corresponding cold block to point
     // to the new code
-    x64::adjustForRelocation(rel, reloc.coldStart, reloc.coldEnd);
+    adjustForRelocation(rel, reloc.coldStart, reloc.coldEnd);
 
     if (visitedFuncs.insert(f).second) {
       if (auto adjusted = rel.adjustedAddressAfter(f->getFuncBody())) {
@@ -419,7 +432,7 @@ void relocate(std::vector<TransRelocInfo>& relocs, CodeBlock& dest,
     always_assert(!rel.adjustedAddressAfter(stub));
     fprintf(newRelocMap, "%" PRIxPTR " 0 %s\n", uintptr_t(stub), "NewStub");
   }
-  x64::adjustCodeForRelocation(rel, fixups);
+  adjustCodeForRelocation(rel, fixups);
 
   unlink(Debug::DebugInfo::Get()->getRelocMapName().c_str());
   rename(newRelocMapName.c_str(),
@@ -467,7 +480,7 @@ bool relocateNewTranslation(TransLoc& loc, CodeCache::View cache,
     mainSize += pad;
 
     dest.init(mainStartRel, mainSize, "New Main");
-    asm_count += x64::relocate(rel, dest, mainStart, loc.mainEnd(),
+    asm_count += relocate(rel, dest, mainStart, loc.mainEnd(),
                                fixups, nullptr);
     mainEndRel = dest.frontier();
 
@@ -481,7 +494,7 @@ bool relocateNewTranslation(TransLoc& loc, CodeCache::View cache,
     frozenSize += pad;
 
     dest.init(frozenStartRel + sizeof(uint32_t), frozenSize, "New Frozen");
-    asm_count += x64::relocate(rel, dest, frozenStart, loc.frozenEnd(),
+    asm_count += relocate(rel, dest, frozenStart, loc.frozenEnd(),
                                fixups, nullptr);
     frozenEndRel = dest.frontier();
 
@@ -496,7 +509,7 @@ bool relocateNewTranslation(TransLoc& loc, CodeCache::View cache,
       coldSize += pad;
 
       dest.init(coldStartRel + sizeof(uint32_t), coldSize, "New Cold");
-      asm_count += x64::relocate(rel, dest, coldStart, loc.coldEnd(),
+      asm_count += relocate(rel, dest, coldStart, loc.coldEnd(),
                                  fixups, nullptr);
       coldEndRel = dest.frontier();
 
@@ -518,18 +531,30 @@ bool relocateNewTranslation(TransLoc& loc, CodeCache::View cache,
   }
 
   if (asm_count) {
-    x64::adjustForRelocation(rel);
-    x64::adjustMetaDataForRelocation(rel, nullptr, fixups);
-    x64::adjustCodeForRelocation(rel, fixups);
+    adjustForRelocation(rel);
+    adjustMetaDataForRelocation(rel, nullptr, fixups);
+    adjustCodeForRelocation(rel, fixups);
   }
 
   if (debug) {
     auto clearRange = [](TCA start, TCA end) {
       CodeBlock cb;
       cb.init(start, end - start, "Dead code");
-      X64Assembler a {cb};
-      while (cb.available() >= 2) a.ud2();
-      if (cb.available() > 0) a.int3();
+      switch (arch()) {
+        case Arch::PPC64: {
+          ppc64_asm::Assembler a{cb};
+          a.emitExceptions(cb.available());
+          break;
+        }
+        case Arch::X64: {
+          X64Assembler a{cb};
+          a.emitExceptions(cb.available());
+          break;
+        }
+        case Arch::ARM:
+          not_implemented();
+          break;
+      }
       always_assert(!cb.available());
     };
 
@@ -579,10 +604,8 @@ void liveRelocate(int time) {
   case Arch::X64:
     break;
   case Arch::ARM:
-    // Relocation is not supported on arm.
-    return;
   case Arch::PPC64:
-    // Relocation is not implemented on ppc64.
+    // Relocation is not supported on arm nor on ppc64.
     return;
   }
 
@@ -720,10 +743,10 @@ void relocateTranslation(
   RelocationInfo rel;
   size_t asm_count{0};
 
-  asm_count += x64::relocate(rel, main_in,
+  asm_count += relocate(rel, main_in,
                              main.base(), main.frontier(),
                              meta, nullptr);
-  asm_count += x64::relocate(rel, cold_in,
+  asm_count += relocate(rel, cold_in,
                              cold.base(), cold.frontier(),
                              meta, nullptr);
 
@@ -733,9 +756,9 @@ void relocateTranslation(
     rel.recordRange(frozen_start, frozen.frontier(),
                     frozen_start, frozen.frontier());
   }
-  x64::adjustForRelocation(rel);
-  x64::adjustMetaDataForRelocation(rel, ai, meta);
-  x64::adjustCodeForRelocation(rel, meta);
+  adjustForRelocation(rel);
+  adjustMetaDataForRelocation(rel, ai, meta);
+  adjustCodeForRelocation(rel, meta);
 
   if (ai) {
     static int64_t mainDeltaTotal = 0, coldDeltaTotal = 0;

--- a/hphp/runtime/vm/jit/tc-relocate.cpp
+++ b/hphp/runtime/vm/jit/tc-relocate.cpp
@@ -341,7 +341,7 @@ void relocate(std::vector<TransRelocInfo>& relocs, CodeBlock& dest,
     auto start DEBUG_ONLY = dest.frontier();
     try {
       relocate(rel, dest,
-                    reloc.start, reloc.end, reloc.fixups, nullptr);
+               reloc.start, reloc.end, reloc.fixups, nullptr);
     } catch (const DataBlockFull& dbf) {
       break;
     }
@@ -744,11 +744,11 @@ void relocateTranslation(
   size_t asm_count{0};
 
   asm_count += relocate(rel, main_in,
-                             main.base(), main.frontier(),
-                             meta, nullptr);
+                        main.base(), main.frontier(),
+                        meta, nullptr);
   asm_count += relocate(rel, cold_in,
-                             cold.base(), cold.frontier(),
-                             meta, nullptr);
+                        cold.base(), cold.frontier(),
+                        meta, nullptr);
 
   TRACE(1, "asm %ld\n", asm_count);
 

--- a/hphp/runtime/vm/jit/vasm-gen.cpp
+++ b/hphp/runtime/vm/jit/vasm-gen.cpp
@@ -105,6 +105,24 @@ Vauto::~Vauto() {
       return;
     }
   }
+
+  if (unit().padding) {
+    // Force emission due to padding
+    if (!main().closed()) main() << fallthru{};
+    if (!cold().closed()) cold() << fallthru{};
+
+    switch (arch()) {
+      case Arch::X64:
+        emitX64(unit(), m_text, m_fixups, nullptr);
+        break;
+      case Arch::ARM:
+        emitARM(unit(), m_text, m_fixups, nullptr);
+        break;
+      case Arch::PPC64:
+        emitPPC64(unit(), m_text, m_fixups, nullptr);
+        break;
+    }
+  }
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/hphp/util/asm-x64.h
+++ b/hphp/util/asm-x64.h
@@ -1206,14 +1206,6 @@ public:
   }
 
   /*
-   * Emit exception traps until the end of the codeblock.
-   */
-  void emitTrap() {
-    while (available() >= 2) ud2();
-    if (available() > 0) int3();
-  }
-
-  /*
    * Low-level emitter functions.
    *
    * These functions are the core of the assembler, and can also be

--- a/hphp/util/asm-x64.h
+++ b/hphp/util/asm-x64.h
@@ -1205,7 +1205,7 @@ public:
     bytes(n, nops[n]);
   }
 
-  void emitExceptions(int n) {
+  void emitTrap(int n) {
     while (canEmit(2)) ud2();
     if (n > 0) int3();
   }

--- a/hphp/util/asm-x64.h
+++ b/hphp/util/asm-x64.h
@@ -1205,9 +1205,12 @@ public:
     bytes(n, nops[n]);
   }
 
-  void emitTrap(int n) {
-    while (canEmit(2)) ud2();
-    if (n > 0) int3();
+  /*
+   * Emit exception traps until the end of the codeblock.
+   */
+  void emitTrap() {
+    while (available() >= 2) ud2();
+    if (available() > 0) int3();
   }
 
   /*

--- a/hphp/util/asm-x64.h
+++ b/hphp/util/asm-x64.h
@@ -1205,6 +1205,11 @@ public:
     bytes(n, nops[n]);
   }
 
+  void emitExceptions(int n) {
+    while (canEmit(2)) ud2();
+    if (n > 0) int3();
+  }
+
   /*
    * Low-level emitter functions.
    *


### PR DESCRIPTION
Took a similar approach as smashable, but avoided ARCH_SWITCH_CALL as
this feature may not be implemented by all architectures.