### PR TITLE
[AArch64] Adds cmake option to set mcpu for GCC.

### DIFF
--- a/CMake/HPHPCompiler.cmake
+++ b/CMake/HPHPCompiler.cmake
@@ -175,6 +175,28 @@ if (${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang" OR ${CMAKE_CXX_COMPILER_ID} STREQU
       list(APPEND GENERAL_CXX_OPTIONS "mcrc32")
     endif()
 
+    # ARM64
+    if(IS_AARCH64)
+      # Force char type to be signed, which is not the case on aarch64.
+      list(APPEND GENERAL_OPTIONS "fsigned-char")
+
+      # If a CPU was specified, build a -mcpu option for the compiler.
+      set(CPU "" CACHE STRING "CPU to tell gcc to optimize for (-mcpu)")
+      if(CPU)
+        list(APPEND GENERAL_OPTIONS "mcpu=${CPU}")
+      endif()
+
+      # Make sure GCC is not using the fix for errata 843419. This change
+      # interferes with the gold linker. Note that GCC applies this fix
+      # even if you specify an mcpu other than cortex-a53, which is why
+      # it's explicitly being disabled here for any cpu other than
+      # cortex-a53. If you're running a newer pass of the cortex-a53, then
+      # you can likely disable this fix with the following flag too. YMMV
+      if(NOT ${CPU} STREQUAL "cortex-a53")
+        list(APPEND GENERAL_OPTIONS "mno-fix-cortex-a53-843419")
+      endif()
+    endif()
+
     # PPC64
     if(NOT IS_PPC64)
       list(APPEND RELEASE_CXX_OPTIONS "momit-leaf-frame-pointer")


### PR DESCRIPTION
GCC defaults to cortex-a53, which is inappropriate for
out-of-order machines. Additionally sets signed chars and disables
the fix for cortex-a53 errata 843419 which GCC applies even when
mcpu != cortex-a53.