### PR TITLE
remove unneeded assertions (Aarch64)

### DIFF
--- a/hphp/runtime/vm/jit/vasm-arm.cpp
+++ b/hphp/runtime/vm/jit/vasm-arm.cpp
@@ -106,6 +106,7 @@ int64_t MSKTOP(int64_t value) {
 vixl::MemOperand M(Vptr p) {
   assertx(p.base.isValid());
   if (p.index.isValid()) {
+    assertx(p.disp == 0);
     return MemOperand(X(p.base), X(p.index), LSL, Log2(p.scale));
   }
   return MemOperand(X(p.base), p.disp);

--- a/hphp/runtime/vm/jit/vasm-arm.cpp
+++ b/hphp/runtime/vm/jit/vasm-arm.cpp
@@ -106,10 +106,8 @@ int64_t MSKTOP(int64_t value) {
 vixl::MemOperand M(Vptr p) {
   assertx(p.base.isValid());
   if (p.index.isValid()) {
-    assertx(p.disp == 0);
     return MemOperand(X(p.base), X(p.index), LSL, Log2(p.scale));
   }
-  assertx(p.disp >= -256 && p.disp <= 255);
   return MemOperand(X(p.base), p.disp);
 }
 
@@ -744,7 +742,6 @@ void Vgen::emit(const lea& i) {
     assertx(p.disp == 0);
     a->Add(X(i.d), X(p.base), Operand(X(p.index), LSL, Log2(p.scale)));
   } else {
-    assertx(p.disp >= -256 && p.disp <= 255);
     a->Add(X(i.d), X(p.base), p.disp);
   }
 }


### PR DESCRIPTION

On a debug build for an Aarch64 host  the following test was failing due to an assertion:

hphp/test/zend/good/ext/intl/tests/grapheme.php

The assertion was not needed since the call to the macro assembler will use a temporary
if the immediate is out of range.

Additionally, two other regression tests now pass.  They are:

hphp/test/slow/stack-overflow/reenter.php
hphp/test/slow/stack-overflow/catch-trace-rematerialize.php

The change was tested with 6 different option sets.

/usr/bin/php hphp/test/run -v --no-fun -m interp  
/usr/bin/php hphp/test/run -v --no-fun -m interp -r 
/usr/bin/php hphp/test/run -v --no-fun -m jit -a '-vEval.JitPGO=0' 
/usr/bin/php hphp/test/run -v --no-fun -m jit -r -a '-vEval.JitPGO=0' 
/usr/bin/php hphp/test/run -v --no-fun -m jit -a '-vEval.JitPGO=1' 
/usr/bin/php hphp/test/run -v --no-fun -m jit -r -a '-vEval.JitPGO=1'  

This was the git log for the repository before commit
swalk@1scrb-7:~/master/hhvm$ git log | head
commit 7e3addb8bc1cf1e3dbbab2de6f1690050ea33b71
Author: Michael O'Farrell <michaelofarrell@fb.com>
Date:   Mon Nov 7 07:04:47 2016 -0800

This was the repository before I pushed the change to github
swalk@1scrb-7:~/master/hhvm_110816/hhvm$ git log | head
commit 8f964f0cc101acdc8e8c5e3d43497a6d41a6b0d0
Author: Steve Walk <Steve.Walk@cavium.com>
Date:   Wed Nov 9 07:08:25 2016 -0800

A CLA was submitted last week.

