### PR TITLE
[AArch64] Favors use of toInt64(double) helper routine.

### DIFF
--- a/hphp/runtime/base/array-util.cpp
+++ b/hphp/runtime/base/array-util.cpp
@@ -215,7 +215,7 @@ Variant ArrayUtil::Range(double low, double high, int64_t step /* = 1 */) {
     }
     rangeCheckAlloc((low - high) / step);
     for (; low >= high; low -= step) {
-      ret.append((int64_t)low);
+      ret.append(toInt64(low));
     }
   } else if (high > low) { // Positive steps
     if (high - low < step || step <= 0) {
@@ -224,10 +224,10 @@ Variant ArrayUtil::Range(double low, double high, int64_t step /* = 1 */) {
     }
     rangeCheckAlloc((high - low) / step);
     for (; low <= high; low += step) {
-      ret.append((int64_t)low);
+      ret.append(toInt64(low));
     }
   } else {
-    ret.append((int64_t)low);
+    ret.append(toInt64(low));
   }
   return ret;
 }

--- a/hphp/runtime/ext/array/ext_array.cpp
+++ b/hphp/runtime/ext/array/ext_array.cpp
@@ -1613,7 +1613,7 @@ TypedValue HHVM_FUNCTION(range,
         return tvReturn(ArrayUtil::Range(d1, d2, dstep));
       }
 
-      int64_t lstep = (int64_t) dstep;
+      int64_t lstep = toInt64(dstep);
       if (type1 == KindOfInt64 || type2 == KindOfInt64) {
         if (type1 != KindOfInt64) n1 = slow.toInt64();
         if (type2 != KindOfInt64) n2 = shigh.toInt64();
@@ -1629,7 +1629,7 @@ TypedValue HHVM_FUNCTION(range,
     return tvReturn(ArrayUtil::Range(low.toDouble(), high.toDouble(), dstep));
   }
 
-  int64_t lstep = (int64_t) dstep;
+  int64_t lstep = toInt64(dstep);
   return tvReturn(ArrayUtil::Range(low.toDouble(), high.toDouble(), lstep));
 }
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
The behavior when casting doubles with values of min/max uint64_t
is unspecified and therefore can vary amongst architectures.
toInt64(double) in type-conversion.h avoids this problem.

Fixes test/slow/ext_array/1766.php