### PR TITLE
[AArch64] Fixes the load in the implementation of cmpbm.

### DIFF
--- a/hphp/runtime/vm/jit/vasm-arm.cpp
+++ b/hphp/runtime/vm/jit/vasm-arm.cpp
@@ -1403,7 +1403,7 @@ void lower(Vunit& u, vasm_opc& i, Vlabel b, size_t z) { \
   });                                                   \
 }
 
-Y(cmpbm, movzbl, loadb, cmpl)
+Y(cmpbm, movzbl, loadzbl, cmpl)
 Y(cmpwm, uxth, loadw, cmpl)
 
 #undef Y


### PR DESCRIPTION
The needs to zero out the upper 3 bytes of the load before the
comparison.

Fixes:
  Nearly all OSS tests.