### PR TITLE
[PPC64] Add a new class to support TOC

### DIFF
--- a/hphp/ppc64-asm/asm-ppc64.cpp
+++ b/hphp/ppc64-asm/asm-ppc64.cpp
@@ -767,8 +767,8 @@ void Assembler::loadTOC(const Reg64& rt, const Reg64& rttoc,  int64_t imm64,
 }
 
 void Assembler::limmediate(const Reg64& rt, int64_t imm64, ImmType immt) {
-  always_assert(HPHP::RuntimeOption::EvalPPC64minTOCImmSize >= 0 &&
-    HPHP::RuntimeOption::EvalPPC64minTOCImmSize <= 64);
+  always_assert(HPHP::RuntimeOption::EvalPPC64MinTOCImmSize >= 0 &&
+    HPHP::RuntimeOption::EvalPPC64MinTOCImmSize <= 64);
 
   auto fits = [](int64_t imm64, uint16_t shift_n) {
      return (static_cast<uint64_t>(imm64) >> shift_n) == 0 ? true : false;
@@ -778,7 +778,7 @@ void Assembler::limmediate(const Reg64& rt, int64_t imm64, ImmType immt) {
 #ifndef USE_TOC_ON_BRANCH
       1 ||
 #endif
-      (fits(imm64, HPHP::RuntimeOption::EvalPPC64minTOCImmSize)
+      (fits(imm64, HPHP::RuntimeOption::EvalPPC64MinTOCImmSize)
       && (immt != ImmType::TocOnly))) {
     li64(rt, imm64, immt != ImmType::AnyCompact);
     return;

--- a/hphp/ppc64-asm/asm-ppc64.cpp
+++ b/hphp/ppc64-asm/asm-ppc64.cpp
@@ -17,8 +17,16 @@
 #include "hphp/ppc64-asm/asm-ppc64.h"
 #include "hphp/ppc64-asm/decoder-ppc64.h"
 #include "hphp/runtime/base/runtime-option.h"
+#include "hphp/util/trace.h"
+
+TRACE_SET_MOD(asmppc64);
 
 namespace ppc64_asm {
+VMTOC::~VMTOC() {
+  FTRACE(1, "Number of values stored in TOC: {}\n",
+    std::to_string(m_last_elem_pos));
+}
+
 int64_t VMTOC::pushElem(int64_t elem) {
   if (m_map.find(elem) != m_map.end()) {
     return m_map[elem];

--- a/hphp/ppc64-asm/asm-ppc64.cpp
+++ b/hphp/ppc64-asm/asm-ppc64.cpp
@@ -60,7 +60,7 @@ intptr_t VMTOC::getPtrVector() {
 
 int64_t VMTOC::getValue(int64_t index, bool qword) {
   HPHP::Address addr = reinterpret_cast<HPHP::Address>(
-      reinterpret_cast<intptr_t>(index) + getPtrVector());
+      static_cast<intptr_t>(index) + getPtrVector());
   int64_t ret_val = 0;
   int max_elem = qword ? 8 : 4;
   for (int i = max_elem-1; i >= 0; i--) {

--- a/hphp/ppc64-asm/asm-ppc64.cpp
+++ b/hphp/ppc64-asm/asm-ppc64.cpp
@@ -784,7 +784,7 @@ void Assembler::limmediate(const Reg64& rt, int64_t imm64, ImmType immt) {
     return;
   }
 
-  bool fits32 = HPHP::RuntimeOption::EvalPPC64useTOCLwz && fits(imm64, 32);
+  bool fits32 = fits(imm64, 32);
   int64_t TOCoffset;
   if (fits32) {
     TOCoffset = VMTOC::getInstance().pushElem(

--- a/hphp/ppc64-asm/asm-ppc64.cpp
+++ b/hphp/ppc64-asm/asm-ppc64.cpp
@@ -759,8 +759,8 @@ void Assembler::loadTOC(const Reg64& rt, const Reg64& rttoc,  int64_t imm64,
 }
 
 void Assembler::limmediate(const Reg64& rt, int64_t imm64, ImmType immt) {
-  always_assert(HPHP::RuntimeOption::Evalppc64minTOCImmSize >= 0 &&
-    HPHP::RuntimeOption::Evalppc64minTOCImmSize <= 64);
+  always_assert(HPHP::RuntimeOption::EvalPPC64minTOCImmSize >= 0 &&
+    HPHP::RuntimeOption::EvalPPC64minTOCImmSize <= 64);
 
   auto fits = [](int64_t imm64, uint16_t shift_n) {
      return (static_cast<uint64_t>(imm64) >> shift_n) == 0 ? true : false;
@@ -770,13 +770,13 @@ void Assembler::limmediate(const Reg64& rt, int64_t imm64, ImmType immt) {
 #ifndef USE_TOC_ON_BRANCH
       1 ||
 #endif
-      (fits(imm64, HPHP::RuntimeOption::Evalppc64minTOCImmSize)
+      (fits(imm64, HPHP::RuntimeOption::EvalPPC64minTOCImmSize)
       && (immt != ImmType::TocOnly))) {
     li64(rt, imm64, immt != ImmType::AnyCompact);
     return;
   }
 
-  bool fits32 = HPHP::RuntimeOption::Evalppc64useTOCLwz && fits(imm64, 32);
+  bool fits32 = HPHP::RuntimeOption::EvalPPC64useTOCLwz && fits(imm64, 32);
   int64_t TOCoffset;
   if (fits32) {
     TOCoffset = VMTOC::getInstance().pushElem(

--- a/hphp/ppc64-asm/asm-ppc64.cpp
+++ b/hphp/ppc64-asm/asm-ppc64.cpp
@@ -16,8 +16,81 @@
 
 #include "hphp/ppc64-asm/asm-ppc64.h"
 #include "hphp/ppc64-asm/decoder-ppc64.h"
+#include "hphp/runtime/base/runtime-option.h"
 
 namespace ppc64_asm {
+int64_t VMTOC::pushElem(int64_t elem) {
+  if (m_map.find(elem) != m_map.end()) {
+    return m_map[elem];
+  }
+  auto offset = allocTOC(static_cast<int32_t>(elem & 0xffffffff), true);
+  m_map.insert( { elem, offset });
+  allocTOC(static_cast<int32_t>((elem & 0xffffffff00000000) >> 32));
+  m_last_elem_pos += 2;
+  return offset;
+}
+
+int64_t VMTOC::pushElem(int32_t elem) {
+  if (m_map.find(elem) != m_map.end()) {
+    return m_map[elem];
+  }
+  auto offset = allocTOC(elem);
+  m_map.insert( { elem, offset });
+  m_last_elem_pos++;
+  return offset;
+}
+
+VMTOC& VMTOC::getInstance() {
+  static VMTOC instance;
+  return instance;
+}
+
+intptr_t VMTOC::getPtrVector() {
+  always_assert(m_tocvector != nullptr);
+  return reinterpret_cast<intptr_t>(m_tocvector->base() + INT16_MAX + 1);
+}
+
+int64_t VMTOC::getValue(int64_t index, bool qword) {
+  HPHP::Address addr = reinterpret_cast<HPHP::Address>(
+      reinterpret_cast<intptr_t>(index) + getPtrVector());
+  int64_t ret_val = 0;
+  int max_elem = qword ? 8 : 4;
+  for (int i = max_elem-1; i >= 0; i--) {
+    ret_val = addr[i] + (ret_val << 8);
+  }
+  return ret_val;
+}
+
+int64_t VMTOC::allocTOC(int32_t target, bool align) {
+  HPHP::Address addr = m_tocvector->frontier();
+  if (align) {
+    forceAlignment(addr);
+    always_assert(reinterpret_cast<uintptr_t>(addr) % 8 == 0);
+  }
+
+  m_tocvector->assertCanEmit(sizeof(int32_t));
+  m_tocvector->dword(reinterpret_cast<int32_t>(target));
+  return addr - (m_tocvector->base() + INT16_MAX + 1);
+}
+
+void VMTOC::setTOCDataBlock(HPHP::DataBlock *db) {
+  if(m_tocvector == nullptr) {
+    m_tocvector = db;
+    HPHP::Address addr = m_tocvector->frontier();
+    forceAlignment(addr);
+  }
+  return;
+}
+
+void VMTOC::forceAlignment(HPHP::Address& addr) {
+  // keep 8-byte alignment
+  while (reinterpret_cast<uintptr_t>(addr) % 8 != 0) {
+    uint8_t fill_byte = 0xf0;
+    m_tocvector->assertCanEmit(sizeof(uint8_t));
+    m_tocvector->byte(fill_byte);
+    addr = m_tocvector->frontier();
+  }
+}
 
 void BranchParams::decodeInstr(const PPC64Instr* const pinstr) {
   const DecoderInfo dinfo = Decoder::GetDecoder().decode(pinstr);
@@ -669,6 +742,68 @@ int32_t Assembler::getLi32(PPC64Instr* pinstr) {
     imm32 |= getImm(pinstr + 1);        // ori
   }
   return static_cast<int32_t>(imm32);
+}
+
+void Assembler::loadTOC(const Reg64& rt, const Reg64& rttoc,  int64_t imm64,
+      uint64_t offset, bool fixedSize, bool fits32) {
+  if (fits32) {
+    Assembler::lwz(rt,rttoc[offset]);
+  }
+  else {
+    Assembler::ld(rt, rttoc[offset]);
+  }
+  if (fixedSize) {
+    emitNop(3 * instr_size_in_bytes);
+  }
+  return;
+}
+
+void Assembler::limmediate(const Reg64& rt, int64_t imm64, ImmType immt) {
+  always_assert(HPHP::RuntimeOption::Evalppc64minTOCImmSize >= 0 &&
+    HPHP::RuntimeOption::Evalppc64minTOCImmSize <= 64);
+
+  auto fits = [](int64_t imm64, uint16_t shift_n) {
+     return (static_cast<uint64_t>(imm64) >> shift_n) == 0 ? true : false;
+  };
+
+  if (
+#ifndef USE_TOC_ON_BRANCH
+      1 ||
+#endif
+      (fits(imm64, HPHP::RuntimeOption::Evalppc64minTOCImmSize)
+      && (immt != ImmType::TocOnly))) {
+    li64(rt, imm64, immt != ImmType::AnyCompact);
+    return;
+  }
+
+  bool fits32 = HPHP::RuntimeOption::Evalppc64useTOCLwz && fits(imm64, 32);
+  int64_t TOCoffset;
+  if (fits32) {
+    TOCoffset = VMTOC::getInstance().pushElem(
+        static_cast<int32_t>(UINT32_MAX & imm64));
+  }
+  else {
+    TOCoffset = VMTOC::getInstance().pushElem(imm64);
+  }
+
+  if (TOCoffset > INT16_MAX) {
+    int16_t complement = 0;
+    // If last four bytes is still bigger than a signed 16bits, uses as two
+    // complement.
+    if ((TOCoffset & UINT16_MAX) > INT16_MAX) complement = 1;
+    addis(rt, reg::r2, static_cast<int16_t>((TOCoffset >> 16) + complement));
+    loadTOC(rt, rt, imm64, TOCoffset & UINT16_MAX,
+        immt == ImmType::AnyFixed, fits32);
+  }
+  else {
+    loadTOC(rt, reg::r2, imm64, TOCoffset, immt == ImmType::AnyFixed, fits32);
+    bool toc_may_grow = HPHP::RuntimeOption::EvalJitRelocationSize != 0;
+    if ((immt != ImmType::AnyCompact) || toc_may_grow) {
+      emitNop(1 * instr_size_in_bytes);
+    }
+  }
+
+  return;
 }
 
 //////////////////////////////////////////////////////////////////////

--- a/hphp/ppc64-asm/asm-ppc64.h
+++ b/hphp/ppc64-asm/asm-ppc64.h
@@ -62,6 +62,9 @@ constexpr uint8_t instr_size_in_bytes       = sizeof(PPC64Instr);
 constexpr uint8_t call_skip_bytes_for_ret   = 1 * instr_size_in_bytes;
 
 
+// Allow TOC usage on branches - disabled at the moment.
+//#define USE_TOC_ON_BRANCH
+
 //////////////////////////////////////////////////////////////////////
 
 enum class RegNumber : uint32_t {};

--- a/hphp/ppc64-asm/asm-ppc64.h
+++ b/hphp/ppc64-asm/asm-ppc64.h
@@ -20,8 +20,6 @@
 #include <cstdint>
 #include <cassert>
 #include <vector>
-#include <iostream>
-#include <fstream>
 
 #include "hphp/util/data-block.h"
 
@@ -33,6 +31,7 @@
 #include "hphp/ppc64-asm/isa-ppc64.h"
 
 #include "hphp/runtime/base/runtime-option.h"
+
 
 namespace ppc64_asm {
 
@@ -240,19 +239,7 @@ private:
 
   {}
 
-  ~VMTOC(){
-    if (HPHP::RuntimeOption::EvalPPC64dumpTOCNelements) {
-     pid_t pid = getpid();
-     std::string dumpedfile = "/tmp/nelements." + std::to_string(pid);
-     std::ofstream nelemdumped;
-     nelemdumped.open(dumpedfile);
-     if (nelemdumped.is_open())
-       nelemdumped << "Number of values stored in TOC: ";
-       nelemdumped << std::to_string(m_last_elem_pos);
-       nelemdumped << "\n";
-       nelemdumped.close();
-    }
-  }
+  ~VMTOC();
 
 public:
   VMTOC(VMTOC const&) = delete;

--- a/hphp/ppc64-asm/asm-ppc64.h
+++ b/hphp/ppc64-asm/asm-ppc64.h
@@ -241,7 +241,7 @@ private:
   {}
 
   ~VMTOC(){
-    if (HPHP::RuntimeOption::Evalppc64dumpTOCNelements) {
+    if (HPHP::RuntimeOption::EvalPPC64dumpTOCNelements) {
      pid_t pid = getpid();
      std::string dumpedfile = "/tmp/nelements." + std::to_string(pid);
      std::ofstream nelemdumped;

--- a/hphp/runtime/base/runtime-option.h
+++ b/hphp/runtime/base/runtime-option.h
@@ -619,8 +619,6 @@ struct RuntimeOption {
   F(uint32_t, PerfMemEventSampleFreq, 80)                               \
   /* PPC64 Option: Minimum immediate size to use TOC */                 \
   F(uint16_t, PPC64minTOCImmSize, 64)                                   \
-  /* PPC64 Option: Dump the number of elements stored in TOC */         \
-  F(bool, PPC64dumpTOCNelements, false)                                 \
   /* */
 
 private:

--- a/hphp/runtime/base/runtime-option.h
+++ b/hphp/runtime/base/runtime-option.h
@@ -621,8 +621,6 @@ struct RuntimeOption {
   F(uint16_t, PPC64minTOCImmSize, 64)                                   \
   /* PPC64 Option: Dump the number of elements stored in TOC */         \
   F(bool, PPC64dumpTOCNelements, false)                                 \
-  /* PPC64 Option: Allow lwz and not only ld to be used for TOC read */ \
-  F(bool, PPC64useTOCLwz, false)                                        \
   /* */
 
 private:

--- a/hphp/runtime/base/runtime-option.h
+++ b/hphp/runtime/base/runtime-option.h
@@ -604,6 +604,8 @@ struct RuntimeOption {
   F(uint32_t, ReusableTCPadding, 128)                                   \
   F(int64_t,  StressUnitCacheFreq, 0)                                   \
   F(int64_t, PerfWarningSampleRate, 1)                                  \
+  /* PPC64 Option: Minimum immediate size to use TOC */                 \
+  F(uint16_t, PPC64MinTOCImmSize, 64)                                   \
   /********************                                                 \
    | Profiling flags. |                                                 \
    ********************/                                                \
@@ -617,8 +619,6 @@ struct RuntimeOption {
    * kept low to avoid the risk of collecting a sample while we're      \
    * processing a previous sample. */                                   \
   F(uint32_t, PerfMemEventSampleFreq, 80)                               \
-  /* PPC64 Option: Minimum immediate size to use TOC */                 \
-  F(uint16_t, PPC64MinTOCImmSize, 64)                                   \
   /* */
 
 private:

--- a/hphp/runtime/base/runtime-option.h
+++ b/hphp/runtime/base/runtime-option.h
@@ -617,6 +617,12 @@ struct RuntimeOption {
    * kept low to avoid the risk of collecting a sample while we're      \
    * processing a previous sample. */                                   \
   F(uint32_t, PerfMemEventSampleFreq, 80)                               \
+  /* PPC64 Option: Minimum immediate size to use TOC */                 \
+  F(uint16_t, ppc64minTOCImmSize, 64)                                   \
+  /* PPC64 Option: Dump the number of elements stored in TOC */         \
+  F(bool, ppc64dumpTOCNelements, false)                                 \
+  /* PPC64 Option: Allow lwz and not only ld to be used for TOC read */ \
+  F(bool, ppc64useTOCLwz, false)                                        \
   /* */
 
 private:

--- a/hphp/runtime/base/runtime-option.h
+++ b/hphp/runtime/base/runtime-option.h
@@ -618,11 +618,11 @@ struct RuntimeOption {
    * processing a previous sample. */                                   \
   F(uint32_t, PerfMemEventSampleFreq, 80)                               \
   /* PPC64 Option: Minimum immediate size to use TOC */                 \
-  F(uint16_t, ppc64minTOCImmSize, 64)                                   \
+  F(uint16_t, PPC64minTOCImmSize, 64)                                   \
   /* PPC64 Option: Dump the number of elements stored in TOC */         \
-  F(bool, ppc64dumpTOCNelements, false)                                 \
+  F(bool, PPC64dumpTOCNelements, false)                                 \
   /* PPC64 Option: Allow lwz and not only ld to be used for TOC read */ \
-  F(bool, ppc64useTOCLwz, false)                                        \
+  F(bool, PPC64useTOCLwz, false)                                        \
   /* */
 
 private:

--- a/hphp/runtime/base/runtime-option.h
+++ b/hphp/runtime/base/runtime-option.h
@@ -618,7 +618,7 @@ struct RuntimeOption {
    * processing a previous sample. */                                   \
   F(uint32_t, PerfMemEventSampleFreq, 80)                               \
   /* PPC64 Option: Minimum immediate size to use TOC */                 \
-  F(uint16_t, PPC64minTOCImmSize, 64)                                   \
+  F(uint16_t, PPC64MinTOCImmSize, 64)                                   \
   /* */
 
 private:

--- a/hphp/util/trace.h
+++ b/hphp/util/trace.h
@@ -89,6 +89,7 @@ namespace Trace {
       TM(tprefix)     /* Meta: prefix with string */  \
       TM(traceAsync)  /* Meta: lazy writes to disk */ \
       TM(asmx64)        \
+      TM(asmppc64)      \
       TM(atomicvector)  \
       TM(bcinterp)      \
       TM(bisector)      \


### PR DESCRIPTION
This is the first pull request of many to use a special feature for ppc:
TOC.

TOC (table of contents) is a memory region pointed by r2 that
contains immediate values to be loaded throughout the jit execution.
That is currently using hhvm's data-block as the memory region.

In this first pull request the code is not yet integrated as all our changes
in one PR would make it too big to be reviewed. For now, it just implemented
the singleton class that manages what is stored in TOC, and the "limmediate"
function that decides wether it is good or not to use TOC to load a specific
immediate value.