### PR TITLE
correction to pr#7522 - testb specialization

### DIFF
--- a/hphp/runtime/vm/jit/vasm-arm.cpp
+++ b/hphp/runtime/vm/jit/vasm-arm.cpp
@@ -1575,7 +1575,7 @@ Y(cmpwm, movzwl, loadw, cmpl)
 void lower(Vunit& u, testb& i, Vlabel b, size_t z) {
   lower_impl(u, b, z, [&] (Vout& v) {
     if (i.s0 == i.s1) {
-      v << testbi{(int8_t)0xff, i.s1, i.sf};
+      v << testbi{(uint8_t)0xff, i.s1, i.sf};
     } else {
       auto s0 = v.makeReg();
       auto s1 = v.makeReg();


### PR DESCRIPTION

Change associated with pr#7522 caused an safe_cast failure for debug builds.
The root cause was the wrong type specified in the cast used in specializing the
testbi lowering.  This shows up in debug builds.

Ran default test.  All pass.
nohup nice /usr/bin/php hphp/test/run >myOut.test 2>&1 &
      6 All tests passed.
      7               |    |    |
      8              )_)  )_)  )_)
      9             )___))___))___)\
     10            )____)____)_____)\
     11          _____|____|____|____\\__
     12 ---------\      SHIP IT      /---------
     13   ^^^^^ ^^^^^^^^^^^^^^^^^^^^^
     14     ^^^^      ^^^^     ^^^    ^^
     15          ^^^^      ^^^
     16 
     17 Total time for all executed tests as run: 222.49s
     18 Total time for all executed tests if run serially: 8290.46s
