### PR TITLE
[arm64] Fix geneneric emit() function signature.

### DIFF
--- a/hphp/runtime/vm/jit/vasm-arm.cpp
+++ b/hphp/runtime/vm/jit/vasm-arm.cpp
@@ -150,7 +150,7 @@ struct Vgen {
 
   /////////////////////////////////////////////////////////////////////////////
 
-  template<class Inst> void emit(Inst& i) {
+  template<class Inst> void emit(const Inst& i) {
     always_assert_flog(false, "unimplemented instruction: {} in B{}\n",
                        vinst_names[Vinstr(i).op], size_t(current));
   }


### PR DESCRIPTION
A recent change in the hhvm source tree broke the vasm module for aarch64.
This patch fixes the regression.

The problem manifests in assertion failures of the following form:

Assertion Failure: /mnt/hhvm-arm64/hhvm/hphp/runtime/vm/jit/vasm-arm.cpp:155: void HPHP::jit::{anonymous}::Vgen::emit(Inst&) [with Inst = HPHP::jit::store]: assertion `false' failed.

Signed-off-by: Christoph Muellner <christoph.muellner@theobroma-systems.com>