### PR TITLE
Change return from a nullptr to bool to remove narrowing error.

### DIFF
--- a/hphp/util/cache/cache-manager.cpp
+++ b/hphp/util/cache/cache-manager.cpp
@@ -121,7 +121,7 @@ bool CacheManager::addEmptyEntry(const std::string& name) {
 template<class F>
 bool CacheManager::existsHelper(const std::string& name, F fn) const {
   auto it = m_cache_map.find(name);
-  if (it == m_cache_map.end()) return nullptr;
+  if (it == m_cache_map.end()) return false;
 
   auto cd = it->second.get();
 


### PR DESCRIPTION
For AArch64, sizeof(bool) = 1 and sizeof(nullptr) = 8.