### PR TITLE
test: cycle_debug_backtrace: Fix hard coded value.

### DIFF
--- a/hphp/test/slow/async/cycle_debug_backtrace.php.expectf
+++ b/hphp/test/slow/async/cycle_debug_backtrace.php.expectf
@@ -16,14 +16,14 @@ array(4) {
   [3]=>
   string(18) "testCycleBackTrace"
 }
-string(184) "Encountered dependency cycle.
+string(%d) "Encountered dependency cycle.
 Existing stack:
   {closure} (%d) (dupe)
   <await-all> (%d)
 Trying to introduce dependency on:
   {closure} (%d) (dupe)
 "
-string(184) "Encountered dependency cycle.
+string(%d) "Encountered dependency cycle.
 Existing stack:
   {closure} (%d) (dupe)
   <await-all> (%d)


### PR DESCRIPTION
The expected test output for test
hphp/test/slow/async/cycle_debug_backtrace.php
contains a hard coded string length for the expected
stack. As the stack contains object IDs, which happen
to be virtual addresses in HHVM, expecting a specific
length of a string output is not correct.
In fact this test never matched on arm64.

Signed-off-by: Christoph Muellner <christoph.muellner@theobroma-systems.com>