### PR TITLE
[Aarch64] Fix decqmlock with acquire and release semantics

### DIFF
--- a/hphp/runtime/vm/jit/vasm-arm.cpp
+++ b/hphp/runtime/vm/jit/vasm-arm.cpp
@@ -667,9 +667,9 @@ void Vgen::emit(const vasm_opc& i) {   \
   auto adr = M(i.m);                   \
   vixl::Label again;                   \
   a->bind(&again);                     \
-  a->ldxr(rAsm, adr);                  \
+  a->ldaxr(rAsm, adr);                 \
   a->arm_opc(rAsm, rAsm, 1, SetFlags); \
-  a->stxr(rAsm.W(), rAsm, adr);        \
+  a->stlxr(rAsm.W(), rAsm, adr);       \
   a->Cbnz(rAsm.W(), &again);           \
 }
 

--- a/hphp/vixl/a64/assembler-a64.cc
+++ b/hphp/vixl/a64/assembler-a64.cc
@@ -1135,6 +1135,23 @@ void Assembler::ldr(const FPRegister& ft, double imm) {
 }
 
 
+void Assembler::ldaxr(const Register& rt,
+                      const MemOperand& src) {
+  assert(src.IsImmediateOffset() && (src.offset() == 0));
+  LoadStoreExclusive op = rt.Is64Bits() ? LDAXR_x : LDAXR_w;
+  Emit(op | Rs_mask | Rt(rt) | Rt2_mask | RnSP(src.base()));
+}
+
+
+void Assembler::stlxr(const Register& rs,
+                      const Register& rt,
+                      const MemOperand& dst) {
+  assert(dst.IsImmediateOffset() && (dst.offset() == 0));
+  LoadStoreExclusive op = rt.Is64Bits() ? STLXR_x : STLXR_w;
+  Emit(op | Rs(rs) | Rt(rt) | Rt2_mask | RnSP(dst.base()));
+}
+
+
 void Assembler::ldxr(const Register& rt, const MemOperand& src) {
   assert(src.IsImmediateOffset() && (src.offset() == 0));
   LoadStoreExclusive op = rt.Is64Bits() ? LDXR_x : LDXR_w;

--- a/hphp/vixl/a64/assembler-a64.h
+++ b/hphp/vixl/a64/assembler-a64.h
@@ -1112,6 +1112,12 @@ class Assembler {
   // Load literal to FP register.
   void ldr(const FPRegister& ft, double imm);
 
+  // Load-acquire exclusive register.
+  void ldaxr(const Register& rt, const MemOperand& src);
+
+  // Store-release exclusive register.
+  void stlxr(const Register& rs, const Register& rt, const MemOperand& dst);
+
   // Load exclusive register.
   void ldxr(const Register& rt, const MemOperand& src);
 


### PR DESCRIPTION
The VASM decqmlock and incqmlock have no ordering semantics when
using ldxr and stxr Aarch64 instructions. The current code is
broken and could be fixed by adding DMB barrier instructions,
however the cleaner approach taken here is to use the load-acquire
and store-release, which is equal to x86 including ordering
characteristics. This is also the same as PPC64's decqmlock.