### PR TITLE
[PPC64] Fix segfault when using ActRec

### DIFF
--- a/hphp/util/portability.h
+++ b/hphp/util/portability.h
@@ -162,7 +162,7 @@
 #  error Clang implementation not done for PPC64
 # endif
 # define DECLARE_FRAME_POINTER(fp) \
-  auto const fp = (ActRec*) __builtin_frame_address(0)
+  auto const fp = ((ActRec*) __builtin_frame_address(0))->m_sfp
 # define FRAME_POINTER_IS_ACCURATE
 
 #else


### PR DESCRIPTION
As PPC64 has one frame closed in advance, the builtin function returns the
current frame when the one being searched is the previous, which is the
first after the last VM frame.