### PR TITLE
Fix sign ext/mov vasms for PPC64.

### DIFF
--- a/hphp/ppc64-asm/asm-ppc64.cpp
+++ b/hphp/ppc64-asm/asm-ppc64.cpp
@@ -269,11 +269,11 @@ void Assembler::extsb(const Reg64& ra, const Reg64& rs, bool rc) {
 }
 
 void Assembler::extsh(const Reg64& ra, const Reg64& rs, bool rc) {
-  EmitXForm(31, rn(rs), rn(ra), rn(0), 922);
+  EmitXForm(31, rn(rs), rn(ra), rn(0), 922, rc);
 }
 
 void Assembler::extsw(const Reg64& ra, const Reg64& rs, bool rc) {
-  EmitXForm(31, rn(rs), rn(ra), rn(0), 986);
+  EmitXForm(31, rn(rs), rn(ra), rn(0), 986, rc);
 }
 
 void Assembler::isel(const Reg64& rt, const Reg64& ra, const Reg64& rb,

--- a/hphp/runtime/vm/jit/vasm-dead.cpp
+++ b/hphp/runtime/vm/jit/vasm-dead.cpp
@@ -86,7 +86,7 @@ bool effectful(Vinstr& inst) {
     case Vinstr::divint:
     case Vinstr::divsd:
     case Vinstr::extsb:
-    case Vinstr::extsw:
+    case Vinstr::extsl:
     case Vinstr::fabs:
     case Vinstr::fcmpo:
     case Vinstr::fcmpu:

--- a/hphp/runtime/vm/jit/vasm-dead.cpp
+++ b/hphp/runtime/vm/jit/vasm-dead.cpp
@@ -85,8 +85,6 @@ bool effectful(Vinstr& inst) {
     case Vinstr::defvmsp:
     case Vinstr::divint:
     case Vinstr::divsd:
-    case Vinstr::extrb:
-    case Vinstr::extrw:
     case Vinstr::extsb:
     case Vinstr::extsw:
     case Vinstr::fabs:

--- a/hphp/runtime/vm/jit/vasm-instr.cpp
+++ b/hphp/runtime/vm/jit/vasm-instr.cpp
@@ -207,7 +207,7 @@ Width width(Vinstr::Opcode op) {
     case Vinstr::uxth:
     // ppc64 instructions
     case Vinstr::extsb:
-    case Vinstr::extsw:
+    case Vinstr::extsl:
     case Vinstr::fcmpo:
     case Vinstr::fcmpu:
     case Vinstr::fctidz:

--- a/hphp/runtime/vm/jit/vasm-instr.cpp
+++ b/hphp/runtime/vm/jit/vasm-instr.cpp
@@ -206,8 +206,6 @@ Width width(Vinstr::Opcode op) {
     case Vinstr::subsb:
     case Vinstr::uxth:
     // ppc64 instructions
-    case Vinstr::extrb:
-    case Vinstr::extrw:
     case Vinstr::extsb:
     case Vinstr::extsw:
     case Vinstr::fcmpo:

--- a/hphp/runtime/vm/jit/vasm-instr.h
+++ b/hphp/runtime/vm/jit/vasm-instr.h
@@ -316,8 +316,6 @@ struct Vunit;
   O(subsb, Inone, UA(s0) U(s1), D(d) D(sf))\
   O(uxth, Inone, U(s), D(d))\
   /* ppc64 instructions */\
-  O(extrb, Inone, UH(s,d), DH(d,s))\
-  O(extrw, Inone, UH(s,d), DH(d,s))\
   O(extsb, Inone, UH(s,d), DH(d,s))\
   O(extsw, Inone, UH(s,d), DH(d,s))\
   O(fcmpo, Inone, U(s0) U(s1), D(sf))\
@@ -1156,10 +1154,8 @@ struct uxth { Vreg16 s; Vreg32 d; };
 /*
  * ppc64 intrinsics.
  */
-struct extrb { Vreg8 s; Vreg8 d; };   // Extract and zeros the upper bits
-struct extrw { Vreg16 s; Vreg64 d; }; // Extract and zeros the upper bits
-struct extsb { Vreg64 s; Vreg64 d; }; // Extend byte sign
-struct extsw { Vreg64 s; Vreg64 d; }; // Extend word sign
+struct extsb { Vreg8 s; Vreg64 d; };  // Extend byte sign
+struct extsw { Vreg32 s; Vreg64 d; }; // Extend word sign
 struct fcmpo { VregDbl s0; VregDbl s1; VregSF sf; };
 struct fcmpu { VregDbl s0; VregDbl s1; VregSF sf; };
 struct fctidz { VregDbl s; VregDbl d; VregSF sf; };

--- a/hphp/runtime/vm/jit/vasm-instr.h
+++ b/hphp/runtime/vm/jit/vasm-instr.h
@@ -317,7 +317,7 @@ struct Vunit;
   O(uxth, Inone, U(s), D(d))\
   /* ppc64 instructions */\
   O(extsb, Inone, UH(s,d), DH(d,s))\
-  O(extsw, Inone, UH(s,d), DH(d,s))\
+  O(extsl, Inone, UH(s,d), DH(d,s))\
   O(fcmpo, Inone, U(s0) U(s1), D(sf))\
   O(fcmpu, Inone, U(s0) U(s1), D(sf))\
   O(fctidz, Inone, U(s), D(d) D(sf))\
@@ -1155,7 +1155,7 @@ struct uxth { Vreg16 s; Vreg32 d; };
  * ppc64 intrinsics.
  */
 struct extsb { Vreg8 s; Vreg64 d; };  // Extend byte sign
-struct extsw { Vreg32 s; Vreg64 d; }; // Extend word sign
+struct extsl { Vreg32 s; Vreg64 d; }; // Extend word sign
 struct fcmpo { VregDbl s0; VregDbl s1; VregSF sf; };
 struct fcmpu { VregDbl s0; VregDbl s1; VregSF sf; };
 struct fctidz { VregDbl s; VregDbl d; VregSF sf; };

--- a/hphp/runtime/vm/jit/vasm-ppc64.cpp
+++ b/hphp/runtime/vm/jit/vasm-ppc64.cpp
@@ -211,7 +211,7 @@ struct Vgen {
   void emit(const divint& i) { a.divd(i.d,  i.s0, i.s1, false); }
   void emit(const divsd& i) { a.fdiv(i.d, i.s1, i.s0); }
   void emit(const extsb& i) { a.extsb(i.d, Reg64(i.s)); }
-  void emit(const extsw& i) { a.extsw(i.d, Reg64(i.s)); }
+  void emit(const extsl& i) { a.extsw(i.d, Reg64(i.s)); }
   void emit(const fabs& i) { a.fabs(i.d, i.s, false); }
   void emit(const fallthru& i) {}
   void emit(const fcmpo& i) {
@@ -1062,19 +1062,6 @@ X(cmpwm,  cmpq,  loadw, ONE_R64(s0))
 
 #undef X
 
-/*#define X(vasm_src, vasm_dst, vasm_load, attr_addr, attr)               \
-void lowerForPPC64(Vout& v, vasm_src& inst) {                           \
-  Vreg tmp = v.makeReg();                                               \
-  Vptr p = inst.attr_addr;                                              \
-  v << vasm_load{p, tmp};                                               \
-  v << vasm_dst{Reg64(inst.attr), tmp, inst.sf};                        \
-}
-
-X(cmpbm, cmpq, loadb, s1, s0)
-X(cmpwm, cmpq, loadw, s1, s0)
-
-#undef X*/
-
 #define X(vasm_src, vasm_dst, vasm_ext, operands)                       \
 void lowerForPPC64(Vout& v, vasm_src& inst) {                           \
   Vreg tmp1 = v.makeReg(), tmp2 = v.makeReg();                          \
@@ -1085,8 +1072,8 @@ void lowerForPPC64(Vout& v, vasm_src& inst) {                           \
 
 X(cmpb,  cmpq,  movzbq, NONE)
 X(testb, testq, extsb,  NONE)
-X(testl, testq, extsw,  NONE)
-X(subl,  subq,  extsw,  ONE_R64(d))
+X(testl, testq, extsl,  NONE)
+X(subl,  subq,  extsl,  ONE_R64(d))
 
 #undef X
 
@@ -1099,9 +1086,9 @@ void lowerForPPC64(Vout& v, vasm_src& inst) {                           \
 
 X(cmpbi,  cmpqi,  movzbq, NONE)
 X(subbi,  subqi,  extsb,  ONE_R64(d))
-X(subli,  subqi,  extsw,  ONE_R64(d))
+X(subli,  subqi,  extsl,  ONE_R64(d))
 X(testbi, testqi, extsb,  NONE)
-X(testli, testqi, extsw,  NONE)
+X(testli, testqi, extsl,  NONE)
 
 #undef X
 

--- a/hphp/runtime/vm/jit/vasm-reg.h
+++ b/hphp/runtime/vm/jit/vasm-reg.h
@@ -55,6 +55,7 @@ struct Vreg {
   explicit Vreg(size_t r) : rn(r) {}
   /* implicit */ Vreg(Reg64 r)  : rn(int(r)) {}
   /* implicit */ Vreg(Reg32 r)  : rn(int(r)) {}
+  /* implicit */ Vreg(Reg16 r)  : rn(int(r)) {}
   /* implicit */ Vreg(Reg8 r)   : rn(int(r)) {}
   /* implicit */ Vreg(RegXMM r) : rn(X0+int(r)) {}
   /* implicit */ Vreg(RegSF r)  : rn(S0+int(r)) {}

--- a/hphp/runtime/vm/jit/vasm-simplify.cpp
+++ b/hphp/runtime/vm/jit/vasm-simplify.cpp
@@ -398,7 +398,6 @@ bool simplify(Env& env, const copyargs& inst, Vlabel b, size_t i) {
 }
 
 bool simplify(Env& env, const movzlq& inst, Vlabel b, size_t i) {
-  if (!arch_any(Arch::X64, Arch::ARM)) return false;
   auto const def_op = env.def_insts[inst.s];
 
   // Check if `inst.s' was defined by an instruction with Vreg32 operands, or

--- a/hphp/runtime/vm/jit/vasm-util.cpp
+++ b/hphp/runtime/vm/jit/vasm-util.cpp
@@ -29,9 +29,7 @@ bool is_nop(const copy& i) { return i.s == i.d; }
 bool is_nop(const copy2& i) { return i.s0 == i.d0 && i.s1 == i.d1; }
 
 // movb r,r is a nop, however movl is not since it zeros upper bits.
-bool is_nop(const movb& i) {
-  return i.s == i.d;
-}
+bool is_nop(const movb& i) { return i.s == i.d; }
 
 bool is_nop(const lea& i) {
   if (i.s.disp != 0) return false;

--- a/hphp/runtime/vm/jit/vasm-util.cpp
+++ b/hphp/runtime/vm/jit/vasm-util.cpp
@@ -30,9 +30,6 @@ bool is_nop(const copy2& i) { return i.s0 == i.d0 && i.s1 == i.d1; }
 
 // movb r,r is a nop, however movl is not since it zeros upper bits.
 bool is_nop(const movb& i) {
-  // On PPC64 movb r,r cannot be considered a trivial nop since it zeros
-  // upper bits
-  if (arch() == Arch::PPC64) return false;
   return i.s == i.d;
 }
 

--- a/hphp/runtime/vm/jit/vasm-util.cpp
+++ b/hphp/runtime/vm/jit/vasm-util.cpp
@@ -29,7 +29,12 @@ bool is_nop(const copy& i) { return i.s == i.d; }
 bool is_nop(const copy2& i) { return i.s0 == i.d0 && i.s1 == i.d1; }
 
 // movb r,r is a nop, however movl is not since it zeros upper bits.
-bool is_nop(const movb& i) { return i.s == i.d; }
+bool is_nop(const movb& i) {
+  // On PPC64 movb r,r cannot be considered a trivial nop since it zeros
+  // upper bits
+  if (arch() == Arch::PPC64) return false;
+  return i.s == i.d;
+}
 
 bool is_nop(const lea& i) {
   if (i.s.disp != 0) return false;


### PR DESCRIPTION
Summary:

This commit fixes move and (signal) extensions vasms for PPC64. Some vasms
that needs to move values less than 64 bits to 64 bits registers. Those vasms were 
translated to pairs that mov and sign extend (rlwinm + exts*) that are used even 
when a sign extended are not intended like movz* or bitwise (xor*, and*) 
which can lead to a wrong behaviour or emit a extra useless sign extend/mov instruction.

This commit also fixes some lowers that uses the same VReg in instructions 
with operands that have different. Some lowered vasms are using movb and use 
the result (VReg8) in operations that use VReg64 as input operands when we should 
use movzbq in those cases. 

To summarize this fix:

- Delete some redundant/wrong move instructions on sign extension instructions.
- Fix the problem with replacement by a nop when mov{r,r}. Some lowering instructions 
like was using movb instructions, remove the instruction lead to invalid values 
on registers. Replaced by movzbq.
- Replace movb/ext by instruction versions that have operands with correctly 
width avoiding use the same Vreg in instructions that expect operands with different 
widths.
- Refactor some of X lower macros.
- Avoid lower instructions that can be emitted directly.
- Kill two ppc64 intrinsic unused vasms extrb and extrw.
- Vasm instruction extsw was changed to extsl. Using 'l' suffix to maintain name 
convention. Change first operand to VReg32 as we expect a 32 bit VReg as src 
operand.
- Remove some weird calculations for mask size when map mov* instructions to
  ppc64 asm.
- Fix extsw, extsh on ppc assembler to include Rc parameter even if we don't emit 
Rc (CR record) version of those instructions.