### PR TITLE
[AArch64] Refactor smashable implementation.

### DIFF
--- a/hphp/runtime/vm/jit/tc-bind.cpp
+++ b/hphp/runtime/vm/jit/tc-bind.cpp
@@ -59,16 +59,8 @@ TCA bindJmp(TCA toSmash, SrcKey destSk, TransFlags trflags, bool& smashed) {
       }
 
       case Arch::ARM: {
-        using namespace vixl;
-        struct JccDecoder : public Decoder {
-          void VisitConditionalBranch(Instruction* inst) override {
-            cc = true;
-          }
-          bool cc = false;
-        };
-        JccDecoder decoder;
-        decoder.Decode(Instruction::Cast(toSmash));
-        return decoder.cc;
+        auto instr = reinterpret_cast<vixl::Instruction*>(toSmash);
+        return instr->IsCondBranchImm();
       }
 
       case Arch::PPC64:


### PR DESCRIPTION
Remove the emitSmashable*Impl() functions and roll their
code directly into the emitSmash*() functions. Originally, the
impl functions were created because emitSmashableJccImpl() was
used in the body of smashJcc().

Modify smashJcc() to directly smashs the conditional branch and
then smash the target instead of simply re-emitting the entire
smashable jcc.

Adopt a light-weight approach to instruction decoding in the
smashable*Target() functions. Add additional checking also similar
to x86_64.

Similarly, replace heavy wate instruction decoding in bindJmp().