### PR TITLE
[AArch64] Fix overflowing integer multiplication for AArch64

### DIFF
--- a/hphp/runtime/vm/jit/irlower-arith.cpp
+++ b/hphp/runtime/vm/jit/irlower-arith.cpp
@@ -128,7 +128,6 @@ ARITH_OPS
 
 
 void cgMulIntO(IRLS& env, const IRInstruction* inst) {
-  //  implMulIntO(vmain(env), env, inst);
   auto const d = dstLoc(env, inst, 0).reg();
   auto const s0 = srcLoc(env, inst, 0).reg();
   auto const s1 = srcLoc(env, inst, 1).reg();

--- a/hphp/runtime/vm/jit/irlower-arith.cpp
+++ b/hphp/runtime/vm/jit/irlower-arith.cpp
@@ -105,7 +105,6 @@ void implShift(Vout& v, IRLS& env, const IRInstruction* inst) {
   AO(MulInt,  BinopSF,  imul)   \
   AO(AddIntO, ArithO,   addq)   \
   AO(SubIntO, ArithO,   subq)   \
-  AO(MulIntO, ArithO,   imul)   \
   AO(AddDbl,  Binop,    addsd)  \
   AO(SubDbl,  Binop,    subsd)  \
   AO(MulDbl,  Binop,    mulsd)  \
@@ -126,6 +125,17 @@ ARITH_OPS
 #undef ARITH_OPS
 
 ///////////////////////////////////////////////////////////////////////////////
+
+
+void cgMulIntO(IRLS& env, const IRInstruction* inst) {
+  //  implMulIntO(vmain(env), env, inst);
+  auto const d = dstLoc(env, inst, 0).reg();
+  auto const s0 = srcLoc(env, inst, 0).reg();
+  auto const s1 = srcLoc(env, inst, 1).reg();
+  auto& v = vmain(env);
+
+  v << mulint{s0, s1, d, {label(env, inst->next()), label(env, inst->taken())}};
+}
 
 void cgFloor(IRLS& env, const IRInstruction* inst) {
   implRound<RoundDirection::floor>(vmain(env), env, inst);

--- a/hphp/runtime/vm/jit/irlower-arith.cpp
+++ b/hphp/runtime/vm/jit/irlower-arith.cpp
@@ -133,7 +133,7 @@ void cgMulIntO(IRLS& env, const IRInstruction* inst) {
   auto const s1 = srcLoc(env, inst, 1).reg();
   auto& v = vmain(env);
 
-  v << mulint{s0, s1, d, {label(env, inst->next()), label(env, inst->taken())}};
+  v << mulinto{s0, s1, d, {label(env, inst->next()), label(env, inst->taken())}};
 }
 
 void cgFloor(IRLS& env, const IRInstruction* inst) {

--- a/hphp/runtime/vm/jit/vasm-arm.cpp
+++ b/hphp/runtime/vm/jit/vasm-arm.cpp
@@ -1135,7 +1135,7 @@ void lower(Vunit& u, absdbl& i, Vlabel b, size_t z) {
   });
 }
 
-void lower(Vunit& u, mulint& i, Vlabel b, size_t z) {
+void lower(Vunit& u, mulinto& i, Vlabel b, size_t z) {
   lower_impl(u, b, z, [&] (Vout& v) {
     auto tmp = v.makeReg();
     auto sf = v.makeReg();

--- a/hphp/runtime/vm/jit/vasm-dead.cpp
+++ b/hphp/runtime/vm/jit/vasm-dead.cpp
@@ -144,7 +144,7 @@ bool effectful(Vinstr& inst) {
     case Vinstr::mrs:
     case Vinstr::mul:
     case Vinstr::mulsd:
-    case Vinstr::mulint:
+    case Vinstr::mulinto:
     case Vinstr::neg:
     case Vinstr::nop:
     case Vinstr::not:

--- a/hphp/runtime/vm/jit/vasm-dead.cpp
+++ b/hphp/runtime/vm/jit/vasm-dead.cpp
@@ -95,8 +95,6 @@ bool effectful(Vinstr& inst) {
     case Vinstr::fctidz:
     case Vinstr::fcvtzs:
     case Vinstr::imul:
-    case Vinstr::smulh:
-    case Vinstr::mul:
     case Vinstr::incl:
     case Vinstr::incq:
     case Vinstr::incw:
@@ -144,6 +142,7 @@ bool effectful(Vinstr& inst) {
     case Vinstr::movzbq:
     case Vinstr::movzlq:
     case Vinstr::mrs:
+    case Vinstr::mul:
     case Vinstr::mulsd:
     case Vinstr::mulint:
     case Vinstr::neg:
@@ -167,6 +166,7 @@ bool effectful(Vinstr& inst) {
     case Vinstr::shlqi:
     case Vinstr::shrli:
     case Vinstr::shrqi:
+    case Vinstr::smulh:
     case Vinstr::sqrtsd:
     case Vinstr::srem:
     case Vinstr::subbi:

--- a/hphp/runtime/vm/jit/vasm-dead.cpp
+++ b/hphp/runtime/vm/jit/vasm-dead.cpp
@@ -69,6 +69,7 @@ bool effectful(Vinstr& inst) {
     case Vinstr::cmpqi:
     case Vinstr::cmpqim:
     case Vinstr::cmpqm:
+    case Vinstr::cmpqsign:
     case Vinstr::cmpsd:
     case Vinstr::cmpsds:
     case Vinstr::cmpwim:
@@ -94,6 +95,8 @@ bool effectful(Vinstr& inst) {
     case Vinstr::fctidz:
     case Vinstr::fcvtzs:
     case Vinstr::imul:
+    case Vinstr::smulh:
+    case Vinstr::mul:
     case Vinstr::incl:
     case Vinstr::incq:
     case Vinstr::incw:
@@ -142,6 +145,7 @@ bool effectful(Vinstr& inst) {
     case Vinstr::movzlq:
     case Vinstr::mrs:
     case Vinstr::mulsd:
+    case Vinstr::mulint:
     case Vinstr::neg:
     case Vinstr::nop:
     case Vinstr::not:

--- a/hphp/runtime/vm/jit/vasm-fusion.cpp
+++ b/hphp/runtime/vm/jit/vasm-fusion.cpp
@@ -54,6 +54,7 @@ bool sets_flags(const Vunit& unit, const Vinstr& inst) {
   case Vinstr::callphp:
   case Vinstr::callarray:
   case Vinstr::contenter:
+  case Vinstr::mulint:
     return true;
   default:
     break;

--- a/hphp/runtime/vm/jit/vasm-fusion.cpp
+++ b/hphp/runtime/vm/jit/vasm-fusion.cpp
@@ -54,7 +54,7 @@ bool sets_flags(const Vunit& unit, const Vinstr& inst) {
   case Vinstr::callphp:
   case Vinstr::callarray:
   case Vinstr::contenter:
-  case Vinstr::mulint:
+  case Vinstr::mulinto:
     return true;
   default:
     break;

--- a/hphp/runtime/vm/jit/vasm-instr.cpp
+++ b/hphp/runtime/vm/jit/vasm-instr.cpp
@@ -67,7 +67,7 @@ bool isBlockEnd(const Vinstr& inst) {
     case Vinstr::leavetc:
     case Vinstr::fallthru:
     // slow-path for overflow
-    case Vinstr::mulint:
+    case Vinstr::mulinto:
       return true;
     default:
       return false;
@@ -305,7 +305,7 @@ Width width(Vinstr::Opcode op) {
     case Vinstr::incqm:
     case Vinstr::incqmlock:
     case Vinstr::imul:
-    case Vinstr::mulint:
+    case Vinstr::mulinto:
     case Vinstr::neg:
     case Vinstr::not:
     case Vinstr::orq:

--- a/hphp/runtime/vm/jit/vasm-instr.cpp
+++ b/hphp/runtime/vm/jit/vasm-instr.cpp
@@ -66,6 +66,8 @@ bool isBlockEnd(const Vinstr& inst) {
     case Vinstr::phpret:
     case Vinstr::leavetc:
     case Vinstr::fallthru:
+    // slow-path for overflow
+    case Vinstr::mulint:
       return true;
     default:
       return false;
@@ -184,6 +186,7 @@ Width width(Vinstr::Opcode op) {
     case Vinstr::bln:
     case Vinstr::cmplims:
     case Vinstr::cmpsds:
+    case Vinstr::cmpqsign:
     case Vinstr::fabs:
     case Vinstr::lslwi:
     case Vinstr::lslwis:
@@ -195,6 +198,7 @@ Width width(Vinstr::Opcode op) {
     case Vinstr::lsrxis:
     case Vinstr::mrs:
     case Vinstr::msr:
+    case Vinstr::mul:
     case Vinstr::orsw:
     case Vinstr::orswi:
     case Vinstr::popp:
@@ -301,6 +305,7 @@ Width width(Vinstr::Opcode op) {
     case Vinstr::incqm:
     case Vinstr::incqmlock:
     case Vinstr::imul:
+    case Vinstr::mulint:
     case Vinstr::neg:
     case Vinstr::not:
     case Vinstr::orq:
@@ -311,6 +316,7 @@ Width width(Vinstr::Opcode op) {
     case Vinstr::sarqi:
     case Vinstr::shlqi:
     case Vinstr::shrqi:
+    case Vinstr::smulh:
     case Vinstr::subq:
     case Vinstr::subqi:
     case Vinstr::xorq:

--- a/hphp/runtime/vm/jit/vasm-instr.h
+++ b/hphp/runtime/vm/jit/vasm-instr.h
@@ -895,7 +895,16 @@ struct srem { Vreg s0, s1, d; };
 struct divint { Vreg s0, s1, d; };
 
 /*
- * Integer multiplication.
+ * Integer multiplication (with overflow).
+ * 
+ * Performs a 64bit integer multiplication (d := s0 * s1) and checks for a
+ * possible overflow.  Given that the method to check for the overflow will
+ * be architecture specific, we don't expose any internal flag status and
+ * mark this as killing the flag register.
+ *
+ * Targets have the same order as for branch instructions (see below):
+ *   target[0] = next (i.e. fall-through)
+ *   target[1] = taken (i.e. slow-path)
  */
 struct mulint { Vreg s0, s1, d; Vlabel targets[2]; };
 

--- a/hphp/runtime/vm/jit/vasm-instr.h
+++ b/hphp/runtime/vm/jit/vasm-instr.h
@@ -128,6 +128,7 @@ struct Vunit;
   O(absdbl, Inone, U(s), D(d))\
   O(srem, Inone, U(s0) U(s1), D(d))\
   O(divint, Inone, U(s0) U(s1), D(d))\
+  O(mulint, Inone, U(s0) U(s1), D(d))	\
   /* nop and trap */\
   O(nop, Inone, Un, Dn)\
   O(ud2, Inone, Un, Dn)\
@@ -160,6 +161,8 @@ struct Vunit;
   O(incqm, Inone, U(m), D(sf))\
   O(incqmlock, Inone, U(m), D(sf))\
   O(imul, Inone, U(s0) U(s1), D(d) D(sf))\
+  O(smulh, Inone, U(s0) U(s1), D(d)) \
+  O(mul, Inone, U(s0) U(s1), D(d)) \
   O(neg, Inone, UH(s,d), DH(d,s) D(sf))\
   O(notb, Inone, UH(s,d), DH(d,s))\
   O(not, Inone, UH(s,d), DH(d,s))\
@@ -203,6 +206,7 @@ struct Vunit;
   O(cmpqi, I(s0), U(s1), D(sf))\
   O(cmpqm, Inone, U(s0) U(s1), D(sf))\
   O(cmpqim, I(s0), U(s1), D(sf))\
+  O(cmpqsign, Inone, U(s0) U(s1), D(sf))	\
   O(cmpsd, I(pred), UA(s0) U(s1), D(d))\
   O(ucomisd, Inone, U(s0) U(s1), D(sf))\
   O(testb, Inone, U(s0) U(s1), D(sf))\
@@ -890,6 +894,11 @@ struct srem { Vreg s0, s1, d; };
  */
 struct divint { Vreg s0, s1, d; };
 
+/*
+ * Integer multiplication.
+ */
+struct mulint { Vreg s0, s1, d; Vlabel targets[2]; };
+
 ///////////////////////////////////////////////////////////////////////////////
 
 /*
@@ -939,6 +948,8 @@ struct incqm { Vptr m; VregSF sf; };
 struct incqmlock { Vptr m; VregSF sf; };
 // mul: s0 * s1 => d, sf
 struct imul { Vreg64 s0, s1, d; VregSF sf; };
+struct mul { Vreg64 s0, s1, d; };
+struct smulh { Vreg64 s0, s1, d; };
 // neg: 0 - s => d, sf
 struct neg { Vreg64 s, d; VregSF sf; };
 // not: ~s => d
@@ -992,6 +1003,7 @@ struct cmpq { Vreg64 s0; Vreg64 s1; VregSF sf; };
 struct cmpqi { Immed s0; Vreg64 s1; VregSF sf; };
 struct cmpqm { Vreg64 s0; Vptr s1; VregSF sf; };
 struct cmpqim { Immed s0; Vptr s1; VregSF sf; };
+struct cmpqsign { Vreg64 s0; Vreg64 s1; VregSF sf; };
 struct cmpsd { ComparisonPred pred; VregDbl s0, s1, d; };
 struct ucomisd { VregDbl s0, s1; VregSF sf; };
 // s1 & s0 => sf

--- a/hphp/runtime/vm/jit/vasm-instr.h
+++ b/hphp/runtime/vm/jit/vasm-instr.h
@@ -128,7 +128,7 @@ struct Vunit;
   O(absdbl, Inone, U(s), D(d))\
   O(srem, Inone, U(s0) U(s1), D(d))\
   O(divint, Inone, U(s0) U(s1), D(d))\
-  O(mulint, Inone, U(s0) U(s1), D(d))	\
+  O(mulinto, Inone, U(s0) U(s1), D(d))	\
   /* nop and trap */\
   O(nop, Inone, Un, Dn)\
   O(ud2, Inone, Un, Dn)\
@@ -906,7 +906,7 @@ struct divint { Vreg s0, s1, d; };
  *   target[0] = next (i.e. fall-through)
  *   target[1] = taken (i.e. slow-path)
  */
-struct mulint { Vreg s0, s1, d; Vlabel targets[2]; };
+struct mulinto { Vreg s0, s1, d; Vlabel targets[2]; };
 
 ///////////////////////////////////////////////////////////////////////////////
 

--- a/hphp/runtime/vm/jit/vasm-instr.h
+++ b/hphp/runtime/vm/jit/vasm-instr.h
@@ -161,7 +161,6 @@ struct Vunit;
   O(incqm, Inone, U(m), D(sf))\
   O(incqmlock, Inone, U(m), D(sf))\
   O(imul, Inone, U(s0) U(s1), D(d) D(sf))\
-  O(smulh, Inone, U(s0) U(s1), D(d)) \
   O(mul, Inone, U(s0) U(s1), D(d)) \
   O(neg, Inone, UH(s,d), DH(d,s) D(sf))\
   O(notb, Inone, UH(s,d), DH(d,s))\
@@ -314,6 +313,7 @@ struct Vunit;
   O(orsw, Inone, U(s0) U(s1), D(d) D(sf)) \
   O(popp, Inone, Un, D(d0) D(d1))\
   O(pushp, Inone, U(s0) U(s1), Dn)\
+  O(smulh, Inone, U(s0) U(s1), D(d)) \
   O(subsb, Inone, UA(s0) U(s1), D(d) D(sf))\
   O(uxth, Inone, U(s), D(d))\
   /* ppc64 instructions */\
@@ -957,8 +957,6 @@ struct incqm { Vptr m; VregSF sf; };
 struct incqmlock { Vptr m; VregSF sf; };
 // mul: s0 * s1 => d, sf
 struct imul { Vreg64 s0, s1, d; VregSF sf; };
-struct mul { Vreg64 s0, s1, d; };
-struct smulh { Vreg64 s0, s1, d; };
 // neg: 0 - s => d, sf
 struct neg { Vreg64 s, d; VregSF sf; };
 // not: ~s => d
@@ -1012,7 +1010,6 @@ struct cmpq { Vreg64 s0; Vreg64 s1; VregSF sf; };
 struct cmpqi { Immed s0; Vreg64 s1; VregSF sf; };
 struct cmpqm { Vreg64 s0; Vptr s1; VregSF sf; };
 struct cmpqim { Immed s0; Vptr s1; VregSF sf; };
-struct cmpqsign { Vreg64 s0; Vreg64 s1; VregSF sf; };
 struct cmpsd { ComparisonPred pred; VregDbl s0, s1, d; };
 struct ucomisd { VregDbl s0, s1; VregSF sf; };
 // s1 & s0 => sf
@@ -1150,6 +1147,8 @@ struct asrxis { Immed s0; Vreg64 s1, d, df; VregSF sf; };
 struct bln {};
 struct cmplims { Immed s0; Vptr s1; VregSF sf; };
 struct cmpsds { ComparisonPred pred; VregDbl s0, s1, d; VregSF sf; };
+// cmpqsign: compares if s0 is the sign-extension of s1
+struct cmpqsign { Vreg64 s0; Vreg64 s1; VregSF sf; };
 struct fabs { VregDbl s, d; };
 struct fcvtzs { VregDbl s; Vreg64 d;};
 struct lslwi { Immed s0; Vreg32 s1, d; };
@@ -1162,10 +1161,12 @@ struct lsrxi { Immed s0; Vreg64 s1, d; };
 struct lsrxis { Immed s0; Vreg64 s1, d, df; VregSF sf; };
 struct mrs { Immed s; Vreg64 r; };
 struct msr { Vreg64 r; Immed s; };
+struct mul { Vreg64 s0, s1, d; };
 struct orswi { Immed s0; Vreg32 s1, d; VregSF sf; };
 struct orsw { Vreg32 s0, s1, d; VregSF sf; };
 struct popp { Vreg64 d0, d1; };
 struct pushp { Vreg64 s0, s1; };
+struct smulh { Vreg64 s0, s1, d; };
 struct subsb { Vreg8 s0, s1, d; VregSF sf; };
 struct uxth { Vreg16 s; Vreg32 d; };
 

--- a/hphp/runtime/vm/jit/vasm-ppc64.cpp
+++ b/hphp/runtime/vm/jit/vasm-ppc64.cpp
@@ -1469,6 +1469,13 @@ void lowerForPPC64(Vout& v, absdbl& inst) {
   v << copy{after_conv, inst.d};
 }
 
+void lowerForPPC64(Vout& v, mulint& inst) {
+  auto sf = v.makeReg();
+
+  v << imul{inst.s1, inst.s0, inst.d, sf};
+  v << jcc{CC_O, sf, inst.targets[0], inst.targets[1]};
+}
+
 void lowerForPPC64(Vout& v, decqmlock& inst) {
   Vptr p = inst.m;
   patchVptr(p, v);

--- a/hphp/runtime/vm/jit/vasm-ppc64.cpp
+++ b/hphp/runtime/vm/jit/vasm-ppc64.cpp
@@ -1469,7 +1469,7 @@ void lowerForPPC64(Vout& v, absdbl& inst) {
   v << copy{after_conv, inst.d};
 }
 
-void lowerForPPC64(Vout& v, mulint& inst) {
+void lowerForPPC64(Vout& v, mulinto& inst) {
   auto sf = v.makeReg();
 
   v << imul{inst.s1, inst.s0, inst.d, sf};

--- a/hphp/runtime/vm/jit/vasm-x64.cpp
+++ b/hphp/runtime/vm/jit/vasm-x64.cpp
@@ -870,7 +870,7 @@ void lower(Vunit& unit, divint& inst, Vlabel b, size_t i) {
   });
 }
 
-void lower(Vunit& unit, mulint& inst, Vlabel b, size_t i) {
+void lower(Vunit& unit, mulinto& inst, Vlabel b, size_t i) {
   lower_impl(unit, b, i, [&] (Vout& v) {
     auto sf = v.makeReg();
 

--- a/hphp/runtime/vm/jit/vasm-x64.cpp
+++ b/hphp/runtime/vm/jit/vasm-x64.cpp
@@ -875,7 +875,7 @@ void lower(Vunit& unit, mulint& inst, Vlabel b, size_t i) {
     auto sf = v.makeReg();
 
     v << imul{inst.s1, inst.s0, inst.d, sf};
-    v << jcc{CC_NE, sf, inst.targets[0], inst.targets[1]};
+    v << jcc{CC_O, sf, inst.targets[0], inst.targets[1]};
   });
 }
 

--- a/hphp/runtime/vm/jit/vasm-x64.cpp
+++ b/hphp/runtime/vm/jit/vasm-x64.cpp
@@ -870,6 +870,15 @@ void lower(Vunit& unit, divint& inst, Vlabel b, size_t i) {
   });
 }
 
+void lower(Vunit& unit, mulint& inst, Vlabel b, size_t i) {
+  lower_impl(unit, b, i, [&] (Vout& v) {
+    auto sf = v.makeReg();
+
+    v << imul{inst.s1, inst.s0, inst.d, sf};
+    v << jcc{CC_NE, sf, inst.targets[0], inst.targets[1]};
+  });
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 
 void lower(Vunit& unit, movtqb& inst, Vlabel b, size_t i) {

--- a/hphp/runtime/vm/jit/vasm.cpp
+++ b/hphp/runtime/vm/jit/vasm.cpp
@@ -39,6 +39,7 @@ folly::Range<Vlabel*> succs(Vinstr& inst) {
     case Vinstr::unwind:      return {inst.unwind_.targets, 2};
     case Vinstr::vcallarray:  return {inst.vcallarray_.targets, 2};
     case Vinstr::vinvoke:     return {inst.vinvoke_.targets, 2};
+    case Vinstr::mulint:      return {inst.mulint_.targets, 2};
     default:                  return {nullptr, nullptr};
   }
 }

--- a/hphp/runtime/vm/jit/vasm.cpp
+++ b/hphp/runtime/vm/jit/vasm.cpp
@@ -39,7 +39,7 @@ folly::Range<Vlabel*> succs(Vinstr& inst) {
     case Vinstr::unwind:      return {inst.unwind_.targets, 2};
     case Vinstr::vcallarray:  return {inst.vcallarray_.targets, 2};
     case Vinstr::vinvoke:     return {inst.vinvoke_.targets, 2};
-    case Vinstr::mulint:      return {inst.mulint_.targets, 2};
+    case Vinstr::mulinto:     return {inst.mulinto_.targets, 2};
     default:                  return {nullptr, nullptr};
   }
 }


### PR DESCRIPTION
AArch64 does not set flags on an integer-multiply and the common
way to detect an overflow on integer multiplication will only
provide EQ/NEQ flags.  To avoid taking a major penalty when
checking for overflows on integer multiplication, we make the
lowering of MulIntO architecture-specific and introduce a new
architecture-independent mulint (similarily to divint) vasm-insn.

The MulIntO node is lowered into the new 'mulint' vasm-instr, which
is a special kind of branching instruction (i.e. it takes a label
for the slow-path, in case an integer-overflow occurs).
'mulint' is marked to clobber the condition-code register.

The recommended way to detect an overflow on integer multiplication
on AArch64 is:
  mul	  calculate lower 64bit of the result
  smulh	  calculate the upper (signed/sign-extended) 64bits
  cmp	  compare if the upper 64bits are the sign-extension
	      of the lower 64bits (i.e. if all bits in the
 	      upper register are the same as the sign-bit in
	      the lower register.

To efficiently expand into such a sequence, the following vasm
instructions have been added:
  smulh	     upper 64bits of the 128bit result of a signed multiply
	       (could be named more nicely, but as only AArch64 is
	        using anyway...)
  cmpqsign   compare if one operand is the sign-extension of the
               other operand (i.e if all bits in one register are
               equivalent to the sign-bit of the other)
  mulint     integer-multiplication w/ overflow-checking

At the same time, the 'imul' vasm has been altered to _not_ set any
flags and _not_ perform any overflow-checking.  As it's only used
from the non-overflowing multiplication path in irlower-arith.c this
seems to be safe.  We an not remove 'imul', as it will still be used
to expand to lower 'MulInt'.

X-AffectedTests: quick/float-overflow.php
Signed-off-by: Philipp Tomsich <philipp.tomsich@theobroma-systems.com>