### PR TITLE
Correction for load/store exclusive disassembly

### DIFF
--- a/hphp/runtime/vm/jit/vasm-arm.cpp
+++ b/hphp/runtime/vm/jit/vasm-arm.cpp
@@ -109,6 +109,7 @@ vixl::MemOperand M(Vptr p) {
     assertx(p.disp == 0);
     return MemOperand(X(p.base), X(p.index), LSL, Log2(p.scale));
   }
+  assertx(p.disp >= -256 && p.disp <= 255);
   return MemOperand(X(p.base), p.disp);
 }
 
@@ -743,6 +744,7 @@ void Vgen::emit(const lea& i) {
     assertx(p.disp == 0);
     a->Add(X(i.d), X(p.base), Operand(X(p.index), LSL, Log2(p.scale)));
   } else {
+    assertx(p.disp >= -256 && p.disp <= 255);
     a->Add(X(i.d), X(p.base), p.disp);
   }
 }

--- a/hphp/runtime/vm/jit/vasm-arm.cpp
+++ b/hphp/runtime/vm/jit/vasm-arm.cpp
@@ -106,6 +106,7 @@ int64_t MSKTOP(int64_t value) {
 vixl::MemOperand M(Vptr p) {
   assertx(p.base.isValid());
   if (p.index.isValid()) {
+    assertx(p.disp == 0);
     return MemOperand(X(p.base), X(p.index), LSL, Log2(p.scale));
   }
   return MemOperand(X(p.base), p.disp);

--- a/hphp/runtime/vm/jit/vasm-arm.cpp
+++ b/hphp/runtime/vm/jit/vasm-arm.cpp
@@ -106,10 +106,8 @@ int64_t MSKTOP(int64_t value) {
 vixl::MemOperand M(Vptr p) {
   assertx(p.base.isValid());
   if (p.index.isValid()) {
-    assertx(p.disp == 0);
     return MemOperand(X(p.base), X(p.index), LSL, Log2(p.scale));
   }
-  assertx(p.disp >= -256 && p.disp <= 255);
   return MemOperand(X(p.base), p.disp);
 }
 
@@ -744,7 +742,6 @@ void Vgen::emit(const lea& i) {
     assertx(p.disp == 0);
     a->Add(X(i.d), X(p.base), Operand(X(p.index), LSL, Log2(p.scale)));
   } else {
-    assertx(p.disp >= -256 && p.disp <= 255);
     a->Add(X(i.d), X(p.base), p.disp);
   }
 }

--- a/hphp/vixl/a64/decoder-a64.cc
+++ b/hphp/vixl/a64/decoder-a64.cc
@@ -280,8 +280,7 @@ void Decoder::DecodeLoadStore(Instruction* instr) {
     if (instr->Bit(28) == 0) {
       if (instr->Bit(29) == 0) {
         if (instr->Bit(26) == 0) {
-          // TODO: VisitLoadStoreExclusive.
-          VisitUnimplemented(instr);
+          VisitLoadStoreExclusive(instr);
         } else {
           DecodeAdvSIMDLoadStore(instr);
         }

--- a/hphp/vixl/a64/decoder-a64.h
+++ b/hphp/vixl/a64/decoder-a64.h
@@ -59,6 +59,7 @@
   V(LoadStorePreIndex)              \
   V(LoadStoreRegisterOffset)        \
   V(LoadStoreUnsignedOffset)        \
+  V(LoadStoreExclusive)             \
   V(LogicalShifted)                 \
   V(AddSubShifted)                  \
   V(AddSubExtended)                 \

--- a/hphp/vixl/a64/disasm-a64.cc
+++ b/hphp/vixl/a64/disasm-a64.cc
@@ -945,6 +945,46 @@ void Disassembler::VisitLoadStorePairNonTemporal(Instruction* instr) {
   Format(instr, mnemonic, form);
 }
 
+void Disassembler::VisitLoadStoreExclusive(Instruction* instr) {
+  const char *mnemonic = "unimplemented";
+  const char *form;
+  switch(instr->Mask(LoadStoreExclusiveMask)) {
+    case STXRB_w:  mnemonic = "stxrb";  form = "'Ws, 'Wt, ['Xns]"; break;
+    case STXRH_w:  mnemonic = "stxrh";  form = "'Ws, 'Wt, ['Xns]"; break;
+    case STXR_w:   mnemonic = "stxr";   form = "'Ws, 'Wt, ['Xns]"; break;
+    case STXR_x:   mnemonic = "stxr";   form = "'Ws, 'Xt, ['Xns]"; break;
+    case LDXRB_w:  mnemonic = "ldxrb";  form = "'Wt, ['Xns]"; break;
+    case LDXRH_w:  mnemonic = "ldxrh";  form = "'Wt, ['Xns]"; break;
+    case LDXR_w:   mnemonic = "ldxr";   form = "'Wt, ['Xns]"; break;
+    case LDXR_x:   mnemonic = "ldxr";   form = "'Xt, ['Xns]"; break;
+    case STXP_w:   mnemonic = "stxp";   form = "'Ws, 'Wt, 'Wt2, ['Xns]"; break;
+    case STXP_x:   mnemonic = "stxp";   form = "'Ws, 'Xt, 'Xt2, ['Xns]"; break;
+    case LDXP_w:   mnemonic = "ldxp";   form = "'Wt, 'Wt2, ['Xns]"; break;
+    case LDXP_x:   mnemonic = "ldxp";   form = "'Xt, 'Xt2, ['Xns]"; break;
+    case STLXRB_w: mnemonic = "stlxrb"; form = "'Ws, 'Wt, ['Xns]"; break;
+    case STLXRH_w: mnemonic = "stlxrh"; form = "'Ws, 'Wt, ['Xns]"; break;
+    case STLXR_w:  mnemonic = "stlxr";  form = "'Ws, 'Wt, ['Xns]"; break;
+    case STLXR_x:  mnemonic = "stlxr";  form = "'Ws, 'Xt, ['Xns]"; break;
+    case LDAXRB_w: mnemonic = "ldaxrb"; form = "'Wt, ['Xns]"; break;
+    case LDAXRH_w: mnemonic = "ldaxrh"; form = "'Wt, ['Xns]"; break;
+    case LDAXR_w:  mnemonic = "ldaxr";  form = "'Wt, ['Xns]"; break;
+    case LDAXR_x:  mnemonic = "ldaxr";  form = "'Xt, ['Xns]"; break;
+    case STLXP_w:  mnemonic = "stlxp";  form = "'Ws, 'Wt, 'Wt2, ['Xns]"; break;
+    case STLXP_x:  mnemonic = "stlxp";  form = "'Ws, 'Xt, 'Xt2, ['Xns]"; break;
+    case LDAXP_w:  mnemonic = "ldaxp";  form = "'Wt, 'Wt2, ['Xns]"; break;
+    case LDAXP_x:  mnemonic = "ldaxp";  form = "'Xt, 'Xt2, ['Xns]"; break;
+    case STLRB_w:  mnemonic = "stlrb";  form = "'Wt, ['Xns]"; break;
+    case STLRH_w:  mnemonic = "stlrh";  form = "'Wt, ['Xns]"; break;
+    case STLR_w:   mnemonic = "stlr";   form = "'Wt, ['Xns]"; break;
+    case STLR_x:   mnemonic = "stlr";   form = "'Xt, ['Xns]"; break;
+    case LDARB_w:  mnemonic = "ldarb";  form = "'Wt, ['Xns]"; break;
+    case LDARH_w:  mnemonic = "ldarh";  form = "'Wt, ['Xns]"; break;
+    case LDAR_w:   mnemonic = "ldar";   form = "'Wt, ['Xns]"; break;
+    case LDAR_x:   mnemonic = "ldar";   form = "'Xt, ['Xns]"; break;
+    default: form = "(LoadStoreExclusive)";
+  }
+  Format(instr, mnemonic, form);
+}
 
 void Disassembler::VisitFPCompare(Instruction* instr) {
   const char *mnemonic = "unimplemented";
@@ -1298,6 +1338,7 @@ int Disassembler::SubstituteRegisterField(Instruction* instr,
       }
       break;
     }
+    case 's': reg_num = instr->Rs(); break;
     default: not_reached();
   }
 

--- a/hphp/vixl/a64/instrument-a64.cc
+++ b/hphp/vixl/a64/instrument-a64.cc
@@ -466,6 +466,13 @@ void Instrument::VisitLoadStoreUnsignedOffset(Instruction* instr) {
   InstrumentLoadStore(instr);
 }
 
+void Instrument::VisitLoadStoreExclusive(Instruction* instr) {
+  USE(instr);
+  Update();
+  static Counter* counter = GetCounter("Other");
+  counter->Increment();
+}
+
 
 void Instrument::VisitLogicalShifted(Instruction* instr) {
   USE(instr);

--- a/hphp/vixl/a64/simulator-a64.cc
+++ b/hphp/vixl/a64/simulator-a64.cc
@@ -824,6 +824,9 @@ void Simulator::VisitLoadStorePairNonTemporal(Instruction* instr) {
   LoadStorePairHelper(instr, Offset);
 }
 
+void Simulator::VisitLoadStoreExclusive(Instruction* instr) {
+  VisitUnimplemented(instr);
+}
 
 void Simulator::LoadStorePairHelper(Instruction* instr,
                                     AddrMode addrmode) {


### PR DESCRIPTION
This brings forward some of the changes in vixl which has to do with
the disassembly of the loadStoreExclusive Aarch64 instructions.  It was
noticed that some instructions where not disassembled correctly when
examining the output from TRACE=printir:9

Before
====
    478     (03) IncProfCounter<1>
    479         Main:
    480               0x11a00030  d2800100              movz x0, #0x8
    481               0x11a00034  f2b4f000              movk x0, #0xa780, lsl #16
    482               0x11a00038  f2dfffe0              movk x0, #0xffff, lsl #32
    483               0x11a0003c  c85f7c12              unimplemented (Unimplemented)
    484               0x11a00040  f1000652              subs x18, x18, #0x1 (1)
    485               0x11a00044  c8127c12              unimplemented (Unimplemented)
    486               0x11a00048  35ffffb2              cbnz w18, #-0xc
    487

After
===
  (comments added manually)

    511     (03) IncProfCounter<1>
    512         Main:
    513               0x2aa00030  d2800100              movz x0, #0x8
    514               0x2aa00034  f2ae0800              movk x0, #0x7040, lsl #16 
    515               0x2aa00038  f2dfffe0              movk x0, #0xffff, lsl #32 
    516               0x2aa0003c  c85f7c12              ldxr x18, [x0]          // <<--- fixed
    517               0x2aa00040  f1000652              subs x18, x18, #0x1 (1) 
    518               0x2aa00044  c8127c12              stxr w18, x18, [x0]     // <<--- fixed
    519               0x2aa00048  35ffffb2              cbnz w18, #-0xc
    520 

Since code generation only generates these two instructions currently, the
others are not yet tested.  The remaining instructions will require an update to
the assembler.

The visitor for the Instrument class will count this as an "other".
The visitor for the Simulator class will report an unimplemented instruction (no change).

