### PR TITLE
Fix "SYS_memfd_create" redefined warning.

### DIFF
--- a/hphp/hack/src/heap/hh_shared.c
+++ b/hphp/hack/src/heap/hh_shared.c
@@ -142,11 +142,11 @@
 #if !defined __APPLE__ && !defined _WIN32
   // Linux version for the architecture must support syscall memfd_create
   #if defined(__x86_64__)
-    #define SYS_memfd_create 319
+    #define SYSC_memfd_create 319
   #elif defined(__powerpc64__)
-    #define SYS_memfd_create 360
+    #define SYSC_memfd_create 360
   #elif defined(__aarch64__)
-    #define SYS_memfd_create 385
+    #define SYSC_memfd_create 385
   #else
     #error "hh_shared.c requires a architecture that supports memfd_create"
   #endif
@@ -161,7 +161,7 @@
    * kernel is < 3.17, and that's good enough.
    */
   static int memfd_create(const char *name, unsigned int flags) {
-    return syscall(SYS_memfd_create, name, flags);
+    return syscall(SYSC_memfd_create, name, flags);
   }
 #endif
 

--- a/hphp/hack/src/heap/hh_shared.c
+++ b/hphp/hack/src/heap/hh_shared.c
@@ -141,14 +141,16 @@
  ****************************************************************************/
 #if !defined __APPLE__ && !defined _WIN32
   // Linux version for the architecture must support syscall memfd_create
-  #if defined(__x86_64__)
-    #define SYSC_memfd_create 319
-  #elif defined(__powerpc64__)
-    #define SYSC_memfd_create 360
-  #elif defined(__aarch64__)
-    #define SYSC_memfd_create 385
-  #else
-    #error "hh_shared.c requires a architecture that supports memfd_create"
+  #ifndef SYS_memfd_create
+    #if defined(__x86_64__)
+      #define SYS_memfd_create 319
+    #elif defined(__powerpc64__)
+      #define SYS_memfd_create 360
+    #elif defined(__aarch64__)
+      #define SYS_memfd_create 385
+    #else
+      #error "hh_shared.c requires a architecture that supports memfd_create"
+    #endif
   #endif
 
   #define MEMFD_CREATE 1
@@ -161,7 +163,7 @@
    * kernel is < 3.17, and that's good enough.
    */
   static int memfd_create(const char *name, unsigned int flags) {
-    return syscall(SYSC_memfd_create, name, flags);
+    return syscall(SYS_memfd_create, name, flags);
   }
 #endif
 


### PR DESCRIPTION
Summary:

This commit fixes "SYS_memfd_create" redefined warning.
This warning happens on POWER because SYS_memfd_create is already
defined on: powerpc64le-linux-gnu/sys/syscall.h:31:0.