### PR TITLE
Fix "flexible array member in an otherwise empty struct" error on GCC 6.2

### DIFF
--- a/hphp/runtime/vm/bytecode.h
+++ b/hphp/runtime/vm/bytecode.h
@@ -125,7 +125,7 @@ private:
   static void* allocMem(unsigned nargs);
 
 private:
-  TypedValue m_extraArgs[];
+  TypedValue m_extraArgs[0];
   TYPE_SCAN_FLEXIBLE_ARRAY_FIELD(m_extraArgs);
 };
 


### PR DESCRIPTION
Fixes the following error on GCC 6.2:

```
In file included from /hphp/runtime/base/rds-header.h:24:0,
                 from /hphp/runtime/base/request-injection-data.h:20,
                 from /hphp/runtime/base/thread-info.h:24,
                 from /hphp/runtime/base/array-init.h:26,
                 from /hphp/system/systemlib.cpp:18:
/hphp/runtime/vm/bytecode.h: At global scope:
/hphp/runtime/vm/bytecode.h:128:26: error: flexible array member ‘HPHP::ExtraArgs::m_extraArgs’ in an otherwise empty ‘struct HPHP::ExtraArgs’
   TypedValue m_extraArgs[];
                          ^
/hphp/runtime/vm/bytecode.h:80:8: note: in the definition of ‘struct HPHP::ExtraArgs’
 struct ExtraArgs {
        ^~~~~~~~~
```

Closes #6933