### PR TITLE
Ignore .hhconfig for Hack typechecker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.hhbc
 .mkdir
 .DS_Store
+.hhconfig
 hphp.log
 /build
 /deps


### PR DESCRIPTION
Update .gitignore to include .hhconfig file, necessary for using the Hack typechecker (which is in turn necessary for several of the built-in tests to pass).