### PR TITLE
Fix cdecl warnings on PPC64

### DIFF
--- a/hphp/runtime/vm/jit/vtune/ittnotify_config.h
+++ b/hphp/runtime/vm/jit/vtune/ittnotify_config.h
@@ -90,7 +90,8 @@
 #  if ITT_PLATFORM==ITT_PLATFORM_WIN
 #    define CDECL __cdecl
 #  else /* ITT_PLATFORM==ITT_PLATFORM_WIN */
-#    if defined _M_X64 || defined _M_AMD64 || defined __x86_64__
+#    if defined _M_X64 || defined _M_AMD64 || defined __x86_64_ \
+        || defined __powerpc64__
 #      define CDECL /* not actual on x86_64 platform */
 #    else  /* _M_X64 || _M_AMD64 || __x86_64__ */
 #      define CDECL __attribute__ ((__cdecl__))

--- a/hphp/runtime/vm/jit/vtune/jitprofiling.h
+++ b/hphp/runtime/vm/jit/vtune/jitprofiling.h
@@ -248,7 +248,8 @@ extern "C" {
 #  if defined WIN32 || defined _WIN32
 #    define CDECL __cdecl
 #  else /* defined WIN32 || defined _WIN32 */
-#    if defined _M_X64 || defined _M_AMD64 || defined __x86_64__
+#    if defined _M_X64 || defined _M_AMD64 || defined __x86_64__ \
+        || defined __powerpc64__
 #      define CDECL /* not actual on x86_64 platform */
 #    else  /* _M_X64 || _M_AMD64 || __x86_64__ */
 #      define CDECL __attribute__ ((__cdecl__))


### PR DESCRIPTION
The cdecl attribute is not defined for PPC64