### PR TITLE
Remove NO_OPT from decoder

### DIFF
--- a/CMake/HPHPCompiler.cmake
+++ b/CMake/HPHPCompiler.cmake
@@ -124,11 +124,17 @@ if (${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang" OR ${CMAKE_CXX_COMPILER_ID} STREQU
     )
     list(APPEND RELEASE_CXX_OPTIONS
       "-param max-inline-insns-auto=100"
-      "-param early-inlining-insns=200"
-      "-param max-early-inliner-iterations=50"
       "-param=inline-unit-growth=200"
       "-param=large-unit-insns=10000"
     )
+    # The params bellow causes problem on GCC 4.8 4.8 and 5.4 on PPC64
+    # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=72855
+    if(NOT IS_PPC64)
+      list(APPEND RELEASE_CXX_OPTIONS
+        "-param early-inlining-insns=200"
+        "-param max-early-inliner-iterations=50"
+       )
+    endif()
 
     execute_process(COMMAND ${CMAKE_CXX_COMPILER} ${CMAKE_CXX_COMPILER_ARG1} -dumpversion OUTPUT_VARIABLE GCC_VERSION)
     if(GCC_VERSION VERSION_GREATER 4.8 OR GCC_VERSION VERSION_EQUAL 4.8)

--- a/hphp/ppc64-asm/decoder-ppc64.h
+++ b/hphp/ppc64-asm/decoder-ppc64.h
@@ -461,13 +461,7 @@ class Decoder : private boost::noncopyable {
     }
   }
 
-  /*
-   * Disable optimizations for this constructor.  In release mode -O3 causes
-   * compilation to hang due the huge initialization list.  This is a static
-   * singleton constructor, it's only called once and, when trace is enabled so
-   * optimization here is not a big issue.
-   */
-  NO_OPT Decoder();
+  Decoder();
 
   ~Decoder() {
     for(int i = 0; i < kDecoderSize; i++)


### PR DESCRIPTION
Summary:

This commit removes __attribute__(optimize("O0")) of decoder and
remove early-inlining-insns compilation options for ppc64.

After some investigation and interlock with gcc developers we found
that's caused by early-inlining-insns due a gcc bug on ppc64el.
A bugzilla was openned on:

https://gcc.gnu.org/bugzilla/show_bug.cgi?id=72855

Was pointed out we should be careful about those parameters as it
may have to be fine tunned for each architecture to avoid problems
like that.

Removing NO_OPT increase build time on others architectures but
after pull request https://github.com/facebook/hhvm/pull/7359
we reduce the number of instructions on decoder so we can remove
NO_OPT without increase build time.