### PR TITLE
[AArch64] Rework push/pop to avoid 8-byte operation.

### DIFF
--- a/hphp/runtime/vm/jit/phys-reg-saver.cpp
+++ b/hphp/runtime/vm/jit/phys-reg-saver.cpp
@@ -50,7 +50,7 @@ PhysRegSaver::PhysRegSaver(Vout& v, RegSet regs)
       // Push r0 twice to avoid vasm-check failures
       v << pushp{r0, r0};
     } else {
-      v << pushp{r1, r0};
+      v << pushp{r0, r1};
     }
   });
 }

--- a/hphp/runtime/vm/jit/phys-reg-saver.cpp
+++ b/hphp/runtime/vm/jit/phys-reg-saver.cpp
@@ -46,7 +46,12 @@ PhysRegSaver::PhysRegSaver(Vout& v, RegSet regs)
   }
 
   gpr.forEachPair([&] (PhysReg r0, PhysReg r1) {
-    v << pushp{r1, r0};
+    // Push r0 twice to avoid vasm-check failures
+    if (r1 == InvalidReg) {
+      v << pushp{r0, r0};
+    } else {
+      v << pushp{r1, r0};
+    }
   });
 }
 
@@ -58,7 +63,12 @@ PhysRegSaver::~PhysRegSaver() {
   auto xmm = m_regs & abi().simd();
 
   gpr.forEachPairR([&] (PhysReg r0, PhysReg r1) {
-    v << popp{r0, r1};
+    // Pop second value into new virtual to avoid vasm-check failures
+    if (r1 == InvalidReg) {
+      v << popp{r0, v.makeReg()};
+    } else {
+      v << popp{r0, r1};
+    }
   });
 
   if (!xmm.empty()) {

--- a/hphp/runtime/vm/jit/phys-reg-saver.cpp
+++ b/hphp/runtime/vm/jit/phys-reg-saver.cpp
@@ -64,8 +64,8 @@ PhysRegSaver::~PhysRegSaver() {
 
   gpr.forEachPairR([&] (PhysReg r0, PhysReg r1) {
     // Pop second value into new virtual to avoid vasm-check failures
-    if (r1 == InvalidReg) {
-      v << popp{r0, v.makeReg()};
+    if (r0 == InvalidReg) {
+        v << popp{v.makeReg(), r1};
     } else {
       v << popp{r0, r1};
     }

--- a/hphp/runtime/vm/jit/phys-reg-saver.cpp
+++ b/hphp/runtime/vm/jit/phys-reg-saver.cpp
@@ -46,8 +46,8 @@ PhysRegSaver::PhysRegSaver(Vout& v, RegSet regs)
   }
 
   gpr.forEachPair([&] (PhysReg r0, PhysReg r1) {
-    // Push r0 twice to avoid vasm-check failures
     if (r1 == InvalidReg) {
+      // Push r0 twice to avoid vasm-check failures
       v << pushp{r0, r0};
     } else {
       v << pushp{r1, r0};
@@ -63,9 +63,9 @@ PhysRegSaver::~PhysRegSaver() {
   auto xmm = m_regs & abi().simd();
 
   gpr.forEachPairR([&] (PhysReg r0, PhysReg r1) {
-    // Pop second value into new virtual to avoid vasm-check failures
     if (r0 == InvalidReg) {
-        v << popp{v.makeReg(), r1};
+      // Pop second value into new virtual to avoid vasm-check failures
+      v << popp{v.makeReg(), r1};
     } else {
       v << popp{r0, r1};
     }

--- a/hphp/runtime/vm/jit/phys-reg-saver.cpp
+++ b/hphp/runtime/vm/jit/phys-reg-saver.cpp
@@ -35,8 +35,6 @@ PhysRegSaver::PhysRegSaver(Vout& v, RegSet regs)
   auto xmm = m_regs & abi().simd();
   auto const sp = rsp();
 
-  m_adjust = gpr.size() & 0x1 ? 8 : 0;
-
   if (!xmm.empty()) {
     v << lea{sp[-16 * xmm.size()], sp};
 
@@ -47,57 +45,21 @@ PhysRegSaver::PhysRegSaver(Vout& v, RegSet regs)
     });
   }
 
-  switch (arch()) {
-    case Arch::X64:
-    case Arch::PPC64:
-      gpr.forEach([&] (PhysReg r) {
-        v << push{r};
-      });
-      break;
-    case Arch::ARM:
-      gpr.forEachPair([&] (PhysReg r0, PhysReg r1) {
-        if (r1 == InvalidReg) {
-          v << push{r0};
-        } else {
-          v << pushp{r1, r0};
-        }
-      });
-      break;
-  }
-
-  if (m_adjust) {
-    v << lea{sp[-m_adjust], sp};
-  }
+  gpr.forEachPair([&] (PhysReg r0, PhysReg r1) {
+    v << pushp{r1, r0};
+  });
 }
 
 PhysRegSaver::~PhysRegSaver() {
   auto& v = m_v;
   auto const sp = rsp();
 
-  if (m_adjust) {
-    v << lea{sp[m_adjust], sp};
-  }
-
   auto gpr = m_regs & abi().gp();
   auto xmm = m_regs & abi().simd();
 
-  switch (arch()) {
-    case Arch::X64:
-    case Arch::PPC64:
-      gpr.forEachR([&] (PhysReg r) {
-        v << pop{r};
-      });
-      break;
-    case Arch::ARM:
-      gpr.forEachPairR([&] (PhysReg r0, PhysReg r1) {
-        if (r1 == InvalidReg) {
-          v << pop{r0};
-        } else {
-          v << popp{r0, r1};
-        }
-      });
-      break;
-  }
+  gpr.forEachPairR([&] (PhysReg r0, PhysReg r1) {
+    v << popp{r0, r1};
+  });
 
   if (!xmm.empty()) {
     int offset = 0;
@@ -109,13 +71,9 @@ PhysRegSaver::~PhysRegSaver() {
   }
 }
 
-size_t PhysRegSaver::rspAdjustment() const {
-  return m_adjust;
-}
-
 size_t PhysRegSaver::dwordsPushed() const {
-  assertx((m_adjust % sizeof(int64_t)) == 0);
-  return m_regs.size() + m_adjust / sizeof(int64_t);
+  // Round up the number of regs pushed to an even number
+  return (m_regs.size() + 1) ^ 0x1;
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/hphp/runtime/vm/jit/phys-reg-saver.h
+++ b/hphp/runtime/vm/jit/phys-reg-saver.h
@@ -46,13 +46,11 @@ struct PhysRegSaver {
   PhysRegSaver& operator=(const PhysRegSaver&) = delete;
   PhysRegSaver& operator=(PhysRegSaver&&) = default;
 
-  size_t rspAdjustment() const;
   size_t dwordsPushed() const;
 
 private:
   Vout& m_v;
   RegSet m_regs;
-  int m_adjust;
 };
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/hphp/runtime/vm/jit/phys-reg.h
+++ b/hphp/runtime/vm/jit/phys-reg.h
@@ -434,7 +434,7 @@ public:
           i = 0;
         }
         if (adjust) {
-            f(InvalidReg, PhysReg(r[0]));
+          f(InvalidReg, PhysReg(r[0]));
           adjust = false;
           i = 0;
         }

--- a/hphp/runtime/vm/jit/phys-reg.h
+++ b/hphp/runtime/vm/jit/phys-reg.h
@@ -422,6 +422,7 @@ public:
     uint64_t out;
     uint8_t r[2];
     uint8_t i = 0;
+    bool adjust;
 
     auto const go = [&] (uint64_t& bits, off_t off) {
       while (fls64(bits, out)) {
@@ -432,14 +433,20 @@ public:
           f(PhysReg(r[0]), PhysReg(r[1]));
           i = 0;
         }
+        if (adjust) {
+            f(InvalidReg, PhysReg(r[0]));
+          adjust = false;
+          i = 0;
+        }
       }
     };
 
     // High to low.
     auto copy = *this;
+    adjust = (folly::popcount(copy.m_hi) +
+              folly::popcount(copy.m_lo)) & 0x1;
     go(copy.m_hi, 64);
     go(copy.m_lo, 0);
-    if (i > 0) f(PhysReg(r[0]), InvalidReg);
   }
 
   /*

--- a/hphp/runtime/vm/jit/unique-stubs-arm.cpp
+++ b/hphp/runtime/vm/jit/unique-stubs-arm.cpp
@@ -66,7 +66,7 @@ static TCA emitDecRefHelper(CodeBlock& cb, DataBlock& data, CGMeta& fixups,
                             PhysReg tv, PhysReg type, RegSet live) {
   return vwrap(cb, data, fixups, [&] (Vout& v) {
     // Set up frame linkage to avoid an indirect fixup.
-    v << pushp{rfp(), rlr()};
+    v << pushp{rlr(), rfp()};
     v << copy{rsp(), rfp()};
 
     // We use the first argument register for the TV data because we might pass
@@ -175,7 +175,7 @@ TCA emitFreeLocalsHelpers(CodeBlock& cb, DataBlock& data, UniqueStubs& us) {
 
   // Create a table of branches
   us.freeManyLocalsHelper = vwrap(cb, data, [&] (Vout& v) {
-    v << pushp{rfp(), rlr()};
+    v << pushp{rlr(), rfp()};
 
     // rvmfp() is needed by the freeManyLocalsHelper stub above, so frame
     // linkage setup is deferred until after its use in freeManyLocalsHelper.
@@ -184,7 +184,7 @@ TCA emitFreeLocalsHelpers(CodeBlock& cb, DataBlock& data, UniqueStubs& us) {
   for (auto i = kNumFreeLocalsHelpers - 1; i >= 0; --i) {
     us.freeLocalsHelpers[i] = vwrap(cb, data, [&] (Vout& v) {
       // We set up frame linkage to avoid an indirect fixup.
-      v << pushp{rfp(), rlr()};
+      v << pushp{rlr(), rfp()};
       v << copy{rsp(), rfp()};
       v << jmpi{freeLocalsHelpers[i]};
     });

--- a/hphp/runtime/vm/jit/unique-stubs.cpp
+++ b/hphp/runtime/vm/jit/unique-stubs.cpp
@@ -332,7 +332,7 @@ TCA emitFunctionEnterHelper(CodeBlock& main, CodeBlock& cold,
     // (because of fb_intercept).  If that happens, we need to return to the
     // caller, but the handler will have already popped the callee's frame.
     // So, we need to save these values for later.
-    v << pushpm{ar[AROFF(m_sfp)], ar[AROFF(m_savedRip)]};
+    v << pushpm{ar[AROFF(m_savedRip)], ar[AROFF(m_sfp)]};
 
     v << copy2{ar, v.cns(EventHook::NormalFunc), rarg(0), rarg(1)};
 
@@ -1185,9 +1185,9 @@ TCA emitHandleSRHelper(CodeBlock& cb, DataBlock& data) {
       case Arch::ARM:
         assertx(!(svcreq::kMaxArgs & 1));
         for (auto i = svcreq::kMaxArgs - 1; i > 0; i -= 2) {
-          v << pushp{r_svcreq_arg(i - 1), r_svcreq_arg(i)};
+          v << pushp{r_svcreq_arg(i), r_svcreq_arg(i - 1)};
         }
-        v << pushp{r_svcreq_req(), r_svcreq_stub()};
+        v << pushp{r_svcreq_stub(), r_svcreq_req()};
         break;
     }
 

--- a/hphp/runtime/vm/jit/unique-stubs.cpp
+++ b/hphp/runtime/vm/jit/unique-stubs.cpp
@@ -332,8 +332,7 @@ TCA emitFunctionEnterHelper(CodeBlock& main, CodeBlock& cold,
     // (because of fb_intercept).  If that happens, we need to return to the
     // caller, but the handler will have already popped the callee's frame.
     // So, we need to save these values for later.
-    v << pushm{ar[AROFF(m_savedRip)]};
-    v << pushm{ar[AROFF(m_sfp)]};
+    v << pushpm{ar[AROFF(m_sfp)], ar[AROFF(m_savedRip)]};
 
     v << copy2{ar, v.cns(EventHook::NormalFunc), rarg(0), rarg(1)};
 
@@ -371,8 +370,7 @@ TCA emitFunctionEnterHelper(CodeBlock& main, CodeBlock& cold,
       // callee's frame, so we're ready to continue from the original call
       // site.  We just need to grab the fp/rip of the original frame that we
       // saved earlier, and sync rvmsp().
-      v << pop{rvmfp()};
-      v << pop{saved_rip};
+      v << popp{rvmfp(), saved_rip};
 
       // Drop our call frame; the stublogue{} instruction guarantees that this
       // is exactly 16 bytes.

--- a/hphp/runtime/vm/jit/vasm-arm.cpp
+++ b/hphp/runtime/vm/jit/vasm-arm.cpp
@@ -499,7 +499,7 @@ void Vgen::emit(const calls& i) {
 
 void Vgen::emit(const stublogue& i) {
   // Push FP, LR always regardless of i.saveframe (makes SP 16B aligned)
-  emit(pushp{rfp(), rlr()});
+  emit(pushp{rlr(), rfp()});
 }
 
 void Vgen::emit(const stubret& i) {
@@ -1021,7 +1021,7 @@ void Vgen::emit(const popp& i) {
 }
 
 void Vgen::emit(const pushp& i) {
-  a->Stp(X(i.s0), X(i.s1), MemOperand(sp, -16, PreIndex));
+  a->Stp(X(i.s1), X(i.s0), MemOperand(sp, -16, PreIndex));
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1349,15 +1349,15 @@ void lower(Vunit& u, calltc& i, Vlabel b, size_t z) {
     // Push FP, LR for callToExit(..)
     auto r0 = v.makeReg();
     auto r1 = v.makeReg();
-    v << load{i.fp[AROFF(m_savedRip)], r0};
-    v << ldimmq{i.exittc, r1};
+    v << ldimmq{i.exittc, r0};
+    v << load{i.fp[AROFF(m_savedRip)], r1};
     v << pushp{r0, r1};
 
     // Emit call to next instruction to balance predictor's stack
     v << bln{};
 
     // Set the return address to savedRip and jump to target
-    v << copy{r0, rlr()};
+    v << copy{r1, rlr()};
     v << jmpr{i.target, i.args};
   });
 }
@@ -1367,7 +1367,7 @@ void lower(Vunit& u, resumetc& i, Vlabel b, size_t z) {
     // Push FP, LR for callToExit(..)
     auto r = v.makeReg();
     v << ldimmq{i.exittc, r};
-    v << pushp{rfp(), r};
+    v << pushp{r, rfp()};
 
     // Call the helper
     v << callr{i.target, i.args};

--- a/hphp/runtime/vm/jit/vasm-arm.cpp
+++ b/hphp/runtime/vm/jit/vasm-arm.cpp
@@ -1017,15 +1017,11 @@ Y(lslxis, X, xzr, 64)
 #undef Y
 
 void Vgen::emit(const popp& i) {
-  Register r0 = i.d0.isValid() ? X(i.d0) : vixl::xzr;
-  Register r1 = i.d1.isValid() ? X(i.d1) : vixl::xzr;
-  a->Ldp(r0, r1, MemOperand(sp, 16, PostIndex));
+  a->Ldp(X(i.d0), X(i.d1), MemOperand(sp, 16, PostIndex));
 }
 
 void Vgen::emit(const pushp& i) {
-  Register r0 = i.s0.isValid() ? X(i.s0) : vixl::xzr;
-  Register r1 = i.s1.isValid() ? X(i.s1) : vixl::xzr;
-  a->Stp(r0, r1, MemOperand(sp, -16, PreIndex));
+  a->Stp(X(i.s0), X(i.s1), MemOperand(sp, -16, PreIndex));
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/hphp/runtime/vm/jit/vasm-dead.cpp
+++ b/hphp/runtime/vm/jit/vasm-dead.cpp
@@ -255,10 +255,12 @@ bool effectful(Vinstr& inst) {
     case Vinstr::popm:
     case Vinstr::popf:
     case Vinstr::popp:
+    case Vinstr::poppm:
     case Vinstr::push:
     case Vinstr::pushm:
     case Vinstr::pushf:
     case Vinstr::pushp:
+    case Vinstr::pushpm:
     case Vinstr::resumetc:
     case Vinstr::ret:
     case Vinstr::retransopt:

--- a/hphp/runtime/vm/jit/vasm-instr.cpp
+++ b/hphp/runtime/vm/jit/vasm-instr.cpp
@@ -164,11 +164,15 @@ Width width(Vinstr::Opcode op) {
     case Vinstr::jmpi:
     // push/pop
     case Vinstr::pop:
-    case Vinstr::popm:
     case Vinstr::popf:
+    case Vinstr::popm:
+    case Vinstr::popp:
+    case Vinstr::poppm:
     case Vinstr::push:
-    case Vinstr::pushm:
     case Vinstr::pushf:
+    case Vinstr::pushm:
+    case Vinstr::pushp:
+    case Vinstr::pushpm:
     // floating-point conversions
     case Vinstr::cvttsd2siq:
     case Vinstr::cvtsi2sd:
@@ -199,8 +203,6 @@ Width width(Vinstr::Opcode op) {
     case Vinstr::msr:
     case Vinstr::orsw:
     case Vinstr::orswi:
-    case Vinstr::popp:
-    case Vinstr::pushp:
     case Vinstr::subsb:
     case Vinstr::uxth:
     // ppc64 instructions

--- a/hphp/runtime/vm/jit/vasm-instr.h
+++ b/hphp/runtime/vm/jit/vasm-instr.h
@@ -1102,7 +1102,7 @@ struct poppm { Vptr d0, d1; };
 struct push { Vreg64 s; };
 struct pushf { VregSF s; };
 struct pushm { Vptr s; };
-// pushp[m]{s0, s1} -> push[m]{s1}, push[m]{s0}
+// pushp[m]{s0, s1} -> push[m]{s0}, push[m]{s1}
 struct pushp { Vreg64 s0, s1; };
 struct pushpm { Vptr s0, s1; };
 

--- a/hphp/runtime/vm/jit/vasm-instr.h
+++ b/hphp/runtime/vm/jit/vasm-instr.h
@@ -269,11 +269,15 @@ struct Vunit;
   O(jmpi, I(target), U(args), Dn)\
   /* push/pop */\
   O(pop, Inone, Un, D(d))\
-  O(popm, Inone, U(d), Dn)\
   O(popf, Inone, Un, D(d))\
+  O(popm, Inone, U(d), Dn)\
+  O(popp, Inone, Un, D(d0) D(d1))\
+  O(poppm, Inone, U(d0) U(d1), Dn)\
   O(push, Inone, U(s), Dn)\
-  O(pushm, Inone, U(s), Dn)\
   O(pushf, Inone, U(s), Dn)\
+  O(pushm, Inone, U(s), Dn)\
+  O(pushp, Inone, U(s0) U(s1), Dn)\
+  O(pushpm, Inone, U(s0) U(s1), Dn)\
   /* floating-point conversions */\
   O(cvttsd2siq, Inone, U(s), D(d))\
   O(cvtsi2sd, Inone, U(s), D(d))\
@@ -310,8 +314,6 @@ struct Vunit;
   O(msr, I(s), U(r), Dn)\
   O(orswi, I(s0), UH(s1,d), DH(d,s1) D(sf))\
   O(orsw, Inone, U(s0) U(s1), D(d) D(sf)) \
-  O(popp, Inone, Un, D(d0) D(d1))\
-  O(pushp, Inone, U(s0) U(s1), Dn)\
   O(subsb, Inone, UA(s0) U(s1), D(d) D(sf))\
   O(uxth, Inone, U(s), D(d))\
   /* ppc64 instructions */\
@@ -1092,11 +1094,17 @@ struct jmpi { TCA target; RegSet args; };
  * Push/pop to rsp().
  */
 struct pop { Vreg64 d; };
-struct popm { Vptr d; };
 struct popf { VregSF d; };
+struct popm { Vptr d; };
+// popp[m]{d0, d1} -> pop[m]{d0}, pop[m]{d1}
+struct popp { Vreg64 d0, d1; };
+struct poppm { Vptr d0, d1; };
 struct push { Vreg64 s; };
-struct pushm { Vptr s; };
 struct pushf { VregSF s; };
+struct pushm { Vptr s; };
+// pushp[m]{s0, s1} -> push[m]{s1}, push[m]{s0}
+struct pushp { Vreg64 s0, s1; };
+struct pushpm { Vptr s0, s1; };
 
 /*
  * Integer-float conversions.
@@ -1147,8 +1155,6 @@ struct mrs { Immed s; Vreg64 r; };
 struct msr { Vreg64 r; Immed s; };
 struct orswi { Immed s0; Vreg32 s1, d; VregSF sf; };
 struct orsw { Vreg32 s0, s1, d; VregSF sf; };
-struct popp { Vreg64 d0, d1; };
-struct pushp { Vreg64 s0, s1; };
 struct subsb { Vreg8 s0, s1, d; VregSF sf; };
 struct uxth { Vreg16 s; Vreg32 d; };
 

--- a/hphp/runtime/vm/jit/vasm-lower.cpp
+++ b/hphp/runtime/vm/jit/vasm-lower.cpp
@@ -70,7 +70,7 @@ void lower_vcall(Vunit& unit, Inst& inst, Vlabel b, size_t i) {
     numArgs--;
   }
   for (int i = numArgs - 1; i >= 0; i -= 2) {
-    v << pushp{vargs.stkArgs[i], vargs.stkArgs[i-1]};
+    v << pushp{vargs.stkArgs[i-1], vargs.stkArgs[i]};
   }
 
   // Get the arguments in the proper registers.

--- a/hphp/runtime/vm/jit/vasm-lower.cpp
+++ b/hphp/runtime/vm/jit/vasm-lower.cpp
@@ -70,7 +70,7 @@ void lower_vcall(Vunit& unit, Inst& inst, Vlabel b, size_t i) {
     numArgs--;
   }
   for (int i = numArgs - 1; i >= 0; i -= 2) {
-    v << pushp{vargs.stkArgs[i-1], vargs.stkArgs[i]};
+    v << pushp{vargs.stkArgs[i], vargs.stkArgs[i-1]};
   }
 
   // Get the arguments in the proper registers.

--- a/hphp/runtime/vm/jit/vasm-ppc64.cpp
+++ b/hphp/runtime/vm/jit/vasm-ppc64.cpp
@@ -1159,16 +1159,8 @@ X(andli,  movl, andqi,  ONE_R64(d))
 ///////////////////////////////////////////////////////////////////////////////
 
 void lowerForPPC64(Vout& v, popp& inst) {
-  if (inst.d0.isValid()) {
-    v << pop{inst.d0};
-  } else {
-    lea{reg::rsp[8], reg::rsp};
-  }
-  if (inst.d1.isValid()) {
-    v << pop{inst.d1};
-  } else {
-    lea{reg::rsp[8], reg::rsp};
-  }
+  v << pop{inst.d0};
+  v << pop{inst.d1};
 }
 
 void lowerForPPC64(Vout& v, poppm& inst) {
@@ -1177,16 +1169,8 @@ void lowerForPPC64(Vout& v, poppm& inst) {
 }
 
 void lowerForPPC64(Vout& v, pushp& inst) {
-  if (inst.s1.isValid()) {
-    v << push{inst.s1};
-  } else {
-    lea{reg::rsp[-8], reg::rsp};
-  }
-  if (inst.s0.isValid()) {
-    v << push{inst.s0};
-  } else {
-    lea{reg::rsp[-8], reg::rsp};
-  }
+  v << push{inst.s1};
+  v << push{inst.s0};
 }
 
 void lowerForPPC64(Vout& v, pushpm& inst) {

--- a/hphp/runtime/vm/jit/vasm-ppc64.cpp
+++ b/hphp/runtime/vm/jit/vasm-ppc64.cpp
@@ -1169,13 +1169,13 @@ void lowerForPPC64(Vout& v, poppm& inst) {
 }
 
 void lowerForPPC64(Vout& v, pushp& inst) {
-  v << push{inst.s1};
   v << push{inst.s0};
+  v << push{inst.s1};
 }
 
 void lowerForPPC64(Vout& v, pushpm& inst) {
-  v << pushm{inst.s1};
   v << pushm{inst.s0};
+  v << pushm{inst.s1};
 }
 
 /////////////////////////////////////////////////////////////////////////////

--- a/hphp/runtime/vm/jit/vasm-ppc64.cpp
+++ b/hphp/runtime/vm/jit/vasm-ppc64.cpp
@@ -1156,6 +1156,44 @@ X(andli,  movl, andqi,  ONE_R64(d))
 #undef ONE_R64
 #undef TWO_R64
 
+///////////////////////////////////////////////////////////////////////////////
+
+void lowerForPPC64(Vout& v, popp& inst) {
+  if (inst.d0.isValid()) {
+    v << pop{inst.d0};
+  } else {
+    lea{reg::rsp[8], reg::rsp};
+  }
+  if (inst.d1.isValid()) {
+    v << pop{inst.d1};
+  } else {
+    lea{reg::rsp[8], reg::rsp};
+  }
+}
+
+void lowerForPPC64(Vout& v, poppm& inst) {
+  v << popm{inst.d0};
+  v << popm{inst.d1};
+}
+
+void lowerForPPC64(Vout& v, pushp& inst) {
+  if (inst.s1.isValid()) {
+    v << push{inst.s1};
+  } else {
+    lea{reg::rsp[-8], reg::rsp};
+  }
+  if (inst.s0.isValid()) {
+    v << push{inst.s0};
+  } else {
+    lea{reg::rsp[-8], reg::rsp};
+  }
+}
+
+void lowerForPPC64(Vout& v, pushpm& inst) {
+  v << pushm{inst.s1};
+  v << pushm{inst.s0};
+}
+
 /////////////////////////////////////////////////////////////////////////////
 /*
  * PHP function ABI

--- a/hphp/runtime/vm/jit/vasm-simplify.cpp
+++ b/hphp/runtime/vm/jit/vasm-simplify.cpp
@@ -393,6 +393,23 @@ bool simplify(Env& env, const movzlq& inst, Vlabel b, size_t i) {
   });
 }
 
+bool simplify(Env& env, const popp& inst, Vlabel b, size_t i) {
+  if (!env.use_counts[inst.d0]) { decltype(inst.d0){Vreg::kInvalidReg}; }
+  if (!env.use_counts[inst.d1]) { decltype(inst.d1){Vreg::kInvalidReg}; }
+  return false;
+}
+
+bool simplify(Env& env, const pop& inst, Vlabel b, size_t i) {
+  if (env.use_counts[inst.d]) {
+    return false;
+  } else {
+    return simplify_impl(env, b, i, [&] (Vout& v) {
+      v << lea{reg::rsp[8], reg::rsp};
+      return 1;
+    });
+  }
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 
 /*

--- a/hphp/runtime/vm/jit/vasm-simplify.cpp
+++ b/hphp/runtime/vm/jit/vasm-simplify.cpp
@@ -393,21 +393,16 @@ bool simplify(Env& env, const movzlq& inst, Vlabel b, size_t i) {
   });
 }
 
-bool simplify(Env& env, const popp& inst, Vlabel b, size_t i) {
-  if (!env.use_counts[inst.d0]) { decltype(inst.d0){Vreg::kInvalidReg}; }
-  if (!env.use_counts[inst.d1]) { decltype(inst.d1){Vreg::kInvalidReg}; }
-  return false;
-}
-
 bool simplify(Env& env, const pop& inst, Vlabel b, size_t i) {
   if (env.use_counts[inst.d]) {
     return false;
-  } else {
-    return simplify_impl(env, b, i, [&] (Vout& v) {
-      v << lea{reg::rsp[8], reg::rsp};
-      return 1;
-    });
   }
+
+  // Convert to an lea when popping to a reg without any uses.
+  return simplify_impl(env, b, i, [&] (Vout& v) {
+    v << lea{reg::rsp[8], reg::rsp};
+    return 1;
+  });
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/hphp/runtime/vm/jit/vasm-x64.cpp
+++ b/hphp/runtime/vm/jit/vasm-x64.cpp
@@ -803,16 +803,8 @@ void lower(Vunit& unit, Inst& inst, Vlabel b, size_t i) {}
 
 void lower(Vunit& unit, popp& inst, Vlabel b, size_t i) {
   lower_impl(unit, b, i, [&] (Vout& v) {
-    if (inst.d0.isValid()) {
-      v << pop{inst.d0};
-    } else {
-      lea{reg::rsp[8], reg::rsp};
-    }
-    if (inst.d1.isValid()) {
-      v << pop{inst.d1};
-    } else {
-      lea{reg::rsp[8], reg::rsp};
-    }
+    v << pop{inst.d0};
+    v << pop{inst.d1};
   });
 }
 
@@ -825,16 +817,8 @@ void lower(Vunit& unit, poppm& inst, Vlabel b, size_t i) {
 
 void lower(Vunit& unit, pushp& inst, Vlabel b, size_t i) {
   lower_impl(unit, b, i, [&] (Vout& v) {
-    if (inst.s1.isValid()) {
-      v << push{inst.s1};
-    } else {
-      lea{reg::rsp[-8], reg::rsp};
-    }
-    if (inst.s0.isValid()) {
-      v << push{inst.s0};
-    } else {
-      lea{reg::rsp[-8], reg::rsp};
-    }
+    v << push{inst.s1};
+    v << push{inst.s0};
   });
 }
 

--- a/hphp/runtime/vm/jit/vasm-x64.cpp
+++ b/hphp/runtime/vm/jit/vasm-x64.cpp
@@ -817,15 +817,15 @@ void lower(Vunit& unit, poppm& inst, Vlabel b, size_t i) {
 
 void lower(Vunit& unit, pushp& inst, Vlabel b, size_t i) {
   lower_impl(unit, b, i, [&] (Vout& v) {
-    v << push{inst.s1};
     v << push{inst.s0};
+    v << push{inst.s1};
   });
 }
 
 void lower(Vunit& unit, pushpm& inst, Vlabel b, size_t i) {
   lower_impl(unit, b, i, [&] (Vout& v) {
-    v << pushm{inst.s1};
     v << pushm{inst.s0};
+    v << pushm{inst.s1};
   });
 }
 

--- a/hphp/runtime/vm/jit/vasm-x64.cpp
+++ b/hphp/runtime/vm/jit/vasm-x64.cpp
@@ -801,6 +801,52 @@ void lower(Vunit& unit, Inst& inst, Vlabel b, size_t i) {}
 
 ///////////////////////////////////////////////////////////////////////////////
 
+void lower(Vunit& unit, popp& inst, Vlabel b, size_t i) {
+  lower_impl(unit, b, i, [&] (Vout& v) {
+    if (inst.d0.isValid()) {
+      v << pop{inst.d0};
+    } else {
+      lea{reg::rsp[8], reg::rsp};
+    }
+    if (inst.d1.isValid()) {
+      v << pop{inst.d1};
+    } else {
+      lea{reg::rsp[8], reg::rsp};
+    }
+  });
+}
+
+void lower(Vunit& unit, poppm& inst, Vlabel b, size_t i) {
+  lower_impl(unit, b, i, [&] (Vout& v) {
+    v << popm{inst.d0};
+    v << popm{inst.d1};
+  });
+}
+
+void lower(Vunit& unit, pushp& inst, Vlabel b, size_t i) {
+  lower_impl(unit, b, i, [&] (Vout& v) {
+    if (inst.s1.isValid()) {
+      v << push{inst.s1};
+    } else {
+      lea{reg::rsp[-8], reg::rsp};
+    }
+    if (inst.s0.isValid()) {
+      v << push{inst.s0};
+    } else {
+      lea{reg::rsp[-8], reg::rsp};
+    }
+  });
+}
+
+void lower(Vunit& unit, pushpm& inst, Vlabel b, size_t i) {
+  lower_impl(unit, b, i, [&] (Vout& v) {
+    v << pushm{inst.s1};
+    v << pushm{inst.s0};
+  });
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
 void lower(Vunit& unit, stublogue& inst, Vlabel b, size_t i) {
   if (inst.saveframe) {
     unit.blocks[b].code[i] = push{rvmfp()};

--- a/hphp/runtime/vm/jit/vasm-xls.cpp
+++ b/hphp/runtime/vm/jit/vasm-xls.cpp
@@ -652,10 +652,16 @@ int spEffect(const Vunit& unit, const Vinstr& inst, PhysReg sp,
     case Vinstr::pushf:
     case Vinstr::pushm:
       return -8;
+    case Vinstr::pushp:
+    case Vinstr::pushpm:
+      return -16;
     case Vinstr::pop:
     case Vinstr::popf:
     case Vinstr::popm:
       return 8;
+    case Vinstr::popp:
+    case Vinstr::poppm:
+      return 16;
     case Vinstr::lea: {
       auto& i = inst.lea_;
       if (i.d == Vreg64(sp)) {


### PR DESCRIPTION
In addition to requiring 16 byte sp alignment at ABI boundaries,
AArch64 also requires 16 byte alignment on loads/stores. Currently,
theres a workaround in vasm-arm.cpp to temporarily use rAsm for
8 bytes pushes/pops. This change removes that workaround and instead
adds support to specify a sp operation alignment per platform which
is used wherever offsets calculations are done for pushes/pops.
