### PR TITLE
test: Cleanup after running 1775.php.

### DIFF
--- a/hphp/test/slow/ext_file/1775.php
+++ b/hphp/test/slow/ext_file/1775.php
@@ -1,8 +1,10 @@
 <?php
 
 error_reporting(0);
-$fp = fopen('/tmp/lock.txt', 'w');
+$tempfile = tempnam(sys_get_temp_dir(), 'lock');
+$fp = fopen($tempfile, 'w');
 fclose($fp);
-$fp = fopen('/tmp/lock.txt', 'r+');
+$fp = fopen($tempfile, 'r+');
 var_dump(flock($fp, 0xf0));
 fclose($fp);
+unlink($tempfile);


### PR DESCRIPTION
After creating the file /tmp/lock.txt it should be deleted.

Signed-off-by: Christoph Muellner <christoph.muellner@theobroma-systems.com>