### PR TITLE
Aarch64 - loadb/movxbl  -> loadzbl peephole

### DIFF
--- a/hphp/runtime/vm/jit/vasm-simplify.cpp
+++ b/hphp/runtime/vm/jit/vasm-simplify.cpp
@@ -431,6 +431,21 @@ bool simplify(Env& env, const copyargs& inst, Vlabel b, size_t i) {
   });
 }
 
+bool simplify(Env& env, const loadb& inst, Vlabel b, size_t i) {
+  return if_inst<Vinstr::movzbl> (env, b, i+1, [&] (const movzbl& cm) {
+    // loadb; movzbl; -> loadzbl;
+    if (!(arch() == Arch::ARM &&
+          env.use_counts[inst.d] == 1 &&
+          env.use_counts[cm.s] == 1 &&
+          inst.d == cm.s)) return false;
+
+    return simplify_impl(env, b, i, [&] (Vout& v) {
+      v << loadzbl{inst.s, cm.d};
+      return 2;
+    });
+  });
+}
+
 bool simplify(Env& env, const movzlq& inst, Vlabel b, size_t i) {
   auto const def_op = env.def_insts[inst.s];
 

--- a/hphp/runtime/vm/jit/vasm-simplify.cpp
+++ b/hphp/runtime/vm/jit/vasm-simplify.cpp
@@ -432,11 +432,10 @@ bool simplify(Env& env, const copyargs& inst, Vlabel b, size_t i) {
 }
 
 bool simplify(Env& env, const loadb& inst, Vlabel b, size_t i) {
-  return if_inst<Vinstr::movzbl> (env, b, i+1, [&] (const movzbl& cm) {
+  return if_inst<Vinstr::movzbl>(env, b, i + 1, [&] (const movzbl& cm) {
     // loadb; movzbl; -> loadzbl;
     if (!(arch() == Arch::ARM &&
           env.use_counts[inst.d] == 1 &&
-          env.use_counts[cm.s] == 1 &&
           inst.d == cm.s)) return false;
 
     return simplify_impl(env, b, i, [&] (Vout& v) {


### PR DESCRIPTION
On Aarch64 the loadb/movxbl sequence would generate ldrsb/uxtb.
This occurred around the  Vinstr cmpbm instructions.  It is equivalent to just use 
the ldrb instruction and save one instruction per instance.

Before
====
    14854    0: FPushFuncD 0 "ut_main"
    14855     (03) EndGuards
    14856     (07) t3:Func = LdFuncCached<ut_main> -> B2<Catch>
    14857         Main:   
    14858               0x296008b0  d28217e0              movz x0, #0x10bf 
    14859               0x296008b4  38e06b60              ldrsb w0, [x27, x0]     // <<--+
    14860               0x296008b8  53001c00              uxtb w0, w0             // <<--+
    14861               0x296008bc  d29fffe1              movz x1, #0xffff 
    14862               0x296008c0  f2a05fe1              movk x1, #0x2ff, lsl #16 
    14863               0x296008c4  38616b61              ldrb w1, [x27, x1] 
    14864               0x296008c8  6b00003f              cmp w1, w0

After
=====
     320    0: FPushFuncD 0 "ut_main"
     321     (03) EndGuards
     322     (07) t3:Func = LdFuncCached<ut_main> -> B2<Catch>
     323         Main:
     324               0x1d40082c  d28217e0              movz x0, #0x10bf
     325               0x1d400830  38606b60              ldrb w0, [x27, x0]  //<<---
     326               0x1d400834  d29fffe1              movz x1, #0xffff
     327               0x1d400838  f2a05fe1              movk x1, #0x2ff, lsl #16
     328               0x1d40083c  38616b61              ldrb w1, [x27, x1]
     329               0x1d400840  6b00003f              cmp w1, w0

This was tested by running the regression tests with six different option sets.
No new issues were found.

