### PR TITLE
[AArch64] Preserve fast call abi rules for dec ref.

### DIFF
--- a/hphp/runtime/vm/jit/code-gen-helpers-inl.h
+++ b/hphp/runtime/vm/jit/code-gen-helpers-inl.h
@@ -60,15 +60,7 @@ template<class Destroy>
 void emitDecRefWork(Vout& v, Vout& vcold, Vreg data,
                     Destroy destroy, bool unlikelyDestroy) {
   auto const sf = v.makeReg();
-  switch (arch()) {
-    case Arch::X64:
-    case Arch::PPC64:
-      v << cmplim{1, data[FAST_REFCOUNT_OFFSET], sf};
-      break;
-    case Arch::ARM:
-      v << cmplims{1, data[FAST_REFCOUNT_OFFSET], sf};
-      break;
-  }
+  v << cmplim{1, data[FAST_REFCOUNT_OFFSET], sf};
   ifThenElse(
     v, vcold, CC_E, sf,
     destroy,

--- a/hphp/runtime/vm/jit/phys-reg-saver.cpp
+++ b/hphp/runtime/vm/jit/phys-reg-saver.cpp
@@ -48,6 +48,8 @@ PhysRegSaver::PhysRegSaver(Vout& v, RegSet regs)
   gpr.forEachPair([&] (PhysReg r0, PhysReg r1) {
     v << pushp{r0, r1 == InvalidReg ? r0 : r1};
   });
+
+  v << vregunrestrict{};
 }
 
 PhysRegSaver::~PhysRegSaver() {
@@ -56,6 +58,8 @@ PhysRegSaver::~PhysRegSaver() {
 
   auto gpr = m_regs & abi().gp();
   auto xmm = m_regs & abi().simd();
+
+  v << vregrestrict{};
 
   gpr.forEachPairR([&] (PhysReg r0, PhysReg r1) {
     v << popp{r0 == InvalidReg ? v.makeReg() : Vreg{r0}, r1};

--- a/hphp/runtime/vm/jit/unique-stubs.cpp
+++ b/hphp/runtime/vm/jit/unique-stubs.cpp
@@ -1022,6 +1022,7 @@ TCA emitDecRefGeneric(CodeBlock& cb, DataBlock& data) {
   CGMeta meta;
 
   auto const start = vwrap(cb, data, meta, [] (Vout& v) {
+    v << vregrestrict{};
     v << stublogue{};
 
     auto const rdata = rarg(0);

--- a/hphp/runtime/vm/jit/vasm-arm.cpp
+++ b/hphp/runtime/vm/jit/vasm-arm.cpp
@@ -337,7 +337,6 @@ struct Vgen {
   void emit(const xorqi& i);
 
   // arm intrinsics
-  void emit(const cmplims& i);
   void emit(const fcvtzs& i) { a->Fcvtzs(X(i.d), D(i.s)); }
   void emit(const mrs& i) { a->Mrs(X(i.r), vixl::SystemRegister(i.s.l())); }
   void emit(const msr& i) { a->Msr(vixl::SystemRegister(i.s.l()), X(i.r)); }
@@ -846,42 +845,6 @@ void Vgen::emit(const unpcklpd& i) {
 
 ///////////////////////////////////////////////////////////////////////////////
 
-/*
- * 'cmplims' instruction is intended for use where temporary Vregs can't be
- * allocated, E.g., in stubs called via callfaststub{}. As the memory
- * operand is not lowered, make sure that it is in one of the following
- * formats
- *  [base]
- *  [base, index]
- *  [base, #imm] where #imm is in the range [-256, 255]
- */
-void Vgen::emit(const cmplims& i) {
-  enum {
-    BASE = 1,
-    INDEX = 2,
-    DISP = 4
-  };
-
-  // TODO: Allow TLS addresses if possible
-  assertx(i.s1.seg == Vptr::DS);
-
-  uint8_t mode = (((i.s1.base.isValid()  & 0x1) << 0) |
-                  ((i.s1.index.isValid() & 0x1) << 1) |
-                  (((i.s1.disp != 0)     & 0x1) << 2));
-  switch (mode) {
-    case BASE:
-    case BASE | INDEX:
-      break;
-    case BASE | DISP:
-      assertx(i.s1.disp >= -256 && i.s1.disp <= 255);
-      break;
-    default:
-      always_assert(false);
-  }
-  a->Ldr(rAsm.W(), M(i.s1));
-  a->Cmp(rAsm.W(), i.s0.l());
-}
-
 void Vgen::emit(const cmpsd& i) {
   /*
    * cmpsd doesn't update SD, so read the flags into a temp.
@@ -1103,7 +1066,7 @@ void lower_impl(Vunit& unit, Vlabel b, size_t i, Lower lower) {
 }
 
 template<typename Inst>
-void lower(Vunit& unit, Inst& inst, Vlabel b, size_t i) {}
+void lower(const VLS& env, Inst& inst, Vlabel b, size_t i) {}
 
 ///////////////////////////////////////////////////////////////////////////////
 
@@ -1203,12 +1166,12 @@ void lowerVptr(Vptr& p, Vout& v) {
   }
 }
 
-#define Y(vasm_opc, m)                                  \
-void lower(Vunit& u, vasm_opc& i, Vlabel b, size_t z) { \
-  lower_impl(u, b, z, [&] (Vout& v) {                   \
-    lowerVptr(i.m, v);                                  \
-    v << i;                                             \
-  });                                                   \
+#define Y(vasm_opc, m)                                      \
+void lower(const VLS& e, vasm_opc& i, Vlabel b, size_t z) { \
+  lower_impl(e.unit, b, z, [&] (Vout& v) {                  \
+    lowerVptr(i.m, v);                                      \
+    v << i;                                                 \
+  });                                                       \
 }
 
 Y(decqmlock, m)
@@ -1236,18 +1199,18 @@ Y(storew, m)
 #define ISLG(w) vixl::Assembler::IsImmLogical(value, w)
 #define U2(v0, v1) v0, v1
 
-#define Y(vasm_opc, lower_opc, load_opc, chk, imm, use) \
-void lower(Vunit& u, vasm_opc& i, Vlabel b, size_t z) { \
-  lower_impl(u, b, z, [&] (Vout& v) {                   \
-    auto value = safe_cast<int64_t>(i.s0.q());          \
-    if (chk) {                                          \
-      v << i;                                           \
-    } else {                                            \
-      auto s0 = v.makeReg();                            \
-      v << load_opc{imm, s0};                           \
-      v << lower_opc{s0, use, i.sf};                    \
-    }                                                   \
-  });                                                   \
+#define Y(vasm_opc, lower_opc, load_opc, chk, imm, use)     \
+void lower(const VLS& e, vasm_opc& i, Vlabel b, size_t z) { \
+  lower_impl(e.unit, b, z, [&] (Vout& v) {                  \
+    auto value = safe_cast<int64_t>(i.s0.q());              \
+    if (chk) {                                              \
+      v << i;                                               \
+    } else {                                                \
+      auto s0 = v.makeReg();                                \
+      v << load_opc{imm, s0};                               \
+      v << lower_opc{s0, use, i.sf};                        \
+    }                                                       \
+  });                                                       \
 }
 
 Y(addli, addl, ldimml, ISAR, i.s0, U2(i.s1, i.d))
@@ -1272,15 +1235,15 @@ Y(xorqi, xorq, ldimmq, ISLG(64), Immed64(value), U2(i.s1, i.d))
 #undef ISLG
 #undef ISAR
 
-#define Y(vasm_opc, lower_opc, load_opc, store_opc, s0, m) \
-void lower(Vunit& u, vasm_opc& i, Vlabel b, size_t z) {    \
-  lower_impl(u, b, z, [&] (Vout& v) {                      \
-    lowerVptr(i.m, v);                                     \
-    auto r0 = v.makeReg(), r1 = v.makeReg();               \
-    v << load_opc{i.m, r0};                                \
-    v << lower_opc{i.s0, r0, r1, i.sf};                    \
-    v << store_opc{r1, i.m};                               \
-  });                                                      \
+#define Y(vasm_opc, lower_opc, load_opc, store_opc, s0, m)  \
+void lower(const VLS& e, vasm_opc& i, Vlabel b, size_t z) { \
+  lower_impl(e.unit, b, z, [&] (Vout& v) {                  \
+    lowerVptr(i.m, v);                                      \
+    auto r0 = v.makeReg(), r1 = v.makeReg();                \
+    v << load_opc{i.m, r0};                                 \
+    v << lower_opc{i.s0, r0, r1, i.sf};                     \
+    v << store_opc{r1, i.m};                                \
+  });                                                       \
 }
 
 Y(addlim, addli, loadl, storel, s0, m)
@@ -1293,14 +1256,14 @@ Y(orwim, orqi, loadw, storew, s0, m)
 
 #undef Y
 
-#define Y(vasm_opc, lower_opc, load_opc)                \
-void lower(Vunit& u, vasm_opc& i, Vlabel b, size_t z) { \
-  lower_impl(u, b, z, [&] (Vout& v) {                   \
-    lowerVptr(i.s1, v);                                 \
-    auto r = v.makeReg();                               \
-    v << load_opc{i.s1, r};                             \
-    v << lower_opc{i.s0, r, i.sf};                      \
-  });                                                   \
+#define Y(vasm_opc, lower_opc, load_opc)                         \
+void lower(const VLS& e, vasm_opc& i, Vlabel b, size_t z) {      \
+  lower_impl(e.unit, b, z, [&] (Vout& v) {                       \
+    lowerVptr(i.s1, v);                                          \
+    auto r = e.allow_vreg() ? v.makeReg() : Vreg(PhysReg(rAsm)); \
+    v << load_opc{i.s1, r};                                      \
+    v << lower_opc{i.s0, r, i.sf};                               \
+  });                                                            \
 }
 
 Y(cmpbim, cmpli, loadb)
@@ -1317,8 +1280,8 @@ Y(testwim, testli, loadw)
 
 #undef Y
 
-void lower(Vunit& u, cvtsi2sdm& i, Vlabel b, size_t z) {
-  lower_impl(u, b, z, [&] (Vout& v) {
+void lower(const VLS& e, cvtsi2sdm& i, Vlabel b, size_t z) {
+  lower_impl(e.unit, b, z, [&] (Vout& v) {
     lowerVptr(i.s, v);
     auto r = v.makeReg();
     v << load{i.s, r};
@@ -1326,15 +1289,16 @@ void lower(Vunit& u, cvtsi2sdm& i, Vlabel b, size_t z) {
   });
 }
 
-#define Y(vasm_opc, lower_opc, load_opc, store_opc, m)  \
-void lower(Vunit& u, vasm_opc& i, Vlabel b, size_t z) { \
-  lower_impl(u, b, z, [&] (Vout& v) {                   \
-    lowerVptr(i.m, v);                                  \
-    auto r0 = v.makeReg(), r1 = v.makeReg();            \
-    v << load_opc{i.m, r0};                             \
-    v << lower_opc{r0, r1, i.sf};                       \
-    v << store_opc{r1, i.m};                            \
-  });                                                   \
+#define Y(vasm_opc, lower_opc, load_opc, store_opc, m)            \
+void lower(const VLS& e, vasm_opc& i, Vlabel b, size_t z) {       \
+  lower_impl(e.unit, b, z, [&] (Vout& v) {                        \
+    lowerVptr(i.m, v);                                            \
+    auto r0 = e.allow_vreg() ? v.makeReg() : Vreg(PhysReg(rAsm)); \
+    auto r1 = e.allow_vreg() ? v.makeReg() : Vreg(PhysReg(rAsm)); \
+    v << load_opc{i.m, r0};                                       \
+    v << lower_opc{r0, r1, i.sf};                                 \
+    v << store_opc{r1, i.m};                                      \
+  });                                                             \
 }
 
 Y(declm, decl, loadl, storel, m)
@@ -1345,8 +1309,8 @@ Y(incwm, incw, loadw, storew, m)
 
 #undef Y
 
-void lower(Vunit& unit, cvttsd2siq& i, Vlabel b, size_t idx) {
-  lower_impl(unit, b, idx, [&] (Vout& v) {
+void lower(const VLS& e, cvttsd2siq& i, Vlabel b, size_t idx) {
+  lower_impl(e.unit, b, idx, [&] (Vout& v) {
     // Clear FPSR IOC flag.
     auto const tmp1 = v.makeReg();
     auto const tmp2 = v.makeReg();
@@ -1373,8 +1337,8 @@ void lower(Vunit& unit, cvttsd2siq& i, Vlabel b, size_t idx) {
   });
 }
 
-void lower(Vunit& u, callm& i, Vlabel b, size_t z) {
-  lower_impl(u, b, z, [&] (Vout& v) {
+void lower(const VLS& e, callm& i, Vlabel b, size_t z) {
+  lower_impl(e.unit, b, z, [&] (Vout& v) {
     lowerVptr(i.target, v);
 
     auto const scratch = v.makeReg();
@@ -1385,8 +1349,8 @@ void lower(Vunit& u, callm& i, Vlabel b, size_t z) {
   });
 }
 
-void lower(Vunit& u, jmpm& i, Vlabel b, size_t z) {
-  lower_impl(u, b, z, [&] (Vout& v) {
+void lower(const VLS& e, jmpm& i, Vlabel b, size_t z) {
+  lower_impl(e.unit, b, z, [&] (Vout& v) {
     lowerVptr(i.target, v);
 
     auto const scratch = v.makeReg();
@@ -1398,15 +1362,15 @@ void lower(Vunit& u, jmpm& i, Vlabel b, size_t z) {
 
 ///////////////////////////////////////////////////////////////////////////////
 
-void lower(Vunit& u, stublogue& i, Vlabel b, size_t z) {
-  lower_impl(u, b, z, [&] (Vout& v) {
+void lower(const VLS& e, stublogue& i, Vlabel b, size_t z) {
+  lower_impl(e.unit, b, z, [&] (Vout& v) {
     // Push both the LR and FP regardless of i.saveframe to align SP.
     v << pushp{rlr(), rvmfp()};
   });
 }
 
-void lower(Vunit& u, stubret& i, Vlabel b, size_t z) {
-  lower_impl(u, b, z, [&] (Vout& v) {
+void lower(const VLS& e, stubret& i, Vlabel b, size_t z) {
+  lower_impl(e.unit, b, z, [&] (Vout& v) {
     // Pop LR and (optionally) FP.
     if (i.saveframe) {
       v << popp{rvmfp(), rlr()};
@@ -1418,8 +1382,8 @@ void lower(Vunit& u, stubret& i, Vlabel b, size_t z) {
   });
 }
 
-void lower(Vunit& u, tailcallstub& i, Vlabel b, size_t z) {
-  lower_impl(u, b, z, [&] (Vout& v) {
+void lower(const VLS& e, tailcallstub& i, Vlabel b, size_t z) {
+  lower_impl(e.unit, b, z, [&] (Vout& v) {
     // Restore LR from native stack and adjust SP.
     v << popp{PhysReg(rAsm), rlr()};
 
@@ -1428,22 +1392,22 @@ void lower(Vunit& u, tailcallstub& i, Vlabel b, size_t z) {
   });
 }
 
-void lower(Vunit& u, stubunwind& i, Vlabel b, size_t z) {
-  lower_impl(u, b, z, [&] (Vout& v) {
+void lower(const VLS& e, stubunwind& i, Vlabel b, size_t z) {
+  lower_impl(e.unit, b, z, [&] (Vout& v) {
     // Pop the call frame.
     v << lea{rsp()[16], rsp()};
   });
 }
 
-void lower(Vunit& u, stubtophp& i, Vlabel b, size_t z) {
-  lower_impl(u, b, z, [&] (Vout& v) {
+void lower(const VLS& e, stubtophp& i, Vlabel b, size_t z) {
+  lower_impl(e.unit, b, z, [&] (Vout& v) {
     // Pop the call frame
     v << lea{rsp()[16], rsp()};
   });
 }
 
-void lower(Vunit& u, loadstubret& i, Vlabel b, size_t z) {
-  lower_impl(u, b, z, [&] (Vout& v) {
+void lower(const VLS& e, loadstubret& i, Vlabel b, size_t z) {
+  lower_impl(e.unit, b, z, [&] (Vout& v) {
     // Load the LR to the destination.
     v << load{rsp()[AROFF(m_savedRip)], i.d};
   });
@@ -1451,14 +1415,14 @@ void lower(Vunit& u, loadstubret& i, Vlabel b, size_t z) {
 
 ///////////////////////////////////////////////////////////////////////////////
 
-void lower(Vunit& u, phplogue& i, Vlabel b, size_t z) {
-  lower_impl(u, b, z, [&] (Vout& v) {
+void lower(const VLS& e, phplogue& i, Vlabel b, size_t z) {
+  lower_impl(e.unit, b, z, [&] (Vout& v) {
     v << store{rlr(), i.fp[AROFF(m_savedRip)]};
   });
 }
 
-void lower(Vunit& u, tailcallphp& i, Vlabel b, size_t z) {
-  lower_impl(u, b, z, [&] (Vout& v) {
+void lower(const VLS& e, tailcallphp& i, Vlabel b, size_t z) {
+  lower_impl(e.unit, b, z, [&] (Vout& v) {
     // Undoes the prologue by restoring LR from saved RIP.
     v << load{i.fp[AROFF(m_savedRip)], rlr()};
 
@@ -1468,8 +1432,8 @@ void lower(Vunit& u, tailcallphp& i, Vlabel b, size_t z) {
 
 ///////////////////////////////////////////////////////////////////////////////
 
-void lower(Vunit& u, resumetc& i, Vlabel b, size_t z) {
-  lower_impl(u, b, z, [&] (Vout& v) {
+void lower(const VLS& e, resumetc& i, Vlabel b, size_t z) {
+  lower_impl(e.unit, b, z, [&] (Vout& v) {
     // Call the translation target.
     v << callr{i.target, i.args};
 
@@ -1480,8 +1444,8 @@ void lower(Vunit& u, resumetc& i, Vlabel b, size_t z) {
 
 ///////////////////////////////////////////////////////////////////////////////
 
-void lower(Vunit& u, popm& i, Vlabel b, size_t z) {
-  lower_impl(u, b, z, [&] (Vout& v) {
+void lower(const VLS& e, popm& i, Vlabel b, size_t z) {
+  lower_impl(e.unit, b, z, [&] (Vout& v) {
     auto r = v.makeReg();
     v << pop{r};
     lowerVptr(i.d, v);
@@ -1489,8 +1453,8 @@ void lower(Vunit& u, popm& i, Vlabel b, size_t z) {
   });
 }
 
-void lower(Vunit& u, poppm& i, Vlabel b, size_t z) {
-  lower_impl(u, b, z, [&] (Vout& v) {
+void lower(const VLS& e, poppm& i, Vlabel b, size_t z) {
+  lower_impl(e.unit, b, z, [&] (Vout& v) {
     auto r0 = v.makeReg();
     auto r1 = v.makeReg();
     v << popp{r0, r1};
@@ -1501,8 +1465,8 @@ void lower(Vunit& u, poppm& i, Vlabel b, size_t z) {
   });
 }
 
-void lower(Vunit& u, pushm& i, Vlabel b, size_t z) {
-  lower_impl(u, b, z, [&] (Vout& v) {
+void lower(const VLS& e, pushm& i, Vlabel b, size_t z) {
+  lower_impl(e.unit, b, z, [&] (Vout& v) {
     auto r = v.makeReg();
     lowerVptr(i.s, v);
     v << load{i.s, r};
@@ -1510,8 +1474,8 @@ void lower(Vunit& u, pushm& i, Vlabel b, size_t z) {
   });
 }
 
-void lower(Vunit& u, pushpm& i, Vlabel b, size_t z) {
-  lower_impl(u, b, z, [&] (Vout& v) {
+void lower(const VLS& e, pushpm& i, Vlabel b, size_t z) {
+  lower_impl(e.unit, b, z, [&] (Vout& v) {
     auto r0 = v.makeReg();
     auto r1 = v.makeReg();
     lowerVptr(i.s0, v);
@@ -1522,22 +1486,22 @@ void lower(Vunit& u, pushpm& i, Vlabel b, size_t z) {
   });
 }
 
-void lower(Vunit& u, movtdb& i, Vlabel b, size_t z) {
-  lower_impl(u, b, z, [&] (Vout& v) {
+void lower(const VLS& e, movtdb& i, Vlabel b, size_t z) {
+  lower_impl(e.unit, b, z, [&] (Vout& v) {
     auto d = v.makeReg();
     v << copy{i.s, d};
     v << movtqb{d, i.d};
   });
 }
 
-void lower(Vunit& u, movtdq& i, Vlabel b, size_t z) {
-  lower_impl(u, b, z, [&] (Vout& v) {
+void lower(const VLS& e, movtdq& i, Vlabel b, size_t z) {
+  lower_impl(e.unit, b, z, [&] (Vout& v) {
     v << copy{i.s, i.d};
   });
 }
 
-void lower(Vunit& u, cmpb& i, Vlabel b, size_t z) {
-  lower_impl(u, b, z, [&] (Vout& v) {
+void lower(const VLS& e, cmpb& i, Vlabel b, size_t z) {
+  lower_impl(e.unit, b, z, [&] (Vout& v) {
     auto s0 = v.makeReg();
     auto s1 = v.makeReg();
     v << movzbl{i.s0, s0};
@@ -1546,24 +1510,24 @@ void lower(Vunit& u, cmpb& i, Vlabel b, size_t z) {
   });
 }
 
-void lower(Vunit& u, cmpbi& i, Vlabel b, size_t z) {
-  lower_impl(u, b, z, [&] (Vout& v) {
+void lower(const VLS& e, cmpbi& i, Vlabel b, size_t z) {
+  lower_impl(e.unit, b, z, [&] (Vout& v) {
     auto s1 = v.makeReg();
     v << movzbl{i.s1, s1};
     v << cmpli{i.s0, s1, i.sf};
   });
 }
 
-#define Y(vasm_opc, conv_opc, load_opc, cmp_opc)        \
-void lower(Vunit& u, vasm_opc& i, Vlabel b, size_t z) { \
-  lower_impl(u, b, z, [&] (Vout& v) {                   \
-    auto s0 = v.makeReg();                              \
-    v << conv_opc{i.s0, s0};                            \
-    lowerVptr(i.s1, v);                                 \
-    auto s1 = v.makeReg();                              \
-    v << load_opc{i.s1, s1};                            \
-    v << cmp_opc{s0, s1, i.sf};                         \
-  });                                                   \
+#define Y(vasm_opc, conv_opc, load_opc, cmp_opc)            \
+void lower(const VLS& e, vasm_opc& i, Vlabel b, size_t z) { \
+  lower_impl(e.unit, b, z, [&] (Vout& v) {                  \
+    auto s0 = v.makeReg();                                  \
+    v << conv_opc{i.s0, s0};                                \
+    lowerVptr(i.s1, v);                                     \
+    auto s1 = v.makeReg();                                  \
+    v << load_opc{i.s1, s1};                                \
+    v << cmp_opc{s0, s1, i.sf};                             \
+  });                                                       \
 }
 
 Y(cmpbm, movzbl, loadzbl, cmpl)
@@ -1571,8 +1535,8 @@ Y(cmpwm, movzwl, loadw, cmpl)
 
 #undef Y
 
-void lower(Vunit& u, testb& i, Vlabel b, size_t z) {
-  lower_impl(u, b, z, [&] (Vout& v) {
+void lower(const VLS& e, testb& i, Vlabel b, size_t z) {
+  lower_impl(e.unit, b, z, [&] (Vout& v) {
     if (i.s0 == i.s1) {
       v << testbi{(uint8_t)0xff, i.s1, i.sf};
     } else {
@@ -1585,22 +1549,22 @@ void lower(Vunit& u, testb& i, Vlabel b, size_t z) {
   });
 }
 
-void lower(Vunit& u, testbi& i, Vlabel b, size_t z) {
-  lower_impl(u, b, z, [&] (Vout& v) {
+void lower(const VLS& e, testbi& i, Vlabel b, size_t z) {
+  lower_impl(e.unit, b, z, [&] (Vout& v) {
     auto s1 = v.makeReg();
     v << movzbl{i.s1, s1};
     v << testli{i.s0, s1, i.sf};
   });
 }
 
-#define Y(vasm_opc, lower_opc, load_opc, imm)           \
-void lower(Vunit& u, vasm_opc& i, Vlabel b, size_t z) { \
-  lower_impl(u, b, z, [&] (Vout& v) {                   \
-    lowerVptr(i.m, v);                                  \
-    auto r = v.makeReg();                               \
-    v << load_opc{imm, r};                              \
-    v << lower_opc{r, i.m};                             \
-  });                                                   \
+#define Y(vasm_opc, lower_opc, load_opc, imm)               \
+void lower(const VLS& e, vasm_opc& i, Vlabel b, size_t z) { \
+  lower_impl(e.unit, b, z, [&] (Vout& v) {                  \
+    lowerVptr(i.m, v);                                      \
+    auto r = v.makeReg();                                   \
+    v << load_opc{imm, r};                                  \
+    v << lower_opc{r, i.m};                                 \
+  });                                                       \
 }
 
 Y(storebi, storeb, ldimmb, i.s)
@@ -1610,8 +1574,8 @@ Y(storewi, storew, ldimmw, i.s)
 
 #undef Y
 
-void lower(Vunit& u, cloadq& i, Vlabel b, size_t z) {
-  lower_impl(u, b, z, [&] (Vout& v) {
+void lower(const VLS& e, cloadq& i, Vlabel b, size_t z) {
+  lower_impl(e.unit, b, z, [&] (Vout& v) {
     auto const scratch = v.makeReg();
 
     lowerVptr(i.t, v);
@@ -1621,8 +1585,8 @@ void lower(Vunit& u, cloadq& i, Vlabel b, size_t z) {
   });
 }
 
-void lower(Vunit& u, loadqp& i, Vlabel b, size_t z) {
-  lower_impl(u, b, z, [&] (Vout& v) {
+void lower(const VLS& e, loadqp& i, Vlabel b, size_t z) {
+  lower_impl(e.unit, b, z, [&] (Vout& v) {
     auto const scratch = v.makeReg();
 
     v << leap{i.s, scratch};
@@ -1630,8 +1594,8 @@ void lower(Vunit& u, loadqp& i, Vlabel b, size_t z) {
   });
 }
 
-void lower(Vunit& u, loadqd& i, Vlabel b, size_t z) {
-  lower_impl(u, b, z, [&] (Vout& v) {
+void lower(const VLS& e, loadqd& i, Vlabel b, size_t z) {
+  lower_impl(e.unit, b, z, [&] (Vout& v) {
     auto const scratch = v.makeReg();
 
     v << lead{i.s.getRaw(), scratch};
@@ -1642,11 +1606,11 @@ void lower(Vunit& u, loadqd& i, Vlabel b, size_t z) {
 ///////////////////////////////////////////////////////////////////////////////
 
 void lowerForARM(Vunit& unit) {
-  vasm_lower(unit, [&] (Vinstr& inst, Vlabel b, size_t i) {
+  vasm_lower(unit, [&] (const VLS& env, Vinstr& inst, Vlabel b, size_t i) {
     switch (inst.op) {
 #define O(name, ...)                      \
       case Vinstr::name:                  \
-        lower(unit, inst.name##_, b, i);  \
+        lower(env, inst.name##_, b, i);  \
         break;
 
       VASM_OPCODES

--- a/hphp/runtime/vm/jit/vasm-dead.cpp
+++ b/hphp/runtime/vm/jit/vasm-dead.cpp
@@ -60,7 +60,6 @@ bool effectful(Vinstr& inst) {
     case Vinstr::cmpl:
     case Vinstr::cmpli:
     case Vinstr::cmplim:
-    case Vinstr::cmplims:
     case Vinstr::cmplm:
     case Vinstr::cmpq:
     case Vinstr::cmpqi:
@@ -271,6 +270,8 @@ bool effectful(Vinstr& inst) {
     case Vinstr::vcall:
     case Vinstr::vcallarray:
     case Vinstr::vinvoke:
+    case Vinstr::vregrestrict:
+    case Vinstr::vregunrestrict:
     case Vinstr::conjure:
     case Vinstr::conjureuse:
       return true;

--- a/hphp/runtime/vm/jit/vasm-instr.cpp
+++ b/hphp/runtime/vm/jit/vasm-instr.cpp
@@ -142,6 +142,9 @@ Width width(Vinstr::Opcode op) {
     // nop and trap
     case Vinstr::nop:
     case Vinstr::ud2:
+    // restrict/unrestrict new virtuals
+    case Vinstr::vregrestrict:
+    case Vinstr::vregunrestrict:
     // zero-extending/truncating copies
     case Vinstr::movzbw:
     case Vinstr::movzbl:
@@ -182,7 +185,6 @@ Width width(Vinstr::Opcode op) {
     case Vinstr::sarq:
     case Vinstr::shlq:
     // arm instructions
-    case Vinstr::cmplims:
     case Vinstr::fcvtzs:
     case Vinstr::mrs:
     case Vinstr::msr:

--- a/hphp/runtime/vm/jit/vasm-instr.h
+++ b/hphp/runtime/vm/jit/vasm-instr.h
@@ -126,6 +126,9 @@ struct Vunit;
   /* nop and trap */\
   O(nop, Inone, Un, Dn)\
   O(ud2, Inone, Un, Dn)\
+  /* restrict/unrestrict new virtuals */\
+  O(vregrestrict, Inone, Un, Dn)\
+  O(vregunrestrict, Inone, Un, Dn)\
   /* arithmetic instructions */\
   O(addl, I(fl), U(s0) U(s1), D(d) D(sf)) \
   O(addli, I(s0) I(fl), UH(s1,d), DH(d,s1) D(sf)) \
@@ -292,7 +295,6 @@ struct Vunit;
   O(sarq, I(fl), UH(s,d), DH(d,s) D(sf))\
   O(shlq, I(fl), UH(s,d), DH(d,s) D(sf))\
   /* arm instructions */\
-  O(cmplims, I(s0) I(fl), U(s1), D(sf))\
   O(fcvtzs, Inone, U(s), D(d))\
   O(mrs, I(s), Un, D(r))\
   O(msr, I(s), U(r), Dn)\
@@ -870,6 +872,12 @@ struct nop {};
 struct ud2 {};
 
 /*
+ * Restrict/unrestrict new virtuals.
+ */
+struct vregrestrict {};
+struct vregunrestrict {};
+
+/*
  * Arithmetic instructions.
  */
 // add: s0 + {s1|m} => {d|m}, sf
@@ -1101,7 +1109,6 @@ struct shlq { Vreg64 s, d; VregSF sf; Vflags fl; }; // uses rcx
 /*
  * arm intrinsics.
  */
-struct cmplims { Immed s0; Vptr s1; VregSF sf; Vflags fl; };
 struct fcvtzs { VregDbl s; Vreg64 d;};
 struct mrs { Immed s; Vreg64 r; };
 struct msr { Vreg64 r; Immed s; };

--- a/hphp/runtime/vm/jit/vasm-lower-inl.h
+++ b/hphp/runtime/vm/jit/vasm-lower-inl.h
@@ -36,9 +36,8 @@ namespace detail {
  * The dominating restriction is used initially for the block and then updated
  * whenever a vregrestrict/vregunrestrict is encountered.
  *
- *   INT_MAX: uninitialized
- *      >= 0: new vregs allowed
- *      <  0: new vregs restricted
+ *   >= 0: new vregs allowed
+ *    < 0: new vregs restricted
  *
  * vregrestrict and vregunrestrict can be nested for scoping purposes. Each
  * nested vregrestrict decreases the constraint. vregunrestrict increases it.

--- a/hphp/runtime/vm/jit/vasm-lower-inl.h
+++ b/hphp/runtime/vm/jit/vasm-lower-inl.h
@@ -27,6 +27,28 @@ namespace HPHP { namespace jit {
 
 ///////////////////////////////////////////////////////////////////////////////
 
+namespace detail {
+
+/*
+ * Computes the dominating vreg constraint for each block. When lowering, this
+ * will be used to determine if a lowerer can use a new vreg as a scratch, or
+ * if it must rely on platform specific assembler scratch registers.
+ * The dominating restriction is used initially for the block and then updated
+ * whenever a vregrestrict/vregunrestrict is encountered.
+ *
+ *   INT_MAX: uninitialized
+ *      >= 0: new vregs allowed
+ *      <  0: new vregs restricted
+ *
+ * vregrestrict and vregunrestrict can be nested for scoping purposes. Each
+ * nested vregrestrict decreases the constraint. vregunrestrict increases it.
+ */
+jit::vector<int> computeDominatingConstraints(Vunit& unit);
+
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
 template<class Vlower>
 void vasm_lower(Vunit& unit, Vlower lower_impl) {
   Timer timer(Timer::vasm_lower, unit.log_entry);
@@ -38,14 +60,23 @@ void vasm_lower(Vunit& unit, Vlower lower_impl) {
   // iterators.
   auto& blocks = unit.blocks;
 
+  VLS env { unit };
+  auto const vregConstraints = detail::computeDominatingConstraints(unit);
+
   // The vlower() implementations, and `lower', may allocate scratch blocks and
   // modify instruction streams, so we cannot use standard iterators here.
   PostorderWalker{unit}.dfs([&] (Vlabel b) {
     assertx(!blocks[b].code.empty());
 
+    env.vreg_restrict_level = vregConstraints[b];
     for (size_t i = 0; i < blocks[b].code.size(); ++i) {
-      vlower(unit, b, i);
-      lower_impl(blocks[b].code[i], b, i);
+      DEBUG_ONLY auto const allow = env.allow_vreg();
+      DEBUG_ONLY auto const next = unit.next_vr;
+
+      vlower(env, b, i);
+      lower_impl(env, blocks[b].code[i], b, i);
+
+      assertx(allow || unit.next_vr == next);
     }
   });
 

--- a/hphp/runtime/vm/jit/vasm-lower.cpp
+++ b/hphp/runtime/vm/jit/vasm-lower.cpp
@@ -33,6 +33,52 @@ namespace HPHP { namespace jit {
 
 ///////////////////////////////////////////////////////////////////////////////
 
+namespace detail {
+
+jit::vector<int> computeDominatingConstraints(Vunit& unit) {
+  jit::vector<int> vregConstraints(unit.blocks.size(), INT_MAX);
+
+  // Build reverse postorder list of blocks
+  auto const rpo = sortBlocks(unit);
+
+  // Calculate each block's dominating vreg constraint. The lowerers will use
+  // this as the initial vreg constraint for each block, adjusting as they
+  // encounter vregrestrict/vregunrestrict during lowering.
+  vregConstraints[rpo[0]] = 0;
+  for (auto b : rpo) {
+    // Iterate through the instructions updating the constraint accordingly.
+    auto con = vregConstraints[b];
+    for (size_t i = 0; i < unit.blocks[b].code.size(); ++i) {
+      auto& inst = unit.blocks[b].code[i];
+      if (inst.op == Vinstr::vregrestrict) {
+        con--;
+      } else if (inst.op == Vinstr::vregunrestrict) {
+        con++;
+      }
+    }
+    assert_flog(con != INT_MAX,
+                "Dominating constraint can't be uninitialized.");
+
+    // Pass the contraint to each of the successors, enforcing that a block
+    // isn't passed conflicting contraints from predecessors. i.e. A successor
+    // must be pass all restrict or all allow/none.
+    for (auto s : succs(unit.blocks[b])) {
+      if (vregConstraints[s] == INT_MAX) {
+        vregConstraints[s] = con;
+      } else {
+        assert_flog(vregConstraints[s] == con,
+                    "Block must be dominated by a single vreg constraint level.\n");
+      }
+    }
+  }
+
+  return vregConstraints;
+}
+
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
 namespace {
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -203,21 +249,21 @@ void lower_vcall(Vunit& unit, Inst& inst, Vlabel b, size_t i) {
 ///////////////////////////////////////////////////////////////////////////////
 
 template<typename Inst>
-void lower(Vunit& unit, Inst& inst, Vlabel b, size_t i) {}
+void lower(VLS& env, Inst& inst, Vlabel b, size_t i) {}
 
-void lower(Vunit& unit, vcall& inst, Vlabel b, size_t i) {
-  lower_vcall(unit, inst, b, i);
+void lower(VLS& env, vcall& inst, Vlabel b, size_t i) {
+  lower_vcall(env.unit, inst, b, i);
 }
-void lower(Vunit& unit, vinvoke& inst, Vlabel b, size_t i) {
-  lower_vcall(unit, inst, b, i);
+void lower(VLS& env, vinvoke& inst, Vlabel b, size_t i) {
+  lower_vcall(env.unit, inst, b, i);
 }
 
-void lower(Vunit& unit, vcallarray& inst, Vlabel b, size_t i) {
+void lower(VLS& env, vcallarray& inst, Vlabel b, size_t i) {
   // vcallarray can only appear at the end of a block.
-  assertx(i == unit.blocks[b].code.size() - 1);
+  assertx(i == env.unit.blocks[b].code.size() - 1);
 
-  lower_impl(unit, b, i, [&] (Vout& v) {
-    auto const& srcs = unit.tuples[inst.extraArgs];
+  lower_impl(env.unit, b, i, [&] (Vout& v) {
+    auto const& srcs = env.unit.tuples[inst.extraArgs];
     auto args = inst.args;
     auto dsts = jit::vector<Vreg>{};
 
@@ -226,28 +272,36 @@ void lower(Vunit& unit, vcallarray& inst, Vlabel b, size_t i) {
       args |= rarg(i);
     }
 
-    v << copyargs{unit.makeTuple(srcs), unit.makeTuple(std::move(dsts))};
+    v << copyargs{env.unit.makeTuple(srcs), env.unit.makeTuple(std::move(dsts))};
     v << callarray{inst.target, args};
     v << unwind{{inst.targets[0], inst.targets[1]}};
   });
 }
 
-void lower(Vunit& unit, defvmsp& inst, Vlabel b, size_t i) {
-  unit.blocks[b].code[i] = copy{rvmsp(), inst.d};
+void lower(VLS& env, defvmsp& inst, Vlabel b, size_t i) {
+  env.unit.blocks[b].code[i] = copy{rvmsp(), inst.d};
 }
-void lower(Vunit& unit, syncvmsp& inst, Vlabel b, size_t i) {
-  unit.blocks[b].code[i] = copy{inst.s, rvmsp()};
+void lower(VLS& env, syncvmsp& inst, Vlabel b, size_t i) {
+  env.unit.blocks[b].code[i] = copy{inst.s, rvmsp()};
 }
 
-void lower(Vunit& unit, defvmretdata& inst, Vlabel b, size_t i) {
-  unit.blocks[b].code[i] = copy{rret_data(), inst.data};
+void lower(VLS& env, defvmretdata& inst, Vlabel b, size_t i) {
+  env.unit.blocks[b].code[i] = copy{rret_data(), inst.data};
 }
-void lower(Vunit& unit, defvmrettype& inst, Vlabel b, size_t i) {
-  unit.blocks[b].code[i] = copy{rret_type(), inst.type};
+void lower(VLS& env, defvmrettype& inst, Vlabel b, size_t i) {
+  env.unit.blocks[b].code[i] = copy{rret_type(), inst.type};
 }
-void lower(Vunit& unit, syncvmret& inst, Vlabel b, size_t i) {
-  unit.blocks[b].code[i] = copy2{inst.data,   inst.type,
-                                 rret_data(), rret_type()};
+void lower(VLS& env, syncvmret& inst, Vlabel b, size_t i) {
+  env.unit.blocks[b].code[i] = copy2{inst.data,   inst.type,
+                                     rret_data(), rret_type()};
+}
+void lower(VLS& env, vregrestrict& inst, Vlabel b, size_t i) {
+  env.vreg_restrict_level--;
+  env.unit.blocks[b].code[i] = nop{};
+}
+void lower(VLS& env, vregunrestrict& inst, Vlabel b, size_t i) {
+  env.vreg_restrict_level++;
+  env.unit.blocks[b].code[i] = nop{};
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -256,13 +310,13 @@ void lower(Vunit& unit, syncvmret& inst, Vlabel b, size_t i) {
 
 ///////////////////////////////////////////////////////////////////////////////
 
-void vlower(Vunit& unit, Vlabel b, size_t i) {
-  auto& inst = unit.blocks[b].code[i];
+void vlower(VLS& env, Vlabel b, size_t i) {
+  auto& inst = env.unit.blocks[b].code[i];
 
   switch (inst.op) {
 #define O(name, ...)                    \
     case Vinstr::name:                  \
-      lower(unit, inst.name##_, b, i);  \
+      lower(env, inst.name##_, b, i);  \
       break;
 
     VASM_OPCODES

--- a/hphp/runtime/vm/jit/vasm-lower.h
+++ b/hphp/runtime/vm/jit/vasm-lower.h
@@ -25,6 +25,18 @@ namespace HPHP { namespace jit {
 
 struct Vunit;
 
+/*
+ * Vasm-to-vasm lowering state.
+ */
+struct VLS {
+  Vunit& unit;
+  int vreg_restrict_level;
+
+  bool allow_vreg() const {
+    return vreg_restrict_level >= 0;
+  }
+};
+
 ///////////////////////////////////////////////////////////////////////////////
 
 /*
@@ -32,7 +44,7 @@ struct Vunit;
  *
  * The `lower_impl' callback should have the signature:
  *
- *    void lower_impl(Vinstr& inst, Vlabel b, size_t i);
+ *    void lower_impl(const VLS& env, Vinstr& inst, Vlabel b, size_t i);
  *
  * where `b' and `i' are the block and code index of `inst' in `unit'.  This
  * callback is responsible for any architecture-specific lowering that is
@@ -47,7 +59,7 @@ void vasm_lower(Vunit& unit, Vlower lower_impl);
  * Replaces the instruction at `unit.blocks[b].code[i]` with an appropriate
  * sequence of one or more instructions.
  */
-void vlower(Vunit& unit, Vlabel b, size_t i);
+void vlower(VLS& env, Vlabel b, size_t i);
 
 ///////////////////////////////////////////////////////////////////////////////
 

--- a/hphp/runtime/vm/jit/vasm-ppc64.cpp
+++ b/hphp/runtime/vm/jit/vasm-ppc64.cpp
@@ -1362,7 +1362,7 @@ void lowerForPPC64(Vout& v, decqmlock& inst) {
  * that intend to deal with smaller data will actually operate on 64bits
  */
 void lowerForPPC64(Vunit& unit) {
-  vasm_lower(unit, [&] (Vinstr& inst, Vlabel b, size_t i) {
+  vasm_lower(unit, [&] (const VLS& env, Vinstr& inst, Vlabel b, size_t i) {
     vmodify(unit, b, i, [&] (Vout& v) {
       switch (inst.op) {
 #define O(name, imms, uses, defs)                         \

--- a/hphp/runtime/vm/jit/vasm-x64.cpp
+++ b/hphp/runtime/vm/jit/vasm-x64.cpp
@@ -1023,7 +1023,7 @@ void lower(Vunit& unit, movtql& inst, Vlabel b, size_t i) {
  * Lower a few abstractions to facilitate straightforward x64 codegen.
  */
 void lowerForX64(Vunit& unit) {
-  vasm_lower(unit, [&] (Vinstr& inst, Vlabel b, size_t i) {
+  vasm_lower(unit, [&] (const VLS& env, Vinstr& inst, Vlabel b, size_t i) {
     switch (inst.op) {
 #define O(name, ...)                      \
       case Vinstr::name:                  \


### PR DESCRIPTION
Previously the dec ref stub made use of cmplim and declm, which when
lowered on AArch64 would use virtuals. This problem was originally
addressed with special vasm variations which when lowered/emitted for
AArch64 would avoid the use of new virtuals.

The new solution introduces a flag, `fast`, in the `Vunit` which indicates to
any relevant lowerers that the platform's rAsm should be used instead of
new virtuals.
