### PR TITLE
Enable OCaml for PPC64.

### DIFF
--- a/CMake/FindOCaml.cmake
+++ b/CMake/FindOCaml.cmake
@@ -1,11 +1,6 @@
 set(OCAMLC_FOUND FALSE)
 set(OCAMLC_OPT_SUFFIX "")
 
-if(IS_PPC64)
-  # No OCaml port for PPC64 yet, skip it
-  return()
-endif()
-
 find_program(OCAMLC_EXECUTABLE ocamlc DOC "path to ocamlc")
 mark_as_advanced(OCAMLC_EXECUTABLE)
 


### PR DESCRIPTION
Summary:

This commit enables OCaml for PPC64 since
ocaml-native-compiler was already ported to PPC64.