### PR TITLE
Add Relocation and integrate TOC on PPC64

### DIFF
--- a/hphp/ppc64-asm/asm-ppc64.cpp
+++ b/hphp/ppc64-asm/asm-ppc64.cpp
@@ -29,20 +29,22 @@ VMTOC::~VMTOC() {
 }
 
 int64_t VMTOC::pushElem(int64_t elem) {
-  if (m_map.count(elem)) return m_map[elem];
+  auto& map_elem = m_map[elem];
+  if (map_elem) return map_elem;
 
   auto offset = allocTOC(static_cast<int32_t>(elem & 0xffffffff), true);
-  m_map.insert( { elem, offset });
+  map_elem = offset;
   allocTOC(static_cast<int32_t>((elem & 0xffffffff00000000) >> 32));
   m_last_elem_pos += 2;
   return offset;
 }
 
 int64_t VMTOC::pushElem(int32_t elem) {
-  if (m_map.count(elem)) return m_map[elem];
+  auto& map_elem = m_map[elem];
+  if (map_elem) return map_elem;
 
   auto offset = allocTOC(elem);
-  m_map.insert( { elem, offset });
+  map_elem = offset;
   m_last_elem_pos++;
   return offset;
 }

--- a/hphp/ppc64-asm/asm-ppc64.cpp
+++ b/hphp/ppc64-asm/asm-ppc64.cpp
@@ -15,6 +15,7 @@
 */
 
 #include "hphp/ppc64-asm/asm-ppc64.h"
+#include "hphp/ppc64-asm/decoded-instr-ppc64.h"
 #include "hphp/ppc64-asm/decoder-ppc64.h"
 #include "hphp/runtime/base/runtime-option.h"
 #include "hphp/util/trace.h"
@@ -464,106 +465,32 @@ void Assembler::unimplemented(){
 
 //////////////////////////////////////////////////////////////////////
 
-/*
- * Auxiliaries for Assembler::patchBranch
- */
-static void patchOffset(CodeAddress jmp, ssize_t diff) {
-  // Used for a relative branch
-  PPC64Instr* instr = reinterpret_cast<PPC64Instr*>(jmp);
-
-  DecoderInfo dinfo = Decoder::GetDecoder().decode(instr);
-  OpcodeNames opn = dinfo.opcode_name();
-  switch (opn) {
-    case OpcodeNames::op_b:
-    case OpcodeNames::op_bl:
-      assert(dinfo.form() == Form::kI);
-      I_form_t iform;
-      iform.instruction = dinfo.instruction_image();
-
-      // relative branch. Branch offset can be up to 26 bits
-      always_assert(HPHP::jit::deltaFitsBits(diff, 26) &&
-          "Patching offset is too big");
-
-      // address is 4 bytes aligned and it optimizes these 2 bits.
-      iform.LI = static_cast<uint32_t>(diff >> 2);
-      *instr = iform.instruction;
-      break;
-    case OpcodeNames::op_bc:
-      assert(dinfo.form() == Form::kB);
-      B_form_t bform;
-      bform.instruction = dinfo.instruction_image();
-
-      // relative branch
-      always_assert(HPHP::jit::deltaFits(diff, HPHP::sz::word) &&
-          "Patching offset is too big");
-
-      // address is 4 bytes aligned and it optimizes these 2 bits.
-      bform.BD = static_cast<uint32_t>(diff >> 2);
-      *instr = bform.instruction;
-      break;
-    default:
-      always_assert(false && "tried to patch not-expected-branch instruction");
-      break;
-  }
-}
-
-static void patchAbsolute(CodeAddress jmp, CodeAddress dest) {
+void Assembler::patchAbsolute(CodeAddress jmp, CodeAddress dest) {
   // Initialize code block cb pointing to li64
   HPHP::CodeBlock cb;
-  cb.init(jmp, Assembler::kLi64InstrLen, "patched bctr");
+  cb.init(jmp, Assembler::kLimmLen, "patched bctr");
   Assembler a{ cb };
-  a.li64(reg::r12, ssize_t(dest));
+  a.limmediate(reg::r12, ssize_t(dest),
+#ifdef USE_TOC_ON_BRANCH
+      ImmType::TocOnly
+#else
+      ImmType::AnyFixed
+#endif
+      );
 }
 
 void Assembler::patchBranch(CodeAddress jmp, CodeAddress dest) {
-  // Detecting absolute branching: if it's an bcctr or bcctrl
-  {
-    // skips the li64, 2*nop and a mtctr instruction
-    CodeAddress bctr_addr =
-      jmp + Assembler::kLi64InstrLen + 3 * instr_size_in_bytes;
+  auto di = DecodedInstruction(jmp);
 
-    // check for instruction opcode
-    DecoderInfo dinfo = Decoder::GetDecoder().decode(bctr_addr);
-    OpcodeNames opn = dinfo.opcode_name();
-    if ((opn == OpcodeNames::op_bcctr) || (opn == OpcodeNames::op_bcctrl)) {
-      patchAbsolute(jmp, dest);
-      return;
-    }
+  // Detect Far branch
+  if (di.isFarBranch()) {
+    patchAbsolute(jmp, dest);
+    return;
   }
 
-  // Now analyses if the offset fits by checking how big is the difference to
-  // be patched
-  auto new_target = reinterpret_cast<int64_t>(dest);
-
-  // Define the branch as the origin of the branch offset calculation
-  auto base = reinterpret_cast<int64_t>(jmp);
-  auto diff = new_target - base;
-
-  // There are 2 flavors of offset branching. (See BranchType for more info)
-  DecoderInfo dinfo = Decoder::GetDecoder().decode(jmp);
-  OpcodeNames opn = dinfo.opcode_name();
-
-  // checks if @opn is 'b', 'bl' or 'bc' and if the offset @diff fits it
-  auto branch_fits_offset = [](OpcodeNames opn, int64_t diff) -> bool {
-    auto is_and_fits_b = [](OpcodeNames opn, int64_t diff) -> bool {
-      return ((opn == OpcodeNames::op_b) || (opn == OpcodeNames::op_bl)) &&
-              HPHP::jit::deltaFitsBits(diff, 26);
-    };
-
-    auto is_and_fits_bc = [](OpcodeNames opn, int64_t diff) -> bool {
-      return opn == OpcodeNames::op_bc &&
-              HPHP::jit::deltaFits(diff, HPHP::sz::word);
-    };
-
-    return is_and_fits_b(opn, diff) || is_and_fits_bc(opn, diff);
-  };
-
-  if (!branch_fits_offset(opn, diff)) {
+  // Regular patch for branch by offset type
+  if (!di.setNearBranchTarget(dest))
     assert(false && "Can't patch a branch with such a big offset");
-  } else {
-    // Regular patch for branch by offset type
-    patchOffset(jmp, diff);
-  }
 }
 
 //////////////////////////////////////////////////////////////////////
@@ -583,9 +510,9 @@ void Assembler::li64 (const Reg64& rt, int64_t imm64, bool fixedSize) {
       // clear extended sign that should not be set
       // (32bits number. Sets the 16th bit but not the 17th, it's not negative!)
       clrldi(rt, rt, 48);
-      missing = kLi64InstrLen - 2 * instr_size_in_bytes;
+      missing = kLi64Len - 2 * instr_size_in_bytes;
     } else {
-      missing = kLi64InstrLen - 1 * instr_size_in_bytes;
+      missing = kLi64Len - 1 * instr_size_in_bytes;
     }
   } else if (HPHP::jit::deltaFits(imm64, HPHP::sz::dword)) {
     // immediate has only low 32 bits set
@@ -595,9 +522,9 @@ void Assembler::li64 (const Reg64& rt, int64_t imm64, bool fixedSize) {
       // clear extended sign
       // (64bits number. Sets the 32th bit but not the 33th, it's not negative!)
       clrldi(rt, rt, 32);
-      missing = kLi64InstrLen - 3 * instr_size_in_bytes;
+      missing = kLi64Len - 3 * instr_size_in_bytes;
     } else {
-      missing = kLi64InstrLen - 2 * instr_size_in_bytes;
+      missing = kLi64Len - 2 * instr_size_in_bytes;
     }
   } else if (imm64 >> 48 == 0) {
     // immediate has only low 48 bits set
@@ -609,7 +536,7 @@ void Assembler::li64 (const Reg64& rt, int64_t imm64, bool fixedSize) {
       // clear extended sign
       clrldi(rt, rt, 16);
     } else {
-      missing = kLi64InstrLen - 4 * instr_size_in_bytes;
+      missing = kLi64Len - 4 * instr_size_in_bytes;
     }
   } else {
     // load all 64 bits
@@ -619,95 +546,12 @@ void Assembler::li64 (const Reg64& rt, int64_t imm64, bool fixedSize) {
     oris(rt, rt, static_cast<int16_t>((imm64 >> 16) & UINT16_MAX));
     ori(rt, rt, static_cast<int16_t>(imm64 & UINT16_MAX));
   }
-  if(fixedSize){
+
+  if (fixedSize) {
     emitNop(missing);
-    // guarantee our math with kLi64InstrLen is working
-    assert(kLi64InstrLen == frontier() - li64StartPos);
+    // guarantee our math with kLi64Len is working
+    assert(kLi64Len == frontier() - li64StartPos);
   }
-}
-
-int64_t Assembler::getLi64(PPC64Instr* pinstr) {
-  // @pinstr should be pointing to the beginning of the li64 block
-  //
-  // It's easier to know how many 16bits of data the immediate uses
-  // by counting how many nops there are inside of the code
-  uint8_t nops = [&]() {
-    uint8_t nNops = 0;
-    auto total_li64_instr = kLi64InstrLen/instr_size_in_bytes;
-    for (PPC64Instr* i = pinstr; i < pinstr + total_li64_instr; i++) {
-      if (Decoder::GetDecoder().decode(i).isNop()) nNops++;
-    }
-    return nNops;
-  }();
-
-  auto hasClearSignBit = [&](PPC64Instr* i) -> bool {
-    return Decoder::GetDecoder().decode(i).isClearSignBit();
-  };
-
-  auto getImm = [&](PPC64Instr* i) -> uint16_t {
-    return Decoder::GetDecoder().decode(i).offset();
-  };
-
-  uint8_t immParts = 0;
-  switch (nops) {
-    case 4:
-      immParts = 1;                                   // 16bits, sign bit = 0
-      break;
-    case 3:
-      if (hasClearSignBit(pinstr + 1)) immParts = 1;  // 16bits, sign bit = 1
-      else immParts = 2;                              // 32bits, sign bit = 0
-      break;
-    case 2:
-      immParts = 2;                                   // 32bits, sign bit = 1
-      break;
-    case 1:
-      immParts = 3;                                   // 48bits, sign bit = 0
-      break;
-    case 0:
-      if (hasClearSignBit(pinstr + 4)) immParts = 3;  // 48bits, sign bit = 1
-      else immParts = 4;                              // 64bits, sign bit = 0
-      break;
-    default:
-      assert(false && "Unexpected number of nops in getLi64");
-      break;
-  }
-
-  // first getImm is suppose to get the sign
-  uint64_t imm64 = static_cast<uint64_t>(getImm(pinstr));
-  switch (immParts) {
-    case 1:
-      break;
-    case 2:
-      imm64 <<= 16;
-      imm64 |= getImm(pinstr + 1);
-      break;
-    case 3:
-      imm64 <<= 16;
-      imm64 |= getImm(pinstr + 1);
-      imm64 <<= 16;
-      imm64 |= getImm(pinstr + 3);  // jumps the sldi
-      break;
-    case 4:
-      imm64 <<= 16;
-      imm64 |= getImm(pinstr + 1);
-      imm64 <<= 16;
-      imm64 |= getImm(pinstr + 3);  // jumps the sldi
-      imm64 <<= 16;
-      imm64 |= getImm(pinstr + 4);
-      break;
-    default:
-      assert(false && "No immediate detected on getLi64");
-      break;
-  }
-
-  return static_cast<int64_t>(imm64);
-}
-
-Reg64 Assembler::getLi64Reg(PPC64Instr* instr) {
-  // First instruction is always either li or lis, both are D-form
-  D_form_t d_instr;
-  d_instr.instruction = *instr;
-  return Reg64(d_instr.RT);
 }
 
 void Assembler::li32 (const Reg64& rt, int32_t imm32) {
@@ -727,29 +571,6 @@ void Assembler::li32 (const Reg64& rt, int32_t imm32) {
     lis(rt, static_cast<int16_t>(imm32 >> 16));
     ori(rt, rt, static_cast<int16_t>(imm32 & UINT16_MAX));
   }
-}
-
-int32_t Assembler::getLi32(PPC64Instr* pinstr) {
-  // @pinstr should be pointing to the beginning of the li32 block
-
-  auto getImm = [&](PPC64Instr* i) -> uint32_t {
-    return Decoder::GetDecoder().decode(i).offset();
-  };
-
-  // if first instruction is a li, it's using 16bits only
-  bool is_16b_only = [&](PPC64Instr* i) -> bool {
-    auto opn = Decoder::GetDecoder().decode(i).opcode_name();
-    return OpcodeNames::op_addi == opn;
-  }(pinstr);
-
-  uint32_t imm32 = 0;
-  if (is_16b_only) {
-    imm32 |= static_cast<int16_t>(getImm(pinstr));
-  } else {
-    imm32 |= getImm(pinstr)     << 16;  // lis
-    imm32 |= getImm(pinstr + 1);        // ori
-  }
-  return static_cast<int32_t>(imm32);
 }
 
 void Assembler::loadTOC(const Reg64& rt, const Reg64& rttoc,  int64_t imm64,
@@ -866,23 +687,28 @@ void Label::branch(Assembler& a, BranchConditions bc, LinkReg lr) {
   branchFar(a, bc, lr);
 }
 
-void Label::branchFar(Assembler& a, BranchConditions bc, LinkReg lr) {
+void Label::branchFar(Assembler& a,
+                  BranchConditions bc,
+                  LinkReg lr,
+                  ImmType immt) {
   // Marking current address for patchAbsolute
   addJump(&a);
 
   // Use reserved function linkage register
   const ssize_t address = ssize_t(m_address);
-  a.li64(reg::r12, address);
+  a.limmediate(reg::r12, address, immt);
 
   // When branching to another context, r12 need to keep the target address
   // to correctly set r2 (TOC reference).
   a.mtctr(reg::r12);
 
   // Special code for overflow handling
+  bool cond = (BranchConditions::Always != bc);
   if (bc == BranchConditions::Overflow || bc == BranchConditions::NoOverflow) {
     a.xor(reg::r0, reg::r0, reg::r0,false);
     a.mtspr(Assembler::SpecialReg::XER, reg::r0);
-  } else {
+  } else if (cond && immt != ImmType::AnyCompact) {
+    // Unconditional branch (jmp or call) doesn't need this reserve bytes
     a.emitNop(2 * instr_size_in_bytes);
   }
 

--- a/hphp/ppc64-asm/asm-ppc64.cpp
+++ b/hphp/ppc64-asm/asm-ppc64.cpp
@@ -29,7 +29,7 @@ VMTOC::~VMTOC() {
 }
 
 int64_t VMTOC::pushElem(int64_t elem) {
-  if (m_map.find(elem) != m_map.end()) return m_map[elem];
+  if (m_map.count(elem)) return m_map[elem];
 
   auto offset = allocTOC(static_cast<int32_t>(elem & 0xffffffff), true);
   m_map.insert( { elem, offset });
@@ -39,7 +39,7 @@ int64_t VMTOC::pushElem(int64_t elem) {
 }
 
 int64_t VMTOC::pushElem(int32_t elem) {
-  if (m_map.find(elem) != m_map.end()) return m_map[elem];
+  if (m_map.count(elem)) return m_map[elem];
 
   auto offset = allocTOC(elem);
   m_map.insert( { elem, offset });

--- a/hphp/ppc64-asm/asm-ppc64.h
+++ b/hphp/ppc64-asm/asm-ppc64.h
@@ -23,14 +23,9 @@
 
 #include "hphp/util/data-block.h"
 
-#include "hphp/runtime/vm/jit/code-cache.h"
-#include "hphp/runtime/vm/jit/types.h"
-
 #include "hphp/ppc64-asm/branch-ppc64.h"
 #include "hphp/ppc64-asm/decoded-instr-ppc64.h"
 #include "hphp/ppc64-asm/isa-ppc64.h"
-
-#include "hphp/runtime/base/runtime-option.h"
 
 
 namespace ppc64_asm {

--- a/hphp/ppc64-asm/asm-ppc64.h
+++ b/hphp/ppc64-asm/asm-ppc64.h
@@ -200,7 +200,10 @@ struct Label {
   Label& operator=(const Label&) = delete;
 
   void branch(Assembler& a, BranchConditions bc, LinkReg lr);
-  void branchFar(Assembler& a, BranchConditions bc, LinkReg lr);
+  void branchFar(Assembler& a,
+                  BranchConditions bc,
+                  LinkReg lr,
+                  ImmType immt = ImmType::TocOnly);
   void asm_label(Assembler& a);
 
 private:
@@ -376,60 +379,27 @@ struct Assembler {
     CR7      = 7,
   };
 
-  // Prologue size of call function (mflr, std, std, addi, std)
-  static const uint8_t kCallPrologueLen = instr_size_in_bytes * 5;
+  // Total amount of bytes that a li64 function emits as fixed size
+  static const uint8_t kLi64Len = instr_size_in_bytes * 5;
+  // TOC emit length: (ld/lwz + nop) or (addis + ld/lwz)
+  static const uint8_t kTocLen = instr_size_in_bytes * 2;
 
-  // Epilogue size of call function after the return address.
-  // ld, addi, ld, mtlr
-  static const uint8_t kCallEpilogueLen = instr_size_in_bytes * 4;
+  // Compile time switch for using TOC or not on branches
+  static const uint8_t kLimmLen =
+#ifdef USE_TOC_ON_BRANCH
+    kTocLen
+#else
+    kLi64Len
+#endif
+    ;
 
-  // Jcc length
-  static const uint8_t kJccLen = instr_size_in_bytes * 9;
+  // Jcc using TOC length: toc/li64 + mtctr + nop + nop + bcctr
+  static const uint8_t kJccLen = kLimmLen + instr_size_in_bytes * 4;
 
-  // Call length prologue + jcc
-  static const uint8_t kCallLen = instr_size_in_bytes * 9;
+  // Call using TOC length: toc/li64 + mtctr + bctr
+  static const uint8_t kCallLen = kLimmLen + instr_size_in_bytes * 2;
 
-  // Total ammount of bytes that a li64 function emits
-  static const uint8_t kLi64InstrLen = 5 * instr_size_in_bytes;
-
-  // TODO(rcardoso): Must create a macro for these similar instructions.
-  // This will make code more clean.
-
-  // #define CC_ARITH_REG_OP(name, opcode, x_opcode)
-  //   void name##c
-  //   void name##co
-  //   ...
-  // #define CC_ARITH_IMM_OP(name, opcode)
-
-  // #define LOAD_STORE_OP(name)
-  // void #name(const Reg64& rt, MemoryRef m);
-  // void #name##u(const Reg64& rt, MemoryRef m);
-  // void #name##x(const Reg64& rt, MemoryRef m);
-  // void #name##ux(const Reg64& rt, MemoryRef m);
-
-  // #define LOAD_STORE_OP_BYTE_REVERSED(name)
-  // void #name##brx(const Reg64& rt, MemoryRef m);
-
-  // LOAD_STORE_OP(lbz)
-  // LOAD_STORE_OP(lh)
-  // LOAD_STORE_OP(lha)
-  // LOAD_STORE_OP_BYTE_REVERSED(lh)
-  // LOAD_STORE_OP(lwz)
-  // LOAD_STORE_OP(lwa)
-  // LOAD_STORE_OP(ld)
-  // LOAD_STORE_OP_BYTE_REVERSED(ld)
-  // LOAD_STORE_OP(stb)
-  // LOAD_STORE_OP(sth)
-  // LOAD_STORE_OP_BYTE_REVERSED(sth)
-  // LOAD_STORE_OP(stw)
-  // LOAD_STORE_OP_BYTE_REVERSED(stw)
-  // LOAD_STORE_OP(std)
-  // LOAD_STORE_OP_BYTE_REVERSED(std)
-
-  // #undef LOAD_STORE_OP
-  // #undef LOAD_STORE_OP_BYTE_REVERSED
-
-  //PPC64 Instructions
+  // PPC64 Instructions
   void add(const Reg64& rt, const Reg64& ra, const Reg64& rb, bool rc = 0);
   void addi(const Reg64& rt, const Reg64& ra, Immed imm);
   void addis(const Reg64& rt, const Reg64& ra, Immed imm);
@@ -731,7 +701,6 @@ struct Assembler {
 
   // Simplify to conditional branch that always branch
   void b(Label& l)  { bc(l, BranchConditions::Always); }
-  void bl(Label& l)  { bcl(l, BranchConditions::Always); }
 
   void bc(Label& l, BranchConditions bc) {
     l.branch(*this, bc, LinkReg::DoNotTouch);
@@ -739,8 +708,8 @@ struct Assembler {
   void bc(Label& l, ConditionCode cc) {
     l.branch(*this, BranchParams::convertCC(cc), LinkReg::DoNotTouch);
   }
-  void bcl(Label& l, BranchConditions bc) {
-    l.branch(*this, bc, LinkReg::Save);
+  void bl(Label& l) {
+    l.branch(*this, BranchConditions::Always, LinkReg::Save);
   }
 
   void branchAuto(Label& l,
@@ -764,21 +733,30 @@ struct Assembler {
 
   void branchFar(Label& l,
                  BranchConditions bc = BranchConditions::Always,
-                 LinkReg lr = LinkReg::DoNotTouch) {
-    l.branchFar(*this, bc, lr);
+                 LinkReg lr = LinkReg::DoNotTouch,
+                 ImmType immt = ImmType::TocOnly) {
+    l.branchFar(*this, bc, lr, immt);
   }
 
   void branchFar(CodeAddress c,
                  BranchConditions bc = BranchConditions::Always,
-                 LinkReg lr = LinkReg::DoNotTouch) {
+                 LinkReg lr = LinkReg::DoNotTouch,
+                 ImmType immt = ImmType::TocOnly) {
     Label l(c);
-    l.branchFar(*this, bc, lr);
+    l.branchFar(*this, bc, lr, immt);
   }
 
   void branchFar(CodeAddress c,
                  ConditionCode cc,
-                 LinkReg lr = LinkReg::DoNotTouch) {
-    branchFar(c, BranchParams::convertCC(cc), lr);
+                 LinkReg lr = LinkReg::DoNotTouch,
+                 ImmType immt = ImmType::TocOnly) {
+    branchFar(c, BranchParams::convertCC(cc), lr, immt);
+  }
+
+  void branchFar(CodeAddress c, BranchParams bp,
+                 ImmType immt = ImmType::TocOnly) {
+    LinkReg lr = (bp.savesLR()) ? LinkReg::Save : LinkReg::DoNotTouch;
+    branchFar(c, static_cast<BranchConditions>(bp), lr, immt);
   }
 
   // ConditionCode variants
@@ -794,23 +772,22 @@ struct Assembler {
                 // --------------------------
     Internal,   // No            | No
     External,   // Yes           | No
-    Smashable,  // No (internal) | Yes
+    SmashInt,   // No            | Yes
+    SmashExt,   // Yes           | Yes
   };
 
   void callEpilogue(CallArg ca) {
     // Several vasms like nothrow, unwind and syncpoint will skip one
     // instruction after call and use it as expected return address. Use a nop
     // to guarantee this consistency even if toc doesn't need to be saved
-    if (CallArg::External != ca) nop();
+    if ((CallArg::SmashInt == ca) || (CallArg::Internal == ca)) nop();
     else ld(reg::r2, reg::r1[toc_position_on_frame]);
   }
 
   // generic template, for CodeAddress and Label
   template <typename T>
   void call(T& target, CallArg ca = CallArg::Internal) {
-    if (CallArg::Smashable == ca) {
-      // To make a branch smashable, the most conservative method needs to be
-      // used so the target can be changed later or on bindCall.
+    if ((CallArg::SmashInt == ca) || (CallArg::SmashExt == ca)) {
       branchFar(target, BranchConditions::Always, LinkReg::Save);
     } else {
       // tries best performance possible
@@ -827,12 +804,6 @@ struct Assembler {
     callEpilogue(ca);
   }
 
-  // checks if the @inst is pointing to a call
-  static inline bool isCall(HPHP::jit::TCA inst) {
-    DecodedInstruction di(inst);
-    return di.isCall();
-  }
-
 //////////////////////////////////////////////////////////////////////
 // Auxiliary for loading immediates in the best way
 
@@ -846,37 +817,10 @@ public:
                   ImmType immt = ImmType::AnyCompact);
 
   // Auxiliary for loading a complete 64bits immediate into a register
-  void li64(const Reg64& rt, int64_t imm64, bool fixedSize = true);
-
-  // Retrieve the target defined by li64 instruction
-  static int64_t getLi64(PPC64Instr* pinstr);
-  static int64_t getLi64(CodeAddress pinstr) {
-    return getLi64(reinterpret_cast<PPC64Instr*>(pinstr));
-  }
-
-  // Retrieve the register used by li64 instruction
-  static Reg64 getLi64Reg(PPC64Instr* instr);
-  static Reg64 getLi64Reg(CodeAddress instr) {
-    return getLi64Reg(reinterpret_cast<PPC64Instr*>(instr));
-  }
+  void li64(const Reg64& rt, int64_t imm64, bool fixedSize = false);
 
   // Auxiliary for loading a 32bits immediate into a register
   void li32 (const Reg64& rt, int32_t imm32);
-
-  // Retrieve the target defined by li32 instruction
-  static int32_t getLi32(PPC64Instr* pinstr);
-  static int32_t getLi32(CodeAddress pinstr) {
-    return getLi32(reinterpret_cast<PPC64Instr*>(pinstr));
-  }
-
-  // Retrieve the register used by li32 instruction
-  static Reg64 getLi32Reg(PPC64Instr* instr) {
-    // it also starts with li or lis, so the same as getLi64
-    return getLi64Reg(instr);
-  }
-  static Reg64 getLi32Reg(CodeAddress instr) {
-    return getLi32Reg(reinterpret_cast<PPC64Instr*>(instr));
-  }
 
   void emitNop(int nbytes) {
     assert((nbytes % 4 == 0) && "This arch supports only 4 bytes alignment");
@@ -902,6 +846,7 @@ public:
    * offset branch and patches it properly.
    */
   static void patchBranch(CodeAddress jmp, CodeAddress dest);
+  static void patchAbsolute(CodeAddress jmp, CodeAddress dest);
 
 //////////////////////////////////////////////////////////////////////
 

--- a/hphp/ppc64-asm/asm-ppc64.h
+++ b/hphp/ppc64-asm/asm-ppc64.h
@@ -807,11 +807,6 @@ struct Assembler {
 //////////////////////////////////////////////////////////////////////
 // Auxiliary for loading immediates in the best way
 
-private:
-  void loadTOC(const Reg64& rt, const Reg64& rttoc, int64_t imm64,
-      uint64_t offset, bool fixedSize, bool fits32);
-
-public:
   void limmediate(const Reg64& rt,
                   int64_t imm64,
                   ImmType immt = ImmType::AnyCompact);

--- a/hphp/ppc64-asm/decoded-instr-ppc64.cpp
+++ b/hphp/ppc64-asm/decoded-instr-ppc64.cpp
@@ -313,10 +313,10 @@ uint8_t DecodedInstruction::decodeImm() {
   if (m_dinfo.isLd(true)) {
     m_imm = VMTOC::getInstance().getValue(calcIndex(0, m_dinfo.offsetDS()),
       true);
-    return instr_size_in_bytes;
+    return Assembler::kLimmLen;
   } else if (m_dinfo.isLwz(true)) {
     m_imm = VMTOC::getInstance().getValue(calcIndex(0, m_dinfo.offsetD()));
-    return instr_size_in_bytes;
+    return Assembler::kLimmLen;
   } else if (m_dinfo.isAddis(true)) {
     auto bigIndexTOC = m_dinfo.offsetD();
     // Get next instruction
@@ -324,11 +324,11 @@ uint8_t DecodedInstruction::decodeImm() {
     if (di.isLd()) {
       m_imm = VMTOC::getInstance().getValue(calcIndex(bigIndexTOC,
           di.offsetDS()), true);
-      return 2*instr_size_in_bytes;
+      return Assembler::kLimmLen;
     } else if (di.isLwz()) {
       m_imm = VMTOC::getInstance().getValue(calcIndex(bigIndexTOC,
           di.offsetD()));
-      return 2*instr_size_in_bytes;
+      return Assembler::kLimmLen;
     }
   }
 
@@ -412,6 +412,8 @@ uint8_t DecodedInstruction::decodeImm() {
       m_imm = m_imm | tmp_bits;
     } else if (isOris(&dinfo, dest_reg, &tmp_bits)) {
       m_imm = m_imm | (tmp_bits << 16);
+    } else if (dinfo.isNop()) {
+      // do nothing but let it count as a part of it.
     } else { break; }
 
     pinstr++;

--- a/hphp/ppc64-asm/decoded-instr-ppc64.cpp
+++ b/hphp/ppc64-asm/decoded-instr-ppc64.cpp
@@ -21,51 +21,432 @@
 #include "hphp/ppc64-asm/decoder-ppc64.h"
 #include "hphp/ppc64-asm/asm-ppc64.h"
 
-#include "hphp/util/safe-cast.h"
+#include "hphp/util/data-block.h"
+
+#ifndef MIN
+#define MIN(a, b)       (((a) < (b)) ? (a) : (b))
+#endif
+
+#ifndef MAX
+#define MAX(a, b)       (((a) > (b)) ? (a) : (b))
+#endif
 
 namespace ppc64_asm {
 
-size_t DecodedInstruction::size() const {
-  not_implemented();
-  return size_t{0};
+bool DecodedInstruction::couldBeNearBranch() {
+  assert(isFarBranch());
+  ptrdiff_t diff = farBranchTarget() - m_ip;
+
+  // assert already stated it's a Far branch, but depending if it's conditional
+  // or not, an additional range can be used.
+  return fitsOnNearBranch(diff, isFarBranch(AllowCond::OnlyUncond));
 }
 
-int32_t DecodedInstruction::offset() const {
-  return Decoder::GetDecoder().decode(m_ip).offset();
+uint8_t* DecodedInstruction::nearBranchTarget() const {
+  assert(isNearBranch());
+  auto address = reinterpret_cast<uint64_t>(m_ip) + m_dinfo.branchOffset();
+  return reinterpret_cast<uint8_t*>(address);
 }
 
-bool DecodedInstruction::isNop() const {
-  return Decoder::GetDecoder().decode(m_ip).isNop();
+bool DecodedInstruction::setNearBranchTarget(uint8_t* target) {
+  if (!isNearBranch()) return false;
+  ptrdiff_t diff = target - m_ip;
+  bool uncond = m_dinfo.isOffsetBranch(AllowCond::OnlyUncond);
+  if (fitsOnNearBranch(diff, uncond)) {
+    auto pinstr = reinterpret_cast<PPC64Instr*>(m_ip);
+    *pinstr = m_dinfo.setBranchOffset(int32_t(diff));
+    return true;
+  } else {
+    return false;
+  }
 }
 
-bool DecodedInstruction::isBranch(bool allowCond /* = true */) const {
-  // skip the preparation instructions that are not actually the branch.
-  auto branch_instr = m_ip + Assembler::kJccLen - instr_size_in_bytes;
-  return Decoder::GetDecoder().decode(branch_instr).isBranch(allowCond);
+bool DecodedInstruction::isImmediate() const {
+  // if destination register is r12, then it's preparing to branch
+  return isLimmediatePossible() && (reg::r12 != getLimmediateReg());
+}
+
+bool DecodedInstruction::setImmediate(int64_t value) {
+  if (!isImmediate()) return false;
+
+  // Initialize code block cb pointing to li64
+  HPHP::CodeBlock cb;
+  cb.init(m_ip, Assembler::kLimmLen, "setImmediate relocation");
+  HPHP::CodeCursor cursor { cb, m_ip };
+  Assembler a{ cb };
+
+  a.limmediate(getLimmediateReg(), ssize_t(value),
+#ifdef USE_TOC_ON_BRANCH
+      ImmType::TocOnly
+#else
+      ImmType::AnyFixed
+#endif
+      );
+
+  // refresh m_imm and other parameters
+  decode();
+  return true;
+}
+
+bool DecodedInstruction::shrinkBranch() {
+  // It should be a Far branch, otherwise don't do anything if it's Near.
+  assertx(isBranch() && "Can't shrink instruction that is not a branch.");
+
+  auto uncondBranch = isFarBranch(AllowCond::OnlyUncond);
+  auto call = isCall();
+  auto condBranch = isFarBranch(AllowCond::OnlyCond);
+
+  if (uncondBranch || call || condBranch) {
+    HPHP::CodeBlock cb;
+    cb.init(m_ip, instr_size_in_bytes, "shrinkBranch relocation");
+    HPHP::CodeCursor cursor { cb, m_ip };
+    Assembler a { cb };
+
+    if (uncondBranch || call) {     // unconditional will be set as b
+      // offset will be patched later
+      if (call) a.bl(0);
+      else      a.b(0);
+    } else {                        // conditional will be bc
+      // grab conditional parameters
+      auto branch_instr = m_ip + Assembler::kJccLen - instr_size_in_bytes;
+      BranchParams bp(branch_instr);
+
+      // offset will be patched later
+      a.bc(bp.bo(), bp.bi(), 0);
+    }
+    // refresh m_size and other parameters
+    decode();
+    return true;
+  }
+  return false;
+}
+
+void DecodedInstruction::widenBranch(uint8_t* target) {
+  // currently, it should be a Near branch, else don't do anything if it's Far.
+  assertx(isBranch() && "Can't widen instruction that is not a branch.");
+
+  if (isNearBranch()) {
+    // grab conditional parameters
+    BranchParams bp(m_ip);
+    bool uncond = (bp.bo() == uint8_t(BranchParams::BO::Always));
+    auto block_size = uncond ? Assembler::kCallLen : Assembler::kJccLen;
+
+    HPHP::CodeBlock cb;
+    cb.init(m_ip, block_size, "widenBranch relocation");
+    HPHP::CodeCursor cursor { cb, m_ip };
+    Assembler a { cb };
+    a.branchFar(target, bp,
+#ifdef USE_TOC_ON_BRANCH
+      ImmType::TocOnly
+#else
+      ImmType::AnyFixed
+#endif
+      );
+
+    // refresh m_size and other parameters
+    decode();
+  }
+}
+
+bool DecodedInstruction::isBranch(AllowCond ac /* = AllowCond::Any */) const {
+  return isFarBranch(ac) || isNearBranch(ac);
+}
+
+bool DecodedInstruction::isNearBranch(AllowCond ac /* = Any */) const {
+  return m_dinfo.isOffsetBranch(ac);
+}
+
+bool DecodedInstruction::isFarBranch(AllowCond ac /* = Any */) const {
+  return !getFarBranch(ac).isInvalid();
+}
+
+DecoderInfo DecodedInstruction::getFarBranch(AllowCond ac /* = Any */) const {
+  return getFarBranchLength(ac).m_di;
+}
+
+// Returns -1 if not found, otherwise the offset from m_ip that a register
+// branch instruction is found
+DecInfoOffset DecodedInstruction::getFarBranchLength(AllowCond ac) const {
+  DecInfoOffset ret;
+  if (!isLimmediatePossible() || (reg::r12 != getLimmediateReg())) return ret;
+
+  // only read bytes up to the smallest of @max_read or @bytes.
+  auto canRead = [](uint8_t n, uint8_t max_read, uint8_t bytes) -> bool {
+    if (max_read)
+      return n < MIN(max_read, bytes);
+    else
+      return n < bytes;
+  };
+
+  auto branch_size = ((ac == AllowCond::OnlyCond)
+      ? Assembler::kJccLen
+      : ((ac == AllowCond::OnlyUncond)
+        ? Assembler::kCallLen
+        : MAX(Assembler::kCallLen, Assembler::kJccLen)
+        )
+      );
+
+  // Search for a register branch instruction like bctr. Return when found.
+  for (ret.m_offset = 0;
+      canRead(ret.m_offset, m_max_size, branch_size);
+      ret.m_offset += instr_size_in_bytes) {
+    // skip the preparation instructions that are not actually the branch.
+    auto far_branch_instr = m_ip + ret.m_offset;
+    ret.m_di = Decoder::GetDecoder().decode(far_branch_instr);
+    if (ret.m_di.isRegisterBranch(ac)) return ret;
+  }
+  return DecInfoOffset();
+}
+
+bool DecodedInstruction::setFarBranchTarget(uint8_t* target, bool smashable) {
+  DecoderInfo di = getFarBranch();
+  if (di.isInvalid()) return false;
+
+  BranchParams bp(di.ip());
+  bool uncond = (bp.bo() == uint8_t(BranchParams::BO::Always));
+  auto block_size = uncond ? Assembler::kCallLen : Assembler::kJccLen;
+
+  HPHP::CodeBlock cb;
+  cb.init(m_ip, block_size, "setFarBranchTarget");
+  Assembler a{ cb };
+  a.branchFar(target, bp,
+#ifdef USE_TOC_ON_BRANCH
+      ImmType::TocOnly
+#else
+      ImmType::AnyFixed
+#endif
+      );
+
+  // Check if something was overwritten
+  if ((a.frontier() - m_ip) > m_size) {
+    return false;
+  }
+
+  // refresh m_imm and other parameters
+  decode();
+  return true;
 }
 
 bool DecodedInstruction::isCall() const {
-  // skip the preparation instructions that are not actually the branch.
-  auto branch_instr = m_ip + Assembler::kCallLen - instr_size_in_bytes;
-  return Decoder::GetDecoder().decode(branch_instr).isBranch(false);
+  // Near branch
+  if (m_dinfo.isBranchWithLR()) return true;
+
+  // Far branch: get first register branch instruction in the range.
+  // Note: a call is always unconditional
+  DecoderInfo branch_di = getFarBranch(AllowCond::OnlyUncond);
+
+  // A Call sets the Link Register when branching
+  if (branch_di.isInvalid()) return false;
+  return branch_di.isBranchWithLR();
 }
 
-bool DecodedInstruction::isJmp() const {
-  // if it's conditional branch, it's not a jmp
-  return isBranch(false);
+Reg64 DecodedInstruction::getLimmediateReg() const {
+  auto di = Decoder::GetDecoder().decode(m_ip);
+  if (m_dinfo.isLd(true)) {
+    DS_form_t ds_instr;
+    ds_instr.instruction = m_dinfo.instruction_image();
+    return Reg64(ds_instr.RT);
+  }
+  else if (m_dinfo.isLwz(true)) {
+    D_form_t d_instr;
+    d_instr.instruction = m_dinfo.instruction_image();
+    return Reg64(d_instr.RT);
+  }
+  else if (m_dinfo.isAddis(true)) {
+    auto di = Decoder::GetDecoder().decode(m_ip+4);
+    if (di.isLd()) {
+      DS_form_t ds_instr;
+      ds_instr.instruction = di.instruction_image();
+      return Reg64(ds_instr.RT);
+    } else if (di.isLwz()) {
+      D_form_t d_instr;
+      d_instr.instruction = di.instruction_image();
+      return Reg64(d_instr.RT);
+    }
+  }
+  return getLi64Reg();
 }
 
-bool DecodedInstruction::isSpOffsetInstr() const {
-  return Decoder::GetDecoder().decode(m_ip).isSpOffsetInstr();
+Reg64 DecodedInstruction::getLi64Reg() const {
+  // First instruction is always either li or lis, both are D-form
+  assertx(isLi64Possible());
+  D_form_t d_instr;
+  d_instr.instruction = m_dinfo.instruction_image();
+  return Reg64(d_instr.RT);
 }
 
-bool DecodedInstruction::isClearSignBit() const {
-  return Decoder::GetDecoder().decode(m_ip).isClearSignBit();
+///////////////////////////////////////////////////////////////////////////////
+// Private Interface
+///////////////////////////////////////////////////////////////////////////////
+
+void DecodedInstruction::decode() {
+  m_dinfo = Decoder::GetDecoder().decode(m_ip);
+
+  if (isLimmediatePossible() && (reg::r12 == getLimmediateReg())) {
+    // Compute the whole branch on the m_size. Used on relocation to skip
+    // instructions
+    DecInfoOffset dio = getFarBranchLength();
+    assertx(dio.m_offset > 0 && "Expected to find a Far branch");
+    m_size = dio.m_offset + instr_size_in_bytes;
+    decodeImm();            // sets m_imm for farBranchTarget()
+  } else if (isImmediate()) {
+    m_size = decodeImm();
+  } else {
+    m_size = instr_size_in_bytes;
+  }
 }
 
-HPHP::jit::ConditionCode DecodedInstruction::jccCondCode() const {
-  not_implemented();
-  return HPHP::jit::CC_None;
+/*
+ * Reads back the immediate when emmited with (without nops) and return the
+ * number of bytes read for this immediate decoding.
+ */
+uint8_t DecodedInstruction::decodeImm() {
+  // Functions that detect if @dinfo is exactly the instructions flavor that
+  // our limmediate uses. Also the target register to be modified has to be
+  // the same.
+
+  auto calcIndex = [&](int16_t indexBigTOC, int16_t indexTOC) {
+    return static_cast<int64_t>(static_cast<int64_t>(indexTOC) +
+              static_cast<int64_t>(indexBigTOC << 16));
+  };
+
+  if (m_dinfo.isLd(true)) {
+    m_imm = VMTOC::getInstance().getValue(calcIndex(0, m_dinfo.offsetDS()),
+      true);
+    return instr_size_in_bytes;
+  } else if (m_dinfo.isLwz(true)) {
+    m_imm = VMTOC::getInstance().getValue(calcIndex(0, m_dinfo.offsetD()));
+    return instr_size_in_bytes;
+  } else if (m_dinfo.isAddis(true)) {
+    auto bigIndexTOC = m_dinfo.offsetD();
+    // Get next instruction
+    auto di = Decoder::GetDecoder().decode(m_ip+4);
+    if (di.isLd()) {
+      m_imm = VMTOC::getInstance().getValue(calcIndex(bigIndexTOC,
+          di.offsetDS()), true);
+      return 2*instr_size_in_bytes;
+    } else if (di.isLwz()) {
+      m_imm = VMTOC::getInstance().getValue(calcIndex(bigIndexTOC,
+          di.offsetD()));
+      return 2*instr_size_in_bytes;
+    }
+  }
+
+  auto isLi = [](DecoderInfo* dinfo, const Reg64& dest, int16_t* imm) {
+    D_form_t dform;
+    dform.instruction = dinfo->instruction_image();
+    *imm = dform.D;
+    return (OpcodeNames::op_addi == dinfo->opcode_name()) &&
+      (dest == Reg64(dform.RT)) &&
+      (!dform.RA);
+  };
+  auto isLis = [](DecoderInfo* dinfo, const Reg64& dest, int16_t* imm) {
+    D_form_t dform;
+    dform.instruction = dinfo->instruction_image();
+    *imm = dform.D;
+    return (OpcodeNames::op_addis == dinfo->opcode_name()) &&
+      (dest == Reg64(dform.RT)) &&
+      (!dform.RA);
+  };
+  auto isSldi = [](DecoderInfo* dinfo, const Reg64& dest, uint16_t* bits) {
+    MD_form_t mdform;
+    mdform.instruction = dinfo->instruction_image();
+
+    // Assembling these crazy encodings
+    *bits = (mdform.sh << 5) | mdform.SH;
+    auto mask = ((mdform.MB & 0x1) << 5) | (mdform.MB >> 1);
+
+    // It is only interesting when it's shifting 16bits multiples
+    return (OpcodeNames::op_rldicr == dinfo->opcode_name()) &&
+      (dest == Reg64(mdform.RS)) &&
+      (1 == mdform.XO) &&
+      ((16 == *bits) || (32 == *bits) || (48 == *bits)) &&
+      ((63 - *bits) == mask);
+  };
+  auto isOri = [](DecoderInfo* dinfo, const Reg64& dest, uint16_t* bits) {
+    D_form_t dform;
+    dform.instruction = dinfo->instruction_image();
+    *bits = dform.D;
+    return (OpcodeNames::op_ori == dinfo->opcode_name()) &&
+      (dest == Reg64(dform.RT)) &&
+      (dest == Reg64(dform.RA));
+  };
+  auto isOris = [](DecoderInfo* dinfo, const Reg64& dest, uint16_t* bits) {
+    D_form_t dform;
+    dform.instruction = dinfo->instruction_image();
+    *bits = dform.D;
+    return (OpcodeNames::op_oris == dinfo->opcode_name()) &&
+      (dest == Reg64(dform.RT)) &&
+      (dest == Reg64(dform.RA));
+  };
+
+  const auto dest_reg = getLi64Reg();
+  PPC64Instr* base = reinterpret_cast<PPC64Instr*>(m_ip);
+  PPC64Instr* last_instr = base +
+    (Assembler::kLi64Len / instr_size_in_bytes);
+
+  // If m_max_size is 0, it can always read more, otherwise it's limited
+  auto canReadMore = [&](uint8_t bytes_read) -> bool {
+    if (m_max_size) return bytes_read < m_max_size;
+    else            return true;
+  };
+
+  // Analyze at maximum kLi64Len instructions (and limited by m_max_size, if
+  // not 0) but stop when some other instruction appears (or any that doesn't
+  // have the dest_reg as a target).
+  PPC64Instr* pinstr = base;
+  uint8_t bytes_read = 0;
+  while ((pinstr < last_instr) && canReadMore(bytes_read)) {
+
+    auto dinfo = Decoder::GetDecoder().decode(pinstr);
+    int16_t tmp_imm = 0;
+    uint16_t tmp_bits = 0;
+
+    if (isLi(&dinfo, dest_reg, &tmp_imm)) {
+      m_imm = tmp_imm;
+    } else if (isLis(&dinfo, dest_reg, &tmp_imm)) {
+      m_imm = tmp_imm << 16;
+    } else if (isSldi(&dinfo, dest_reg, &tmp_bits)) {
+      m_imm = m_imm << tmp_bits;
+    } else if (isOri(&dinfo, dest_reg, &tmp_bits)) {
+      m_imm = m_imm | tmp_bits;
+    } else if (isOris(&dinfo, dest_reg, &tmp_bits)) {
+      m_imm = m_imm | (tmp_bits << 16);
+    } else { break; }
+
+    pinstr++;
+    bytes_read += instr_size_in_bytes;
+  }
+
+  // amount of bytes read by this immediate reading
+  return bytes_read;
+}
+
+bool DecodedInstruction::fitsOnNearBranch(ptrdiff_t diff, bool uncond) const {
+  // is it b or bc? b can use offsets up to 26bits and bc only 16bits
+  auto bitsize = uncond ? 26 : 16;
+  return HPHP::jit::deltaFitsBits(diff, bitsize);
+}
+
+bool DecodedInstruction::isLimmediatePossible() const {
+  if (m_dinfo.isLd(true) || m_dinfo.isLwz(true) || m_dinfo.isAddis(true)) {
+    return true;
+  }
+  return isLi64Possible();
+}
+
+bool DecodedInstruction::isLi64Possible() const {
+  // The beginning of a li64 starts with either li or lis.
+  auto opn = m_dinfo.opcode_name();
+  if ((OpcodeNames::op_addi == opn) || (OpcodeNames::op_addis == opn)) {
+    D_form_t dform;
+    dform.instruction = m_dinfo.instruction_image();
+    if (!dform.RA) {
+      // li or lis
+      return true;
+    }
+  }
+  return false;
 }
 
 }

--- a/hphp/ppc64-asm/decoded-instr-ppc64.h
+++ b/hphp/ppc64-asm/decoded-instr-ppc64.h
@@ -21,23 +21,119 @@
 
 #include "hphp/util/asm-x64.h"
 
+#include "hphp/ppc64-asm/decoder-ppc64.h"
+#include "hphp/ppc64-asm/isa-ppc64.h"
+
 namespace ppc64_asm {
 
-struct DecodedInstruction {
-  explicit DecodedInstruction(uint8_t* ip) : m_ip(ip) { }
+struct DecInfoOffset {
+  DecInfoOffset()
+    : m_di(Decoder::GetDecoder().getInvalid())
+    , m_offset(-1) {}
 
-  size_t size() const;
-  int32_t offset() const;
-  bool isNop() const;
-  bool isBranch(bool allowCond = true) const;
+  DecoderInfo m_di;
+  int8_t m_offset;
+};
+
+struct DecodedInstruction {
+  explicit DecodedInstruction(PPC64Instr* ip, uint8_t max_size = 0)
+    : m_ip(reinterpret_cast<uint8_t*>(ip))
+    , m_imm(0)
+    , m_dinfo(Decoder::GetDecoder().getInvalid())
+    , m_size(instr_size_in_bytes)
+    , m_max_size(max_size)
+  {
+    decode();
+  }
+  // 0 as @max_size means unlimited size
+  explicit DecodedInstruction(uint8_t* ip, uint8_t max_size = 0)
+    : m_ip(ip)
+    , m_imm(0)
+    , m_dinfo(Decoder::GetDecoder().getInvalid())
+    , m_size(instr_size_in_bytes)
+    , m_max_size(max_size)
+  {
+    decode();
+  }
+
+  DecodedInstruction() = delete;
+
+  size_t size() const           { return size_t{m_size}; }
+
+  // True if a Far branch can be changed to a Near branch
+  bool couldBeNearBranch();
+
+  // Conditional branch: up to 16bits.
+  // Unconditional branch: up to 26bits (b instruction)
+  // (aka Near branch)
+  bool isNearBranch(AllowCond ac = AllowCond::Any) const;
+  uint8_t* nearBranchTarget() const;
+  bool setNearBranchTarget(uint8_t* target);
+
+  bool isImmediate() const;
+  int64_t immediate() const     { return m_imm; }
+  bool setImmediate(int64_t value);
+
+  // The following function transform branches to:
+  // shrink : branch by offset up to 16bits. Return true if success.
+  // wide   : branch by absolute address.
+  bool shrinkBranch();
+  void widenBranch(uint8_t* target);
+  int32_t offsetDS() const      { return m_dinfo.offsetDS(); }
+  int16_t offsetD() const       { return m_dinfo.offsetD(); }
+  bool isLd(bool toc) const     { return m_dinfo.isLd(toc); }
+  bool isLwz(bool toc) const    { return m_dinfo.isLwz(toc); }
+  bool isAddis(bool toc) const  { return m_dinfo.isAddis(toc); }
+  // if it's conditional branch, it's not a jmp
+  uint8_t* ip() const           { return m_ip; }
+  int32_t offset() const        { return m_dinfo.offset(); }
+  bool isException() const      { return m_dinfo.isException(); }
+  bool isNop() const            { return m_dinfo.isNop(); }
+  // if it's conditional branch, it's not a jmp
+  bool isJmp() const            { return isBranch(AllowCond::OnlyUncond); }
+  bool isSpOffsetInstr() const  { return m_dinfo.isSpOffsetInstr(); }
+  bool isClearSignBit() const   { return m_dinfo.isClearSignBit(); }
+
+  // True if it's Near or Far type.
+  bool isBranch(AllowCond ac = AllowCond::Any) const;
+
+  bool isFarBranch(AllowCond ac = AllowCond::Any) const;
+  DecoderInfo getFarBranch(AllowCond ac = AllowCond::Any) const;
+  DecInfoOffset getFarBranchLength(AllowCond ac = AllowCond::Any) const;
+  uint8_t* farBranchTarget() const { return (uint8_t*)m_imm; }
+  bool setFarBranchTarget(uint8_t* target, bool smashable);
+
   bool isCall() const;
-  bool isJmp() const;
-  bool isSpOffsetInstr() const;
-  bool isClearSignBit() const;
-  HPHP::jit::ConditionCode jccCondCode() const;
+
+  // Retrieve the register used by li64 instruction
+  HPHP::jit::Reg64 getLi64Reg() const;
+
+  // Retrieve the register used by limmediate instruction
+  HPHP::jit::Reg64 getLimmediateReg() const;
+
+  // Retrieve the register used by li32 instruction
+  HPHP::jit::Reg64 getLi32Reg() const { return getLi64Reg(); }
 
 private:
+  // Initialize m_dinfo and m_size up to m_max_size
+  void decode();
+  uint8_t decodeImm();
+
+  // True @diff fits to a Near branch from m_ip
+  bool fitsOnNearBranch(ptrdiff_t diff, bool uncond) const;
+
+  // Check if m_ip points to the beginning of a li64 instruction (relaxed
+  // constraint, only checks a part of it)
+  bool isLi64Possible() const;
+  // Check if m_ip points to the beginning of a limmediate instruction (relaxed
+  // constraint, only checks a part of it)
+  bool isLimmediatePossible() const;
+
   uint8_t* m_ip;
+  int64_t m_imm;
+  DecoderInfo m_dinfo;
+  uint8_t m_size;
+  uint8_t m_max_size;
 };
 
 }

--- a/hphp/ppc64-asm/decoder-ppc64.cpp
+++ b/hphp/ppc64-asm/decoder-ppc64.cpp
@@ -20,6 +20,8 @@
 #include "hphp/ppc64-asm/decoder-ppc64.h"
 #include "hphp/ppc64-asm/isa-ppc64.h"
 
+#include "hphp/runtime/vm/jit/abi-ppc64.h"
+
 namespace ppc64_asm {
 
 Decoder* Decoder::s_decoder = nullptr;
@@ -284,7 +286,7 @@ Decoder::Decoder() {
 #undef XS
 #undef XT
 
-std::string DecoderInfo::toString() {
+std::string DecoderInfo::toString() const {
   if (m_form == Form::kInvalid) return ".long " + std::to_string(m_image);
   if (isNop())                  return "nop";
 
@@ -332,6 +334,19 @@ std::string DecoderInfo::toString() {
   return instr;
 }
 
+bool DecoderInfo::isException() const {
+  // trap is a mnemonic of tw 31,0,0
+  if ((m_form == Form::kX) && (m_opn == OpcodeNames::op_tw)) {
+    X_form_t xform;
+    xform.instruction = m_image;
+    if ((31 == xform.RT) && (!xform.RA) && (!xform.RB) && (4 == xform.XO)) {
+      // trap
+      return true;
+    }
+  }
+  return false;
+}
+
 bool DecoderInfo::isNop() const {
   // no-op is a mnemonic of ori 0,0,0
   if ((m_form == Form::kD) && (m_opn == OpcodeNames::op_ori)) {
@@ -345,55 +360,142 @@ bool DecoderInfo::isNop() const {
   return false;
 }
 
+bool DecoderInfo::isLd(bool toc) const {
+  if ((m_form == Form::kDS) && (m_opn == OpcodeNames::op_ld)) {
+    if (!toc) return true;
 
-bool DecoderInfo::isBranch(bool allowCond /* = true */) const {
-  // allowCond: true
-  //   b, ba, bl - unconditional branches
-  //   bc, bca, bcctr, bcctrl, bcl, bcla, bclr, bclrl, bctar, bctarl
-  //
-  // allowCond: false
-  //   b, ba, bl - unconditional branches
+    DS_form_t dsform;
+    dsform.instruction = m_image;
+    if (Reg64(dsform.RA) == reg::r2) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/*
+ * Auxiliary for isLwz and isAddis
+ */
+bool DecoderInfo::isDformOp(OpcodeNames opn, bool toc) const {
+  if ((m_form == Form::kD) && (m_opn == opn)) {
+    if (!toc) return true;
+
+    D_form_t dform;
+    dform.instruction = m_image;
+    if (Reg64(dform.RA) == reg::r2) {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool DecoderInfo::isLwz(bool toc) const {
+  return isDformOp(OpcodeNames::op_lwz, toc);
+}
+
+bool DecoderInfo::isAddis(bool toc) const {
+  return isDformOp(OpcodeNames::op_addis, toc);
+}
+
+bool DecoderInfo::isOffsetBranch(AllowCond ac /* = AllowCond::Any */) const {
+  // ac: OnlyUncond
+  //   b, bl   - unconditional branches
   //  And also, if condition is "branch always" (BO field is 1x1xx):
-  //   bc, bca, bcctr, bcctrl, bcl, bcla, bclr, bclrl, bctar, bctarl
+  //   bc, bcl
+  //
+  // ac: Any
+  //   b, bl   - unconditional branches
+  //   bc, bcl - conditional branches
+  //
+  // ac: OnlyCond
+  //   bc, bcl - conditional branches and it can't be "branch always"
   //
   // (based on the branch instructions defined on this Decoder)
-  constexpr uint32_t uncondition_bo = 0x14;
-
   switch (m_opn) {
     case OpcodeNames::op_b:
-    case OpcodeNames::op_ba:
     case OpcodeNames::op_bl:
-      return true;
+      return (AllowCond::OnlyCond != ac);
       break;
     case OpcodeNames::op_bc:
-    case OpcodeNames::op_bca:
     case OpcodeNames::op_bcl:
-    case OpcodeNames::op_bcla:
-    case OpcodeNames::op_bclr:
-      if (!allowCond) {
+      {
         // checking if the condition is "always branch", then it counts as an
         // unconditional branch
         assert(m_form == Form::kB);
         B_form_t bform;
         bform.instruction = m_image;
-        return ((bform.BO & uncondition_bo) == uncondition_bo);
+        BranchParams uncondition_bp(BranchConditions::Always);
+
+        if (uncondition_bp.bo() == bform.BO) {
+          // not acceptable if it was required to have a condition
+          return (AllowCond::OnlyCond != ac);
+        } else {
+          // it's a conditional branch
+          return (AllowCond::OnlyUncond != ac);
+        }
+        break;
       }
-      return true;
+    default:
       break;
-    case OpcodeNames::op_bcctr:
+  }
+  return false;
+}
+
+/*
+ * True if bcctrl (as "branch always" condition) or bl
+ * False otherwise
+ */
+bool DecoderInfo::isBranchWithLR() const {
+  switch (m_opn) {
     case OpcodeNames::op_bcctrl:
-    case OpcodeNames::op_bclrl:
-    case OpcodeNames::op_bctar:
-    case OpcodeNames::op_bctarl:
-      if (!allowCond) {
+      {
         // checking if the condition is "always branch", then it counts as an
         // unconditional branch
         assert(m_form == Form::kXL);
         XL_form_t xlform;
         xlform.instruction = m_image;
-        return ((xlform.BT & uncondition_bo) == uncondition_bo);
+        BranchParams uncondition_bp(BranchConditions::Always);
+        return xlform.BT == uncondition_bp.bo();
       }
+      break;
+    case OpcodeNames::op_bl:
       return true;
+      break;
+    default:
+      break;
+  }
+  return false;
+}
+
+bool DecoderInfo::isRegisterBranch(AllowCond ac /* = AllowCond::Any */) const {
+  // ac: Any
+  //   bcctr, bcctrl
+  //
+  // ac: OnlyUncond
+  //   bcctr, bcctrl - only if condition is "branch always" (BO field: 1x1xx)
+  //
+  // ac: OnlyCond
+  //   bcctr, bcctrl - only if condition is NOT "branch always" (BO field)
+  //
+  // NOTE: not considering bclr as it's more like a return than a branch
+  switch (m_opn) {
+    case OpcodeNames::op_bcctr:
+    case OpcodeNames::op_bcctrl:
+      {
+        // checking if the condition is "always branch", then it counts as an
+        // unconditional branch
+        assert(m_form == Form::kXL);
+        XL_form_t xlform;
+        xlform.instruction = m_image;
+        BranchParams uncondition_bp(BranchConditions::Always);
+        if (uncondition_bp.bo() == xlform.BT) {
+          // unconditional is only allowed if it's not OnlyCond
+          return (AllowCond::OnlyCond != ac);
+        } else {
+          // it's a conditional branch
+          return (AllowCond::OnlyUncond != ac);
+        }
+      }
       break;
     default:
       break;
@@ -444,6 +546,91 @@ int32_t DecoderInfo::offset() const {
   instr_d.instruction = m_image;
   // As the instruction is known, the immediate is a signed number of
   // 16bits, so to consider the sign, it must be casted to int16_t.
+  return static_cast<int16_t>(instr_d.D);
+}
+
+/*
+ * Return offset of a branch by offset like b or bc.
+ */
+int32_t DecoderInfo::branchOffset() const {
+  int32_t offset = 0;
+  switch (m_opn) {
+    case OpcodeNames::op_b:
+    case OpcodeNames::op_bl:
+      {
+        I_form_t iform;
+        iform.instruction = m_image;
+        // sign bit of LI
+        auto signBit = 1 << 25;
+        auto li = iform.LI << 2;
+        // sign-extend 32-bits from a 26-bit value, if negative
+        offset = (signBit & li) ? ((int32_t(-1) - ((1<<26)-1)) | li) : li;
+        break;
+      }
+    case OpcodeNames::op_bc:
+    case OpcodeNames::op_bcl:
+      {
+        B_form_t bform;
+        bform.instruction = m_image;
+        offset = int16_t(bform.BD << 2);
+        break;
+      }
+    default:
+      always_assert(false && "Instruction not expected.");
+      break;
+  }
+  return offset;
+}
+
+/*
+ * Set offset of a branch by offset like b or bc. Return that instruction
+ */
+PPC64Instr DecoderInfo::setBranchOffset(int32_t offset) const {
+  switch (m_opn) {
+    case OpcodeNames::op_b:
+    case OpcodeNames::op_bl:
+      {
+        I_form_t iform;
+        iform.instruction = m_image;
+        iform.LI = offset >> 2;
+        return iform.instruction;
+        break;
+      }
+    case OpcodeNames::op_bc:
+    case OpcodeNames::op_bcl:
+      {
+        B_form_t bform;
+        bform.instruction = m_image;
+        bform.BD = offset >> 2;
+        return bform.instruction;
+        break;
+      }
+    default:
+      always_assert(false && "Instruction not expected.");
+      return 0;
+      break;
+  }
+}
+/*
+ * Find the offset from instructions like ld, which was created by
+ * limmediate.
+ */
+int16_t DecoderInfo::offsetDS() const {
+  always_assert(m_form == Form::kDS && "Instruction not expected.");
+  DS_form_t instr_d;
+  instr_d.instruction = m_image;
+
+  return static_cast<int16_t>(instr_d.DS << 2);
+}
+
+/*
+ * Find the offset from instructions like lwz.
+ */
+int16_t DecoderInfo::offsetD() const {
+  always_assert(m_form == Form::kD && "Instruction not expected.");
+  D_form_t instr_d;
+  instr_d.instruction = m_image;
+
   return static_cast<int16_t>(instr_d.D);
 }
 

--- a/hphp/ppc64-asm/decoder-ppc64.cpp
+++ b/hphp/ppc64-asm/decoder-ppc64.cpp
@@ -366,7 +366,7 @@ bool DecoderInfo::isLd(bool toc) const {
 
     DS_form_t dsform;
     dsform.instruction = m_image;
-    if (Reg64(dsform.RA) == reg::r2) {
+    if (Reg64(dsform.RA) == HPHP::jit::ppc64::rtoc()) {
       return true;
     }
   }
@@ -382,7 +382,7 @@ bool DecoderInfo::isDformOp(OpcodeNames opn, bool toc) const {
 
     D_form_t dform;
     dform.instruction = m_image;
-    if (Reg64(dform.RA) == reg::r2) {
+    if (Reg64(dform.RA) == HPHP::jit::ppc64::rtoc()) {
       return true;
     }
   }

--- a/hphp/ppc64-asm/decoder-ppc64.cpp
+++ b/hphp/ppc64-asm/decoder-ppc64.cpp
@@ -19,8 +19,7 @@
 #include "hphp/ppc64-asm/branch-ppc64.h"
 #include "hphp/ppc64-asm/decoder-ppc64.h"
 #include "hphp/ppc64-asm/isa-ppc64.h"
-
-#include "hphp/runtime/vm/jit/abi-ppc64.h"
+#include "hphp/ppc64-asm/asm-ppc64.h"
 
 namespace ppc64_asm {
 
@@ -366,7 +365,7 @@ bool DecoderInfo::isLd(bool toc) const {
 
     DS_form_t dsform;
     dsform.instruction = m_image;
-    if (Reg64(dsform.RA) == HPHP::jit::ppc64::rtoc()) {
+    if (Reg64(dsform.RA) == reg::r2) {
       return true;
     }
   }
@@ -382,7 +381,7 @@ bool DecoderInfo::isDformOp(OpcodeNames opn, bool toc) const {
 
     D_form_t dform;
     dform.instruction = m_image;
-    if (Reg64(dform.RA) == HPHP::jit::ppc64::rtoc()) {
+    if (Reg64(dform.RA) == reg::r2) {
       return true;
     }
   }

--- a/hphp/runtime/base/runtime-option.h
+++ b/hphp/runtime/base/runtime-option.h
@@ -607,8 +607,16 @@ struct RuntimeOption {
   F(int64_t,  StressUnitCacheFreq, 0)                                   \
   F(int64_t, PerfWarningSampleRate, 1)                                  \
   F(double, InitialLoadFactor, 1.0)                                     \
-  /* PPC64 Option: Minimum immediate size to use TOC */                 \
+  /******************                                                   \
+   | PPC64 Options. |                                                   \
+   *****************/                                                   \
+  /* Minimum immediate size to use TOC */                               \
   F(uint16_t, PPC64MinTOCImmSize, 64)                                   \
+  /* Relocation features. Use with care on production */                \
+  /*  Allow a Far branch be converted to a Near branch. */              \
+  F(bool, PPC64RelocationShrinkFarBranches, false)                      \
+  /*  Remove nops from a Far branch. */                                 \
+  F(bool, PPC64RelocationRemoveFarBranchesNops, true)                   \
   /********************                                                 \
    | Profiling flags. |                                                 \
    ********************/                                                \

--- a/hphp/runtime/vm/jit/cg-meta.h
+++ b/hphp/runtime/vm/jit/cg-meta.h
@@ -103,6 +103,12 @@ struct CGMeta {
   GrowableVector<IncomingBranch> inProgressTailJumps;
 
   /*
+   * Smashable locations. Used on relocation to be sure a smashable instruction
+   * is not optimized in size.
+   */
+  std::set<TCA> smashableLocations;
+
+  /*
    * Debug-only map from bytecode to machine code address.
    */
   std::vector<TransBCMapping> bcMap;

--- a/hphp/runtime/vm/jit/func-guard-ppc64.cpp
+++ b/hphp/runtime/vm/jit/func-guard-ppc64.cpp
@@ -63,7 +63,8 @@ void emitFuncGuard(const Func* func, CodeBlock& cb, CGMeta& fixups) {
   a.  cmpd   (tmp1, tmp2);
 
   a.  branchFar(tc::ustubs().funcPrologueRedispatch,
-                  ppc64_asm::BranchConditions::NotEqual);
+                  ppc64_asm::BranchConditions::NotEqual,
+                  ppc64_asm::ImmType::TocOnly);
 
   DEBUG_ONLY auto guard = funcGuardFromPrologue(a.frontier(), func);
   assertx(funcGuardMatches(guard, func));
@@ -77,8 +78,9 @@ TCA funcGuardFromPrologue(TCA prologue, const Func* func) {
 bool funcGuardMatches(TCA guard, const Func* func) {
   if (isPrologueStub(guard)) return false;
 
+  const ppc64_asm::DecodedInstruction di(guard);
   auto const ifunc = reinterpret_cast<uintptr_t>(func);
-  return static_cast<uintptr_t>(ppc64_asm::Assembler::getLi64(guard)) == ifunc;
+  return static_cast<uintptr_t>(di.immediate()) == ifunc;
 }
 
 void clobberFuncGuard(TCA guard, const Func* func) {

--- a/hphp/runtime/vm/jit/relocation-ppc64.cpp
+++ b/hphp/runtime/vm/jit/relocation-ppc64.cpp
@@ -1,0 +1,595 @@
+/*
+   +----------------------------------------------------------------------+
+   | HipHop for PHP                                                       |
+   +----------------------------------------------------------------------+
+   | (c) Copyright IBM Corporation 2016                                   |
+   +----------------------------------------------------------------------+
+   | This source file is subject to version 3.01 of the PHP license,      |
+   | that is bundled with this package in the file LICENSE, and is        |
+   | available through the world-wide-web at the following url:           |
+   | http://www.php.net/license/3_01.txt                                  |
+   | If you did not receive a copy of the PHP license and are unable to   |
+   | obtain it through the world-wide-web, please send a note to          |
+   | license@php.net so we can mail you a copy immediately.               |
+   +----------------------------------------------------------------------+
+*/
+
+#include "hphp/runtime/vm/jit/relocation.h"
+
+#include "hphp/runtime/vm/jit/align-ppc64.h"
+#include "hphp/runtime/vm/jit/asm-info.h"
+#include "hphp/runtime/vm/jit/cg-meta.h"
+#include "hphp/runtime/vm/jit/containers.h"
+#include "hphp/runtime/vm/jit/fixup.h"
+#include "hphp/runtime/vm/jit/ir-opcode.h"
+#include "hphp/runtime/vm/jit/smashable-instr.h"
+
+#include "hphp/ppc64-asm/asm-ppc64.h"
+#include "hphp/ppc64-asm/decoded-instr-ppc64.h"
+
+/*
+ * Allow a Far branch be converted to a Near branch.
+ */
+//#define SHRINK_FAR_BRANCHES
+
+/*
+ * Remove nops from a Far branch.
+ */
+#define REMOVE_FAR_BRANCHES_NOPS
+
+namespace HPHP { namespace jit { namespace ppc64 {
+
+/* using override */ using ppc64_asm::DecodedInstruction;
+
+namespace {
+
+TRACE_SET_MOD(hhir);
+
+//////////////////////////////////////////////////////////////////////
+
+using JmpSet = hphp_hash_set<void*>;
+struct JmpOutOfRange : std::exception {};
+
+TcaRange fixupRange(const RelocationInfo& rel, const TcaRange& rng) {
+  /*
+   * We have to be careful with before/after here.
+   * If we relocate two consecutive regions of memory,
+   * but relocate them to two different destinations, then
+   * the end address of the first region is also the start
+   * address of the second region; so adjustedAddressBefore(end)
+   * gives us the relocated address of the end of the first
+   * region, while adjustedAddressAfter(end) gives us the
+   * relocated address of the start of the second region.
+   */
+  auto s = rel.adjustedAddressAfter(rng.begin());
+  auto e = rel.adjustedAddressBefore(rng.end());
+  if (s && e) {
+    return TcaRange(s, e);
+  }
+  if (s && !e) {
+    return TcaRange(s, s + rng.size());
+  }
+  if (!s && e) {
+    return TcaRange(e - rng.size(), e);
+  }
+  return rng;
+}
+
+void fixupRanges(AsmInfo* asmInfo, AreaIndex area, RelocationInfo& rel) {
+  asmInfo->clearBlockRangesForArea(area);
+  for (auto& ii : asmInfo->instRangesForArea(area)) {
+    ii.second = fixupRange(rel, ii.second);
+    asmInfo->updateForBlock(area, ii.first, ii.second);
+  }
+}
+
+size_t relocateImpl(RelocationInfo& rel,
+                    CodeBlock& dest_block,
+                    TCA start, TCA end,
+                    CGMeta& fixups,
+                    TCA* exit_addr,
+                    JmpSet& far_jmps,
+                    JmpSet& near_jmps) {
+  TCA src = start;
+  size_t range = end - src;
+  bool internal_refs_need_update = false;
+  TCA dest_start = dest_block.frontier();
+  size_t asm_count{0};
+  TCA jmp_dest = nullptr;
+  try {
+    while (src != end) {
+      assertx(src < end);
+      DecodedInstruction di(src);
+      asm_count++;
+
+      TCA dest = dest_block.frontier();
+      dest_block.bytes(di.size(), src);
+      DecodedInstruction d2(dest, di.size());
+      if (di.isNearBranch()) {
+        if (di.isBranch(ppc64_asm::AllowCond::OnlyUncond)) {
+          jmp_dest = di.nearBranchTarget();
+        }
+        // Relative branch needs always to be readjusted
+        internal_refs_need_update = true;
+
+        if (far_jmps.count(src)) {
+          TCA old_target = di.nearBranchTarget();
+          TCA adjusted_target = rel.adjustedAddressAfter(old_target);
+          TCA new_target = (adjusted_target) ? adjusted_target : old_target;
+
+          // Near branch will be widen to Far branch. Update d2 in order to be
+          // able to read more bytes than only the Near branch
+          d2 = DecodedInstruction(dest);
+          d2.widenBranch(new_target);
+
+          // widening a branch makes the dest instruction bigger
+          dest_block.setFrontier(dest + d2.size());
+        } else if ((size_t(di.nearBranchTarget() - start) >= range) &&
+            /*
+             * Rip-relative offsets that point outside the range
+             * being moved need to be adjusted so they continue
+             * to point at the right thing
+             */
+            !d2.setNearBranchTarget(di.nearBranchTarget())) {
+          FTRACE(3,
+              "relocate: instruction at {} has target 0x{:x} "
+              "which is too far away for a near branch after relocation\n",
+              dest, di.nearBranchTarget());
+        }
+      }
+      if (di.isImmediate()) {
+        auto imm = di.immediate();
+        if (fixups.addressImmediates.count((TCA)imm)) {
+          auto new_immediate = (int64_t)rel.adjustedAddressAfter((TCA)imm);
+          if (!d2.setImmediate(new_immediate)) {
+            always_assert(false && "Immediate couldn't be relocated");
+          }
+        } else if (fixups.addressImmediates.count(src)) {
+          if (size_t(imm - (uint64_t)start) < range) {
+            internal_refs_need_update = true;
+          }
+        } else {
+          if (fixups.addressImmediates.count((TCA)~uintptr_t(src))) {
+            // Handle weird, encoded offset, used by cgLdObjMethod
+            always_assert(imm == ((uintptr_t(src) << 1) | 1));
+            bool DEBUG_ONLY success =
+              d2.setImmediate(((uintptr_t)dest << 1) | 1);
+            assertx(success);
+          }
+          /*
+           * An immediate that points into the range being moved, but which
+           * isn't tagged as an addressImmediate, is most likely a bug
+           * and its instruction's address needs to be put into
+           * fixups.addressImmediates. But it could just happen by bad
+           * luck, so just log it.
+           */
+          if (size_t(imm - (uint64_t)start) < range) {
+            FTRACE(3,
+                   "relocate: instruction at {} has immediate 0x{:x}"
+                   "which looks like an address that needs relocating\n",
+                   src, imm);
+          }
+        }
+      }
+      if (di.isFarBranch()) {
+        if (near_jmps.count(src)) {
+          // Shrink it to a Near branch
+          if (d2.shrinkBranch()) {
+            internal_refs_need_update = true;
+          } else {
+            // It asked to be patched but it couldn't, then something is odd...
+            assertx(false && "Couldn't change Far -> Near branch");
+          }
+        } else if ((size_t(di.farBranchTarget() - (uint64_t)start) < range) ||
+            (di.couldBeNearBranch())) {
+          // It can be done with a Near branch
+          internal_refs_need_update = true;
+        } else {
+          // re-emit it without nops, except if it's a smashable
+          TCA old_target = di.farBranchTarget();
+          TCA adjusted_target = rel.adjustedAddressAfter(old_target);
+          TCA new_target = (adjusted_target) ? adjusted_target : old_target;
+
+#ifdef REMOVE_FAR_BRANCHES_NOPS
+          // if it's smashable, don't remove nops (leave it as fixed size) and
+          // mark this relocated address to be used on adjustForRelocation
+          bool keep_nops = (0 != fixups.smashableLocations.count(src));
+          if (keep_nops) rel.markSmashableRelocation(dest);
+#else
+          bool keep_nops = true;
+#endif
+          if (!d2.setFarBranchTarget(new_target, keep_nops)) {
+            assertx(false && "Couldn't set Far branch target");
+          }
+        }
+      }
+
+      if (src == start) {
+        // for the start of the range, we only want to overwrite the "after"
+        // address (since the "before" address could belong to the previous
+        // tracelet, which could be being relocated to a completely different
+        // address. recordRange will do that for us, so just make sure we
+        // have the right address setup.
+        dest_start = dest;
+      } else {
+        rel.recordAddress(src, dest, 0);
+      }
+      dest += d2.size();
+      assertx(dest <= dest_block.frontier());
+      dest_block.setFrontier(dest);
+      src += di.size();
+    } // while (src != end)
+
+    if (exit_addr) {
+      *exit_addr = jmp_dest;
+    }
+
+    rel.recordRange(start, end, dest_start, dest_block.frontier());
+
+    if (internal_refs_need_update) {
+      src = start;
+      bool ok = true;
+      while (src != end) {
+        DecodedInstruction di(src);
+        TCA dest = rel.adjustedAddressAfter(src);
+        // Avoid set max_size as it would fail when a branch is widen.
+        DecodedInstruction d2(dest);
+        if (di.isNearBranch()) {
+          TCA old_target = di.nearBranchTarget();
+          TCA adjusted_target = rel.adjustedAddressAfter(old_target);
+          TCA new_target = (adjusted_target) ? adjusted_target : old_target;
+          if (d2.isNearBranch()) {
+            if (!d2.setNearBranchTarget(new_target)) {
+              // It doesn't fit a Near branch anymore. Convert it to Far branch
+              far_jmps.insert(src);
+              ok = false;
+            }
+          } else {
+            bool keep_nops =
+#ifdef REMOVE_FAR_BRANCHES_NOPS
+              false
+#else
+              true
+#endif
+              ;
+            if (!d2.setFarBranchTarget(new_target, keep_nops)) {
+              always_assert(false && "Widen branch relocation failed");
+            }
+          }
+        }
+        if (di.isImmediate()) {
+          int64_t new_immediate =
+            (int64_t)rel.adjustedAddressAfter((TCA)di.immediate());
+          if ((new_immediate) && !d2.setImmediate(new_immediate)) {
+            always_assert(false && "Immediate couldn't be relocated");
+          }
+        }
+        if (di.isFarBranch()) {
+          bool insert_near_jmp = false;
+          auto new_far_target = rel.adjustedAddressAfter(di.farBranchTarget());
+          if ((size_t(di.farBranchTarget() - start) < range) ||
+              (d2.isNearBranch())) {
+            // A Far branch is converted to Near branch.
+            if (near_jmps.count(src)) {
+              // Oh, it's already a near branch! Adjust the offset
+              auto target = new_far_target
+                            ? new_far_target
+                            : di.farBranchTarget();
+              if (!d2.setNearBranchTarget(target)) {
+                assertx(false && "Can't change to a near branch.");
+              }
+            } else {
+              insert_near_jmp = true;
+            }
+          } else if (!new_far_target && d2.couldBeNearBranch()) {
+            // target is close enough, convert it to Near branch
+            insert_near_jmp = true;
+          } else if (new_far_target) {
+            // Far target will be relocated.
+            bool keep_nops =
+#ifdef REMOVE_FAR_BRANCHES_NOPS
+              rel.isSmashableRelocation(dest);
+#else
+              true
+#endif
+              ;
+            if (!d2.setFarBranchTarget(new_far_target, keep_nops)) {
+              assert(false && "Far branch target setting failed");
+            }
+            if (d2.couldBeNearBranch()) {
+              // target is close enough, convert it to Near branch
+              insert_near_jmp = true;
+            }
+          }
+          // shrinkBranch is only allowed for non-smashable branches
+          if (insert_near_jmp && !fixups.smashableLocations.count(src)) {
+            // Mark it as Near branch and run this again
+#ifdef SHRINK_FAR_BRANCHES
+            near_jmps.insert(src);
+            ok = false;
+#endif
+          }
+        }
+        src += di.size();
+      }
+      if (!ok) {
+        throw JmpOutOfRange();
+      }
+    }
+    rel.markAddressImmediates(fixups.addressImmediates);
+  } catch (...) {
+    rel.rewind(start, end);
+    dest_block.setFrontier(dest_start);
+    throw;
+  }
+  return asm_count;
+}
+
+//////////////////////////////////////////////////////////////////////
+
+}
+
+void adjustInstruction(RelocationInfo& rel, DecodedInstruction& di) {
+  if (di.isNearBranch()) {
+    /*
+     * A pointer into something that has been relocated needs to be
+     * updated.
+     */
+    if (TCA adjusted = rel.adjustedAddressAfter(di.nearBranchTarget())) {
+      if (!di.setNearBranchTarget(adjusted)) {
+        assertx(false && "Tried to patch near branch but it doesn't fit.");
+      }
+    }
+  } else if (di.isImmediate()) {
+    /*
+     * Similarly for addressImmediates - and see comment above
+     * for non-address immediates.
+     */
+    if (TCA adjusted = rel.adjustedAddressAfter((TCA)di.immediate())) {
+      if (!di.setImmediate((int64_t)adjusted)) {
+        always_assert(false && "Immediate couldn't be adjusted.");
+      }
+    }
+  } else if (di.isFarBranch()) {
+    if (TCA adjusted = rel.adjustedAddressAfter(di.farBranchTarget())) {
+      bool keep_nops =
+#ifdef REMOVE_FAR_BRANCHES_NOPS
+        rel.isSmashableRelocation(di.ip());
+#else
+      true
+#endif
+        ;
+      if (!di.setFarBranchTarget(adjusted, keep_nops)) {
+        always_assert(false && "Not an expected Far branch.");
+      }
+    }
+  }
+}
+
+/*
+ * This should be called after calling relocate on all relevant ranges. It
+ * will adjust all references into the original src ranges to point into the
+ * corresponding relocated ranges.
+ */
+void adjustForRelocation(RelocationInfo& rel) {
+  for (const auto& range : rel.srcRanges()) {
+    adjustForRelocation(rel, range.first, range.second);
+  }
+}
+
+/*
+ * This will update a single range that was not relocated, but that
+ * might refer to relocated code (such as the cold code corresponding
+ * to a tracelet). Unless its guaranteed to be all position independent,
+ * its "fixups" should have been passed into a relocate call earlier.
+ */
+void adjustForRelocation(RelocationInfo& rel, TCA srcStart, TCA srcEnd) {
+  auto start = rel.adjustedAddressAfter(srcStart);
+  auto end = rel.adjustedAddressBefore(srcEnd);
+  if (!start) {
+    start = srcStart;
+    end = srcEnd;
+  } else {
+    always_assert(end);
+  }
+  while (start != end) {
+    assertx(start < end);
+    DecodedInstruction di(start);
+
+    adjustInstruction(rel, di);
+
+    start += di.size();
+
+    if (start == end && di.isNop() && rel.adjustedAddressAfter(srcEnd)) {
+      smashJmp(start - di.size(), rel.adjustedAddressAfter(end));
+    }
+  }
+}
+
+/*
+ * Adjusts the addresses in asmInfo and fixups to match the new
+ * location of the code.
+ * This will not "hook up" the relocated code in any way, so is safe
+ * to call before the relocated code is ready to run.
+ */
+void adjustMetaDataForRelocation(RelocationInfo& rel,
+                                 AsmInfo* asmInfo,
+                                 CGMeta& meta) {
+  auto& ip = meta.inProgressTailJumps;
+  for (size_t i = 0; i < ip.size(); ++i) {
+    IncomingBranch& ib = const_cast<IncomingBranch&>(ip[i]);
+    if (TCA adjusted = rel.adjustedAddressAfter(ib.toSmash())) {
+      ib.adjust(adjusted);
+    }
+  }
+
+  for (auto watch : meta.watchpoints) {
+    if (auto const adjusted = rel.adjustedAddressBefore(*watch)) {
+      *watch = adjusted;
+    }
+  }
+
+  for (auto& fixup : meta.fixups) {
+    /*
+     * Pending fixups always point after the call instruction,
+     * so use the "before" address, since there may be nops
+     * before the next actual instruction.
+     */
+    if (TCA adjusted = rel.adjustedAddressBefore(fixup.first)) {
+      fixup.first = adjusted;
+    }
+  }
+
+  for (auto& ct : meta.catches) {
+    /*
+     * Similar to fixups - this is a return address so get
+     * the address returned to.
+     */
+    if (auto const adjusted = rel.adjustedAddressBefore(ct.first)) {
+      ct.first = adjusted;
+    }
+    /*
+     * But the target is an instruction, so skip over any nops
+     * that might have been inserted (eg for alignment).
+     */
+    if (auto const adjusted = rel.adjustedAddressAfter(ct.second)) {
+      ct.second = adjusted;
+    }
+  }
+
+  for (auto& jt : meta.jmpTransIDs) {
+    if (auto const adjusted = rel.adjustedAddressAfter(jt.first)) {
+      jt.first = adjusted;
+    }
+  }
+
+  if (!meta.bcMap.empty()) {
+    /*
+     * Most of the time we want to adjust to a corresponding "before" address
+     * with the exception of the start of the range where "before" can point to
+     * the end of a previous range.
+     */
+    auto const aStart = meta.bcMap[0].aStart;
+    auto const acoldStart = meta.bcMap[0].acoldStart;
+    auto const afrozenStart = meta.bcMap[0].afrozenStart;
+    auto adjustAddress = [&](TCA& address, TCA blockStart) {
+      if (TCA adjusted = (address == blockStart
+                            ? rel.adjustedAddressAfter(blockStart)
+                            : rel.adjustedAddressBefore(address))) {
+        address = adjusted;
+      }
+    };
+    for (auto& tbc : meta.bcMap) {
+      adjustAddress(tbc.aStart, aStart);
+      adjustAddress(tbc.acoldStart, acoldStart);
+      adjustAddress(tbc.afrozenStart, afrozenStart);
+    }
+  }
+
+  decltype(meta.addressImmediates) updatedAI;
+  for (auto addrImm : meta.addressImmediates) {
+    if (TCA adjusted = rel.adjustedAddressAfter(addrImm)) {
+      updatedAI.insert(adjusted);
+    } else if (TCA odd = rel.adjustedAddressAfter((TCA)~uintptr_t(addrImm))) {
+      // just for cgLdObjMethod
+      updatedAI.insert((TCA)~uintptr_t(odd));
+    } else {
+      updatedAI.insert(addrImm);
+    }
+  }
+  updatedAI.swap(meta.addressImmediates);
+
+  decltype(meta.alignments) updatedAF;
+  for (auto af : meta.alignments) {
+    if (TCA adjusted = rel.adjustedAddressAfter(af.first)) {
+      updatedAF.emplace(adjusted, af.second);
+    } else {
+      updatedAF.emplace(af);
+    }
+  }
+  updatedAF.swap(meta.alignments);
+
+  for (auto& af : meta.reusedStubs) {
+    if (TCA adjusted = rel.adjustedAddressAfter(af)) {
+      af = adjusted;
+    }
+  }
+
+  if (asmInfo) {
+    assert(asmInfo->validate());
+    fixupRanges(asmInfo, AreaIndex::Main, rel);
+    fixupRanges(asmInfo, AreaIndex::Cold, rel);
+    fixupRanges(asmInfo, AreaIndex::Frozen, rel);
+    assert(asmInfo->validate());
+  }
+}
+
+/*
+ * Adjust potentially live references that point into the relocated
+ * area.
+ * Must not be called until its safe to run the relocated code.
+ */
+void adjustCodeForRelocation(RelocationInfo& rel, CGMeta& fixups) {
+  for (auto addr : fixups.reusedStubs) {
+    /*
+     * The stubs are terminated by a trap. Check for it.
+     */
+    for (auto di = DecodedInstruction(addr); !di.isException(); ) {
+      adjustInstruction(rel, di);
+
+      addr += di.size();
+      di = DecodedInstruction(addr);
+    }
+  }
+
+  for (auto codePtr : fixups.codePointers) {
+    if (TCA adjusted = rel.adjustedAddressAfter(*codePtr)) {
+      *codePtr = adjusted;
+    }
+  }
+}
+
+void findFixups(TCA start, TCA end, CGMeta& meta) {
+  while (start != end) {
+    assert(start < end);
+    DecodedInstruction di(start);
+    start += di.size();
+
+    if (di.isCall()) {
+      if (auto fixup = FixupMap::findFixup(start)) {
+        meta.fixups.emplace_back(start, *fixup);
+      }
+      if (auto ct = getCatchTrace(start)) {
+        meta.catches.emplace_back(start, *ct);
+      }
+    }
+  }
+}
+
+
+/*
+ * Relocate code in the range start, end into dest, and record
+ * information about what was done to rel.
+ * On exit, internal references (references into the source range)
+ * will have been adjusted (ie they are still references into the
+ * relocated code). External code references continue to point to
+ * the same address as before relocation.
+ */
+size_t relocate(RelocationInfo& rel,
+                CodeBlock& dest_block,
+                TCA start, TCA end,
+                CGMeta& fixups,
+                TCA* exit_addr) {
+  JmpSet far_jmps, near_jmps;
+  while (true) {
+    try {
+      return relocateImpl(rel, dest_block, start, end,
+                          fixups, exit_addr, far_jmps, near_jmps);
+    } catch (JmpOutOfRange& j) {
+    }
+  }
+}
+
+//////////////////////////////////////////////////////////////////////
+
+}}}

--- a/hphp/runtime/vm/jit/relocation-ppc64.h
+++ b/hphp/runtime/vm/jit/relocation-ppc64.h
@@ -21,25 +21,12 @@
 
 namespace HPHP { namespace jit { namespace ppc64 {
 
-void adjustForRelocation(RelocationInfo&) {
-  not_implemented();
-}
-void adjustForRelocation(RelocationInfo& rel, TCA srcStart, TCA srcEnd) {
-  not_implemented();
-}
-void adjustCodeForRelocation(RelocationInfo& rel, CGMeta& fixups) {
-  not_implemented();
-}
-void adjustMetaDataForRelocation(RelocationInfo&, AsmInfo*, CGMeta&) {
-  not_implemented();
-}
-void findFixups(TCA start, TCA end, CGMeta& fixups) {
-  not_implemented();
-}
-size_t relocate(RelocationInfo&, CodeBlock&, TCA, TCA, CGMeta&, TCA*) {
-  not_implemented();
-  return 0;
-}
+void adjustForRelocation(RelocationInfo&);
+void adjustForRelocation(RelocationInfo& rel, TCA srcStart, TCA srcEnd);
+void adjustCodeForRelocation(RelocationInfo& rel, CGMeta& fixups);
+void adjustMetaDataForRelocation(RelocationInfo&, AsmInfo*, CGMeta&);
+void findFixups(TCA start, TCA end, CGMeta& fixups);
+size_t relocate(RelocationInfo&, CodeBlock&, TCA, TCA, CGMeta&, TCA*);
 
 }}}
 

--- a/hphp/runtime/vm/jit/relocation.h
+++ b/hphp/runtime/vm/jit/relocation.h
@@ -49,6 +49,12 @@ struct RelocationInfo {
   bool isAddressImmediate(TCA ip) {
     return addressImmediates.count(ip);
   }
+  void markSmashableRelocation(TCA ip) {
+    m_smashableRelocations.insert(ip);
+  }
+  bool isSmashableRelocation(TCA ip) {
+    return m_smashableRelocations.count(ip);
+  }
   typedef std::vector<std::pair<TCA,TCA>> RangeVec;
   const RangeVec& srcRanges() { return m_srcRanges; }
   const RangeVec& dstRanges() { return m_dstRanges; }
@@ -64,6 +70,7 @@ struct RelocationInfo {
    */
   std::map<TCA,std::pair<TCA,TCA>> m_adjustedAddresses;
   std::set<TCA> addressImmediates;
+  std::set<TCA> m_smashableRelocations;
 };
 
 void adjustForRelocation(RelocationInfo&);

--- a/hphp/runtime/vm/jit/smashable-instr-ppc64.cpp
+++ b/hphp/runtime/vm/jit/smashable-instr-ppc64.cpp
@@ -171,7 +171,7 @@ TCA smashableCallTarget(TCA inst) {
 
 static TCA smashableBranchTarget(TCA inst, bool allowCond) {
   const DecodedInstruction di(inst);
-  auto ac = (allowCond)
+  auto ac = allowCond
     ? ppc64_asm::AllowCond::Any
     : ppc64_asm::AllowCond::OnlyUncond;
   if (!di.isBranch(ac)) return nullptr;

--- a/hphp/runtime/vm/jit/smashable-instr-ppc64.cpp
+++ b/hphp/runtime/vm/jit/smashable-instr-ppc64.cpp
@@ -18,67 +18,68 @@
 
 #include "hphp/runtime/vm/jit/abi-ppc64.h"
 #include "hphp/runtime/vm/jit/align-ppc64.h"
+#include "hphp/runtime/vm/jit/cg-meta.h"
 #include "hphp/runtime/vm/jit/code-cache.h"
 #include "hphp/runtime/vm/jit/tc.h"
 #include "hphp/runtime/vm/jit/tc-internal.h"
 
 #include "hphp/ppc64-asm/asm-ppc64.h"
-#include "hphp/ppc64-asm/decoder-ppc64.h"
+#include "hphp/ppc64-asm/decoded-instr-ppc64.h"
+
 #include "hphp/util/data-block.h"
 
 namespace HPHP { namespace jit { namespace ppc64 {
 
 using ppc64_asm::PPC64Instr;
 using ppc64_asm::Assembler;
+using ppc64_asm::ImmType;
+using ppc64_asm::DecodedInstruction;
 
 ///////////////////////////////////////////////////////////////////////////////
 
 
-#define EMIT_BODY(cb, inst, Inst, ...)  \
-  ([&] {                                \
-    align(cb, &fixups,                  \
-          Alignment::Smash##Inst,       \
-          AlignContext::Live);          \
-    auto const start = cb.frontier();   \
-    Assembler a { cb };                 \
-    a.inst(__VA_ARGS__);                \
-    return start;                       \
+#define EMIT_BODY(cb, meta, inst, ...)      \
+  ([&] {                                    \
+    auto const start = cb.frontier();       \
+    meta.smashableLocations.insert(start);  \
+    Assembler a { cb };                     \
+    a.inst(__VA_ARGS__);                    \
+    return start;                           \
   }())
 
 TCA emitSmashableMovq(CodeBlock& cb, CGMeta& fixups, uint64_t imm,
                       PhysReg d) {
-  return EMIT_BODY(cb, li64, Movq, d, imm);
+  return EMIT_BODY(cb, fixups, limmediate, d, imm, ImmType::TocOnly);
 }
 
 TCA emitSmashableCmpq(CodeBlock& cb, CGMeta& fixups, int32_t imm,
                       PhysReg r, int8_t disp) {
-  align(cb, &fixups, Alignment::SmashCmpq, AlignContext::Live);
-
   auto const start = cb.frontier();
+  fixups.smashableLocations.insert(start);
   Assembler a { cb };
 
   // don't use cmpqim because of smashableCmpqImm implementation. A "load 32bits
   // immediate" is mandatory
-  a.li32 (rfuncln(), imm);
+  a.limmediate (rfuncln(), imm, ImmType::TocOnly);
   a.lwz  (rAsm, r[disp]); // base + displacement
   a.extsw(rAsm, rAsm);
   a.cmpd (rfuncln(), rAsm);
   return start;
 }
 
-TCA emitSmashableCall(CodeBlock& cb, CGMeta& fixups, TCA target) {
-  align(cb, &fixups, Alignment::SmashCmpq, AlignContext::Live);
-  return EMIT_BODY(cb, call, Call, target, Assembler::CallArg::Smashable);
+TCA emitSmashableCall(CodeBlock& cb, CGMeta& fixups, TCA target,
+    Assembler::CallArg ca) {
+  return EMIT_BODY(cb, fixups, call, target, ca);
 }
 
 TCA emitSmashableJmp(CodeBlock& cb, CGMeta& fixups, TCA target) {
-  return EMIT_BODY(cb, branchFar, Jmp, target);
+  return EMIT_BODY(cb, fixups, branchFar, target);
 }
 
 TCA emitSmashableJcc(CodeBlock& cb, CGMeta& fixups, TCA target,
                      ConditionCode cc) {
   assertx(cc != CC_None);
-  return EMIT_BODY(cb, branchFar, Jcc, target, cc);
+  return EMIT_BODY(cb, fixups, branchFar, target, cc);
 }
 
 #undef EMIT_BODY
@@ -86,30 +87,28 @@ TCA emitSmashableJcc(CodeBlock& cb, CGMeta& fixups, TCA target,
 ///////////////////////////////////////////////////////////////////////////////
 
 void smashMovq(TCA inst, uint64_t imm) {
-  always_assert(is_aligned(inst, Alignment::SmashMovq));
-
   CodeBlock cb;
   // Initialize code block cb pointing to li64
-  cb.init(inst, Assembler::kLi64InstrLen, "smashing Movq");
+  cb.init(inst, Assembler::kLi64Len, "smashing Movq");
   CodeCursor cursor { cb, inst };
   Assembler a { cb };
 
-  Reg64 reg = Assembler::getLi64Reg(inst);
+  const DecodedInstruction di(inst);
+  Reg64 reg = di.getLimmediateReg();
 
-  a.li64(reg, imm);
+  a.limmediate(reg, imm, ImmType::TocOnly);
 }
 
 void smashCmpq(TCA inst, uint32_t imm) {
-  always_assert(is_aligned(inst, Alignment::SmashCmpq));
-
   auto& cb = tc::code().blockFor(inst);
   CodeCursor cursor { cb, inst };
   Assembler a { cb };
 
   // the first instruction is a vasm ldimml, which is a li32
-  Reg64 reg = Assembler::getLi32Reg(inst);
+  const DecodedInstruction di(inst);
+  Reg64 reg = di.getLimmediateReg();
 
-  a.li32(reg, imm);
+  a.limmediate(reg, imm, ImmType::TocOnly);
 }
 
 void smashCall(TCA inst, TCA target) {
@@ -117,18 +116,18 @@ void smashCall(TCA inst, TCA target) {
   CodeCursor cursor { cb, inst };
   Assembler a { cb };
 
-  if (!Assembler::isCall(inst)) {
+  const DecodedInstruction di(inst);
+  if (!di.isCall()) {
     always_assert(false && "smashCall has unexpected block");
   }
 
   a.setFrontier(inst);
 
-  a.li64(rfuncentry(), reinterpret_cast<uint64_t>(target));
+  a.limmediate(rfuncentry(), reinterpret_cast<uint64_t>(target),
+      ImmType::TocOnly);
 }
 
 void smashJmp(TCA inst, TCA target) {
-  always_assert(is_aligned(inst, Alignment::SmashJmp));
-
   auto& cb = tc::code().blockFor(inst);
   CodeCursor cursor { cb, inst };
   Assembler a { cb };
@@ -136,54 +135,56 @@ void smashJmp(TCA inst, TCA target) {
   if (target > inst && target - inst <= smashableJmpLen()) {
     a.emitNop(target - inst);
   } else {
-    a.branchAuto(target);
+    a.branchFar(target);
   }
 }
 
 void smashJcc(TCA inst, TCA target, ConditionCode cc) {
-  always_assert(is_aligned(inst, Alignment::SmashJcc));
-
   if (cc == CC_None) {
     Assembler::patchBranch(inst, target);
   } else {
     auto& cb = tc::code().blockFor(inst);
     CodeCursor cursor { cb, inst };
     Assembler a { cb };
-    a.branchAuto(target, cc);
+    a.branchFar(target, cc);
   }
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 
 uint64_t smashableMovqImm(TCA inst) {
-  return static_cast<uint64_t>(Assembler::getLi64(inst));
+  const DecodedInstruction di(inst);
+  return di.immediate();
 }
 
 uint32_t smashableCmpqImm(TCA inst) {
-  return static_cast<uint32_t>(Assembler::getLi32(inst));
+  const DecodedInstruction di(inst);
+  return static_cast<uint32_t>(di.immediate());
 }
 
 TCA smashableCallTarget(TCA inst) {
-  if (!Assembler::isCall(inst)) return nullptr;
+  const DecodedInstruction di(inst);
+  if (!di.isCall()) return nullptr;
 
-  return reinterpret_cast<TCA>(
-      Assembler::getLi64(inst));
+  return di.farBranchTarget();
+}
+
+static TCA smashableBranchTarget(TCA inst, bool allowCond) {
+  const DecodedInstruction di(inst);
+  auto ac = (allowCond)
+    ? ppc64_asm::AllowCond::Any
+    : ppc64_asm::AllowCond::OnlyUncond;
+  if (!di.isBranch(ac)) return nullptr;
+
+  return di.farBranchTarget();
 }
 
 TCA smashableJmpTarget(TCA inst) {
-  return smashableJccTarget(inst); // for now, it's the same as Jcc
+  return smashableBranchTarget(inst, false);
 }
 
 TCA smashableJccTarget(TCA inst) {
-  // To analyse the cc, it has to be on the bcctr so we need go backward one
-  // instruction.
-  uint8_t jccLen = smashableJccLen() - kStdIns;
-  auto branch_pinstr = reinterpret_cast<PPC64Instr*>(inst + jccLen);
-  if (!ppc64_asm::Decoder::GetDecoder().decode(branch_pinstr).isBranch(true)) {
-    return nullptr;
-  }
-
-  return reinterpret_cast<TCA>(Assembler::getLi64(inst));
+  return smashableBranchTarget(inst, true);
 }
 
 ConditionCode smashableJccCond(TCA inst) {

--- a/hphp/runtime/vm/jit/smashable-instr-ppc64.h
+++ b/hphp/runtime/vm/jit/smashable-instr-ppc64.h
@@ -31,28 +31,24 @@ namespace ppc64 {
 
 ///////////////////////////////////////////////////////////////////////////////
 
+using ppc64_asm::Assembler;
+
 /*
  * Mirrors the API of smashable-instr.h.
  */
 
 constexpr uint8_t kStdIns = ppc64_asm::instr_size_in_bytes;
 
-// li64
-constexpr size_t smashableMovqLen() { return kStdIns * 5; }
+// limmediate
+constexpr size_t smashableMovqLen() { return Assembler::kLimmLen; }
 
-// li64 + cmpd
-constexpr size_t smashableCmpqLen() { return kStdIns * 6; }
+// limmediate + lwz + extsw + cmpd
+constexpr size_t smashableCmpqLen() { return smashableMovqLen() + 3*kStdIns; }
 
 // The following instruction size is from the beginning of the smashableCall
-// to the address the LR saves upon branching with bctrl (so the following)
-// Currently this calculation considers:
-// prologue, li64 (5 instr), mtctr, nop, nop, bctrl
-constexpr size_t smashableCallLen() {
-  return ppc64_asm::Assembler::kCallLen;
-}
-
-// li64 + mtctr + nop + nop + bcctr
-constexpr size_t smashableJccLen()  { return ppc64_asm::Assembler::kJccLen; }
+// to the address the LR saves upon branching with bctrl
+constexpr size_t smashableCallLen() { return Assembler::kCallLen; }
+constexpr size_t smashableJccLen()  { return Assembler::kJccLen; }
 
 // Same length as Jcc.
 constexpr size_t smashableJmpLen()  { return smashableJccLen(); }
@@ -61,7 +57,8 @@ TCA emitSmashableMovq(CodeBlock& cb, CGMeta& fixups, uint64_t imm,
                       PhysReg d);
 TCA emitSmashableCmpq(CodeBlock& cb, CGMeta& fixups, int32_t imm,
                       PhysReg r, int8_t disp);
-TCA emitSmashableCall(CodeBlock& cb, CGMeta& fixups, TCA target);
+TCA emitSmashableCall(CodeBlock& cb, CGMeta& fixups, TCA target,
+                      Assembler::CallArg ca = Assembler::CallArg::SmashInt);
 TCA emitSmashableJmp(CodeBlock& cb, CGMeta& fixups, TCA target);
 TCA emitSmashableJcc(CodeBlock& cb, CGMeta& fixups, TCA target,
                      ConditionCode cc);

--- a/hphp/runtime/vm/jit/tc-bind.cpp
+++ b/hphp/runtime/vm/jit/tc-bind.cpp
@@ -65,7 +65,7 @@ TCA bindJmp(TCA toSmash, SrcKey destSk, TransFlags trflags, bool& smashed) {
 
       case Arch::PPC64:
         ppc64_asm::DecodedInstruction di(toSmash);
-        return (di.isBranch() && !di.isJmp());
+        return di.isBranch(ppc64_asm::AllowCond::OnlyCond);
     }
     not_reached();
   }();

--- a/hphp/runtime/vm/jit/tc-relocate.cpp
+++ b/hphp/runtime/vm/jit/tc-relocate.cpp
@@ -586,10 +586,10 @@ bool relocateNewTranslation(TransLoc& loc, CodeCache::View cache,
 void liveRelocate(int time) {
   switch (arch()) {
   case Arch::X64:
+  case Arch::PPC64:
     break;
   case Arch::ARM:
-  case Arch::PPC64:
-    // Relocation is not supported on arm nor on ppc64.
+    // Relocation is not supported on arm.
     return;
   }
 

--- a/hphp/runtime/vm/jit/unique-stubs-ppc64.cpp
+++ b/hphp/runtime/vm/jit/unique-stubs-ppc64.cpp
@@ -215,10 +215,10 @@ void assert_tc_saved_rip(void* saved_lr_pointer) {
   auto const branch_instr = branch_block + jccLen;
   auto const exittc = tc::ustubs().enterTCExit;
 
-  ppc64_asm::DecodedInstruction di(branch_instr);
+  ppc64_asm::DecodedInstruction const di(branch_instr);
   if (di.isJmp()) {
-    auto const jmp_target = TCA(ppc64_asm::Assembler::getLi64(branch_block));
-    always_assert(di.isJmp() && jmp_target == exittc);
+    ppc64_asm::DecodedInstruction const di_target(branch_block);
+    always_assert(di.isJmp() && (di_target.farBranchTarget() == exittc));
   } else {
     always_assert(saved_lr == exittc);
   }

--- a/hphp/runtime/vm/jit/vasm-emit.cpp
+++ b/hphp/runtime/vm/jit/vasm-emit.cpp
@@ -135,7 +135,7 @@ void emitVunit(Vunit& vunit, const IRUnit& unit,
   CodeBlock cold;
   CodeBlock* frozen = &code.frozen();
 
-  auto const do_relocate = arch() == Arch::X64 &&
+  auto const do_relocate = ((arch() == Arch::X64) || (arch() == Arch::PPC64)) &&
     !RuntimeOption::EvalEnableReusableTC &&
     RuntimeOption::EvalJitRelocationSize &&
     cold_in.canEmit(RuntimeOption::EvalJitRelocationSize * 3);
@@ -145,7 +145,17 @@ void emitVunit(Vunit& vunit, const IRUnit& unit,
     // Allocate enough space that the relocated cold code doesn't overlap the
     // emitted cold code.
     static unsigned seed = 42;
-    auto off = rand_r(&seed) & (cache_line_size() - 1);
+    auto code_alignment = [](void) -> uint8_t {
+      switch (arch()) {
+        case Arch::X64:
+          return 1;
+        case Arch::PPC64:
+        case Arch::ARM:
+          return 4;
+      }
+      not_reached();
+    }();
+    auto off = rand_r(&seed) & (cache_line_size() - code_alignment);
 
     cold.init(cold_in.frontier() +
               RuntimeOption::EvalJitRelocationSize + off,

--- a/hphp/runtime/vm/jit/vasm-emit.cpp
+++ b/hphp/runtime/vm/jit/vasm-emit.cpp
@@ -135,7 +135,7 @@ void emitVunit(Vunit& vunit, const IRUnit& unit,
   CodeBlock cold;
   CodeBlock* frozen = &code.frozen();
 
-  auto const do_relocate = ((arch() == Arch::X64) || (arch() == Arch::PPC64)) &&
+  auto const do_relocate = arch_any(Arch::X64, Arch::PPC64) &&
     !RuntimeOption::EvalEnableReusableTC &&
     RuntimeOption::EvalJitRelocationSize &&
     cold_in.canEmit(RuntimeOption::EvalJitRelocationSize * 3);

--- a/hphp/runtime/vm/jit/vasm-ppc64.cpp
+++ b/hphp/runtime/vm/jit/vasm-ppc64.cpp
@@ -14,6 +14,8 @@
    +----------------------------------------------------------------------+
 */
 
+#include "hphp/runtime/base/runtime-option.h"
+
 #include "hphp/runtime/vm/jit/vasm-emit.h"
 
 #include "hphp/runtime/vm/jit/abi-ppc64.h"
@@ -257,8 +259,15 @@ struct Vgen {
     }
     a.lxvd2x(i.d, p);
   }
-  void emit(const leap& i) { a.li64(i.d, i.s.r.disp, false); }
-  void emit(const lead& i) { a.li64(i.d, (int64_t)i.s.get(), false); }
+  void emit(const leap& i) {
+    // It can happen that when rellocating, the TOC will need to store the new
+    // pointer and it doesn't fit on a single instruction as the TOC is too big
+    // now. Therefore, emit this limmediate as fixed_size to avoid overlapping.
+    bool toc_may_grow = RuntimeOption::EvalJitRelocationSize != 0;
+    auto imm_type = toc_may_grow ? ImmType::TocOnly : ImmType::AnyCompact;
+    a.limmediate(i.d, i.s.r.disp, imm_type);
+  }
+  void emit(const lead& i) { a.limmediate(i.d, (int64_t)i.s.get()); }
   void emit(const mfcr& i) { a.mfcr(i.d); }
   void emit(const mflr& i) { a.mflr(i.d); }
   void emit(const mfvsrd& i) { a.mfvsrd(i.d, i.s); }
@@ -369,7 +378,7 @@ struct Vgen {
     a.rlwinm(Reg64(i.d), Reg64(i.s), 0, 32-sh, 31); // extract lower byte
   }
   void emit(const orqi& i) {
-    a.li64(rAsm, i.s0.l(), false);
+    a.limmediate(rAsm, i.s0.l());
     a.or(i.d, i.s1, rAsm, true /** or. implies Rc = 1 **/);
     copyCR0toCR1(a, rAsm);
   }
@@ -419,7 +428,7 @@ struct Vgen {
     }
   }
   void emit(const xorqi& i) {
-    a.li64(rAsm, i.s0.l(), false);
+    a.limmediate(rAsm, i.s0.l());
     a.xor(i.d, i.s1, rAsm, true /** xor. implies Rc = 1 **/);
     copyCR0toCR1(a, rAsm);
   }
@@ -521,7 +530,7 @@ void Vgen::emit(const ucomisd& i) {
   a.bc(notNAN, BranchConditions::CR0_NoOverflow);
   {
     // Set "negative" bit if "Overflow" bit is set. Also, keep overflow bit set
-    a.li64(rAsm, 0x99000000, false);
+    a.limmediate(rAsm, 0x99000000);
     a.mtcrf(0xC0, rAsm);
     copyCR0toCR1(a, rAsm);
   }
@@ -541,29 +550,25 @@ void Vgen::emit(const ldimmb& i) {
 
 void Vgen::emit(const ldimml& i) {
   if (i.d.isGP()) {
-    a.li32(i.d, i.s.l());
+    a.limmediate(i.d, i.s.l());
   } else {
     assertx(i.d.isSIMD());
-    a.li32(rAsm, i.s.l());
+    a.limmediate(rAsm, i.s.l());
     // no conversion necessary. The i.s already comes converted to FP
     emit(copy{rAsm, i.d});
   }
 }
 
 void Vgen::emit(const ldimmq& i) {
+  // See leap to better understand the necessity of toc_may_grow
+  bool toc_may_grow = RuntimeOption::EvalJitRelocationSize != 0;
+  auto imm_type = toc_may_grow ? ImmType::TocOnly : ImmType::AnyCompact;
   auto val = i.s.q();
   if (i.d.isGP()) {
-    if (val == 0) {
-      a.xor(i.d, i.d, i.d);
-      // emit nops to fill a standard li64 instruction block
-      // this will be useful on patching and smashable operations
-      a.emitNop(Assembler::kLi64InstrLen - 1 * instr_size_in_bytes);
-    } else {
-      a.li64(i.d, val);
-    }
+    a.limmediate(i.d, val, imm_type);
   } else {
     assertx(i.d.isSIMD());
-    a.li64(rAsm, i.s.q());
+    a.limmediate(rAsm, val, imm_type);
     // no conversion necessary. The i.s already comes converted to FP
     emit(copy{rAsm, i.d});
   }
@@ -616,7 +621,7 @@ void Vgen::emit(const load& i) {
       a.ldx(i.d, i.s);
     } else if (i.s.disp & 0x3) {     // Unaligned memory access
       Vptr p = i.s;
-      a.li64(rAsm, (int64_t)p.disp); // Load disp to reg
+      a.limmediate(rAsm, (int64_t)p.disp); // Load disp to reg
       p.disp = 0;                    // Remove disp
       p.index = rAsm;                // Set disp reg as index
       a.ldx(i.d, p);                 // Use ldx for unaligned memory access
@@ -631,7 +636,7 @@ void Vgen::emit(const load& i) {
 
 // This function can't be lowered as i.get() may not be bound that early.
 void Vgen::emit(const loadqd& i) {
-  a.li64(rAsm, (int64_t)i.s.get());
+  a.limmediate(rAsm, (int64_t)i.s.get());
   a.ld(i.d, rAsm[0]);
 }
 
@@ -647,7 +652,7 @@ void Vgen::emit(const jmp& i) {
   jmps.push_back({a.frontier(), i.target});
 
   // offset to be determined by a.patchBranch
-  a.branchAuto(a.frontier());
+  a.branchAuto(reinterpret_cast<CodeAddress>(-1));
 }
 
 void Vgen::emit(const jmpr& i) {
@@ -665,7 +670,7 @@ void Vgen::emit(const jcc& i) {
     jccs.push_back({a.frontier(), taken});
 
     // offset to be determined by a.patchBranch
-    a.branchAuto(a.frontier(), i.cc);
+    a.branchAuto(reinterpret_cast<CodeAddress>(-1), i.cc);
   }
   emit(jmp{i.targets[0]});
 }
@@ -719,6 +724,15 @@ void Vgen::emit(const mcprep& i) {
 void Vgen::emit(const inittc&) {
   // initialize our rone register
   a.li(ppc64::rone(), 1);
+
+  // Set DataBlock on VMTOC
+  VMTOC::getInstance().setTOCDataBlock(&(env.text.data()));
+
+  // Save TOC pointer in r2
+  // First, assert the PPC64MinTOCImmSize.
+  always_assert(RuntimeOption::EvalPPC64MinTOCImmSize >= 0 &&
+    RuntimeOption::EvalPPC64MinTOCImmSize <= 64);
+  a.li64(ppc64::rtoc(), VMTOC::getInstance().getPtrVector(), false);
 }
 
 void Vgen::emit(const leavetc&) {
@@ -734,7 +748,7 @@ void Vgen::emit(const calltc& i) {
   a.bl(instr_size_in_bytes);  // jump to next instruction
 
   // this will be verified by emitCallToExit
-  a.li64(rAsm, reinterpret_cast<int64_t>(i.exittc), false);
+  a.limmediate(rAsm, reinterpret_cast<int64_t>(i.exittc));
   emit(push{rAsm});
 
   // keep the return address as initialized by the vm frame
@@ -753,7 +767,7 @@ void Vgen::emit(const resumetc& i) {
   a.bl(instr_size_in_bytes);  // jump to next instruction
 
   // this will be verified by emitCallToExit
-  a.li64(rAsm, reinterpret_cast<int64_t>(i.exittc), false);
+  a.limmediate(rAsm, reinterpret_cast<int64_t>(i.exittc));
   emit(push{rAsm});
 
   // and jump. When it returns, it'll be to enterTCExit
@@ -801,7 +815,9 @@ void Vgen::emit(const calls& i) {
   // r1 pointer to a valid frame in order to allow LR save by callee's
   // prologue.
   emitCallPrologue();
-  emitSmashableCall(a.code(), env.meta, i.target);
+  a.std(rtoc(), rsfp()[AROFF(SAVED_TOC())]);
+  emitSmashableCall(a.code(), env.meta, i.target,
+                    Assembler::CallArg::SmashExt);
 }
 
 void Vgen::emit(const callphp& i) {
@@ -844,7 +860,10 @@ void Vgen::emit(const stublogue& i) {
 
 void Vgen::emit(const stubret& i) {
   // rvmfp, if necessary.
-  if (i.saveframe) a.ld(rvmfp(), rsp()[AROFF(m_sfp)]);
+  if (i.saveframe) {
+    a.ld(rvmfp(), rsp()[AROFF(m_sfp)]);
+    a.mr(rsfp(), rvmfp());
+  }
 
   // restore return address.
   a.ld(rfuncln(), rsp()[AROFF(m_savedRip)]);
@@ -868,7 +887,7 @@ void Vgen::emit(const testqi& i) {
   if (i.s0.fits(sz::word)) {
     a.li(rAsm, i.s0);
   } else {
-    a.li32(rAsm, i.s0.l());
+    a.limmediate(rAsm, i.s0.l());
   }
   emit(testq{rAsm, i.s1, i.sf});
 }


### PR DESCRIPTION
Relocation needs a lot of functionalities, so DecodedInstruction and
decoder were updated.

As the TOC functionality was also closely integrated to those functions,
it was also included. The TOC brought changes regarding to immediate
emission on vasm-ppc64.cpp, Smashable and Assembler functions.
