### PR TITLE
[Aarch64] Remove -fsigned-char flag and fix resulting failure

### DIFF
--- a/CMake/HPHPCompiler.cmake
+++ b/CMake/HPHPCompiler.cmake
@@ -183,9 +183,6 @@ if (${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang" OR ${CMAKE_CXX_COMPILER_ID} STREQU
 
     # ARM64
     if(IS_AARCH64)
-      # Force char type to be signed, which is not the case on aarch64.
-      list(APPEND GENERAL_OPTIONS "fsigned-char")
-
       # If a CPU was specified, build a -mcpu option for the compiler.
       set(CPU "" CACHE STRING "CPU to tell gcc to optimize for (-mcpu)")
       if(CPU)

--- a/hphp/runtime/ext/fileinfo/libmagic/apprentice.cpp
+++ b/hphp/runtime/ext/fileinfo/libmagic/apprentice.cpp
@@ -1267,7 +1267,7 @@ file_signextend(struct magic_set *ms, struct magic *m, uint64_t v)
      * the sign extension must have happened.
      */
     case FILE_BYTE:
-      v = (char) v;
+      v = (signed char) v;
       break;
     case FILE_SHORT:
     case FILE_BESHORT:


### PR DESCRIPTION
Remove the -fsigned-char flag for Aarch64 systems. As a result,
the unit test zend/good/ext/fileinfo/tests/finfo_file_002.php
began failing. Thus, this patch changes a cast to (signed char),
and the unit test passes again.