### PR TITLE
[hack] use Rpredicated reason for all is_<builtin_type> funcs

### DIFF
--- a/hphp/hack/src/typing/typing.ml
+++ b/hphp/hack/src/typing/typing.ml
@@ -3765,21 +3765,21 @@ and condition env tparamet =
   | _, Call (Cnormal, (p, Id (_, f)), [lv], [])
     when tparamet && f = SN.StdlibFunctions.is_keyset ->
       is_array env `HackKeyset p f lv
-  | _, Call (Cnormal, (_, Id (_, f)), [lv], [])
+  | _, Call (Cnormal, (p, Id (_, f)), [lv], [])
     when tparamet && f = SN.StdlibFunctions.is_int ->
-      is_type env lv Tint
-  | _, Call (Cnormal, (_, Id (_, f)), [lv], [])
+      is_type env lv Tint (Reason.Rpredicated (p, f))
+  | _, Call (Cnormal, (p, Id (_, f)), [lv], [])
     when tparamet && f = SN.StdlibFunctions.is_bool ->
-      is_type env lv Tbool
-  | _, Call (Cnormal, (_, Id (_, f)), [lv], [])
+      is_type env lv Tbool (Reason.Rpredicated (p, f))
+  | _, Call (Cnormal, (p, Id (_, f)), [lv], [])
     when tparamet && f = SN.StdlibFunctions.is_float ->
-      is_type env lv Tfloat
-  | _, Call (Cnormal, (_, Id (_, f)), [lv], [])
+      is_type env lv Tfloat (Reason.Rpredicated (p, f))
+  | _, Call (Cnormal, (p, Id (_, f)), [lv], [])
     when tparamet && f = SN.StdlibFunctions.is_string ->
-      is_type env lv Tstring
-  | _, Call (Cnormal, (_, Id (_, f)), [lv], [])
+      is_type env lv Tstring (Reason.Rpredicated (p, f))
+  | _, Call (Cnormal, (p, Id (_, f)), [lv], [])
     when tparamet && f = SN.StdlibFunctions.is_resource ->
-      is_type env lv Tresource
+      is_type env lv Tresource (Reason.Rpredicated (p, f))
   | _, Unop (Ast.Unot, e) ->
       condition env (not tparamet) e
   | p, InstanceOf (ivar, cid) when tparamet && is_instance_var ivar ->
@@ -3961,16 +3961,16 @@ and check_null_wtf env p ty =
         | Tfun _ | Tabstract (_, _) | Tclass (_, _) | Ttuple _ | Tanon (_, _)
         | Tunresolved _ | Tobject | Tshape _ ) -> env
 
-and is_type env e tprim =
+and is_type env e tprim r =
   match e with
     | p, Class_get (cname, (_, member_name)) ->
       let env, local = Env.FakeMembers.make_static p env cname member_name in
-      Env.set_local env local (Reason.Rwitness p, Tprim tprim)
+      Env.set_local env local (r, Tprim tprim)
     | p, Obj_get ((_, This | _, Lvar _ as obj), (_, Id (_, member_name)), _) ->
       let env, local = Env.FakeMembers.make p env obj member_name in
-      Env.set_local env local (Reason.Rwitness p, Tprim tprim)
-    | _, Lvar (p, x) ->
-      Env.set_local env x (Reason.Rwitness p, Tprim tprim)
+      Env.set_local env local (r, Tprim tprim)
+    | _, Lvar (_px, x) ->
+      Env.set_local env x (r, Tprim tprim)
     | _ -> env
 
 (* Refine type for is_array, is_vec, is_keyset and is_dict tests

--- a/hphp/hack/src/typing/typing_reason.ml
+++ b/hphp/hack/src/typing/typing_reason.ml
@@ -187,7 +187,7 @@ let rec to_string prefix r =
   | Rused_as_shape _ ->
       [(p, prefix ^ " because it is used as shape-like array here")]
   | Rpredicated (p, f) ->
-      [(p, prefix ^ " from the condition on the predicate " ^ f)]
+      [(p, prefix ^ " from the argument to this "^ f ^" test")]
   | Rinstanceof (p,s) ->
       [(p, prefix ^ " from this instanceof test matching " ^ s)]
 

--- a/hphp/hack/test/typecheck/keyset/is_keyset_fail.php.exp
+++ b/hphp/hack/test/typecheck/keyset/is_keyset_fail.php.exp
@@ -7,4 +7,4 @@ File "is_keyset_fail.php", line 4, characters 7-15:
 File "is_keyset_fail.php", line 3, characters 30-35:
 This is a string
 File "is_keyset_fail.php", line 4, characters 7-15:
-It is incompatible with an array key (int/string) from the condition on the predicate \is_keyset
+It is incompatible with an array key (int/string) from the argument to this \is_keyset test

--- a/hphp/hack/test/typecheck/predicate.php
+++ b/hphp/hack/test/typecheck/predicate.php
@@ -1,0 +1,9 @@
+<?hh // strict
+
+function takes_int(int $x): void {}
+
+function test($arg): void {
+  if (is_float($arg)) {
+    takes_int($arg);
+  }
+}

--- a/hphp/hack/test/typecheck/predicate.php.exp
+++ b/hphp/hack/test/typecheck/predicate.php.exp
@@ -1,0 +1,6 @@
+File "predicate.php", line 7, characters 15-18:
+Invalid argument (Typing[4110])
+File "predicate.php", line 3, characters 20-22:
+This is an int
+File "predicate.php", line 6, characters 7-14:
+It is incompatible with a float from the argument to this \is_float test

--- a/hphp/hack/test/typecheck/vec/is_vec_bad.php.exp
+++ b/hphp/hack/test/typecheck/vec/is_vec_bad.php.exp
@@ -3,4 +3,4 @@ Invalid return type (Typing[4110])
 File "is_vec_bad.php", line 4, characters 38-43:
 This is a string
 File "is_vec_bad.php", line 5, characters 7-12:
-It is incompatible with a value of generic type T#1 from the condition on the predicate \is_vec
+It is incompatible with a value of generic type T#1 from the argument to this \is_vec test


### PR DESCRIPTION
Summary: An Rpredicated reason was introduced for the predicates used
 for is_array and its Hack cousins is_{keyset,vec,dict}. For
 consistency, the same verbiage should be used for the other special
 condition predicates, namely is_{bool,int,float,string,resource}.

Test Plan:
 - added the hphp/hack/test/typecheck/predicate.php test
 - reran hphp/hack/test/typecheck (surprisingly few tests used this in their error messages)