### PR TITLE
Fix TOC register restore due to new backchain fix on PPC64

### DIFF
--- a/hphp/runtime/vm/jit/unique-stubs.cpp
+++ b/hphp/runtime/vm/jit/unique-stubs.cpp
@@ -1088,10 +1088,7 @@ TCA emitEnterTCExit(CodeBlock& cb, DataBlock& data, UniqueStubs& us) {
     storeReturnRegs(v);
 
     // Perform a native return.
-
-    // On PPC64, as there is no new frame created when entering the VM, the FP
-    // must not be saved.
-    v << stubret{RegSet(), arch() != Arch::PPC64};
+    v << stubret{RegSet(), true};
   });
 }
 
@@ -1111,11 +1108,11 @@ TCA emitEnterTCHelper(CodeBlock& cb, DataBlock& data, UniqueStubs& us) {
 #endif
 
   return vwrap2(cb, cb, data, [&] (Vout& v, Vout& vc) {
+    // Native func prologue.
+    v << stublogue{true};
+
     // Architecture-specific setup for entering the TC.
     v << inittc{};
-
-    // Native func prologue.
-    v << stublogue{arch() != Arch::PPC64};
 
 #if defined(__CYGWIN__) || defined(__MINGW__) || defined(_MSC_VER)
     // Windows hates argument registers.

--- a/hphp/runtime/vm/jit/unique-stubs.cpp
+++ b/hphp/runtime/vm/jit/unique-stubs.cpp
@@ -1088,7 +1088,10 @@ TCA emitEnterTCExit(CodeBlock& cb, DataBlock& data, UniqueStubs& us) {
     storeReturnRegs(v);
 
     // Perform a native return.
-    v << stubret{RegSet(), true};
+
+    // On PPC64, as there is no new frame created when entering the VM, the FP
+    // must not be saved.
+    v << stubret{RegSet(), arch() != Arch::PPC64};
   });
 }
 
@@ -1108,11 +1111,11 @@ TCA emitEnterTCHelper(CodeBlock& cb, DataBlock& data, UniqueStubs& us) {
 #endif
 
   return vwrap2(cb, cb, data, [&] (Vout& v, Vout& vc) {
-    // Native func prologue.
-    v << stublogue{true};
-
     // Architecture-specific setup for entering the TC.
     v << inittc{};
+
+    // Native func prologue.
+    v << stublogue{arch() != Arch::PPC64};
 
 #if defined(__CYGWIN__) || defined(__MINGW__) || defined(_MSC_VER)
     // Windows hates argument registers.

--- a/hphp/runtime/vm/jit/vasm-ppc64.cpp
+++ b/hphp/runtime/vm/jit/vasm-ppc64.cpp
@@ -865,10 +865,10 @@ void Vgen::emit(const stublogue& i) {
 
 void Vgen::emit(const stubret& i) {
   // rvmfp, if necessary.
-  if (i.saveframe) {
-    a.ld(rvmfp(), rsp()[AROFF(m_sfp)]);
-    a.mr(rsfp(), rvmfp());
-  }
+  if (i.saveframe) a.ld(rvmfp(), rsp()[AROFF(m_sfp)]);
+
+  // restore r1 appropriately
+  a.mr(ppc64_asm::reg::r1, rvmfp());
 
   // restore return address.
   a.ld(rfuncln(), rsp()[AROFF(m_savedRip)]);

--- a/hphp/runtime/vm/jit/vasm-ppc64.cpp
+++ b/hphp/runtime/vm/jit/vasm-ppc64.cpp
@@ -868,7 +868,7 @@ void Vgen::emit(const stubret& i) {
   if (i.saveframe) a.ld(rvmfp(), rsp()[AROFF(m_sfp)]);
 
   // restore r1 appropriately
-  a.mr(ppc64_asm::reg::r1, rvmfp());
+  a.mr(rsfp(), rvmfp());
 
   // restore return address.
   a.ld(rfuncln(), rsp()[AROFF(m_savedRip)]);


### PR DESCRIPTION
The TOC register restoration was being handled in 2 different ways by 2
pull requests (7389 and 7327) but together there were 7 tests from the
quick test suite that started failing.

When exiting the VM, the r1 register is read in order to reload the r2
(toc register). Other than that, only the r31 is used as a frame pointer
in order to not only read from stack but only to pop the frame.

The TOC register had the same data before toc/relocation PR (7389) so
this bug was not affecting when fix backchain PR (7327) was integrated.