### PR TITLE
Fix tc-print not mapping translations to bytecode

### DIFF
--- a/hphp/runtime/vm/repo-helpers.cpp
+++ b/hphp/runtime/vm/repo-helpers.cpp
@@ -404,7 +404,7 @@ void RepoQuery::getMd5(int iCol, MD5& md5) {
       " (expected 16, got %zu) in '%s'",
       __func__, &m_stmt.repo(), iCol, size, m_stmt.sql().c_str());
   }
-  new (&md5) MD5(blob);
+  new (&md5) MD5(blob, size);
 }
 
 void RepoQuery::getTypedValue(int iCol, TypedValue& tv) {

--- a/hphp/util/md5.h
+++ b/hphp/util/md5.h
@@ -53,7 +53,8 @@ struct MD5 : private boost::totally_ordered<MD5> {
   }
 
   // Blob is assumed to be in network byte order.
-  explicit MD5(const void* blob) {
+  explicit MD5(const void* blob, size_t len) {
+    assertx(len == 16);
     q[0] = ntohq(((const uint64_t*)blob)[0]);
     q[1] = ntohq(((const uint64_t*)blob)[1]);
   }


### PR DESCRIPTION
Commit c28f559 changed MD5's constructor to take a folly::StringPiece parameter
instead of a char*. This was causing OfflineTransData::loadTCData to call the
wrong MD5 constructor; hence an incorrect function md5 was being read from the
tcdata archive.  This diff solves the problem by packing the md5 string into a
StringPiece object.
Fixex #7302.