### PR TITLE
[arm64] Const reference patches

### DIFF
--- a/hphp/runtime/vm/jit/abi-arm.h
+++ b/hphp/runtime/vm/jit/abi-arm.h
@@ -81,17 +81,17 @@ inline vixl::Register x2a(PhysReg x64reg) {
   return vixl::Register(vixl::CPURegister(x64reg));
 }
 
-inline vixl::FPRegister x2f(PhysReg x64reg) {
+inline vixl::FPRegister x2f(const PhysReg& x64reg) {
   always_assert(x64reg.isSIMD());
   return vixl::FPRegister(vixl::CPURegister(x64reg));
 }
 
-inline vixl::VRegister x2v(PhysReg x64reg) {
+inline vixl::VRegister x2v(const PhysReg& x64reg) {
   always_assert(x64reg.isSIMD());
   return vixl::VRegister(vixl::CPURegister(x64reg));
 }
 
-inline vixl::Condition convertCC(jit::ConditionCode cc) {
+inline vixl::Condition convertCC(const jit::ConditionCode& cc) {
   assertx(cc >= 0 && cc <= 0xF);
 
   using namespace vixl;
@@ -119,7 +119,7 @@ inline vixl::Condition convertCC(jit::ConditionCode cc) {
   return mapping[cc];
 }
 
-inline jit::ConditionCode convertCC(vixl::Condition cc) {
+inline jit::ConditionCode convertCC(const vixl::Condition& cc) {
   using namespace vixl;
 
   // We'll index into this array by the arm64 condition code.

--- a/hphp/runtime/vm/jit/vasm-arm.cpp
+++ b/hphp/runtime/vm/jit/vasm-arm.cpp
@@ -49,36 +49,36 @@ namespace arm { struct ImmFolder; }
 namespace {
 ///////////////////////////////////////////////////////////////////////////////
 
-vixl::Register X(Vreg64 r) {
+vixl::Register X(const Vreg64& r) {
   PhysReg pr(r.asReg());
   return x2a(pr);
 }
 
-vixl::Register W(Vreg64 r) {
+vixl::Register W(const Vreg64& r) {
   PhysReg pr(r.asReg());
   return x2a(pr).W();
 }
 
-vixl::Register W(Vreg32 r) {
+vixl::Register W(const Vreg32& r) {
   PhysReg pr(r.asReg());
   return x2a(pr).W();
 }
 
-vixl::Register W(Vreg16 r) {
+vixl::Register W(const Vreg16& r) {
   PhysReg pr(r.asReg());
   return x2a(pr).W();
 }
 
-vixl::Register W(Vreg8 r) {
+vixl::Register W(const Vreg8& r) {
   PhysReg pr(r.asReg());
   return x2a(pr).W();
 }
 
-vixl::FPRegister D(Vreg r) {
+vixl::FPRegister D(const Vreg& r) {
   return x2f(r);
 }
 
-vixl::VRegister V(Vreg r) {
+vixl::VRegister V(const Vreg& r) {
   return x2v(r);
 }
 
@@ -103,7 +103,7 @@ int64_t MSKTOP(int64_t value) {
   return value & ~0u;
 }
 
-vixl::MemOperand M(Vptr p) {
+vixl::MemOperand M(const Vptr& p) {
   assertx(p.base.isValid());
   if (p.index.isValid()) {
     assertx(p.disp == 0);
@@ -113,7 +113,7 @@ vixl::MemOperand M(Vptr p) {
   return MemOperand(X(p.base), p.disp);
 }
 
-vixl::Condition C(ConditionCode cc) {
+vixl::Condition C(const ConditionCode& cc) {
   return arm::convertCC(cc);
 }
 
@@ -401,7 +401,7 @@ void Vgen::emit(const copy2& i) {
   }
 }
 
-void emitSimdImmInt(vixl::MacroAssembler* a, int64_t val, Vreg d) {
+void emitSimdImmInt(vixl::MacroAssembler* a, int64_t val, const Vreg& d) {
   // Assembler::fmov emits a ldr from a literal pool if IsImmFP64 is false.
   // In that case, emit the raw bits into a GPR first and then move them
   // unmodified into destination SIMD

--- a/hphp/vixl/a64/assembler-a64.cc
+++ b/hphp/vixl/a64/assembler-a64.cc
@@ -1197,7 +1197,7 @@ void Assembler::hint(SystemHint code) {
 }
 
 
-void Assembler::fmov(FPRegister fd, double imm) {
+void Assembler::fmov(const FPRegister& fd, double imm) {
   if (fd.Is64Bits() && IsImmFP64(imm)) {
     Emit(FMOV_d_imm | Rd(fd) | ImmFP64(imm));
   } else if (fd.Is32Bits() && IsImmFP32(imm)) {
@@ -1211,21 +1211,21 @@ void Assembler::fmov(FPRegister fd, double imm) {
 }
 
 
-void Assembler::fmov(Register rd, FPRegister fn) {
+void Assembler::fmov(const Register& rd, const FPRegister& fn) {
   assert(rd.size() == fn.size());
   FPIntegerConvertOp op = rd.Is32Bits() ? FMOV_ws : FMOV_xd;
   Emit(op | Rd(rd) | Rn(fn));
 }
 
 
-void Assembler::fmov(FPRegister fd, Register rn) {
+void Assembler::fmov(const FPRegister& fd, const Register& rn) {
   assert(fd.size() == rn.size());
   FPIntegerConvertOp op = fd.Is32Bits() ? FMOV_sw : FMOV_dx;
   Emit(op | Rd(fd) | Rn(rn));
 }
 
 
-void Assembler::fmov(FPRegister fd, FPRegister fn) {
+void Assembler::fmov(const FPRegister& fd, const FPRegister& fn) {
   assert(fd.size() == fn.size());
   Emit(FPType(fd) | FMOV | Rd(fd) | Rn(fn));
 }

--- a/hphp/vixl/a64/assembler-a64.h
+++ b/hphp/vixl/a64/assembler-a64.h
@@ -1180,16 +1180,16 @@ class Assembler {
 
   // FP instructions.
   // Move immediate to FP register.
-  void fmov(FPRegister fd, double imm);
+  void fmov(const FPRegister& fd, double imm);
 
   // Move FP register to register.
-  void fmov(Register rd, FPRegister fn);
+  void fmov(const Register& rd, const FPRegister& fn);
 
   // Move register to FP register.
-  void fmov(FPRegister fd, Register rn);
+  void fmov(const FPRegister& fd, const Register& rn);
 
   // Move FP register to FP register.
-  void fmov(FPRegister fd, FPRegister fn);
+  void fmov(const FPRegister& fd, const FPRegister& fn);
 
   // Move register to FP register 1
   void fmov(const FPRegister& fd, int index, const Register& rn);


### PR DESCRIPTION
Two patches, which changes read-only arguments to be const references instead of copies
in the arm64 JIT code path.