### PR TITLE
Fix PIC register clobbered by r30 error on gcc.

### DIFF
--- a/hphp/util/portability.h
+++ b/hphp/util/portability.h
@@ -182,11 +182,26 @@
   // probably have to use a pair of assembly stubs to manage this.
   #define CALLEE_SAVED_BARRIER() always_assert(false);
 #elif defined (__powerpc64__)
+ // After gcc 5.4.1 we can't clobber r30 on PPC64 anymore because it's used as
+ // PIC register.
+ #if __GNUC__ > 5 || (__GNUC__ == 5 && (__GNUC_MINOR__ >= 4) && \
+   (__GNUC_PATCHLEVEL__ >= 1))
+   #define  CALLEE_SAVED_BARRIER()\
+     asm volatile("" : : : "r2", "r14", "r15", "r16", "r17", "r18", "r19",\
+                  "r20", "r21", "r22", "r23", "r24", "r25", "r26", "r27", \
+                  "r28", "r29", "cr2", "cr3", "cr4", "v20", "v21", "v22", \
+                  "v23", "v24", "v25", "v26", "v27", "v28", "v29", "v30", \
+                  "v31");
+ #else
+  // On gcc versions < 5.4.1 we need to include r30 on barrier as it's not
+  // saved by gcc.
   #define CALLEE_SAVED_BARRIER()\
     asm volatile("" : : : "r2", "r14", "r15", "r16", "r17", "r18", "r19",\
-        "r20", "r21", "r22", "r23", "r24", "r25", "r26", "r27", "r28",   \
-        "r29", "r30", "cr2", "cr3", "cr4", "v20", "v21", "v22", "v23",   \
-        "v24", "v25", "v26", "v27", "v28", "v29", "v30", "v31");
+                 "r20", "r21", "r22", "r23", "r24", "r25", "r26", "r27", \
+                 "r28", "r29", "r30", "cr2", "cr3", "cr4", "v20", "v21", \
+                 "v22", "v23", "v24", "v25", "v26", "v27", "v28", "v29", \
+                 "v30", "v31");
+ #endif
 #elif defined (__AARCH64EL__)
   #define CALLEE_SAVED_BARRIER()\
     asm volatile("" : : : "x19", "x20", "x21", "x22", "x23", "x24", "x25",\


### PR DESCRIPTION
Summary:

On gcc 5.4.1 and above we cannot clobber r30 since it's used
as PIC register on PPC64. We still need to save it on
CALLEE_SAVED_BARRIER on gcc versions bellow 5.4.1 since it's
a callee saved register. On gcc 5.4.1 and above we don't need
to explicit save this register on CALLEE_SAVED_BARRIER since
this register is reserved by gcc abi.

Note that we can still clobber r30 if we pass -fno-pic option
to gcc.