### PR TITLE
Add explicit indirect return arguments.

### DIFF
--- a/hphp/runtime/vm/jit/abi-arm.cpp
+++ b/hphp/runtime/vm/jit/abi-arm.cpp
@@ -161,12 +161,19 @@ PhysReg rarg_simd(size_t i) {
   assertx(i < num_arg_regs_simd());
   return vixl::FPRegister::DRegFromCode(i);
 }
+PhysReg rarg_ind_ret(size_t i) {
+  assertx(i < num_arg_regs_ind_ret());
+  return vixl::x8;
+}
 
 RegSet arg_regs(size_t n) {
   return jit::arg_regs(n);
 }
 RegSet arg_regs_simd(size_t n) {
   return jit::arg_regs_simd(n);
+}
+RegSet arg_regs_ind_ret(size_t n) {
+  return jit::arg_regs_ind_ret(n);
 }
 
 PhysReg r_svcreq_req() { return rarg(0); }

--- a/hphp/runtime/vm/jit/abi-arm.cpp
+++ b/hphp/runtime/vm/jit/abi-arm.cpp
@@ -169,12 +169,6 @@ PhysReg rarg_ind_ret(size_t i) {
 RegSet arg_regs(size_t n) {
   return jit::arg_regs(n);
 }
-RegSet arg_regs_simd(size_t n) {
-  return jit::arg_regs_simd(n);
-}
-RegSet arg_regs_ind_ret(size_t n) {
-  return jit::arg_regs_ind_ret(n);
-}
 
 PhysReg r_svcreq_req() { return rarg(0); }
 PhysReg r_svcreq_stub() { return rarg(1); }

--- a/hphp/runtime/vm/jit/abi-arm.h
+++ b/hphp/runtime/vm/jit/abi-arm.h
@@ -53,19 +53,21 @@ inline PhysReg rret_type() { return vixl::x1; }
 
 PhysReg rret(size_t i = 0);
 PhysReg rret_simd(size_t i);
-inline PhysReg rret_indirect() { return vixl::x8; }
 
 PhysReg rarg(size_t i);
 PhysReg rarg_simd(size_t i);
+PhysReg rarg_ind_ret(size_t i);
 
 inline PhysReg rfp() { return vixl::x29; }
 inline PhysReg rlr() { return vixl::x30; }
 
 constexpr size_t num_arg_regs() { return 8; }
 constexpr size_t num_arg_regs_simd() { return 8; }
+constexpr size_t num_arg_regs_ind_ret() { return 1; }
 
 RegSet arg_regs(size_t n);
 RegSet arg_regs_simd(size_t n);
+RegSet arg_regs_ind_ret(size_t n);
 
 PhysReg r_svcreq_req();
 PhysReg r_svcreq_stub();

--- a/hphp/runtime/vm/jit/abi-arm.h
+++ b/hphp/runtime/vm/jit/abi-arm.h
@@ -66,8 +66,6 @@ constexpr size_t num_arg_regs_simd() { return 8; }
 constexpr size_t num_arg_regs_ind_ret() { return 1; }
 
 RegSet arg_regs(size_t n);
-RegSet arg_regs_simd(size_t n);
-RegSet arg_regs_ind_ret(size_t n);
 
 PhysReg r_svcreq_req();
 PhysReg r_svcreq_stub();

--- a/hphp/runtime/vm/jit/abi-ppc64.cpp
+++ b/hphp/runtime/vm/jit/abi-ppc64.cpp
@@ -172,12 +172,19 @@ PhysReg rarg_simd(size_t i) {
   assertx(i < num_arg_regs_simd());
   return simd_args[i];
 }
+PhysReg rarg_ind_ret(size_t i) {
+  assertx(i < num_arg_regs_ind_ret());
+  return PhysReg();
+}
 
 size_t num_arg_regs() {
   return sizeof(gp_args) / sizeof(PhysReg);
 }
 size_t num_arg_regs_simd() {
   return sizeof(simd_args) / sizeof(PhysReg);
+}
+size_t num_arg_regs_ind_ret() {
+  return 0;
 }
 
 

--- a/hphp/runtime/vm/jit/abi-ppc64.cpp
+++ b/hphp/runtime/vm/jit/abi-ppc64.cpp
@@ -183,9 +183,6 @@ size_t num_arg_regs() {
 size_t num_arg_regs_simd() {
   return sizeof(simd_args) / sizeof(PhysReg);
 }
-size_t num_arg_regs_ind_ret() {
-  return 0;
-}
 
 
 PhysReg r_svcreq_sf() {

--- a/hphp/runtime/vm/jit/abi-ppc64.h
+++ b/hphp/runtime/vm/jit/abi-ppc64.h
@@ -89,13 +89,14 @@ constexpr PhysReg rret_type() { return ppc64_asm::reg::r4; }
 
 PhysReg rret(size_t i = 0);
 PhysReg rret_simd(size_t i);
-constexpr PhysReg rret_indirect() { return ppc64_asm::reg::r3; };
 
 PhysReg rarg(size_t i);
 PhysReg rarg_simd(size_t i);
+PhysReg rarg_ind_ret(size_t i);
 
 size_t num_arg_regs();
 size_t num_arg_regs_simd();
+size_t num_arg_regs_ind_ret();
 
 constexpr PhysReg r_svcreq_req()  { return ppc64_asm::reg::r3; }
 constexpr PhysReg r_svcreq_stub() { return ppc64_asm::reg::r8; }

--- a/hphp/runtime/vm/jit/abi-ppc64.h
+++ b/hphp/runtime/vm/jit/abi-ppc64.h
@@ -96,7 +96,7 @@ PhysReg rarg_ind_ret(size_t i);
 
 size_t num_arg_regs();
 size_t num_arg_regs_simd();
-size_t num_arg_regs_ind_ret();
+constexpr size_t num_arg_regs_ind_ret() { return 0; }
 
 constexpr PhysReg r_svcreq_req()  { return ppc64_asm::reg::r3; }
 constexpr PhysReg r_svcreq_stub() { return ppc64_asm::reg::r8; }

--- a/hphp/runtime/vm/jit/abi-x64.cpp
+++ b/hphp/runtime/vm/jit/abi-x64.cpp
@@ -173,6 +173,10 @@ PhysReg rarg_simd(size_t i) {
   assertx(i < num_arg_regs_simd());
   return simd_args[i];
 }
+PhysReg rarg_ind_ret(size_t i) {
+  assertx(i < num_arg_regs_ind_ret());
+  return PhysReg();
+}
 
 size_t num_arg_regs() {
   return sizeof(gp_args) / sizeof(PhysReg);
@@ -180,12 +184,18 @@ size_t num_arg_regs() {
 size_t num_arg_regs_simd() {
   return sizeof(simd_args) / sizeof(PhysReg);
 }
+size_t num_arg_regs_ind_ret() {
+  return 0;
+}
 
 RegSet arg_regs(size_t n) {
   return jit::arg_regs(n);
 }
 RegSet arg_regs_simd(size_t n) {
   return jit::arg_regs_simd(n);
+}
+RegSet arg_regs_ind_ret(size_t n) {
+  return jit::arg_regs_ind_ret(n);
 }
 
 PhysReg r_svcreq_sf() {

--- a/hphp/runtime/vm/jit/abi-x64.cpp
+++ b/hphp/runtime/vm/jit/abi-x64.cpp
@@ -184,18 +184,9 @@ size_t num_arg_regs() {
 size_t num_arg_regs_simd() {
   return sizeof(simd_args) / sizeof(PhysReg);
 }
-size_t num_arg_regs_ind_ret() {
-  return 0;
-}
 
 RegSet arg_regs(size_t n) {
   return jit::arg_regs(n);
-}
-RegSet arg_regs_simd(size_t n) {
-  return jit::arg_regs_simd(n);
-}
-RegSet arg_regs_ind_ret(size_t n) {
-  return jit::arg_regs_ind_ret(n);
 }
 
 PhysReg r_svcreq_sf() {

--- a/hphp/runtime/vm/jit/abi-x64.h
+++ b/hphp/runtime/vm/jit/abi-x64.h
@@ -49,16 +49,18 @@ constexpr PhysReg rret_type() { return reg::rdx; }
 
 PhysReg rret(size_t i = 0);
 PhysReg rret_simd(size_t i);
-constexpr PhysReg rret_indirect() { return reg::rax; }
 
 PhysReg rarg(size_t i);
 PhysReg rarg_simd(size_t i);
+PhysReg rarg_ind_ret(size_t i);
 
 size_t num_arg_regs();
 size_t num_arg_regs_simd();
+size_t num_arg_regs_ind_ret();
 
 RegSet arg_regs(size_t n);
 RegSet arg_regs_simd(size_t n);
+RegSet arg_regs_ind_ret(size_t n);
 
 constexpr PhysReg r_svcreq_req()  { return reg::rdi; }
 constexpr PhysReg r_svcreq_stub() { return reg::r10; }

--- a/hphp/runtime/vm/jit/abi-x64.h
+++ b/hphp/runtime/vm/jit/abi-x64.h
@@ -56,11 +56,9 @@ PhysReg rarg_ind_ret(size_t i);
 
 size_t num_arg_regs();
 size_t num_arg_regs_simd();
-size_t num_arg_regs_ind_ret();
+constexpr size_t num_arg_regs_ind_ret() { return 0; }
 
 RegSet arg_regs(size_t n);
-RegSet arg_regs_simd(size_t n);
-RegSet arg_regs_ind_ret(size_t n);
 
 constexpr PhysReg r_svcreq_req()  { return reg::rdi; }
 constexpr PhysReg r_svcreq_stub() { return reg::r10; }

--- a/hphp/runtime/vm/jit/abi.cpp
+++ b/hphp/runtime/vm/jit/abi.cpp
@@ -41,13 +41,14 @@ PhysReg rret_type() { return ARCH_SWITCH_CALL(rret_type); }
 
 PhysReg rret(size_t i) { return ARCH_SWITCH_CALL(rret, i); }
 PhysReg rret_simd(size_t i) { return ARCH_SWITCH_CALL(rret_simd, i); }
-PhysReg rret_indirect() { return ARCH_SWITCH_CALL(rret_indirect); }
 
 PhysReg rarg(size_t i) { return ARCH_SWITCH_CALL(rarg, i); }
 PhysReg rarg_simd(size_t i) { return ARCH_SWITCH_CALL(rarg_simd, i); }
+PhysReg rarg_ind_ret(size_t i) { return ARCH_SWITCH_CALL(rarg_ind_ret, i); }
 
 size_t num_arg_regs() { return ARCH_SWITCH_CALL(num_arg_regs); }
 size_t num_arg_regs_simd() { return ARCH_SWITCH_CALL(num_arg_regs_simd); }
+size_t num_arg_regs_ind_ret() { return ARCH_SWITCH_CALL(num_arg_regs_ind_ret); }
 
 PhysReg r_svcreq_req() { return ARCH_SWITCH_CALL(r_svcreq_req); }
 PhysReg r_svcreq_stub() { return ARCH_SWITCH_CALL(r_svcreq_stub); }
@@ -65,6 +66,12 @@ RegSet arg_regs(size_t n) {
 RegSet arg_regs_simd(size_t n) {
   RegSet regs;
   for (auto i = 0; i < n; i++) regs |= rarg_simd(i);
+  return regs;
+}
+
+RegSet arg_regs_ind_ret(size_t n) {
+  RegSet regs;
+  for (auto i = 0; i < n; i++) regs |= rarg_ind_ret(i);
   return regs;
 }
 

--- a/hphp/runtime/vm/jit/abi.cpp
+++ b/hphp/runtime/vm/jit/abi.cpp
@@ -63,18 +63,6 @@ RegSet arg_regs(size_t n) {
   return regs;
 }
 
-RegSet arg_regs_simd(size_t n) {
-  RegSet regs;
-  for (auto i = 0; i < n; i++) regs |= rarg_simd(i);
-  return regs;
-}
-
-RegSet arg_regs_ind_ret(size_t n) {
-  RegSet regs;
-  for (auto i = 0; i < n; i++) regs |= rarg_ind_ret(i);
-  return regs;
-}
-
 ///////////////////////////////////////////////////////////////////////////////
 
 }}

--- a/hphp/runtime/vm/jit/abi.h
+++ b/hphp/runtime/vm/jit/abi.h
@@ -78,25 +78,27 @@ PhysReg rret_type();
  */
 PhysReg rret(size_t i = 0);
 PhysReg rret_simd(size_t i);
-PhysReg rret_indirect();
 
 /*
  * Native argument registers.
  */
 PhysReg rarg(size_t i);
 PhysReg rarg_simd(size_t i);
+PhysReg rarg_ind_ret(size_t i);
 
 /*
  * Number of available argument registers.
  */
 size_t num_arg_regs();
 size_t num_arg_regs_simd();
+size_t num_arg_regs_ind_ret();
 
 /*
  * RegSet for a call with `n' arguments.
  */
 RegSet arg_regs(size_t n);
 RegSet arg_regs_simd(size_t n);
+RegSet arg_regs_ind_ret(size_t n);
 
 /*
  * Service request argument registers.

--- a/hphp/runtime/vm/jit/abi.h
+++ b/hphp/runtime/vm/jit/abi.h
@@ -97,8 +97,6 @@ size_t num_arg_regs_ind_ret();
  * RegSet for a call with `n' arguments.
  */
 RegSet arg_regs(size_t n);
-RegSet arg_regs_simd(size_t n);
-RegSet arg_regs_ind_ret(size_t n);
 
 /*
  * Service request argument registers.

--- a/hphp/runtime/vm/jit/arg-group.cpp
+++ b/hphp/runtime/vm/jit/arg-group.cpp
@@ -29,12 +29,13 @@ TRACE_SET_MOD(hhir);
 
 const char* destTypeName(DestType dt) {
   switch (dt) {
-    case DestType::None: return "None";
-    case DestType::SSA:  return "SSA";
-    case DestType::Byte: return "Byte";
-    case DestType::TV:   return "TV";
-    case DestType::Dbl:  return "Dbl";
-    case DestType::SIMD: return "SIMD";
+    case DestType::None:     return "None";
+    case DestType::Indirect: return "Indirect";
+    case DestType::SSA:      return "SSA";
+    case DestType::Byte:     return "Byte";
+    case DestType::TV:       return "TV";
+    case DestType::Dbl:      return "Dbl";
+    case DestType::SIMD:     return "SIMD";
   }
   not_reached();
 }
@@ -98,7 +99,11 @@ void ArgGroup::push_arg(const ArgDesc& arg) {
   // m_gpArgs or m_stkArgs depending on how many args we've already pushed.
   ArgVec* args = m_override;
   if (!args) {
-    args = m_gpArgs.size() < num_arg_regs() ? &m_gpArgs : &m_stkArgs;
+    if (arg.kind() == ArgDesc::Kind::IndRet && num_arg_regs_ind_ret() > 0) {
+      args = &m_indRetArgs;
+    } else {
+      args = m_gpArgs.size() < num_arg_regs() ? &m_gpArgs : &m_stkArgs;
+    }
   }
   args->push_back(arg);
 }

--- a/hphp/runtime/vm/jit/arg-group.h
+++ b/hphp/runtime/vm/jit/arg-group.h
@@ -84,8 +84,8 @@ struct ArgDesc {
     return m_typeImm;
   }
   Immed disp() const {
-    assertx((m_kind == Kind::Addr) ||
-	    (m_kind == Kind::IndRet));
+    assertx(m_kind == Kind::Addr ||
+	    m_kind == Kind::IndRet);
     return m_disp32;
   }
   bool isZeroExtend() const { return m_zeroExtend; }
@@ -199,6 +199,12 @@ struct ArgGroup {
     return *this;
   }
 
+  /*
+   * indRet args are similar to simple addr args, but are used specifically to
+   * pass the address that the native call will use for indirect returns. If a
+   * platform has no dedicated registers for indirect returns, then it uses
+   * the first general purpose argument register.
+   */
   ArgGroup& indRet(Vreg base, Immed off) {
     push_arg(ArgDesc(ArgDesc::Kind::IndRet, base, off));
     return *this;

--- a/hphp/runtime/vm/jit/arg-group.h
+++ b/hphp/runtime/vm/jit/arg-group.h
@@ -44,12 +44,13 @@ namespace NativeCalls { struct CallInfo; }
 //////////////////////////////////////////////////////////////////////
 
 enum class DestType : uint8_t {
-  None,  // return void (no valid registers)
-  SSA,   // return a single-register value
-  Byte,  // return a single-byte register value
-  TV,    // return a TypedValue packed in two registers
-  Dbl,   // return scalar double in a single FP register
-  SIMD,  // return a TypedValue in one SIMD register
+  None,      // return void (no valid registers)
+  Indirect,  // return struct/object to the address in the first arg
+  SSA,       // return a single-register value
+  Byte,      // return a single-byte register value
+  TV,        // return a TypedValue packed in two registers
+  Dbl,       // return scalar double in a single FP register
+  SIMD,      // return a TypedValue in one SIMD register
 };
 const char* destTypeName(DestType);
 
@@ -58,6 +59,7 @@ struct CallDest {
   Vreg reg0, reg1;
 };
 UNUSED const CallDest kVoidDest { DestType::None };
+UNUSED const CallDest kIndirectDest { DestType::Indirect };
 
 struct ArgDesc {
   enum class Kind {
@@ -66,6 +68,7 @@ struct ArgDesc {
     TypeImm, // DataType Immediate
     Addr,    // Address (register plus 32-bit displacement)
     DataPtr, // Pointer to data section
+    IndRet,  // Indirect Return Address (register plus 32-bit displacement)
   };
 
   PhysReg dstReg() const { return m_dstReg; }
@@ -80,7 +83,11 @@ struct ArgDesc {
     assertx(m_kind == Kind::TypeImm);
     return m_typeImm;
   }
-  Immed disp() const { assertx(m_kind == Kind::Addr); return m_disp32; }
+  Immed disp() const {
+    assertx((m_kind == Kind::Addr) ||
+	    (m_kind == Kind::IndRet));
+    return m_disp32;
+  }
   bool isZeroExtend() const { return m_zeroExtend; }
   bool done() const { return m_done; }
   void markDone() { m_done = true; }
@@ -143,7 +150,7 @@ struct ArgGroup {
   size_t numGpArgs() const { return m_gpArgs.size(); }
   size_t numSimdArgs() const { return m_simdArgs.size(); }
   size_t numStackArgs() const { return m_stkArgs.size(); }
-  bool isIndirect() const { return m_indirect; }
+  size_t numIndRetArgs() const { return m_indRetArgs.size(); }
 
   ArgDesc& gpArg(size_t i) {
     assertx(i < m_gpArgs.size());
@@ -159,6 +166,10 @@ struct ArgGroup {
   const ArgDesc& stkArg(size_t i) const {
     assertx(i < m_stkArgs.size());
     return m_stkArgs[i];
+  }
+  const ArgDesc& indRetArg(size_t i) const {
+    assertx(i < m_indRetArgs.size());
+    return m_indRetArgs[i];
   }
   ArgDesc& operator[](size_t i) = delete;
 
@@ -188,6 +199,11 @@ struct ArgGroup {
     return *this;
   }
 
+  ArgGroup& indRet(Vreg base, Immed off) {
+    push_arg(ArgDesc(ArgDesc::Kind::IndRet, base, off));
+    return *this;
+  }
+
   ArgGroup& ssa(int i, bool isFP = false) {
     auto s = m_inst->src(i);
     ArgDesc arg(s, m_locs[s]);
@@ -200,11 +216,6 @@ struct ArgGroup {
     } else {
       push_arg(arg);
     }
-    return *this;
-  }
-
-  ArgGroup& indirect() {
-    m_indirect = true;
     return *this;
   }
 
@@ -250,10 +261,10 @@ private:
   const IRInstruction* m_inst;
   const StateVector<SSATmp,Vloc>& m_locs;
   ArgVec* m_override{nullptr}; // force args to go into a specific ArgVec
+  ArgVec m_indRetArgs; // Indirect Return Address
   ArgVec m_gpArgs; // INTEGER class args
   ArgVec m_simdArgs; // SSE class args
   ArgVec m_stkArgs; // Overflow
-  bool m_indirect{false}; // has indirect result?
 };
 
 ArgGroup toArgGroup(const NativeCalls::CallInfo&,

--- a/hphp/runtime/vm/jit/irlower-call.cpp
+++ b/hphp/runtime/vm/jit/irlower-call.cpp
@@ -248,8 +248,7 @@ void cgCallBuiltin(IRLS& env, const IRInstruction* inst) {
       // Pass the address of tvBuiltinReturn to the native function as the
       // location where it can construct the return Array, String, Object, or
       // Variant.
-      args.addr(rvmtl(), returnOffset);
-      args.indirect();
+      args.indRet(rvmtl(), returnOffset);
     }
   }
 

--- a/hphp/runtime/vm/jit/irlower-internal.cpp
+++ b/hphp/runtime/vm/jit/irlower-internal.cpp
@@ -46,6 +46,13 @@ namespace {
  */
 void prepareArg(const ArgDesc& arg, Vout& v, VregList& vargs) {
   switch (arg.kind()) {
+    case ArgDesc::Kind::IndRet: {
+      auto tmp = v.makeReg();
+      v << lea{arg.srcReg()[arg.disp().l()], tmp};
+      vargs.push_back(tmp);
+      break;
+    }
+
     case ArgDesc::Kind::Reg: {
       auto reg = arg.srcReg();
       if (arg.isZeroExtend()) {
@@ -111,8 +118,11 @@ Fixup makeFixup(const BCMarker& marker, SyncOptions sync) {
 void cgCallHelper(Vout& v, IRLS& env, CallSpec call, const CallDest& dstInfo,
                   SyncOptions sync, const ArgGroup& args) {
   auto const inst = args.inst();
-  jit::vector<Vreg> vargs, vSimdArgs, vStkArgs;
+  jit::vector<Vreg> vIndRetArgs, vargs, vSimdArgs, vStkArgs;
 
+  for (size_t i = 0; i < args.numIndRetArgs(); ++i) {
+    prepareArg(args.indRetArg(i), v, vIndRetArgs);
+  }
   for (size_t i = 0; i < args.numGpArgs(); ++i) {
     prepareArg(args.gpArg(i), v, vargs);
   }
@@ -174,7 +184,7 @@ void cgCallHelper(Vout& v, IRLS& env, CallSpec call, const CallDest& dstInfo,
     std::move(vargs),
     std::move(vSimdArgs),
     std::move(vStkArgs),
-    args.isIndirect()
+    std::move(vIndRetArgs)
   });
   auto const dstId = v.makeTuple(std::move(dstRegs));
 
@@ -199,6 +209,8 @@ void cgCallNative(Vout& v, IRLS& env, const IRInstruction* inst) {
     switch (info.dest) {
       case DestType::None:
         return kVoidDest;
+      case DestType::Indirect:
+        return kIndirectDest;
       case DestType::TV:
       case DestType::SIMD:
         return callDestTV(env, inst);

--- a/hphp/runtime/vm/jit/irlower-internal.cpp
+++ b/hphp/runtime/vm/jit/irlower-internal.cpp
@@ -47,7 +47,7 @@ namespace {
 void prepareArg(const ArgDesc& arg, Vout& v, VregList& vargs) {
   switch (arg.kind()) {
     case ArgDesc::Kind::IndRet: {
-      auto tmp = v.makeReg();
+      auto const tmp = v.makeReg();
       v << lea{arg.srcReg()[arg.disp().l()], tmp};
       vargs.push_back(tmp);
       break;

--- a/hphp/runtime/vm/jit/vasm-unit.h
+++ b/hphp/runtime/vm/jit/vasm-unit.h
@@ -56,7 +56,7 @@ struct VcallArgs {
   VregList args;
   VregList simdArgs;
   VregList stkArgs;
-  bool indirect;
+  VregList indRetArgs;
 };
 
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
There are stark differences between the x86_64 and AArch64 ABIs
with regards to indirect return arguments. This work is similar
to the work done for the interpreter when calling native functions.
In this case though, the ArgGroups made the port a little more
difficult. This change expands the ArgGroups to handle indirect
return arguments explicitly when the target supports them.
Otherwise, the behavior for targets without dedicated regsiters for
indirect return arguments is to pass it as the first general
purpose argument.

Fixes (AArch64):
   test/slow/php7_backported/ext_openssl/openssl_encrypt_ccm.php
   test/slow/php7_backported/ext_openssl/openssl_encrypt_gcm.php