### PR TITLE
[Aarch64] Add etch helpers to aid assembly routines

### DIFF
--- a/hphp/util/etch-helpers.h
+++ b/hphp/util/etch-helpers.h
@@ -68,10 +68,6 @@
 #define ETCH_ARG4       %x3
 #define ETCH_ARG5       %x4
 #define ETCH_ARG6       %x5
-#define ETCH_ARG7       %x6
-#define ETCH_ARG8       %x7
-#define ETCH_GET_ARG5   /* not used */
-#define ETCH_GET_ARG6   /* not used */
 
 #else /* Other x86 (e.g. linux) */
 #define CFI(x)            .cfi_##x

--- a/hphp/util/etch-helpers.h
+++ b/hphp/util/etch-helpers.h
@@ -49,6 +49,30 @@
 #define ETCH_GET_ARG6     /* not used */
 #define ETCH_RET1         %rax
 
+#elif defined(__aarch64__)
+#define CFI(x)          .cfi_##x
+#define CFI2(x, y)      .cfi_##x y
+#define CFI3C(x, y, z)  .cfi_##x y##, z
+#define ETCH_ALIGN16    .align 16
+#define ETCH_ALIGN8     .align 8
+#define ETCH_ALIGN4     .align 4
+#define ETCH_SECTION(x) .section .text.x,"ax"
+#define ETCH_SIZE(x)    .size x, .-x
+#define ETCH_NAME(x)    x
+#define ETCH_LABEL(x)   .L##x
+#define ETCH_TYPE(x, y) .type x, y
+#define ETCH_NAME_REL(x) $ x
+#define ETCH_ARG1       %x0
+#define ETCH_ARG2       %x1
+#define ETCH_ARG3       %x2
+#define ETCH_ARG4       %x3
+#define ETCH_ARG5       %x4
+#define ETCH_ARG6       %x5
+#define ETCH_ARG7       %x6
+#define ETCH_ARG8       %x7
+#define ETCH_GET_ARG5   /* not used */
+#define ETCH_GET_ARG6   /* not used */
+
 #else /* Other x86 (e.g. linux) */
 #define CFI(x)            .cfi_##x
 #define CFI2(x, y)        .cfi_##x y

--- a/hphp/util/etch-helpers.h
+++ b/hphp/util/etch-helpers.h
@@ -53,9 +53,9 @@
 #define CFI(x)          .cfi_##x
 #define CFI2(x, y)      .cfi_##x y
 #define CFI3C(x, y, z)  .cfi_##x y##, z
-#define ETCH_ALIGN16    .align 16
-#define ETCH_ALIGN8     .align 8
-#define ETCH_ALIGN4     .align 4
+#define ETCH_ALIGN16    .align 4
+#define ETCH_ALIGN8     .align 3
+#define ETCH_ALIGN4     .align 2
 #define ETCH_SECTION(x) .section .text.x,"ax"
 #define ETCH_SIZE(x)    .size x, .-x
 #define ETCH_NAME(x)    x

--- a/hphp/util/etch-helpers.h
+++ b/hphp/util/etch-helpers.h
@@ -53,9 +53,9 @@
 #define CFI(x)          .cfi_##x
 #define CFI2(x, y)      .cfi_##x y
 #define CFI3C(x, y, z)  .cfi_##x y##, z
-#define ETCH_ALIGN16    .align 4
-#define ETCH_ALIGN8     .align 3
-#define ETCH_ALIGN4     .align 2
+#define ETCH_ALIGN16    .balign 16
+#define ETCH_ALIGN8     .balign 8
+#define ETCH_ALIGN4     .balign 4
 #define ETCH_SECTION(x) .section .text.x,"ax"
 #define ETCH_SIZE(x)    .size x, .-x
 #define ETCH_NAME(x)    x


### PR DESCRIPTION
Add the etch helpers for aarch64 targets. This patch will aid in
writing assembly routines for CRC hash routines.