### PR TITLE
Properly re-attaches the LightProcess signal action after exec.

### DIFF
--- a/hphp/runtime/ext/std/ext_std_process.cpp
+++ b/hphp/runtime/ext/std/ext_std_process.cpp
@@ -193,7 +193,7 @@ struct ShellExecContext final {
     // saving the previous signal action.
     struct sigaction sa = {};
     sa.sa_handler = SIG_DFL;
-    if (sigaction(SIGCHLD, &sa, &old_sa) != 0) {
+    if (sigaction(SIGCHLD, &sa, &m_old_sa) != 0) {
       Logger::Error("Couldn't install SIGCHLD handler");
       abort();
     }
@@ -207,8 +207,8 @@ struct ShellExecContext final {
       LightProcess::pclose(m_proc);
 #endif
     }
-    if (old_sa.sa_handler != SIG_DFL) {
-      if (sigaction(SIGCHLD, &old_sa, nullptr) != 0) {
+    if (m_old_sa.sa_handler != SIG_DFL) {
+      if (sigaction(SIGCHLD, &m_old_sa, nullptr) != 0) {
         Logger::Error("Couldn't restore SIGCHLD handler");
         abort();
       }
@@ -250,7 +250,7 @@ struct ShellExecContext final {
   }
 
 private:
-  struct sigaction old_sa = {};
+  struct sigaction m_old_sa = {};
   FILE *m_proc{nullptr};
 };
 

--- a/hphp/runtime/ext/std/ext_std_process.cpp
+++ b/hphp/runtime/ext/std/ext_std_process.cpp
@@ -189,6 +189,8 @@ namespace {
 
 struct ShellExecContext final {
   ShellExecContext() {
+    // Use the default handler while exec'ing in a shell,
+    // saving the previous signal action.
     m_sig_handler = signal(SIGCHLD, SIG_DFL);
   }
 
@@ -201,7 +203,13 @@ struct ShellExecContext final {
 #endif
     }
     if (m_sig_handler) {
-      signal(SIGCHLD, m_sig_handler);
+      // If we saved the previous signal action, then re-attach it now.
+      // Note: We're using LightProcess::AttachHandler() for this since
+      //       instead of the the signal(SIGCHLD, m_sig_handler) that's
+      //       typically seen in example code because we're re-attaching
+      //       a signal action and not a simple signal handler, and the
+      //       latter approach only supports simple signal handlers.
+      LightProcess::AttachHandler();
     }
   }
 

--- a/hphp/runtime/ext/std/ext_std_process.cpp
+++ b/hphp/runtime/ext/std/ext_std_process.cpp
@@ -209,7 +209,7 @@ struct ShellExecContext final {
       //       typically seen in example code because we're re-attaching
       //       a signal action and not a simple signal handler, and the
       //       latter approach only supports simple signal handlers.
-      LightProcess::AttachHandler();
+      LightProcess::AttachHandler(m_sig_handler);
     }
   }
 

--- a/hphp/util/light-process.cpp
+++ b/hphp/util/light-process.cpp
@@ -436,12 +436,12 @@ void LightProcess::SigChldHandler(int sig, siginfo_t* info, void* ctx) {
   }
 }
 
-void LightProcess::AttachHandler(sighandler_t sighandler)
-{
-  if (sighandler) {
-    always_assert_flog(sighandler == (sighandler_t)&SigChldHandler,
-        "Trying to re-attach a sighandler other than SigChldHandler: `{}'",
-        sighandler);
+void LightProcess::AttachHandler(sighandler_t saved) {
+  // If re-attaching the handler after another handler was temporarily
+  // attached, then ensure that the original saved handler is the same.
+  if (saved) {
+    always_assert((saved == (sighandler_t)&SigChldHandler) &&
+        "Trying to re-attach a sighandler other than SigChldHandler.");
   }
 
   struct sigaction sa = {};

--- a/hphp/util/light-process.cpp
+++ b/hphp/util/light-process.cpp
@@ -439,7 +439,7 @@ void LightProcess::SigChldHandler(int sig, siginfo_t* info, void* ctx) {
 void LightProcess::AttachHandler(sighandler_t sighandler)
 {
   if (sighandler) {
-    always_assert_flog((void*)sighandler == (void*)&SigChldHandler,
+    always_assert_flog(sighandler == (sighandler_t)&SigChldHandler,
         "Trying to re-attach a sighandler other than SigChldHandler: `{}'",
         sighandler);
   }

--- a/hphp/util/light-process.cpp
+++ b/hphp/util/light-process.cpp
@@ -654,7 +654,8 @@ void LightProcess::closeShadow() {
       handleException("closeShadow");
     }
     // removes the "zombie" process, so not to interfere with later waits
-    ::waitpid(m_shadowProcess, nullptr, 0);
+    int status;
+    ::waitpid(m_shadowProcess, &status, 0);
     m_shadowProcess = 0;
   }
   closeFiles();

--- a/hphp/util/light-process.h
+++ b/hphp/util/light-process.h
@@ -45,6 +45,7 @@ struct LightProcess {
 
   static void Close();
   static bool Available();
+  static void AttachHandler();
   static void Initialize(const std::string &prefix, int count,
                          bool trackProcessTimes,
                          const std::vector<int> &inherited_fds);

--- a/hphp/util/light-process.h
+++ b/hphp/util/light-process.h
@@ -45,7 +45,7 @@ struct LightProcess {
 
   static void Close();
   static bool Available();
-  static void AttachHandler();
+  static void AttachHandler(sighandler_t sighandler);
   static void Initialize(const std::string &prefix, int count,
                          bool trackProcessTimes,
                          const std::vector<int> &inherited_fds);

--- a/hphp/util/light-process.h
+++ b/hphp/util/light-process.h
@@ -45,7 +45,7 @@ struct LightProcess {
 
   static void Close();
   static bool Available();
-  static void AttachHandler(sighandler_t sighandler);
+  static void AttachHandler(sighandler_t saved);
   static void Initialize(const std::string &prefix, int count,
                          bool trackProcessTimes,
                          const std::vector<int> &inherited_fds);

--- a/hphp/util/light-process.h
+++ b/hphp/util/light-process.h
@@ -45,7 +45,6 @@ struct LightProcess {
 
   static void Close();
   static bool Available();
-  static void AttachHandler(sighandler_t saved);
   static void Initialize(const std::string &prefix, int count,
                          bool trackProcessTimes,
                          const std::vector<int> &inherited_fds);


### PR DESCRIPTION
LightProcess registers a sig action handler with sigaction(), and therefore it must be restored through sigaction in the destructor of ShellExecContext. This patch implements that as well as
updating ShellExecContext to use sigaction when it registers the default signal handler in the contructor.

All platforms were affected by this bug to the effect of LightProcess::SigChldHandler() was being called with only one argument and trash in the other two.

Fixes test/slow/ext_process/lwp.php for AArch64.
