### PR TITLE
Link libnuma even if jemalloc is not available.

### DIFF
--- a/hphp/util/CMakeLists.txt
+++ b/hphp/util/CMakeLists.txt
@@ -52,7 +52,7 @@ if (ENABLE_COTIRE)
   cotire(hphp_util)
 endif()
 
-if (LIBNUMA_LIBRARIES AND JEMALLOC_ENABLED)
+if (LIBNUMA_LIBRARIES)
   target_link_libraries(hphp_util ${LIBNUMA_LIBRARIES})
 endif()
 if (ENABLE_ASYNC_MYSQL)


### PR DESCRIPTION
This fixes a link error in case jemalloc is not
installed, but libnuma is available.

Signed-off-by: Christoph Muellner <christoph.muellner@theobroma-systems.com>