### PR TITLE
[Aarch64] Enable CRC32 instructions for hashing

### DIFF
--- a/CMake/HPHPCompiler.cmake
+++ b/CMake/HPHPCompiler.cmake
@@ -31,7 +31,7 @@ if (${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang" OR ${CMAKE_CXX_COMPILER_ID} STREQU
     "attributes"
     "maybe-uninitialized"
   )
-  
+
   # Warnings to disable by name when building C code.
   set(DISABLED_C_NAMED_WARNINGS)
   list(APPEND DISABLED_C_NAMED_WARNINGS
@@ -193,6 +193,7 @@ if (${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang" OR ${CMAKE_CXX_COMPILER_ID} STREQU
       set(AARCH64_TARGET_CPU "" CACHE STRING "CPU to tell gcc to optimize for (-mcpu)")
       if(AARCH64_TARGET_CPU)
         list(APPEND GENERAL_OPTIONS "mcpu=${AARCH64_TARGET_CPU}")
+        set(CMAKE_ASM_FLAGS  "${CMAKE_ASM_FLAGS} -mcpu=${AARCH64_TARGET_CPU}")
 
         # Make sure GCC is not using the fix for errata 843419. This change
         # interferes with the gold linker. Note that GCC applies this fix
@@ -243,12 +244,12 @@ if (${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang" OR ${CMAKE_CXX_COMPILER_ID} STREQU
   set(CMAKE_C_FLAGS_RELWITHDEBINFO   "-O2 -g${GDB_SUBOPTION} -DNDEBUG")
   set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O2 -g${GDB_SUBOPTION} -DNDEBUG")
   set(CMAKE_C_FLAGS                  "${CMAKE_C_FLAGS} -W -Werror=implicit-function-declaration")
-  
+
 
   foreach(opt ${DISABLED_NAMED_WARNINGS})
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-${opt}")
   endforeach()
-  
+
   foreach(opt ${DISABLED_C_NAMED_WARNINGS})
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-${opt}")
   endforeach()

--- a/CMake/Options.cmake
+++ b/CMake/Options.cmake
@@ -4,6 +4,7 @@ option(ALWAYS_ASSERT "Enabled asserts in a release build" OFF)
 option(ENABLE_SSP "Enabled GCC/LLVM stack-smashing protection" OFF)
 option(STATIC_CXX_LIB "Statically link libstd++ and libgcc." OFF)
 option(ENABLE_AVX2 "Enable the use of AVX2 instructions" OFF)
+option(ENABLE_AARCH64_CRC "Enable the use of CRC instructions" OFF)
 option(ENABLE_FASTCGI "Enable the FastCGI interface." ON)
 
 option(EXECUTION_PROFILER "Enable the execution profiler" OFF)

--- a/hphp/runtime/base/mixed-array-x64.S
+++ b/hphp/runtime/base/mixed-array-x64.S
@@ -2,7 +2,7 @@
 #include "hphp/runtime/base/string-data-macros.h"
 #include "hphp/util/etch-helpers.h"
 
-#if defined(__SSE4_2__) && defined(NO_M_DATA) && !defined(NO_SSECRC) && \
+#if defined(__SSE4_2__) && defined(NO_M_DATA) && !defined(NO_HWCRC) && \
     !defined(__CYGWIN__) && !defined(__MINGW__)&& !defined(_MSC_VER)
 
         .file     "hphp/runtime/base/mixed-array-x64.S"

--- a/hphp/runtime/base/mixed-array.cpp
+++ b/hphp/runtime/base/mixed-array.cpp
@@ -1439,7 +1439,7 @@ const TypedValue* MixedArray::NvGetInt(const ArrayData* ad, int64_t ki) {
   return LIKELY(validPos(i)) ? &a->data()[i].data : nullptr;
 }
 
-#if !defined(__SSE4_2__) || defined(NO_SSECRC) || !defined(NO_M_DATA) || \
+#if !defined(__SSE4_2__) || defined(NO_HWCRC) || !defined(NO_M_DATA) || \
   defined(__CYGWIN__) || defined(__MINGW__) || defined(_MSC_VER)
 // This function is implemented directly in ASM in mixed-array-x64.S otherwise.
 const TypedValue* MixedArray::NvGetStr(const ArrayData* ad,

--- a/hphp/runtime/base/string-data-x64.S
+++ b/hphp/runtime/base/string-data-x64.S
@@ -1,7 +1,7 @@
 #include "hphp/runtime/base/string-data-macros.h"
 #include "hphp/util/etch-helpers.h"
 
-#if defined(__SSE4_2__) && !defined(NO_SSECRC) && defined(NO_M_DATA) && \
+#if defined(__SSE4_2__) && !defined(NO_HWCRC) && defined(NO_M_DATA) && \
     !defined(__CYGWIN__) && !defined(__MINGW__) && !defined(_MSC_VER)
 
         .file     "hphp/runtime/base/string-data-x64.S"

--- a/hphp/runtime/base/string-data.cpp
+++ b/hphp/runtime/base/string-data.cpp
@@ -843,9 +843,9 @@ void StringData::preCompute() {
   }
 }
 
-#if !defined(__SSE4_2__) || defined(NO_SSECRC) || !defined(NO_M_DATA) || \
+#if !defined(__SSE4_2__) || defined(NO_HWCRC) || !defined(NO_M_DATA) || \
   defined(__CYGWIN__) || defined(__MINGW__) || defined(_MSC_VER)
-// This function is implemented directly in ASM in hash-crc.S otherwise.
+// This function is implemented directly in ASM in string-data-*.S otherwise.
 NEVER_INLINE strhash_t StringData::hashHelper() const {
   assert(!isProxy());
   strhash_t h = hash_string_i_unsafe(data(), m_len);

--- a/hphp/tools/oss_hot_section_ordering
+++ b/hphp/tools/oss_hot_section_ordering
@@ -818,7 +818,7 @@
 .text.hash_string_i_unaligned_crc*
 .text._ZN4HPHP9ArrayData10IsValidKeyERKNS_7VariantE*
 .text._ZN4HPHP21tvMatchesRepoAuthTypeENS_10TypedValueENS_12RepoAuthTypeE*
-.text._ZN4HPHP18IsSSEHashSupportedEv*
+.text._ZN4HPHP17IsHwHashSupportedEv*
 .text._ZNK4HPHP6String5toKeyEv*
 .text._ZN4HPHP5VarNRC1EPNS_10StringDataE*
 .text._ZN4HPHP5VarNRC2EPNS_10StringDataE*

--- a/hphp/util/hash-crc-arm.S
+++ b/hphp/util/hash-crc-arm.S
@@ -1,0 +1,189 @@
+#include "hphp/util/etch-helpers.h"
+#include "hphp/util/hphp-config.h"
+
+#if defined(ENABLE_AARCH64_CRC) && !defined(NO_HWCRC) && \
+    !defined(__CYGWIN__) && !defined(__MINGW__) && !defined(_MSC_VER)
+
+.file   "hphp/util/hash-crc-arm.S"
+
+#define HASH_FUNC_NAME _ZN4HPHP20hash_string_i_unsafeEPKcj
+
+ETCH_SECTION(HASH_FUNC_NAME)
+.globl    HASH_FUNC_NAME
+ETCH_TYPE(HASH_FUNC_NAME, @function)
+ETCH_ALIGN16
+ETCH_NAME(HASH_FUNC_NAME):
+        CFI(startproc)
+        negs    w1, w1
+        mov     w9, #0xffffffff
+        beq     ETCH_LABEL(iend)
+        mov     w3, w1
+        mov     x4, #0xdfdfdfdfdfdfdfdf
+        b       ETCH_LABEL(iheader)
+
+ETCH_ALIGN16
+ETCH_LABEL(iloop):
+        crc32cx w9, w9, x2
+ETCH_LABEL(iheader):
+        ldr     x10, [x0], #8
+        adds    w3, w3, #8
+        mov     x2, x4
+        and     x2, x2, x10
+        bcc     ETCH_LABEL(iloop)
+        lsl     w3, w3, #3
+        lsl     x2, x2, x3
+        crc32cx w9, w9, x2
+
+ETCH_LABEL(iend):
+        lsr     w0, w9, #1
+        ret
+        CFI(endproc)
+
+ETCH_SIZE(HASH_FUNC_NAME)
+#undef HASH_FUNC_NAME
+
+
+#define HASH_FUNC_NAME _ZN4HPHP13hash_string_iEPKcj
+
+ETCH_SECTION(HASH_FUNC_NAME)
+.globl    HASH_FUNC_NAME
+ETCH_TYPE(HASH_FUNC_NAME, @function)
+ETCH_ALIGN16
+ETCH_NAME(HASH_FUNC_NAME):
+        CFI(startproc)
+        mov     w9, #0xffffffff
+        subs    w3, wzr, w1
+        beq     ETCH_LABEL(icend)
+
+        tst     w0, #7
+        mov     x4, #0xdfdfdfdfdfdfdfdf
+        bne     ETCH_LABEL(iuheader)
+        b       ETCH_LABEL(icheader)
+
+ETCH_ALIGN16
+ETCH_LABEL(icloop):
+        crc32cx w9, w9, x2
+ETCH_LABEL(icheader):
+        ldr     x10, [x0], #8
+        adds    w3, w3, #8
+        mov     x2, x4
+        and     x2, x2, x10
+        bcc     ETCH_LABEL(icloop)
+
+ETCH_LABEL(ictail):
+        lsl     w3, w3, #3
+        lsl     x2, x2, x3
+        crc32cx w9, w9, x2
+
+ETCH_LABEL(icend):
+        lsr     w0, w9, #1
+        ret
+
+ETCH_ALIGN16
+ETCH_LABEL(iuloop):
+        ldr     x10, [x0], #8
+        and     x2, x2, x10
+        crc32cx w9, w9, x2
+ETCH_LABEL(iuheader):
+        adds    w3, w3, #8
+        mov     x2, x4
+        bcc     ETCH_LABEL(iuloop)
+
+        subs    w3, w3, #8
+        mov     x2, #0
+        beq     ETCH_LABEL(iuend)
+
+ETCH_LABEL(iutailloop):
+        ldrb    w10, [x0], #1
+        adds    w3, w3, #1
+        lsr     x2, x2, #8
+        bfi     x2, x10, #55, #8
+        bne     ETCH_LABEL(iutailloop)
+
+        and     x2, x2, x4
+        crc32cx w9, w9, x2
+ETCH_LABEL(iuend):
+        lsr     w0, w9, #1
+        ret
+        CFI(endproc)
+
+ETCH_SIZE(HASH_FUNC_NAME)
+#undef HASH_FUNC_NAME
+
+
+#define HASH_FUNC_NAME _ZN4HPHP21hash_string_cs_unsafeEPKcj
+
+ETCH_SECTION(HASH_FUNC_NAME)
+.globl    HASH_FUNC_NAME
+ETCH_TYPE(HASH_FUNC_NAME, @function)
+ETCH_ALIGN16
+ETCH_NAME(HASH_FUNC_NAME):
+        CFI(startproc)
+        negs    w1, w1
+        mov     w9, #0xffffffff
+        beq     ETCH_LABEL(csend)
+        mov     w3, w1
+        b       ETCH_LABEL(csheader)
+
+ETCH_ALIGN16
+ETCH_LABEL(csloop):
+        crc32cx w9, w9, x2
+ETCH_LABEL(csheader):
+        ldr     x2, [x0], #8
+        adds    w3, w3, #8
+        bcc     ETCH_LABEL(csloop)
+
+        lsl     w3, w3, #3
+        lsl     x2, x2, x3
+        crc32cx w9, w9, x2
+
+ETCH_LABEL(csend):
+        lsr     w0, w9, #1
+        ret
+        CFI(endproc)
+ETCH_SIZE(HASH_FUNC_NAME)
+#undef HASH_FUNC_NAME
+
+
+#define HASH_FUNC_NAME _ZN4HPHP14hash_string_csEPKcj
+
+ETCH_SECTION(HASH_FUNC_NAME)
+.globl    HASH_FUNC_NAME
+ETCH_TYPE(HASH_FUNC_NAME, @function)
+ETCH_ALIGN16
+ETCH_NAME(HASH_FUNC_NAME):
+        CFI(startproc)
+        subs    w1, w1, #8
+        mov     w9, #0xffffffff
+        bmi     ETCH_LABEL(csutail)
+
+ETCH_ALIGN16
+ETCH_LABEL(csuloop):
+        ldr     x2, [x0], #8
+        subs    w1, w1, #8
+        crc32cx w9, w9, x2
+        bpl     ETCH_LABEL(csuloop)
+
+ETCH_LABEL(csutail):
+        adds    w1, w1, #8
+        beq     ETCH_LABEL(csuend)
+        mov     w3, w1
+        mov     x2, #0
+
+ETCH_LABEL(csutailloop):
+        ldrb    w10, [x0], #1
+        subs    w3, w3, #1
+        lsr     x2, x2, #8
+        bfi     x2, x10, #55, #8
+        bne     ETCH_LABEL(csutailloop)
+        crc32cx w9, w9, x2
+
+ETCH_LABEL(csuend):
+        lsr     w0, w9, #1
+        ret
+        CFI(endproc)
+
+ETCH_SIZE(HASH_FUNC_NAME)
+#undef HASH_FUNC_NAME
+
+#endif

--- a/hphp/util/hash-crc-x64.S
+++ b/hphp/util/hash-crc-x64.S
@@ -1,9 +1,9 @@
 #include "hphp/util/etch-helpers.h"
 
-#if defined(__x86_64__) && !defined(NO_SSECRC) && \
+#if defined(__x86_64__) && !defined(NO_HWCRC) && \
     !defined(__CYGWIN__) && !defined(__MINGW__) && !defined(_MSC_VER)
 
-.file	"hphp/util/hash-crc.S"
+.file	"hphp/util/hash-crc-x64.S"
 
 /*
  * If SSE4.2 is explicitly specified, we define the HPHP::hash_string* funcitons

--- a/hphp/util/hash.cpp
+++ b/hphp/util/hash.cpp
@@ -18,9 +18,9 @@
 
 namespace HPHP {
 
-bool IsSSEHashSupported() {
-#ifdef USE_SSECRC
-#ifdef __SSE4_2__
+bool IsHwHashSupported() {
+#ifdef USE_HWCRC
+#if defined __SSE4_2__
   return true;
 #else
   static folly::CpuId cpuid;
@@ -31,11 +31,12 @@ bool IsSSEHashSupported() {
 #endif
 }
 
-#if !defined(USE_SSECRC) || !defined(__SSE4_2__)
+#if !defined(USE_HWCRC) || !(defined(__SSE4_2__) || \
+                             defined(ENABLE_AARCH64_CRC))
 NEVER_INLINE
 strhash_t hash_string_cs_fallback(const char *arKey, uint32_t nKeyLength) {
-#ifdef USE_SSECRC
-  if (IsSSEHashSupported()) {
+#ifdef USE_HWCRC
+  if (IsHwHashSupported()) {
     return hash_string_cs_unaligned_crc(arKey, nKeyLength);
   }
 #endif
@@ -46,8 +47,8 @@ strhash_t hash_string_cs_fallback(const char *arKey, uint32_t nKeyLength) {
 
 NEVER_INLINE
 strhash_t hash_string_i_fallback(const char *arKey, uint32_t nKeyLength) {
-#ifdef USE_SSECRC
-  if (IsSSEHashSupported()) {
+#ifdef USE_HWCRC
+  if (IsHwHashSupported()) {
     return hash_string_i_unaligned_crc(arKey, nKeyLength);
   }
 #endif

--- a/hphp/util/hash.h
+++ b/hphp/util/hash.h
@@ -20,25 +20,30 @@
 #include <stdint.h>
 #include <cstring>
 
+#include "hphp/util/hphp-config.h"
 #include "hphp/util/portability.h"
 
 #if defined(__x86_64__) && !defined __CYGWIN__ && !defined __MINGW__ && \
   !defined _MSC_VER
-#  if (!defined USE_SSECRC)
-#    define USE_SSECRC
+#  if (!defined USE_HWCRC)
+#    define USE_HWCRC
+#  endif
+#elif defined __aarch64__ && defined ENABLE_AARCH64_CRC
+#  if (!defined USE_HWCRC)
+#    define USE_HWCRC
 #  endif
 #else
-#  undef USE_SSECRC
+#  undef USE_HWCRC
 #endif
 
 // Killswitch
-#if NO_SSECRC
-#  undef USE_SSECRC
+#if NO_HWCRC
+#  undef USE_HWCRC
 #endif
 
 namespace HPHP {
 
-bool IsSSEHashSupported();
+bool IsHwHashSupported();
 
 ///////////////////////////////////////////////////////////////////////////////
 
@@ -59,23 +64,33 @@ inline size_t hash_int64_fallback(int64_t key) {
   return static_cast<size_t>(static_cast<uint32_t>(key));
 }
 
-ALWAYS_INLINE size_t hash_int64(int64_t k) {
-#if defined(USE_SSECRC) && defined(__SSE4_2__)
+inline size_t hash_int64(int64_t k) {
+#if defined(USE_HWCRC) && defined(__SSE4_2__)
   size_t h = 0;
   __asm("crc32q %1, %0\n" : "+r"(h) : "rm"(k));
   return h;
+#elif defined(USE_HWCRC) && defined(ENABLE_AARCH64_CRC)
+  size_t res;
+  __asm("crc32cx %w0, wzr, %x1\n" : "=r"(res) : "r"(k));
+  return res;
 #else
   return hash_int64_fallback(k);
 #endif
 }
 
+
 inline size_t hash_int64_pair(int64_t k1, int64_t k2) {
-#if defined(USE_SSECRC) && defined(__SSE4_2__)
+#if defined(USE_HWCRC) && defined(__SSE4_2__)
   // crc32 is commutative, so we need to perturb k1 so that (k1, k2) hashes
   // differently from (k2, k1).
   k1 += k1;
   __asm("crc32q %1, %0\n" : "+r" (k1) : "rm"(k2));
   return k1;
+#elif defined(USE_HWCRC) && defined(ENABLE_AARCH64_CRC)
+  size_t res;
+  k1 += k1;
+  __asm("crc32cx %w0, %w1, %x2\n" : "=r"(res) : "r"(k2), "r"(k1));
+  return res;
 #else
   return (hash_int64(k1) << 1) ^ hash_int64(k2);
 #endif
@@ -205,14 +220,13 @@ ALWAYS_INLINE void hash128(const void *key, size_t len, uint64_t seed,
 //   i: case-insensitive;
 //   unsafe: safe for strings aligned at 8-byte boundary;
 
-#if defined USE_SSECRC && defined __SSE4_2__
+#if defined USE_HWCRC && (defined __SSE4_2__ || defined ENABLE_AARCH64_CRC)
 
-// We will surely use CRC32, these are implemented directly in hash-crc.S
+// We will surely use CRC32, these are implemented directly in hash-crc-*.S
 strhash_t hash_string_cs_unsafe(const char *arKey, uint32_t nKeyLength);
 strhash_t hash_string_i_unsafe(const char *arKey, uint32_t nKeyLength);
 strhash_t hash_string_cs(const char *arKey, uint32_t nKeyLength);
 strhash_t hash_string_i(const char *arKey, uint32_t nKeyLength);
-
 #else
 
 strhash_t hash_string_cs_fallback(const char*, uint32_t);
@@ -322,10 +336,11 @@ struct StringData;
 ///////////////////////////////////////////////////////////////////////////////
 }
 
-#if defined(USE_SSECRC) && !defined(__SSE4_2__) && \
-  !defined(__CYGWIN__) && !defined(__MINGW__) && !defined(_MSC_VER)
+#if defined(USE_HWCRC) && !defined(__SSE4_2__) && \
+  !defined(ENABLE_AARCH64_CRC) && !defined(__CYGWIN__) && \
+  !defined(__MINGW__) && !defined(_MSC_VER)
 
-// The following functions are implemented in ASM directly for x86_64.
+// The following functions are implemented in ASM directly for x86_64 and ARM
 extern "C" {
   HPHP::strhash_t hash_string_cs_crc(const char*, uint32_t);
   HPHP::strhash_t hash_string_i_crc(const char*, uint32_t);

--- a/hphp/util/hphp-config.h.in
+++ b/hphp/util/hphp-config.h.in
@@ -41,10 +41,12 @@
 
 #ifdef USE_CMAKE
 #cmakedefine ENABLE_AVX2 1
+#cmakedefine ENABLE_AARCH64_CRC 1
 #cmakedefine ENABLE_ZEND_COMPAT 1
 #cmakedefine EXECUTION_PROFILER 1
 #else
 /* #undef ENABLE_AVX2 */
+/* #undef ENABLE_AARCH64_CRC */
 # define ENABLE_ZEND_COMPAT 1
 /* #undef EXECUTION_PROFILER */
 #endif

--- a/hphp/util/test/hash.cpp
+++ b/hphp/util/test/hash.cpp
@@ -55,7 +55,7 @@ TEST(HashTest, Alignment) {
 
 #ifdef __x86_64__
 TEST(HashTest, SSE42) {
-  if (IsSSEHashSupported()) {
+  if (IsHwHashSupported()) {
     {
       char* stra = "abcdeFGHHHh";
       char* strb = "ABcdEfghhHH";


### PR DESCRIPTION
This patch enables CRC32 instructions for the Aarch64 architecture.
It adds new assembly routines to hash-crc-arm.S which utilize the
CRC32 instructions to accelerate string hashing.

It adds a new cmake flag, enabled with -DENABLE_AARCH64_CRC=1, in the
same fashion as the existing ENABLE_AVX flag. This is required since
there are not compile time flags which indicate whether or not the
given CPU truly supports the CRC32 instructions, as they optional.

It renames NO_SSECRC to NO_HWCRC to make the code processor agnostic.

It moves the x64 assembly from the hash-crc.S file to hash-crc-x64.S.

Lastly, it implements hash_int64 and hash_int64_pair using the CRC
instructions.