### PR TITLE
[AArch64] Syncs I$ after vasm patching and padding.

### DIFF
--- a/hphp/runtime/vm/jit/vasm-arm.cpp
+++ b/hphp/runtime/vm/jit/vasm-arm.cpp
@@ -142,8 +142,11 @@ struct Vgen {
 
   static void pad(CodeBlock& cb) {
     vixl::MacroAssembler a { cb };
+    auto const begin = reinterpret_cast<char*>(cb.frontier());
     while (cb.available() >= 4) a.Brk(1);
     assertx(cb.available() == 0);
+    auto const end = reinterpret_cast<char*>(cb.frontier());
+    __builtin___clear_cache(begin, end);
   }
 
   /////////////////////////////////////////////////////////////////////////////
@@ -349,11 +352,17 @@ void Vgen::patch(Venv& env) {
     assertx(env.addrs[p.target]);
     // 'jmp' is 2 instructions, load followed by branch
     *reinterpret_cast<TCA*>(p.instr + 2 * 4) = env.addrs[p.target];
+    auto const begin = reinterpret_cast<char*>(p.instr + 2 * 4);
+    auto const end = begin + sizeof(env.addrs[p.target]);
+    __builtin___clear_cache(begin, end);
   }
   for (auto& p : env.jccs) {
     assertx(env.addrs[p.target]);
     // 'jcc' is 3 instructions, b.!cc + load followed by branch
     *reinterpret_cast<TCA*>(p.instr + 3 * 4) = env.addrs[p.target];
+    auto const begin = reinterpret_cast<char*>(p.instr + 3 * 4);
+    auto const end = begin + sizeof(env.addrs[p.target]);
+    __builtin___clear_cache(begin, end);
   }
 }
 

--- a/hphp/runtime/vm/jit/vasm-arm.cpp
+++ b/hphp/runtime/vm/jit/vasm-arm.cpp
@@ -351,17 +351,17 @@ void Vgen::patch(Venv& env) {
   for (auto& p : env.jmps) {
     assertx(env.addrs[p.target]);
     // 'jmp' is 2 instructions, load followed by branch
-    *reinterpret_cast<TCA*>(p.instr + 2 * 4) = env.addrs[p.target];
     auto const begin = reinterpret_cast<char*>(p.instr + 2 * 4);
     auto const end = begin + sizeof(env.addrs[p.target]);
+    *reinterpret_cast<TCA*>(begin) = env.addrs[p.target];
     __builtin___clear_cache(begin, end);
   }
   for (auto& p : env.jccs) {
     assertx(env.addrs[p.target]);
     // 'jcc' is 3 instructions, b.!cc + load followed by branch
-    *reinterpret_cast<TCA*>(p.instr + 3 * 4) = env.addrs[p.target];
     auto const begin = reinterpret_cast<char*>(p.instr + 3 * 4);
     auto const end = begin + sizeof(env.addrs[p.target]);
+    *reinterpret_cast<TCA*>(begin) = env.addrs[p.target];
     __builtin___clear_cache(begin, end);
   }
 }


### PR DESCRIPTION
Previous patches that synced the I$ missed these two places which
also modify the translation cache. Similar to previous patches,
modifications were not caught by the Vgen destructor. This changes
increases the stability of OSS, particularly when using concurrent
jit.