### PR TITLE
test: Round results in date_sunrise_test.php.

### DIFF
--- a/hphp/test/slow/ext_date/date_sunrise_test.php
+++ b/hphp/test/slow/ext_date/date_sunrise_test.php
@@ -23,32 +23,32 @@ var_dump( date_sunrise($time) );
 
 echo "\n-- Testing date_sunrise() function by passing two parameters --\n";
 var_dump( date_sunrise($time, SUNFUNCS_RET_STRING) );
-var_dump( date_sunrise($time, SUNFUNCS_RET_DOUBLE) );
+var_dump( round( date_sunrise($time, SUNFUNCS_RET_DOUBLE), 4) );
 var_dump( date_sunrise($time, SUNFUNCS_RET_TIMESTAMP) );
 
 echo "\n-- Testing date_sunrise() function by passing two parameters --\n";
 var_dump( date_sunrise($time, SUNFUNCS_RET_STRING, $latitude) );
-var_dump( date_sunrise($time, SUNFUNCS_RET_DOUBLE, $latitude) );
+var_dump( round( date_sunrise($time, SUNFUNCS_RET_DOUBLE, $latitude), 4) );
 var_dump( date_sunrise($time, SUNFUNCS_RET_TIMESTAMP, $latitude) );
 
 echo "\n-- Testing date_sunrise() function by passing three  parameters --\n";
 var_dump( date_sunrise($time, SUNFUNCS_RET_STRING, $latitude, $longitude) );
-var_dump( date_sunrise($time, SUNFUNCS_RET_DOUBLE, $latitude, $longitude) );
+var_dump( round( date_sunrise($time, SUNFUNCS_RET_DOUBLE, $latitude, $longitude), 4) );
 var_dump( date_sunrise($time, SUNFUNCS_RET_TIMESTAMP, $latitude, $longitude) );
 
 echo "\n-- Testing date_sunrise() function by passing four parameters --\n";
 var_dump( date_sunrise($time, SUNFUNCS_RET_STRING,
   $latitude, $longitude, $zenith) );
-var_dump( date_sunrise($time, SUNFUNCS_RET_DOUBLE,
-  $latitude, $longitude, $zenith) );
+var_dump( round( date_sunrise($time, SUNFUNCS_RET_DOUBLE,
+  $latitude, $longitude, $zenith), 4) );
 var_dump( date_sunrise($time, SUNFUNCS_RET_TIMESTAMP,
   $latitude, $longitude, $zenith) );
 
 echo "\n-- Testing date_sunrise() function by passing five parameters --\n";
 var_dump( date_sunrise($time, SUNFUNCS_RET_STRING,
   $latitude, $longitude, $zenith, $gmt_offset) );
-var_dump( date_sunrise($time, SUNFUNCS_RET_DOUBLE,
-  $latitude, $longitude, $zenith, $gmt_offset) );
+var_dump( round( date_sunrise($time, SUNFUNCS_RET_DOUBLE,
+  $latitude, $longitude, $zenith, $gmt_offset), 4) );
 var_dump( date_sunrise($time, SUNFUNCS_RET_TIMESTAMP,
   $latitude, $longitude, $zenith, $gmt_offset) );
 

--- a/hphp/test/slow/ext_date/date_sunrise_test.php.expect
+++ b/hphp/test/slow/ext_date/date_sunrise_test.php.expect
@@ -5,26 +5,26 @@ string(5) "09:37"
 
 -- Testing date_sunrise() function by passing two parameters --
 string(5) "09:37"
-float(9.622663104669)
+float(9.6227)
 int(1356496641)
 
 -- Testing date_sunrise() function by passing two parameters --
 string(5) "09:54"
-float(9.9142368079326)
+float(9.9142)
 int(1356497691)
 
 -- Testing date_sunrise() function by passing three  parameters --
 string(5) "12:51"
-float(12.863799485848)
+float(12.8638)
 int(1356508309)
 
 -- Testing date_sunrise() function by passing four parameters --
 string(5) "12:55"
-float(12.921003983007)
+float(12.921)
 int(1356508515)
 
 -- Testing date_sunrise() function by passing five parameters --
 string(5) "08:55"
-float(8.9210039830067)
+float(8.921)
 int(1356508515)
 ===DONE===


### PR DESCRIPTION
Caclulating the time of sunrise as a double value
can lead to different results on different machines.

The reason is that some machines might use FMA (fused
multiply-add) instructions, which perform a multiplication
followed by an addition without rounding in between.
The result of the FMA instruction might be "more correct"
(i.e. different) than performing two distinct calculations.

This patch rounds the result of the sunrise time calculation
in order to avoid misleading precision expectations of the result.

Fixes https://github.com/facebook/hhvm/issues/7594

Signed-off-by: Christoph Muellner <christoph.muellner@theobroma-systems.com>