### PR TITLE
Add support for multiple seperators in a DSN

### DIFF
--- a/hphp/runtime/ext/pdo/pdo_driver.cpp
+++ b/hphp/runtime/ext/pdo/pdo_driver.cpp
@@ -100,8 +100,8 @@ int PDOConnection::parseDataSource(const char *data_source,
                                    int data_source_len,
                                    struct pdo_data_src_parser *parsed,
                                    int nparams,
-                                   const char *seperators/* = ";" */,
-                                   int seperatorCount/* = 1 */) {
+                                   const char *separators/* = ";" */,
+                                   int separatorCount/* = 1 */) {
   int i, j;
   int valstart = -1;
   int semi = -1;
@@ -110,7 +110,7 @@ int PDOConnection::parseDataSource(const char *data_source,
   int n_matches = 0;
 
   char flags[256];
-  string_charmask(seperators, seperatorCount, flags);
+  string_charmask(separators, separatorCount, flags);
 
   // Can always end with \0
   flags[0] = 1;
@@ -130,7 +130,7 @@ int PDOConnection::parseDataSource(const char *data_source,
 
     valstart = ++i;
 
-    /* now we're looking for VALUE<seperator> or just VALUE<NUL> */
+    /* now we're looking for VALUE<separator> or just VALUE<NUL> */
     semi = -1;
     while (i < data_source_len) {
       if (flags[(unsigned char)data_source[i]]) {

--- a/hphp/runtime/ext/pdo/pdo_driver.cpp
+++ b/hphp/runtime/ext/pdo/pdo_driver.cpp
@@ -29,6 +29,7 @@
 #endif
 #include "hphp/runtime/ext/std/ext_std_variable.h"
 #include "hphp/runtime/base/builtin-functions.h"
+#include "hphp/runtime/base/zend-string.h"
 
 namespace HPHP {
 ///////////////////////////////////////////////////////////////////////////////
@@ -98,13 +99,21 @@ bool PDOConnection::support(SupportedMethod method) {
 int PDOConnection::parseDataSource(const char *data_source,
                                    int data_source_len,
                                    struct pdo_data_src_parser *parsed,
-                                   int nparams) {
+                                   int nparams,
+                                   const char *seperators/* = ";" */,
+                                   int seperatorCount/* = 1 */) {
   int i, j;
   int valstart = -1;
   int semi = -1;
   int optstart = 0;
   int nlen;
   int n_matches = 0;
+
+  char flags[256];
+  string_charmask(seperators, seperatorCount, flags);
+
+  // Can always end with \0
+  flags[0] = 1;
 
   i = 0;
   while (i < data_source_len) {
@@ -121,14 +130,10 @@ int PDOConnection::parseDataSource(const char *data_source,
 
     valstart = ++i;
 
-    /* now we're looking for VALUE; or just VALUE<NUL> */
+    /* now we're looking for VALUE<seperator> or just VALUE<NUL> */
     semi = -1;
     while (i < data_source_len) {
-      if (data_source[i] == '\0') {
-        semi = i++;
-        break;
-      }
-      if (data_source[i] == ';') {
+      if (flags[(unsigned char)data_source[i]]) {
         semi = i++;
         break;
       }

--- a/hphp/runtime/ext/pdo/pdo_driver.h
+++ b/hphp/runtime/ext/pdo/pdo_driver.h
@@ -433,7 +433,9 @@ protected:
   int parseDataSource(const char *data_source,
                       int data_source_len,
                       struct pdo_data_src_parser *parsed,
-                      int nparams);
+                      int nparams,
+                      const char* seperators = ";",
+                      int seperatorCount = 1);
 };
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/hphp/runtime/ext/pdo/pdo_driver.h
+++ b/hphp/runtime/ext/pdo/pdo_driver.h
@@ -434,8 +434,8 @@ protected:
                       int data_source_len,
                       struct pdo_data_src_parser *parsed,
                       int nparams,
-                      const char* seperators = ";",
-                      int seperatorCount = 1);
+                      const char* separators = ";",
+                      int separatorCount = 1);
 };
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/hphp/runtime/ext/pgsql/pdo_pgsql_connection.cpp
+++ b/hphp/runtime/ext/pgsql/pdo_pgsql_connection.cpp
@@ -66,7 +66,7 @@ bool PDOPgSqlConnection::create(const Array &options){
     { "user", nullptr, 0 },
     { "password", nullptr, 0 }
   };
-  parseDataSource(data_source.data(), data_source.size(), vars, 5);
+  parseDataSource(data_source.data(), data_source.size(), vars, 5, "; ", 2);
 
   std::stringstream conninfo;
   conninfo << "host='";


### PR DESCRIPTION
pdo_pgsql allows seperatoring values with a space as well as a
semicolon. Add support to the DSN parser for multiple seperator
characters and set pdo_pgsql to allow ';' and ' '. pdo_mysql, currently
the only other connector using this parser, does not change.

Fixes #7399.