### PR TITLE
Add pg_set_error_verbosity

### DIFF
--- a/hphp/runtime/ext/pgsql/ext_pgsql.php
+++ b/hphp/runtime/ext/pgsql/ext_pgsql.php
@@ -311,6 +311,9 @@ function pg_send_query(resource $connection, string $query): bool;
 function pg_set_client_encoding(resource $connection, string $encoding): int;
 
 <<__Native>>
+function pg_set_error_verbosity(resource $connection, int $verbosity): mixed;
+
+<<__Native>>
 function pg_trace(string $pathname, string $mode, resource $connection): bool;
 
 <<__Native>>

--- a/hphp/runtime/ext/pgsql/pgsql.cpp
+++ b/hphp/runtime/ext/pgsql/pgsql.cpp
@@ -808,6 +808,21 @@ static Variant HHVM_FUNCTION(pg_client_encoding, const Resource& connection) {
   return ret;
 }
 
+static Variant HHVM_FUNCTION(pg_set_error_verbosity,
+  const Resource& connection, int64_t verbosity) {
+  auto pgsql = PGSQL::Get(connection);
+
+  if (!pgsql) {
+    return false;
+  }
+
+  if (verbosity & (PQERRORS_TERSE|PQERRORS_DEFAULT|PQERRORS_VERBOSE)) {
+    return pgsql->get().setErrorVerbosity(verbosity);
+  }
+
+  return false;
+}
+
 static int64_t HHVM_FUNCTION(pg_transaction_status,
   const Resource& connection) {
   auto pgsql = PGSQL::Get(connection);
@@ -1708,6 +1723,7 @@ static struct pgsqlExtension : Extension {
     HHVM_FE(pg_send_prepare);
     HHVM_FE(pg_send_query_params);
     HHVM_FE(pg_send_query);
+    HHVM_FE(pg_set_error_verbosity);
     HHVM_FE(pg_transaction_status);
     HHVM_FE(pg_unescape_bytea);
     HHVM_FE(pg_version);

--- a/hphp/runtime/ext/pgsql/pq.h
+++ b/hphp/runtime/ext/pgsql/pq.h
@@ -343,6 +343,10 @@ struct Connection {
     return pg_encoding_to_char(enc);
   }
 
+  PGVerbosity setErrorVerbosity(int verbosity) {
+    return PQsetErrorVerbosity(m_conn, (PGVerbosity) verbosity);
+  }
+
   int backendPID() {
     return PQbackendPID(m_conn);
   }


### PR DESCRIPTION
See http://php.net/pg_set_error_verbosity for what it is. The constants
already exist, so didn't need to add them.

Part of the fix for #7320