### PR TITLE
[AArch64] Remove remaining extraneous ARM vasm.

### DIFF
--- a/hphp/runtime/vm/jit/abi-arm.cpp
+++ b/hphp/runtime/vm/jit/abi-arm.cpp
@@ -44,7 +44,7 @@ const RegSet kGPCalleeSaved =
 const RegSet kGPUnreserved = kGPCallerSaved | kGPCalleeSaved;
 
 const RegSet kGPReserved =
-  vixl::x16 | vixl::x17 | rAsm | rvmtl() |
+  rVixlScratch0 | rVixlScratch1 | rAsm | rvmtl() |
   rvmfp() | rlr() | vixl::xzr | rsp();
   // ARM machines really only have 32 GP regs.  However, vixl has 33 separate
   // register codes, because it treats the zero register and stack pointer

--- a/hphp/runtime/vm/jit/abi-arm.h
+++ b/hphp/runtime/vm/jit/abi-arm.h
@@ -151,6 +151,10 @@ inline vixl::Register svcReqArgReg(unsigned index) {
   return x2a(rarg(index + 1));
 }
 
+// x16 and x17 are vixl macroassembler temporaries
+const vixl::Register rVixlScratch0(vixl::x16);
+const vixl::Register rVixlScratch1(vixl::x17);
+
 // x18 is used as assembler temporary
 const vixl::Register rAsm(vixl::x18);
 

--- a/hphp/runtime/vm/jit/vasm-dead.cpp
+++ b/hphp/runtime/vm/jit/vasm-dead.cpp
@@ -70,7 +70,6 @@ bool effectful(Vinstr& inst) {
     case Vinstr::cmpqim:
     case Vinstr::cmpqm:
     case Vinstr::cmpsd:
-    case Vinstr::cmpsds:
     case Vinstr::cmpwim:
     case Vinstr::cmpwm:
     case Vinstr::copy:
@@ -149,8 +148,6 @@ bool effectful(Vinstr& inst) {
     case Vinstr::nop:
     case Vinstr::not:
     case Vinstr::notb:
-    case Vinstr::orsw:
-    case Vinstr::orswi:
     case Vinstr::orq:
     case Vinstr::orqi:
     case Vinstr::psllq:
@@ -168,12 +165,12 @@ bool effectful(Vinstr& inst) {
     case Vinstr::shrqi:
     case Vinstr::sqrtsd:
     case Vinstr::srem:
+    case Vinstr::subb:
     case Vinstr::subbi:
     case Vinstr::subl:
     case Vinstr::subli:
     case Vinstr::subq:
     case Vinstr::subqi:
-    case Vinstr::subsb:
     case Vinstr::subsd:
     case Vinstr::testb:
     case Vinstr::testbi:
@@ -188,7 +185,6 @@ bool effectful(Vinstr& inst) {
     case Vinstr::testwim:
     case Vinstr::ucomisd:
     case Vinstr::unpcklpd:
-    case Vinstr::uxth:
     case Vinstr::xorb:
     case Vinstr::xorbi:
     case Vinstr::xorl:

--- a/hphp/runtime/vm/jit/vasm-instr.cpp
+++ b/hphp/runtime/vm/jit/vasm-instr.cpp
@@ -190,8 +190,7 @@ Width width(Vinstr::Opcode op) {
     case Vinstr::asrxi:
     case Vinstr::asrxis:
     case Vinstr::cmplims:
-    case Vinstr::cmpsds:
-    case Vinstr::fabs:
+    case Vinstr::fcvtzs:
     case Vinstr::lslwi:
     case Vinstr::lslwis:
     case Vinstr::lslxi:
@@ -202,19 +201,15 @@ Width width(Vinstr::Opcode op) {
     case Vinstr::lsrxis:
     case Vinstr::mrs:
     case Vinstr::msr:
-    case Vinstr::orsw:
-    case Vinstr::orswi:
-    case Vinstr::subsb:
-    case Vinstr::uxth:
     // ppc64 instructions
     case Vinstr::extrb:
     case Vinstr::extrw:
     case Vinstr::extsb:
     case Vinstr::extsw:
+    case Vinstr::fabs:
     case Vinstr::fcmpo:
     case Vinstr::fcmpu:
     case Vinstr::fctidz:
-    case Vinstr::fcvtzs:
     case Vinstr::ldarx:
     case Vinstr::mfcr:
     case Vinstr::mflr:
@@ -233,6 +228,7 @@ Width width(Vinstr::Opcode op) {
     case Vinstr::andbim:
     case Vinstr::notb:
     case Vinstr::orbim:
+    case Vinstr::subb:
     case Vinstr::subbi:
     case Vinstr::xorb:
     case Vinstr::xorbi:

--- a/hphp/runtime/vm/jit/vasm-instr.h
+++ b/hphp/runtime/vm/jit/vasm-instr.h
@@ -176,6 +176,7 @@ struct Vunit;
   O(shrqi, I(s0), UH(s1,d), DH(d,s1) D(sf))\
   O(psllq, I(s0), UH(s1,d), DH(d,s1))\
   O(psrlq, I(s0), UH(s1,d), DH(d,s1))\
+  O(subb, Inone, UA(s0) U(s1), D(d) D(sf))\
   O(subbi, I(s0), UH(s1,d), DH(d,s1) D(sf))\
   O(subl, Inone, UA(s0) U(s1), D(d) D(sf))\
   O(subli, I(s0), UH(s1,d), DH(d,s1) D(sf))\
@@ -299,8 +300,6 @@ struct Vunit;
   O(asrxi, I(s0), UH(s1,d), DH(d,s1))\
   O(asrxis, I(s0), U(s1) U(d), D(df) D(sf))\
   O(cmplims, I(s0), U(s1), D(sf))\
-  O(cmpsds, I(pred), UA(s0) U(s1), D(d))\
-  O(fabs, Inone, U(s), D(d))\
   O(fcvtzs, Inone, U(s), D(d))\
   O(lslwi, I(s0), UH(s1,d), DH(d,s1))\
   O(lslwis, I(s0), U(s1) U(d), D(df) D(sf))\
@@ -312,15 +311,12 @@ struct Vunit;
   O(lsrxis, I(s0), U(s1) U(d), D(df) D(sf))\
   O(mrs, I(s), Un, D(r))\
   O(msr, I(s), U(r), Dn)\
-  O(orswi, I(s0), UH(s1,d), DH(d,s1) D(sf))\
-  O(orsw, Inone, U(s0) U(s1), D(d) D(sf)) \
-  O(subsb, Inone, UA(s0) U(s1), D(d) D(sf))\
-  O(uxth, Inone, U(s), D(d))\
   /* ppc64 instructions */\
   O(extrb, Inone, UH(s,d), DH(d,s))\
   O(extrw, Inone, UH(s,d), DH(d,s))\
   O(extsb, Inone, UH(s,d), DH(d,s))\
   O(extsw, Inone, UH(s,d), DH(d,s))\
+  O(fabs, Inone, U(s), D(d))\
   O(fcmpo, Inone, U(s0) U(s1), D(sf))\
   O(fcmpu, Inone, U(s0) U(s1), D(sf))\
   O(fctidz, Inone, U(s), D(d) D(sf))\
@@ -966,6 +962,7 @@ struct shrqi { Immed s0; Vreg64 s1, d; VregSF sf; };
 struct psllq { Immed s0; VregDbl s1, d; };
 struct psrlq { Immed s0; VregDbl s1, d; };
 // sub: s1 - s0 => d, sf
+struct subb { Vreg8 s0; Vreg8 s1, d; VregSF sf; };
 struct subbi { Immed s0; Vreg8 s1, d; VregSF sf; };
 struct subl { Vreg32 s0, s1, d; VregSF sf; };
 struct subli { Immed s0; Vreg32 s1, d; VregSF sf; };
@@ -1142,9 +1139,7 @@ struct addxi { Immed s0; Vreg64 s1, d; };
 struct asrxi { Immed s0; Vreg64 s1, d; };
 struct asrxis { Immed s0; Vreg64 s1, d, df; VregSF sf; };
 struct cmplims { Immed s0; Vptr s1; VregSF sf; };
-struct cmpsds { ComparisonPred pred; VregDbl s0, s1, d; VregSF sf; };
-struct fabs { VregDbl s, d; };
-struct fcvtzs { VregDbl s; Vreg64 d;};
+struct fcvtzs { VregDbl s; Vreg64 d; };
 struct lslwi { Immed s0; Vreg32 s1, d; };
 struct lslwis { Immed s0; Vreg32 s1, d, df; VregSF sf; };
 struct lslxi { Immed s0; Vreg64 s1, d; };
@@ -1155,10 +1150,6 @@ struct lsrxi { Immed s0; Vreg64 s1, d; };
 struct lsrxis { Immed s0; Vreg64 s1, d, df; VregSF sf; };
 struct mrs { Immed s; Vreg64 r; };
 struct msr { Vreg64 r; Immed s; };
-struct orswi { Immed s0; Vreg32 s1, d; VregSF sf; };
-struct orsw { Vreg32 s0, s1, d; VregSF sf; };
-struct subsb { Vreg8 s0, s1, d; VregSF sf; };
-struct uxth { Vreg16 s; Vreg32 d; };
 
 /*
  * ppc64 intrinsics.
@@ -1167,6 +1158,7 @@ struct extrb { Vreg8 s; Vreg8 d; };   // Extract and zeros the upper bits
 struct extrw { Vreg16 s; Vreg64 d; }; // Extract and zeros the upper bits
 struct extsb { Vreg64 s; Vreg64 d; }; // Extend byte sign
 struct extsw { Vreg64 s; Vreg64 d; }; // Extend word sign
+struct fabs { VregDbl s, d; };
 struct fcmpo { VregDbl s0; VregDbl s1; VregSF sf; };
 struct fcmpu { VregDbl s0; VregDbl s1; VregSF sf; };
 struct fctidz { VregDbl s; VregDbl d; VregSF sf; };


### PR DESCRIPTION
Several ARM-specific vasm instructions were added for lowering, but
they are no longer needed. Additional cleanup includes:
  - Change complex emitters to lowerers.
  - Flag untested implementations with notYetTested assertions.