### PR TITLE
Implement pad() function in vasm-arm.cpp

### DIFF
--- a/hphp/runtime/vm/jit/vasm-arm.cpp
+++ b/hphp/runtime/vm/jit/vasm-arm.cpp
@@ -139,7 +139,12 @@ struct Vgen {
   }
 
   static void patch(Venv& env);
-  static void pad(CodeBlock& cb) {}
+
+  static void pad(CodeBlock& cb) {
+    vixl::MacroAssembler a { cb };
+    while (cb.available() >= 4) a.Brk(1);
+    assertx(cb.available() == 0);
+  }
 
   /////////////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
Summary:
Replaced the dummy pad() function in vasm-arm.cpp with actual
instruction padding.
Thanks to mxw for pointing this out!

Fixes: 
https://github.com/facebook/hhvm/issues/7282

Testing:
Ran quick tests with debug/non-debug builds. No new failure
seen. OSS wordpress now runs successfully.
