### PR TITLE
corrected hscan handling of output

### DIFF
--- a/hphp/system/php/redis/Redis.php
+++ b/hphp/system/php/redis/Redis.php
@@ -561,7 +561,18 @@ class Redis {
   }
 
   public function hScan($key, &$cursor, $pattern = null, $count = null) {
-    return $this->scanImpl('HSCAN', $key, $cursor, $pattern, $count);
+    $flat = $this->scanImpl('HSCAN', $key, $cursor, $pattern, $count);
+    /*
+     * HScan behaves differently from the other *scan functions. The wire
+     * protocol returns names in even slots s, and the corresponding value
+     * in odd slot s + 1. The PHP client returns these as an array mapping
+     * keys to values.
+     */
+    if ($flat === false) return $flat;
+    assert(count($flat) % 2 == 0);
+    $ret = array();
+    for ($i = 0; $i < count($flat); $i += 2) $ret[$flat[$i]] = $flat[$i + 1];
+    return $ret;
   }
 
   public function zScan($key, &$cursor, $pattern = null, $count = null) {


### PR DESCRIPTION
Current release incorrectly handles HScan output and returns unexpected results.

From Redis, HScan gives similar output to ZScan, where odd numbered line represent the field name and even numbered lines represent value at the given hash key. (see http://redis.io/commands/scan for details on expected output from each).

In the current release code, HScan appears to expect a vector array of values and thus returns an incorrect, incoherent result (a 1xn serial array) when it should be returning a [ key=>value ] associative array.

I have patched the code that translates HSCAN's output so it works the exact same way that ZSCAN already does in 3.15 release. Data returned from redis is now transformed into an associative array of key=>value.



