### PR TITLE
[PPC64] Define sign conditions for each block

### DIFF
--- a/hphp/runtime/vm/jit/vasm-dead.cpp
+++ b/hphp/runtime/vm/jit/vasm-dead.cpp
@@ -60,22 +60,31 @@ bool effectful(Vinstr& inst) {
     case Vinstr::cmpbi:
     case Vinstr::cmpbim:
     case Vinstr::cmpbm:
+    case Vinstr::cmpd:
+    case Vinstr::cmpdi:
     case Vinstr::cmpl:
+    case Vinstr::cmpld:
+    case Vinstr::cmpldi:
     case Vinstr::cmpli:
     case Vinstr::cmplim:
     case Vinstr::cmplims:
     case Vinstr::cmplm:
+    case Vinstr::cmplwi:
+    case Vinstr::cmplw:
     case Vinstr::cmpq:
     case Vinstr::cmpqi:
     case Vinstr::cmpqim:
     case Vinstr::cmpqm:
     case Vinstr::cmpsd:
     case Vinstr::cmpsds:
+    case Vinstr::cmpw:
+    case Vinstr::cmpwi:
     case Vinstr::cmpwim:
     case Vinstr::cmpwm:
     case Vinstr::copy:
     case Vinstr::copy2:
     case Vinstr::copyargs:
+    case Vinstr::copycr:
     case Vinstr::cvtsi2sd:
     case Vinstr::cvtsi2sdm:
     case Vinstr::cvttsd2siq:

--- a/hphp/runtime/vm/jit/vasm-instr.cpp
+++ b/hphp/runtime/vm/jit/vasm-instr.cpp
@@ -202,6 +202,15 @@ Width width(Vinstr::Opcode op) {
     case Vinstr::subsb:
     case Vinstr::uxth:
     // ppc64 instructions
+    case Vinstr::cmpd:
+    case Vinstr::cmpdi:
+    case Vinstr::cmplw:
+    case Vinstr::cmplwi:
+    case Vinstr::cmpld:
+    case Vinstr::cmpldi:
+    case Vinstr::cmpw:
+    case Vinstr::cmpwi:
+    case Vinstr::copycr:
     case Vinstr::extrb:
     case Vinstr::extsb:
     case Vinstr::extsw:

--- a/hphp/runtime/vm/jit/vasm-instr.h
+++ b/hphp/runtime/vm/jit/vasm-instr.h
@@ -313,6 +313,15 @@ struct Vunit;
   O(subsb, Inone, UA(s0) U(s1), D(d) D(sf))\
   O(uxth, Inone, U(s), D(d))\
   /* ppc64 instructions */\
+  O(cmpd, Inone, U(s0) U(s1), D(sf))\
+  O(cmpdi, I(s0), U(s1), D(sf))\
+  O(cmpld, Inone, U(s0) U(s1), D(sf))\
+  O(cmpldi, I(s0), U(s1), D(sf))\
+  O(cmplw, Inone, U(s0) U(s1), D(sf))\
+  O(cmplwi, I(s0), U(s1), D(sf))\
+  O(cmpw, Inone, U(s0) U(s1), D(sf))\
+  O(cmpwi, I(s0), U(s1), D(sf))\
+  O(copycr, Inone, Un, Dn)\
   O(extrb, Inone, UH(s,d), DH(d,s))\
   O(extsb, Inone, UH(s,d), DH(d,s))\
   O(extsw, Inone, UH(s,d), DH(d,s))\
@@ -1151,6 +1160,15 @@ struct uxth { Vreg16 s; Vreg32 d; };
 /*
  * ppc64 intrinsics.
  */
+struct cmpd { Vreg64 s0; Vreg64 s1; VregSF sf; };
+struct cmpdi { Immed s0; Vreg64 s1; VregSF sf; };
+struct cmpld { Vreg64 s0; Vreg64 s1; VregSF sf; };
+struct cmpldi { Immed s0; Vreg64 s1; VregSF sf; };
+struct cmplw { Vreg32 s0; Vreg32 s1; VregSF sf; };
+struct cmplwi { Immed s0; Vreg32 s1; VregSF sf; };
+struct cmpw { Vreg32 s0; Vreg32 s1; VregSF sf; };
+struct cmpwi { Immed s0; Vreg64 s1; VregSF sf; };
+struct copycr {};
 struct extrb { Vreg8 s; Vreg8 d; };   // Extract and zeros the upper bits
 struct extsb { Vreg64 s; Vreg64 d; }; // Extend byte sign
 struct extsw { Vreg64 s; Vreg64 d; }; // Extend word sign
@@ -1161,10 +1179,10 @@ struct ldarx { Vptr s; Vreg64 d; };
 struct mfcr { Vreg64 d; };
 struct mflr { Vreg64 d; };
 struct mfvsrd { Vreg128 s; Vreg64 d; };
-struct xscvdpsxds { Vreg128 s, d; };
 struct mtlr { Vreg64 s; };
 struct mtvsrd { Vreg64 s; Vreg128 d; };
 struct stdcx { Vreg64 s; Vptr d; };
+struct xscvdpsxds { Vreg128 s, d; };
 struct xscvsxddp { Vreg128 s, d; };
 struct xxlxor { Vreg128 s0, s1, d; };
 struct xxpermdi { Vreg128 s0, s1, d; };
@@ -1173,7 +1191,7 @@ struct xxpermdi { Vreg128 s0, s1, d; };
 
 struct Vinstr {
 #define O(name, imms, uses, defs) name,
-  enum Opcode : uint8_t { VASM_OPCODES };
+  enum Opcode : uint16_t { VASM_OPCODES };
 #undef O
 
   /*

--- a/hphp/runtime/vm/jit/vasm-ppc64.cpp
+++ b/hphp/runtime/vm/jit/vasm-ppc64.cpp
@@ -99,12 +99,6 @@ struct Vgen {
     always_assert_flog(false, "unimplemented instruction: {} in B{}\n",
                        vinst_names[Vinstr(i).op], size_t(current));
   }
-  void copyCR0toCR1(Assembler a, Reg64 raux)
-  {
-    a.mfcr(raux);
-    a.sradi(raux,raux,4);
-    a.mtocrf(0x40,raux);
-  }
 
   // intrinsics
   void emit(const copy& i) {
@@ -151,7 +145,6 @@ struct Vgen {
   }
   void emit(const addl& i) {
     a.addo(Reg64(i.d), Reg64(i.s1), Reg64(i.s0), true);
-    copyCR0toCR1(a, rAsm);
   }
   void emit(const ldimmqs& i) {
     emitSmashableMovq(a.code(), env.meta, i.s.q(), i.d);
@@ -163,43 +156,31 @@ struct Vgen {
   }
 
   // instructions
-  void emit(const addq& i) {
-    a.addo(i.d, i.s0, i.s1, true);
-    copyCR0toCR1(a, rAsm);
-  }
+  void emit(const addq& i) { a.addo(i.d, i.s0, i.s1, true); }
   void emit(const addsd& i) { a.fadd(i.d, i.s0, i.s1); }
-  void emit(const andq& i) {
-    a.and(i.d, i.s0, i.s1, true);
-    copyCR0toCR1(a, rAsm);
-  }
-  void emit(const andqi& i) {
-    a.andi(i.d, i.s1, i.s0);
-    copyCR0toCR1(a, rAsm);
-  } // andi changes CR0
-  void emit(const cmpl& i) {
-    a.cmpw(Reg64(i.s1), Reg64(i.s0));
+  void emit(const andq& i) { a.and(i.d, i.s0, i.s1, true); }
+  void emit(const andqi& i) { a.andi(i.d, i.s1, i.s0); } // andi changes CR0
+  void emit(const cmpd& i) { a.cmpd(i.s1, i.s0); }
+  void emit(const cmpdi& i) { a.cmpdi(i.s1, i.s0); }
+  void emit(const cmpw& i) { a.cmpw(Reg64(i.s1), Reg64(i.s0)); }
+  void emit(const cmpld& i) { a.cmpld(i.s1, i.s0, Assembler::CR::CR1); }
+  void emit(const cmpldi& i) { a.cmpldi(i.s1, i.s0, Assembler::CR::CR1); }
+  void emit(const cmplw& i) {
     a.cmplw(Reg64(i.s1), Reg64(i.s0), Assembler::CR::CR1);
   }
-  void emit(const cmpli& i) {
-    a.cmpwi(Reg64(i.s1), i.s0);
+  void emit(const cmplwi& i) {
     a.cmplwi(Reg64(i.s1), i.s0, Assembler::CR::CR1);
   }
-  void emit(const cmpq& i) {
-    a.cmpd(i.s1, i.s0);
-    a.cmpld(i.s1, i.s0, Assembler::CR::CR1);
+  void emit(const cmpwi& i) {
+    a.cmpwi(i.s1, i.s0);
   }
-  void emit(const cmpqi& i) {
-    a.cmpdi(i.s1, i.s0);
-    a.cmpldi(i.s1, i.s0, Assembler::CR::CR1);
+  void emit(const copycr& i) {
+    a.mfcr(rAsm);
+    a.sradi(rAsm,rAsm,4);
+    a.mtocrf(0x40,rAsm);
   }
-  void emit(const decl& i) {
-    a.subfo(Reg64(i.d), rone(), Reg64(i.s), true);
-    copyCR0toCR1(a, rAsm);
-  }
-  void emit(const decq& i) {
-    a.subfo(i.d, rone(), i.s, true);
-    copyCR0toCR1(a, rAsm);
-  }
+  void emit(const decl& i) { a.subfo(Reg64(i.d), rone(), Reg64(i.s), true); }
+  void emit(const decq& i) { a.subfo(i.d, rone(), i.s, true); }
   void emit(const divint& i) { a.divd(i.d,  i.s0, i.s1, false); }
   void emit(const divsd& i) { a.fdiv(i.d, i.s1, i.s0); }
   void emit(const extrb& i ) {
@@ -213,28 +194,16 @@ struct Vgen {
   void emit(const fallthru& i) {}
   void emit(const fcmpo& i) {
     a.fcmpo(i.sf, i.s0, i.s1);
-    copyCR0toCR1(a, rAsm);
+    emit(copycr{});
   }
   void emit(const fcmpu& i) {
     a.fcmpu(i.sf, i.s0, i.s1);
-    copyCR0toCR1(a, rAsm);
+    emit(copycr{});
   }
-  void emit(const imul& i) {
-    a.mulldo(i.d, i.s1, i.s0, true);
-    copyCR0toCR1(a, rAsm);
-  }
-  void emit(const incl& i) {
-    a.addo(Reg64(i.d), Reg64(i.s), rone(), true);
-    copyCR0toCR1(a, rAsm);
-  }
-  void emit(const incq& i) {
-    a.addo(i.d, i.s, rone(), true);
-    copyCR0toCR1(a, rAsm);
-  }
-  void emit(const incw& i) {
-    a.addo(Reg64(i.d), Reg64(i.s), rone(), true);
-    copyCR0toCR1(a, rAsm);
-  }
+  void emit(const imul& i) { a.mulldo(i.d, i.s1, i.s0, true); }
+  void emit(const incl& i) { a.addo(Reg64(i.d), Reg64(i.s), rone(), true); }
+  void emit(const incq& i) { a.addo(i.d, i.s, rone(), true); }
+  void emit(const incw& i) { a.addo(Reg64(i.d), Reg64(i.s), rone(), true); }
   void emit(const jmpi& i) { a.branchAuto(i.target); }
   void emit(const landingpad&) { }
   void emit(const ldimmw& i) { a.li(Reg64(i.d), i.s); }
@@ -265,46 +234,21 @@ struct Vgen {
   void emit(const mtlr& i) { a.mtlr(i.s); }
   void emit(const mtvsrd& i) { a.mtvsrd(i.d, i.s); }
   void emit(const mulsd& i) { a.fmul(i.d, i.s1, i.s0); }
-  void emit(const neg& i) {
-    a.neg(i.d, i.s, true);
-    copyCR0toCR1(a, rAsm);
-  }
+  void emit(const neg& i) { a.neg(i.d, i.s, true); }
   void emit(const nop& i) { a.nop(); } // no-op form
   void emit(const not& i) { a.nor(i.d, i.s, i.s, false); }
-  void emit(const orq& i) {
-    a.or(i.d, i.s0, i.s1, true);
-    copyCR0toCR1(a, rAsm);
-  }
+  void emit(const orq& i) { a.or(i.d, i.s0, i.s1, true); }
   void emit(const ret& i) { a.blr(); }
   void emit(const roundsd& i) { a.xsrdpi(i.d, i.s); }
-  void emit(const sar& i) {
-    a.srad(i.d, i.s1, i.s0, true);
-    copyCR0toCR1(a,rAsm);
-  }
-  void emit(const sarqi& i) {
-    a.sradi(i.d, i.s1, i.s0.b(), true);
-    copyCR0toCR1(a, rAsm);
-  }
-  void emit(const shl& i) {
-    a.sld(i.d, i.s1, i.s0, true);
-    copyCR0toCR1(a, rAsm);
-  }
+  void emit(const sar& i) { a.srad(i.d, i.s1, i.s0, true); }
+  void emit(const sarqi& i) { a.sradi(i.d, i.s1, i.s0.b(), true); }
+  void emit(const shl& i) { a.sld(i.d, i.s1, i.s0, true); }
   void emit(const shlli& i) {
     a.slwi(Reg64(i.d), Reg64(i.s1), i.s0.b(), true);
-    copyCR0toCR1(a, rAsm);
   }
-  void emit(const shlqi& i) {
-    a.sldi(i.d, i.s1, i.s0.b(), true);
-    copyCR0toCR1(a, rAsm);
-  }
-  void emit(const shrli& i) {
-    a.srwi(Reg64(i.d), Reg64(i.s1), i.s0.b(), true);
-    copyCR0toCR1(a, rAsm);
-  }
-  void emit(const shrqi& i) {
-    a.srdi(i.d, i.s1, i.s0.b(), true);
-    copyCR0toCR1(a, rAsm);
-  }
+  void emit(const shlqi& i) { a.sldi(i.d, i.s1, i.s0.b(), true); }
+  void emit(const shrli& i) { a.srwi(Reg64(i.d), Reg64(i.s1), i.s0.b(), true); }
+  void emit(const shrqi& i) { a.srdi(i.d, i.s1, i.s0.b(), true); }
   void emit(const sqrtsd& i) { a.xssqrtdp(i.d,i.s); }
 
   void emit(const stdcx& i) { a.stdcx(i.s, i.d); }
@@ -326,24 +270,16 @@ struct Vgen {
   }
 
   // Subtractions: d = s1 - s0
-  void emit(const subq& i) {
-    a.subfo(i.d, i.s0, i.s1, true);
-    copyCR0toCR1(a, rAsm);
-  }
+  void emit(const subq& i) { a.subfo(i.d, i.s0, i.s1, true); }
   void emit(const subsd& i) { a.fsub(i.d, i.s1, i.s0, false); }
   void emit(const ud2& i) { a.trap(); }
   void emit(const xorb& i) {
     a.xor(Reg64(i.d), Reg64(i.s0), Reg64(i.s1), true);
-    copyCR0toCR1(a, rAsm);
   }
   void emit(const xorl& i) {
     a.xor(Reg64(i.d), Reg64(i.s0), Reg64(i.s1), true);
-    copyCR0toCR1(a, rAsm);
   }
-  void emit(const xorq& i) {
-    a.xor(i.d, i.s0, i.s1, true);
-    copyCR0toCR1(a, rAsm);
-  }
+  void emit(const xorq& i) { a.xor(i.d, i.s0, i.s1, true); }
   void emit(const xscvdpsxds& i) { a.xscvdpsxds(i.d, i.s); }
   void emit(const xscvsxddp& i) { a.xscvsxddp(i.d, i.s); }
   void emit(const xxlxor& i) { a.xxlxor(i.d, i.s1, i.s0); }
@@ -371,7 +307,6 @@ struct Vgen {
   void emit(const orqi& i) {
     a.li64(rAsm, i.s0.l(), false);
     a.or(i.d, i.s1, rAsm, true /** or. implies Rc = 1 **/);
-    copyCR0toCR1(a, rAsm);
   }
   // macro for commonlizing X-/D-form of load/store instructions
 #define X(instr, dst, ptr)                                \
@@ -412,16 +347,15 @@ struct Vgen {
     // https://goo.gl/F1wrbO
     if (i.s0 != i.s1) {
       a.and(rAsm, i.s0, i.s1, true);   // result is not used, only flags
-      copyCR0toCR1(a, rAsm);
+      emit(copycr{});
     } else {
       a.cmpdi(i.s0, Immed(0));
-      a.cmpldi(i.s0, Immed(0));
+      a.cmpldi(i.s0, Immed(0), Assembler::CR::CR1);
     }
   }
   void emit(const xorqi& i) {
-    a.li64(rAsm, i.s0.l(), false);
+    a.li64(rAsm, i.s0.l());
     a.xor(i.d, i.s1, rAsm, true /** xor. implies Rc = 1 **/);
-    copyCR0toCR1(a, rAsm);
   }
 
   void emit(const conjure& i) { always_assert(false); }
@@ -517,7 +451,7 @@ void Vgen::emit(const ucomisd& i) {
     // Set "negative" bit if "Overflow" bit is set. Also, keep overflow bit set
     a.li64(rAsm, 0x99000000, false);
     a.mtcrf(0xC0, rAsm);
-    copyCR0toCR1(a, rAsm);
+    emit(copycr{});
   }
   notNAN.asm_label(a);
 }
@@ -1568,6 +1502,260 @@ void fixVptrsForPPC64(Vunit& unit) {
     }
   });
 }
+
+///////////////////////////////////////////////////////////////////////////////
+
+// Sign conditions
+enum Signs {
+  signedOnly,
+  unsignedOnly,
+  both,
+  neither
+};
+
+/*
+ * Define condition to testq instruction.
+ */
+void defCond_testq (Vout& v, testq& i, Signs blockSigns) {
+  // More information on:
+  // https://goo.gl/F1wrbO
+  if (i.s0 != i.s1) {
+    v << andq { i.s0, i.s1, rAsm, i.sf };
+
+    if (blockSigns == unsignedOnly || blockSigns == both) {
+      v << copycr{};
+    }
+  } else {
+    if (blockSigns == signedOnly || blockSigns == both) {
+      v << cmpdi{ Immed(0), i.s0, i.sf };
+    }
+    if (blockSigns == unsignedOnly || blockSigns == both) {
+      v << cmpldi{ Immed(0), i.s0, i.sf };
+    }
+  }
+}
+
+/*
+ * If for the current block there is at least one logical comparison,
+ * the flags from cr0 must be copied to cr1 in order to use it on the
+ * next comparison instruction
+ */
+void defCond (Vout& v, Vinstr inst, Signs blockSigns) {
+  if (blockSigns == unsignedOnly || blockSigns == both) {
+    v << inst;
+    v << copycr{};
+  }
+}
+
+/*
+ * If in the current block there are only signed comparisons, use
+ * the cmpw instruction, if has only unsigned, use cmplw, otherwise
+ * use both to cover signed and unsigned instructions.
+ */
+void defCond_cmpl (Vout& v, cmpl& i, Signs blockSigns) {
+  if (blockSigns == signedOnly || blockSigns == both) {
+    v << cmpw{ i.s0, i.s1, i.sf };
+  }
+  if (blockSigns == unsignedOnly || blockSigns == both) {
+    v << cmplw{ i.s0, i.s1, i.sf };
+  }
+}
+
+/*
+ * If in the current block there are only signed comparisons, use
+ * the cmpwi instruction, if has only unsigned, use cmplwi, otherwise
+ * use both to cover signed and unsigned instructions.
+ */
+void defCond_cmpli (Vout& v, cmpli& i, Signs blockSigns) {
+  if (blockSigns == signedOnly || blockSigns == both) {
+    v << cmpwi{ i.s0, Reg64(i.s1), i.sf };
+  }
+  if (blockSigns == unsignedOnly || blockSigns == both) {
+    v << cmplwi{ i.s0, i.s1, i.sf };
+  }
+}
+
+/*
+ * If in the current block there are only signed comparisons, use
+ * the cmpd instruction, if has only unsigned, use cmpld, otherwise
+ * use both to cover signed and unsigned instructions.
+ */
+void defCond_cmpq (Vout& v, cmpq& i, Signs blockSigns) {
+  if (blockSigns == signedOnly || blockSigns == both) {
+    v << cmpd{ i.s0, i.s1, i.sf };
+  }
+  if (blockSigns == unsignedOnly || blockSigns == both) {
+    v << cmpld{ i.s0, i.s1, i.sf };
+  }
+}
+
+/*
+ * If in the current block there are only signed comparisons, use
+ * the cmpdi instruction, if has only unsigned, use cmpldi, otherwise
+ * use both to cover signed and unsigned instructions.
+ */
+void defCond_cmpqi (Vout& v, cmpqi& i, Signs blockSigns) {
+  if (blockSigns == signedOnly || blockSigns == both) {
+    v << cmpdi{ i.s0, i.s1, i.sf };
+  }
+  if (blockSigns == unsignedOnly || blockSigns == both) {
+    v << cmpldi{ i.s0, i.s1, i.sf };
+  }
+}
+
+/*
+ * Check signs for each kind of comparison
+ */
+Signs signNeeds(const ConditionCode cc) {
+  Signs ret = neither;
+  switch (cc) {
+  case HPHP::jit::CC_O:
+  case HPHP::jit::CC_NO:
+  case HPHP::jit::CC_E:
+  case HPHP::jit::CC_NE:
+  case HPHP::jit::CC_S:
+  case HPHP::jit::CC_NS:
+  case HPHP::jit::CC_P:
+  case HPHP::jit::CC_NP:
+  case HPHP::jit::CC_L:
+  case HPHP::jit::CC_NL:
+  case HPHP::jit::CC_NG:
+  case HPHP::jit::CC_G:
+    ret = signedOnly;
+    break;
+
+  case HPHP::jit::CC_B:
+  case HPHP::jit::CC_AE:
+  case HPHP::jit::CC_BE:
+  case HPHP::jit::CC_A:
+    ret = unsignedOnly;
+    break;
+
+  default:
+    not_implemented();
+    break;
+  }
+  return ret;
+}
+
+/*
+ * Merge sign flags of current block signs with the current instruction sign.
+ */
+static inline Signs addSigns(Signs blockSigns, Signs currentSigns) {
+  if (blockSigns == both || currentSigns == both) return both;
+  else if (blockSigns == neither) return currentSigns;
+  else if (currentSigns == neither) return blockSigns;
+  else if (blockSigns == signedOnly) {
+    // by now, a, b are either signed or unsigned
+    if (currentSigns != signedOnly) return both;
+    return signedOnly;
+  } else if (blockSigns == unsignedOnly) {
+    if (currentSigns != unsignedOnly) return both;
+    return unsignedOnly;
+  }
+  always_assert(false);
+  return both;
+}
+
+#define extractCC(name)                                   \
+    case Vinstr::name:                                    \
+      blockSigns = addSigns(blockSigns,                   \
+                signNeeds(inst.name##_.cc));              \
+      break                                               \
+
+/*
+ * Check all comparison instructions in order to set the correct flags
+ * according with parameter's signs.
+ */
+void defConditions(Vunit& unit) {
+  // Scratch block can change blocks allocation, hence cannot use regular
+  // iterators.
+  auto& blocks = unit.blocks;
+
+  PostorderWalker{unit}.dfs([&] (Vlabel ib) {
+    assertx(!blocks[ib].code.empty());
+
+    Signs blockSigns = neither;
+
+    // Extract signs from comparisons
+    for (auto i = blocks[ib].code.begin(); i != blocks[ib].code.end(); i++) {
+      auto& inst = *i;
+      switch (inst.op) {
+      extractCC(jcc);
+      extractCC(jcci);
+      extractCC(bindjcc);
+      extractCC(fallbackcc);
+      extractCC(phijcc);
+      extractCC(cloadq);
+      extractCC(cmovb);
+      extractCC(cmovw);
+      extractCC(cmovl);
+      extractCC(cmovq);
+      extractCC(setcc);
+      default:
+        break;
+      }
+    }
+
+    if (blockSigns == neither) return;
+
+    for (size_t ii = 0; ii < blocks[ib].code.size(); ++ii) {
+
+      auto scratch = unit.makeScratchBlock();
+      auto& inst = blocks[ib].code[ii];
+      SCOPE_EXIT {unit.freeScratchBlock(scratch);};
+      Vout v(unit, scratch, inst.irctx());
+
+      switch (inst.op) {
+      case Vinstr::addl:
+      case Vinstr::addq:
+      case Vinstr::andq:
+      case Vinstr::andqi:
+      case Vinstr::decl:
+      case Vinstr::decq:
+      case Vinstr::imul:
+      case Vinstr::incl:
+      case Vinstr::incq:
+      case Vinstr::incw:
+      case Vinstr::neg:
+      case Vinstr::orq:
+      case Vinstr::orqi:
+      case Vinstr::sar:
+      case Vinstr::sarqi:
+      case Vinstr::shl:
+      case Vinstr::shlli:
+      case Vinstr::shlqi:
+      case Vinstr::shrli:
+      case Vinstr::shrqi:
+      case Vinstr::subq:
+      case Vinstr::xorb:
+      case Vinstr::xorl:
+      case Vinstr::xorq:
+      case Vinstr::xorqi: defCond(v, inst, blockSigns);
+        break;
+      case Vinstr::testq: defCond_testq(v, inst.testq_, blockSigns);
+        break;
+      case Vinstr::cmpl: defCond_cmpl(v, inst.cmpl_, blockSigns);
+        break;
+      case Vinstr::cmpli: defCond_cmpli(v, inst.cmpli_, blockSigns);
+        break;
+      case Vinstr::cmpq: defCond_cmpq(v, inst.cmpq_, blockSigns);
+        break;
+      case Vinstr::cmpqi: defCond_cmpqi(v, inst.cmpqi_, blockSigns);
+        break;
+      default:
+        break;
+      }
+
+      if (!v.empty()) {
+        vector_splice(unit.blocks[ib].code, ii, 1,
+                      unit.blocks[scratch].code);
+      }
+    }
+  });
+}
+
+///////////////////////////////////////////////////////////////////////////////
 } // anonymous namespace
 
 void optimizePPC64(Vunit& unit, const Abi& abi, bool regalloc) {
@@ -1596,6 +1784,9 @@ void optimizePPC64(Vunit& unit, const Abi& abi, bool regalloc) {
   if (unit.blocks.size() > 1) {
     optimizeJmps(unit);
   }
+
+  // Add correct comparing VASMs.
+  defConditions(unit);
 }
 
 void emitPPC64(const Vunit& unit, Vtext& text, CGMeta& fixups,


### PR DESCRIPTION
On PPC64 there is more than one Condition Register and depending if the
operation is signed or unsigned, a different CR is set.
After the VASM emission and all optimization phases, the new "Define
Conditions" phase is called to check if the block has signed, unsigned,
neither or both kind of operations, so based on that, the correct
comparing instruction is emitted.