### PR TITLE
Fix GP args to include r10 on PPC64

### DIFF
--- a/hphp/runtime/vm/jit/abi-ppc64.cpp
+++ b/hphp/runtime/vm/jit/abi-ppc64.cpp
@@ -123,7 +123,7 @@ const Abi helper_abi {
 };
 
 constexpr PhysReg gp_args[] = {
-  reg::r3, reg::r4, reg::r5, reg::r6, reg::r7, reg::r8, reg::r9
+  reg::r3, reg::r4, reg::r5, reg::r6, reg::r7, reg::r8, reg::r9, reg::r10
 };
 
 constexpr PhysReg simd_args[] = {


### PR DESCRIPTION
Somehow only r3-r9 were defined although the ABI points out that r10 is
also a GP arg. This didn't bring problems to PPC64 before as it's rare
to call a function with so many arguments however the msg_receive
function is one of them and the garbage it used was valid for most of
the time.  (The issue happened when installing hhvm to
/usr/local/bin/hhvm and running hphp/test/run)

When calling a function with 8 GP args, HHVM was spilling the 8th
argument onto the stack (and keeping 16-bytes alignment, of course)
before setting all the other register arguments:
addi    r3,r31,-128
addi    r27,r27,-8
stdu    r3,-8(r27)

But msg_receive was reading from r10 even if it was undefined, therefore
garbage was being read. Now it correctly sets it as:
addi    r10,r31,-128