### PR TITLE
Adding common interface implemented by Map and Vector that is mutable and iterable

### DIFF
--- a/hphp/hack/hhi/collections/interfaces.hhi
+++ b/hphp/hack/hhi/collections/interfaces.hhi
@@ -270,6 +270,19 @@ interface MapAccess<Tk, Tv> extends ConstMapAccess<Tk, Tv>,
 }
 
 /**
+ * Represents a write-enabled (mutable) sequence of key/value pairs
+ * that can be both indexed using square-bracket syntax (e.g.
+ * `$keyed_container[key]`) and mutated.
+ *
+ * This interface provides no new methods, but it combines the
+ * iterability and mutability of some Hack collections into a common
+ * superclass.
+ */
+interface MutableKeyedContainer<Tk, Tv> extends IndexAccess<Tk, Tv>,
+                                                KeyedContainer<Tk, Tv> {
+}
+
+/**
  * Represents a read-only (immutable) sequence of values, indexed by integers
  * (i.e., a vector).
  *
@@ -530,8 +543,8 @@ interface ConstVector<+Tv> extends ConstCollection<Tv>,
  * @guide /hack/collections/interfaces
  */
 interface MutableVector<Tv> extends ConstVector<Tv>,
-                                    Collection<Tv>,
-                                    IndexAccess<int, Tv> {
+                                    MutableKeyedContainer<int, Tv>,
+                                    Collection<Tv> {
   /**
    * Returns a `MutableVector` containing the values of the current
    * `MutableVector`. Essentially a copy of the current `MutableVector`.
@@ -1035,6 +1048,7 @@ interface ConstMap<Tk, +Tv> extends ConstCollection<Pair<Tk, Tv>>,
  */
 interface MutableMap<Tk, Tv> extends ConstMap<Tk, Tv>,
                                      Collection<Pair<Tk, Tv>>,
+                                     MutableKeyedContainer<Tk, Tv>,
                                      MapAccess<Tk, Tv> {
   /**
    * Returns a `MutableVector` containing the values of the current


### PR DESCRIPTION
`MutableMap` and `MutableVector` both already implement `KeyedContainer` and `IndexAccess`. The extends `KeyedTraversable`, while the latter gives these classes basic mutability through `set[All]` and `removeKey`.

Currently, the only way to admit both `Map` and `Vector` to an immutable wrapper with mutable descendants is to upper-bound the collection generic type by `ConstIndexAccess` and refine to a mutable `IndexWrapper` in the descendants. For example:

```php
<?hh // strict
class ImmutableWrapper<Tk, +Tv, +TCollection as \ConstIndexAccess<Tk, Tv>> {
	public function __construct(private TCollection $collection) {}
	public function get_collection(): TCollection {
		return $this->collection;
	}
}
class MutableWrapper<Tk, Tv, +TCollection as \IndexAccess<Tk, Tv>> extends ImmutableWrapper<Tk, Tv, TCollection> {
	public function mutate(Tk $k, Tv $v): void {
		$this->get_collection()->set($k, $v); // for example
	}
}
```

However, without iterability, working with the `IndexAccess` family is cumbersome, and attempts to add iterability get messy. Keeping track of keys in a separate iterable collection, for example, leads quickly to generic hell, especially when the mutability of this collection is considered.

Of the `Traversable` descendants, I'm proposing `KeyedContainer` because it and `Indexish` are the only common ancestors of `Map` and `Vector` to define an indexing method — in this case, the square bracket syntax. `Indexish` is also a good candidate, but I figure that in the future, some core Hack classes might extend `KeyedContainer` but not `Indexish`, judging from Typing[4005] (the [illegal-use-of-square-bracket-indexing error](https://github.com/facebook/hhvm/blob/35c6d1ef834bf2cb81c4ab206c786e475968db0d/hphp/hack/src/utils/errors.ml#L1669)).