### PR TITLE
[AArch64] Cleanup and fix abi-related vasm.

### DIFF
--- a/hphp/runtime/vm/jit/vasm-arm.cpp
+++ b/hphp/runtime/vm/jit/vasm-arm.cpp
@@ -171,29 +171,23 @@ struct Vgen {
 
   // native function abi
   void emit(const call& i);
-  void emit(const callm& i);
   void emit(const callr& i) { a->Blr(X(i.target)); }
   void emit(const calls& i);
   void emit(const ret& i) { a->Ret(); }
 
   // stub function abi
-  void emit(const stublogue& i);
-  void emit(const stubret& i);
-  void emit(const callstub& i);
   void emit(const callfaststub& i);
-  void emit(const tailcallstub& i);
+  void emit(const callstub& i);
 
   // php function abi
-  void emit(const phplogue& i);
-  void emit(const phpret& i);
   void emit(const callphp& i);
-  void emit(const tailcallphp& i);
   void emit(const callarray& i);
   void emit(const contenter& i);
 
   // vm entry abi
+  void emit(const calltc& i);
   void emit(const inittc& i) {}
-  void emit(const leavetc&);
+  void emit(const leavetc& i);
 
   // exceptions
   void emit(const landingpad& i) {}
@@ -235,7 +229,6 @@ struct Vgen {
   void emit(const jcci& i);
   void emit(const jmp& i);
   void emit(const jmpi& i);
-  void emit(const jmpm& i);
   void emit(const jmpr& i) { a->Br(X(i.target)); }
   void emit(const lea& i);
   void emit(const leap& i) { a->Mov(X(i.d), i.s.r.disp); }
@@ -308,7 +301,6 @@ struct Vgen {
   void emit(const addxi& i) { a->Add(X(i.d), X(i.s1), i.s0.q()); }
   void emit(const asrxi& i);
   void emit(const asrxis& i);
-  void emit(const bln& i);
   void emit(const cmplims& i);
   void emit(const cmpsds& i);
   void emit(const fabs& i) { a->Fabs(D(i.d), D(i.s)); }
@@ -488,71 +480,26 @@ void Vgen::emit(const call& i) {
   }
 }
 
-void Vgen::emit(const callm& i) {
-  a->Ldr(rAsm, M(i.target));
-  a->Blr(rAsm);
-}
-
 void Vgen::emit(const calls& i) {
   emitSmashableCall(a->code(), env.meta, i.target);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 
-void Vgen::emit(const stublogue& i) {
-  // Push FP, LR always regardless of i.saveframe (makes SP 16B aligned)
-  emit(pushp{rlr(), rfp()});
-}
-
-void Vgen::emit(const stubret& i) {
-  if (i.saveframe) {
-    emit(popp{rfp(), rlr()});
-  } else {
-    emit(popp{PhysReg(rAsm), rlr()});
-  }
-  emit(ret{});
+void Vgen::emit(const callfaststub& i) {
+  emit(call{i.target, i.args});
+  emit(syncpoint{i.fix});
 }
 
 void Vgen::emit(const callstub& i) {
   emit(call{i.target, i.args});
 }
 
-void Vgen::emit(const callfaststub& i) {
-  emit(call{i.target, i.args});
-  emit(syncpoint{i.fix});
-}
-
-void Vgen::emit(const tailcallstub& i) {
-  // Pop off FP/LR pair and jump to target
-  emit(popp{rfp(), rlr()});
-  emit(jmpi{i.target, i.args});
-}
-
 ///////////////////////////////////////////////////////////////////////////////
-
-void Vgen::emit(const phplogue& i) {
-  // Save LR in m_savedRip on the current VM frame pointed by 'i.fp'
-  a->Str(X(rlr()), X(i.fp)[AROFF(m_savedRip)]);
-}
-
-void Vgen::emit(const phpret& i) {
-  a->Ldr(X(rlr()), X(i.fp)[AROFF(m_savedRip)]);
-  if (!i.noframe) {
-    a->Ldr(X(i.d), X(i.fp)[AROFF(m_sfp)]);
-  }
-  emit(ret{});
-}
 
 void Vgen::emit(const callphp& i) {
   emitSmashableCall(a->code(), env.meta, i.stub);
   emit(unwind{{i.targets[0], i.targets[1]}});
-}
-
-void Vgen::emit(const tailcallphp& i) {
-  // To make callee's return as caller's return, load the return address at
-  // i.fp[AROFF(m_savedRip)] into LR and jmp to target
-  a->Ldr(X(rlr()), X(i.fp)[AROFF(m_savedRip)]);
-  emit(jmpr{i.target, i.args});
 }
 
 void Vgen::emit(const callarray& i) {
@@ -560,19 +507,46 @@ void Vgen::emit(const callarray& i) {
 }
 
 void Vgen::emit(const contenter& i) {
-  vixl::Label End;
+  vixl::Label stub, end;
 
-  a->Adr(rAsm, &End);
-  a->Str(rAsm, X(i.fp)[AROFF(m_savedRip)]);
-  a->Blr(X(i.target));
-  a->bind(&End);
-  // m_savedRip will point here.
+  // Jump past the stub below.
+  a->B(&end);
+
+  // We call into this stub from the end below. Take that LR and store it in
+  // m_savedRip. Then jump to the target.
+  a->bind(&stub);
+  a->Str(X(rlr()), M(i.fp[AROFF(m_savedRip)]));
+  a->Br(X(i.target));
+
+  // Call to stub above and then unwind.
+  a->bind(&end);
+  a->Bl(&stub);
   emit(unwind{{i.targets[0], i.targets[1]}});
 }
 
+///////////////////////////////////////////////////////////////////////////////
+
+void Vgen::emit(const calltc& i) {
+  vixl::Label stub;
+
+  // Preserve the LR (exittc) on the stack, pushing twice for SP alignment.
+  a->Mov(rAsm, i.exittc);
+  a->Stp(rAsm, rAsm, MemOperand(sp, -16, PreIndex));
+
+  // Branch and link to nowhere to balance the LR stack.
+  a->bl(&stub);
+  a->bind(&stub);
+
+  // Load the saved RIP into LR and branch without link.
+  a->Ldr(X(rlr()), M(i.fp[AROFF(m_savedRip)]));
+  a->Br(X(i.target));
+}
+
 void Vgen::emit(const leavetc& i) {
-  emit(popp{PhysReg(rAsm), rlr()});
-  emit(ret{});
+  // The LR was preserved on the stack by calltc above. Pop it while preserving
+  // SP alignment and return.
+  a->Ldp(rAsm, X(rlr()), MemOperand(sp, 16, PostIndex));
+  a->Ret();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -656,7 +630,7 @@ void Vgen::emit(const imul& i) {
   a->Eor(rAsm, rAsm, X(i.d));
   a->Tbnz(rAsm, 63, &Overflow);
 
-  // No Overflow, so conditionally set the N and Z only
+  // No Overflow, so conditionally set the N and Z only.
   a->Bic(vixl::xzr, X(i.d), vixl::xzr, SetFlags);
 
   a->bind(&after);
@@ -720,7 +694,7 @@ void Vgen::emit(const jmpi& i) {
   vixl::Label data;
 
   // If target can be addressed by pc relative offset (signed 26 bits), emit
-  // PC relative jump. Else, emit target address into code and load from there
+  // PC relative jump. Else, emit target address into code and load from there.
   auto diff = (i.target - a->frontier()) >> vixl::kInstructionSizeLog2;
   if (vixl::is_int26(diff)) {
     a->b(diff);
@@ -730,11 +704,6 @@ void Vgen::emit(const jmpi& i) {
     a->bind(&data);
     a->dc64(i.target);
   }
-}
-
-void Vgen::emit(const jmpm& i) {
-  a->Ldr(rAsm, M(i.target));
-  a->Br(rAsm);
 }
 
 void Vgen::emit(const lea& i) {
@@ -807,7 +776,7 @@ Y(xorqi, Eor, X, i.s0.q(), xzr);
 #undef Y
 
 void Vgen::emit(const pop& i) {
-  // SP access must be 8 byte aligned. Use rAsm instead
+  // SP access must be 8 byte aligned. Use rAsm instead.
   a->Mov(rAsm, sp);
   a->Ldr(X(i.d), MemOperand(rAsm, 8, PostIndex));
   a->Mov(sp, rAsm);
@@ -821,14 +790,14 @@ void Vgen::emit(const psllq& i) {
 }
 
 void Vgen::emit(const psrlq& i) {
-  // TODO: Needs simd shift support in vixl
+  // TODO: Needs simd shift support in vixl.
   a->Fmov(rAsm, D(i.s1));
   a->Lsr(rAsm, rAsm, i.s0.l());
   a->Fmov(D(i.d), rAsm);
 }
 
 void Vgen::emit(const push& i) {
-  // SP access must be 8 byte aligned. Use rAsm instead
+  // SP access must be 8 byte aligned. Use rAsm instead.
   a->Mov(rAsm, sp);
   a->Str(X(i.s), MemOperand(rAsm, -8, PreIndex));
   a->Mov(sp, rAsm);
@@ -880,20 +849,13 @@ void Vgen::emit(const srem& i) {
 }
 
 void Vgen::emit(const unpcklpd& i) {
-  // i.d and i.s1 can be same, i.s0 is unique
+  // i.d and i.s1 can be same, i.s0 is unique.
   if (i.d != i.s1) a->fmov(D(i.d), D(i.s1));
   a->fmov(rAsm, D(i.s0));
   a->fmov(D(i.d), 1, rAsm);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-
-void Vgen::emit(const bln& i) {
-  vixl::Label stub;
-
-  a->Bl(&stub);
-  a->bind(&stub);
-}
 
 /*
  * 'cmplims' instruction is intended for use where temporary Vregs can't be
@@ -932,7 +894,7 @@ void Vgen::emit(const cmplims& i) {
 }
 
 void Vgen::emit(const cmpsds& i) {
-  // Updates flags
+  // Updates flags.
   a->Fcmp(D(i.s0), D(i.s1));
   switch (i.pred) {
     case ComparisonPred::eq_ord: {
@@ -1054,11 +1016,11 @@ void lowerVptr(Vptr& p, Vout& v) {
   switch (mode) {
     case BASE:
     case BASE | INDEX:
-      // ldr/str allow [base] and [base, index], nothing to lower
+      // ldr/str allow [base] and [base, index], nothing to lower.
       break;
 
     case INDEX:
-      // Not supported, convert to [base]
+      // Not supported, convert to [base].
       if (p.scale > 1) {
         auto t = v.makeReg();
         v << lslxi{Log2(p.scale), p.index, t};
@@ -1071,7 +1033,7 @@ void lowerVptr(Vptr& p, Vout& v) {
       break;
 
     case BASE | DISP: {
-      // ldr/str allow [base, #imm], where #imm is [-256 .. 255]
+      // ldr/str allow [base, #imm], where #imm is [-256 .. 255].
       if (p.disp >= -256 && p.disp <= 255)
         break;
 
@@ -1085,7 +1047,7 @@ void lowerVptr(Vptr& p, Vout& v) {
     }
 
     case DISP: {
-      // Not supported, convert to [base]
+      // Not supported, convert to [base].
       auto base = v.makeReg();
       v << ldimmq{Immed64(p.disp), base};
       p.base = base;
@@ -1096,7 +1058,7 @@ void lowerVptr(Vptr& p, Vout& v) {
     }
 
     case INDEX | DISP:
-      // Not supported, convert to [base, #imm] or [base, index]
+      // Not supported, convert to [base, #imm] or [base, index].
       if (p.scale > 1) {
         auto t = v.makeReg();
         v << lslxi{Log2(p.scale), p.index, t};
@@ -1117,7 +1079,7 @@ void lowerVptr(Vptr& p, Vout& v) {
       break;
 
     case BASE | INDEX | DISP: {
-      // Not supported, convert to [base, index]
+      // Not supported, convert to [base, index].
       auto index = v.makeReg();
       if (p.scale > 1) {
         auto t = v.makeReg();
@@ -1142,11 +1104,9 @@ void lower(Vunit& u, vasm_opc& i, Vlabel b, size_t z) { \
   });                                                   \
 }
 
-Y(callm, target)
 Y(cloadq, t)
 Y(decqmlock, m)
 Y(incqmlock, m)
-Y(jmpm, target)
 Y(lea, s)
 Y(loadb, s)
 Y(loadl, s)
@@ -1309,7 +1269,7 @@ void lower(Vunit& unit, cvttsd2siq& i, Vlabel b, size_t idx) {
     v << andqi{~0x01, tmp1, tmp2, v.makeReg()};
     v << msr{tmp2, FPSR};
 
-    // Load error value
+    // Load error value.
     auto const err = v.makeReg();
     v << ldimmq{0x8000000000000000, err};
 
@@ -1328,54 +1288,124 @@ void lower(Vunit& unit, cvttsd2siq& i, Vlabel b, size_t idx) {
   });
 }
 
+void lower(Vunit& u, callm& i, Vlabel b, size_t z) {
+  lower_impl(u, b, z, [&] (Vout& v) {
+    lowerVptr(i.target, v);
+
+    auto const scratch = v.makeReg();
+
+    // Load the target from memory and then call it.
+    v << load{i.target, scratch};
+    v << callr{scratch, i.args};
+  });
+}
+
+void lower(Vunit& u, jmpm& i, Vlabel b, size_t z) {
+  lower_impl(u, b, z, [&] (Vout& v) {
+    lowerVptr(i.target, v);
+
+    auto const scratch = v.makeReg();
+
+    v << load{i.target, scratch};
+    v << jmpr{scratch, i.args};
+  });
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+void lower(Vunit& u, tailcallstub& i, Vlabel b, size_t z) {
+  lower_impl(u, b, z, [&] (Vout& v) {
+    // Restore LR from native stack and adjust SP.
+    v << popp{PhysReg(rAsm), rlr()};
+
+    // Then directly jump to the target.
+    v << jmpi{i.target, i.args};
+  });
+}
+
+void lower(Vunit& u, stubret& i, Vlabel b, size_t z) {
+  lower_impl(u, b, z, [&] (Vout& v) {
+    // Pop LR and (optionally) FP.
+    if (i.saveframe) {
+      v << popp{rvmfp(), rlr()};
+    } else {
+      v << popp{PhysReg(rAsm), rlr()};
+    }
+
+    v << ret{i.args};
+  });
+}
+
+void lower(Vunit& u, stublogue& i, Vlabel b, size_t z) {
+  lower_impl(u, b, z, [&] (Vout& v) {
+    // Push both the LR and FP regardless of i.saveframe to align SP.
+    v << pushp{rlr(), rvmfp()};
+  });
+}
+
 void lower(Vunit& u, stubunwind& i, Vlabel b, size_t z) {
   lower_impl(u, b, z, [&] (Vout& v) {
+    // Pop the call frame.
     v << lea{rsp()[16], rsp()};
   });
 }
 
 void lower(Vunit& u, stubtophp& i, Vlabel b, size_t z) {
   lower_impl(u, b, z, [&] (Vout& v) {
+    // Pop the call frame
     v << lea{rsp()[16], rsp()};
   });
 }
 
 void lower(Vunit& u, loadstubret& i, Vlabel b, size_t z) {
   lower_impl(u, b, z, [&] (Vout& v) {
-    v << load{rsp()[8], i.d};
+    // Load the LR to the destination.
+    v << load{rsp()[AROFF(m_savedRip)], i.d};
   });
 }
 
-void lower(Vunit& u, calltc& i, Vlabel b, size_t z) {
+///////////////////////////////////////////////////////////////////////////////
+
+void lower(Vunit& u, phplogue& i, Vlabel b, size_t z) {
   lower_impl(u, b, z, [&] (Vout& v) {
-    // Push FP, LR for callToExit(..)
-    auto r0 = v.makeReg();
-    auto r1 = v.makeReg();
-    v << ldimmq{i.exittc, r0};
-    v << load{i.fp[AROFF(m_savedRip)], r1};
-    v << pushp{r0, r1};
+    v << store{rlr(), i.fp[AROFF(m_savedRip)]};
+  });
+}
 
-    // Emit call to next instruction to balance predictor's stack
-    v << bln{};
+void lower(Vunit& u, phpret& i, Vlabel b, size_t z) {
+  lower_impl(u, b, z, [&] (Vout& v) {
+    v << load{i.fp[AROFF(m_savedRip)], rlr()};
 
-    // Set the return address to savedRip and jump to target
-    v << copy{r1, rlr()};
+    if (!i.noframe) {
+      v << load{i.fp[AROFF(m_sfp)], i.d};
+    }
+
+    v << ret{i.args};
+  });
+}
+
+void lower(Vunit& u, tailcallphp& i, Vlabel b, size_t z) {
+  lower_impl(u, b, z, [&] (Vout& v) {
+    // Undoes the prologue by restoring LR from saved RIP.
+    v << load{i.fp[AROFF(m_savedRip)], rlr()};
+
     v << jmpr{i.target, i.args};
   });
 }
 
+///////////////////////////////////////////////////////////////////////////////
+
 void lower(Vunit& u, resumetc& i, Vlabel b, size_t z) {
   lower_impl(u, b, z, [&] (Vout& v) {
-    // Push FP, LR for callToExit(..)
-    auto r = v.makeReg();
-    v << ldimmq{i.exittc, r};
-    v << pushp{r, rfp()};
-
-    // Call the helper
+    // Call the translation target.
     v << callr{i.target, i.args};
+
+    // After returning to the translation, jump directly to the exit.
     v << jmpi{i.exittc};
   });
 }
+
+///////////////////////////////////////////////////////////////////////////////
 
 void lower(Vunit& u, popm& i, Vlabel b, size_t z) {
   lower_impl(u, b, z, [&] (Vout& v) {
@@ -1491,7 +1521,7 @@ void lower(Vunit& u, testbi& i, Vlabel b, size_t z) {
  * other updates the flags. Following code makes a copy of the original
  * register, outputs the shift instruction followed by flags update instruction.
  * If the 'SF' register is not used by subsequent code, the copy and flags
- * update instructions are removed by the dead code elimination pass
+ * update instructions are removed by the dead code elimination pass.
  */
 #define Y(vasm_opc, lower_opc, sf_opc)                  \
 void lower(Vunit& u, vasm_opc& i, Vlabel b, size_t z) { \

--- a/hphp/runtime/vm/jit/vasm-dead.cpp
+++ b/hphp/runtime/vm/jit/vasm-dead.cpp
@@ -207,7 +207,6 @@ bool effectful(Vinstr& inst) {
     case Vinstr::bindaddr:
     case Vinstr::bindjcc:
     case Vinstr::bindjmp:
-    case Vinstr::bln:
     case Vinstr::call:
     case Vinstr::callarray:
     case Vinstr::callfaststub:

--- a/hphp/runtime/vm/jit/vasm-instr.cpp
+++ b/hphp/runtime/vm/jit/vasm-instr.cpp
@@ -189,7 +189,6 @@ Width width(Vinstr::Opcode op) {
     case Vinstr::addxi:
     case Vinstr::asrxi:
     case Vinstr::asrxis:
-    case Vinstr::bln:
     case Vinstr::cmplims:
     case Vinstr::cmpsds:
     case Vinstr::fabs:

--- a/hphp/runtime/vm/jit/vasm-instr.h
+++ b/hphp/runtime/vm/jit/vasm-instr.h
@@ -298,7 +298,6 @@ struct Vunit;
   O(addxi, I(s0), UH(s1,d), DH(d,s1))\
   O(asrxi, I(s0), UH(s1,d), DH(d,s1))\
   O(asrxis, I(s0), U(s1) U(d), D(df) D(sf))\
-  O(bln, Inone, Un, Dn)\
   O(cmplims, I(s0), U(s1), D(sf))\
   O(cmpsds, I(pred), UA(s0) U(s1), D(d))\
   O(fabs, Inone, U(s), D(d))\
@@ -1142,7 +1141,6 @@ struct shlq { Vreg64 s, d; VregSF sf; }; // uses rcx
 struct addxi { Immed s0; Vreg64 s1, d; };
 struct asrxi { Immed s0; Vreg64 s1, d; };
 struct asrxis { Immed s0; Vreg64 s1, d, df; VregSF sf; };
-struct bln {};
 struct cmplims { Immed s0; Vptr s1; VregSF sf; };
 struct cmpsds { ComparisonPred pred; VregDbl s0, s1, d; VregSF sf; };
 struct fabs { VregDbl s, d; };


### PR DESCRIPTION
Moved several abi-related vasm implementations from emitters to
lowerers. Change calltc to push FP/LR pair instead of the saved
RIP from the activation record and the i.exittc. Remove extra
pop of FP/LR in the emulated return to enterTCExit. While x86_64
actually pops the LR when a return occurs AArch64 does not.
Lastly, add syncpoint after calling destructors in emitDecRefHelper.