### PR TITLE
Fix relocation adjustment when a stub is reused

### DIFF
--- a/hphp/runtime/vm/jit/relocation.cpp
+++ b/hphp/runtime/vm/jit/relocation.cpp
@@ -672,6 +672,16 @@ void relocateTranslation(
     rel.recordRange(frozen_start, frozen.frontier(),
                     frozen_start, frozen.frontier());
   }
+
+  // Add reused stubs to the list, if not already there, as it may be used by
+  // service-request's emit_ephemeral and it would not be tracked for
+  // adjustment.
+  for (auto& stub : meta.reusedStubs) {
+    if (nullptr == rel.adjustedAddressAfter(stub)) {
+      auto const stub_end = stub + svcreq::stub_size();
+      rel.recordRange(stub, stub_end, stub, stub_end);
+    }
+  }
   x64::adjustForRelocation(rel);
   x64::adjustMetaDataForRelocation(rel, ai, meta);
   x64::adjustCodeForRelocation(rel, meta);


### PR DESCRIPTION
Service-request's emit_ephemeral can emit code by reusing stub and as
nothing new is emitted on main, cold or frozen, it would not be tracked
for adjustment.