### PR TITLE
Aarch64 - specialize phpret to prefer ldp

### DIFF
--- a/hphp/runtime/vm/jit/vasm-arm.cpp
+++ b/hphp/runtime/vm/jit/vasm-arm.cpp
@@ -482,6 +482,16 @@ void Vgen::emit(const callfaststub& i) {
 
 ///////////////////////////////////////////////////////////////////////////////
 
+void Vgen::emit(const phpret& i) {
+  // prefer load-pair instruction
+  if (!i.noframe) {
+    a->ldp(X(i.d), X(rlr()), X(i.fp)[AROFF(m_sfp)]);
+  } else {
+    a->Ldr(X(rlr()), X(i.fp)[AROFF(m_savedRip)]);
+  }
+  emit(ret{});
+}
+
 void Vgen::emit(const callphp& i) {
   emitSmashableCall(a->code(), env.meta, i.stub);
   emit(unwind{{i.targets[0], i.targets[1]}});

--- a/hphp/runtime/vm/jit/vasm-arm.cpp
+++ b/hphp/runtime/vm/jit/vasm-arm.cpp
@@ -181,6 +181,7 @@ struct Vgen {
   void emit(const callphp& i);
   void emit(const callarray& i);
   void emit(const contenter& i);
+  void emit(const phpret& i);
 
   // vm entry abi
   void emit(const calltc& i);
@@ -1314,18 +1315,6 @@ void lower(Vunit& u, loadstubret& i, Vlabel b, size_t z) {
 void lower(Vunit& u, phplogue& i, Vlabel b, size_t z) {
   lower_impl(u, b, z, [&] (Vout& v) {
     v << store{rlr(), i.fp[AROFF(m_savedRip)]};
-  });
-}
-
-void lower(Vunit& u, phpret& i, Vlabel b, size_t z) {
-  lower_impl(u, b, z, [&] (Vout& v) {
-    v << load{i.fp[AROFF(m_savedRip)], rlr()};
-
-    if (!i.noframe) {
-      v << load{i.fp[AROFF(m_sfp)], i.d};
-    }
-
-    v << ret{i.args};
   });
 }
 


### PR DESCRIPTION
The phpret vasm instruction can be specialized to use the load-pair instruction
when conditions are right.  The architecture manual says that both reads are done
separately so there should be no alignment issues.  It also states that the write back
is done after the reads.

Before
====
            655  B9: [profCount=1] (preds B8 B7) 
            656     (23) RetCtrl<2> t1:StkPtr, t0:FramePtr, 1
            657         Main:
            658               0x3ca009b8  910083bc              add x28, x29, #0x20 (32)
            659               0x3ca009bc  aa1403e0              mov x0, x20 
            660               0x3ca009c0  aa1303e1              mov x1, x19 
            661               0x3ca009c4  f94007be              ldr x30, [x29, #8]  // <<----
            662               0x3ca009c8  f94003bd              ldr x29, [x29]        // <<----
            663               0x3ca009cc  d65f03c0              ret 
    
After
===
   B9: [profCount=1] (preds B8 B7)
      (23) RetCtrl<2> t1:StkPtr, t0:FramePtr, 1
          Main:   
                0x4c0009b8  910083bc              add x28, x29, #0x20 (32)
                0x4c0009bc  aa1403e0              mov x0, x20 
                0x4c0009c0  aa1303e1              mov x1, x19 
                0x4c0009c4  a9407bbd              ldp x29, x30, [x29]  // <<---
                0x4c0009c8  d65f03c0              ret     

Test case
======
<?php

function main() {
  echo false;
  echo 'x';
  echo true;
  echo 'x';
  echo null;
  echo 'x';
  echo 0;
  echo 'x';
  echo 1;
  echo 1.0;
  echo "\n";

}
main();

Command Line
=========
TRACE='printir:9,vasm:6' ../hhvm_111416/hhvm/hphp/hhvm/hhvm --file 'echo.php' 

Ran the regression tests with 6 option sets.  No additional regressions.

Test Script
=======
echo "Test Started - `date`"

HPHP_TEST=all
PATH=`pwd`/hphp/hhvm:${PATH}
 
echo "/usr/bin/php hphp/test/run -v -m interp ${HPHP_TEST}"
      /usr/bin/php hphp/test/run -v -m interp ${HPHP_TEST} || true

echo "/usr/bin/php hphp/test/run -v -m interp -r ${HPHP_TEST}"
      /usr/bin/php hphp/test/run -v -m interp -r ${HPHP_TEST} || true

echo "/usr/bin/php hphp/test/run -v -m jit -a '-vEval.JitPGO=0' ${HPHP_TEST}"
      /usr/bin/php hphp/test/run -v -m jit -a '-vEval.JitPGO=0' ${HPHP_TEST} || true

echo "/usr/bin/php hphp/test/run -v -m jit -r -a '-vEval.JitPGO=0' ${HPHP_TEST}"
      /usr/bin/php hphp/test/run -v -m jit -r -a '-vEval.JitPGO=0' ${HPHP_TEST} || true

echo "/usr/bin/php hphp/test/run -v -m jit -a '-vEval.JitPGO=1' ${HPHP_TEST}"
      /usr/bin/php hphp/test/run -v -m jit -a '-vEval.JitPGO=1' ${HPHP_TEST} || true

echo "/usr/bin/php hphp/test/run -v -m jit -r -a '-vEval.JitPGO=1' ${HPHP_TEST}"
      /usr/bin/php hphp/test/run -v -m jit -r -a '-vEval.JitPGO=1' ${HPHP_TEST} || true

echo "Test Ended - `date`"

