### PR TITLE
test: Cleanup after running eval.php.

### DIFF
--- a/hphp/test/slow/ext_xdebug/remote/eval.php.expectf
+++ b/hphp/test/slow/ext_xdebug/remote/eval.php.expectf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="iso-8859-1"?>
 <init xmlns="urn:debugger_protocol_v1" xmlns:xdebug="http://xdebug.org/dbgp/xdebug" fileuri="file://%s/test/slow/ext_xdebug/remote/eval.php.test" language="PHP" protocol_version="" appid=""><engine version=""><![CDATA[xdebug]]></engine><author><![CDATA[HHVM]]></author><url><![CDATA[http://hhvm.com/]]></url><copyright><![CDATA[Copyright (c) 2002-2013 by Derick Rethans]]></copyright></init>
-(cmd) breakpoint_set -i 0 -t line -f eval.php.test -n 45
+(cmd) breakpoint_set -i 0 -t line -f eval.php.test -n 46
 <?xml version="1.0" encoding="iso-8859-1"?>
 <response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="http://xdebug.org/dbgp/xdebug" command="breakpoint_set" transaction_id="0" id="0" state="enabled"></response>
 (cmd) run -i 0
@@ -68,14 +68,14 @@ array(10) {
 }
 resource(4) of type (stream)
 <?xml version="1.0" encoding="iso-8859-1"?>
-<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="http://xdebug.org/dbgp/xdebug" status="break" reason="ok" command="run" transaction_id="0"><xdebug:message lineno="45" filename="file://%s/test/slow/ext_xdebug/remote/eval.php.test"></xdebug:message></response>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="http://xdebug.org/dbgp/xdebug" status="break" reason="ok" command="run" transaction_id="0"><xdebug:message lineno="46" filename="file://%s/test/slow/ext_xdebug/remote/eval.php.test"></xdebug:message></response>
 (cmd) eval -i 0 -- NSs1
 <?xml version="1.0" encoding="iso-8859-1"?>
 <response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="http://xdebug.org/dbgp/xdebug" command="eval" transaction_id="0"><property address="" type="int"><![CDATA[10]]></property></response>
 (cmd) eval -i 0 -- IyRsW0AjJEA=
 Hit fatal : syntax error, unexpected $end
     #0 at [:1]
-    #1 include(), called at [%s/test/slow/ext_xdebug/remote/eval.php.test:45]
+    #1 include(), called at [%s/test/slow/ext_xdebug/remote/eval.php.test:46]
 <?xml version="1.0" encoding="iso-8859-1"?>
 <response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="http://xdebug.org/dbgp/xdebug" command="eval" transaction_id="0"><error code="206"><message><![CDATA[error evaluating code
 Hit fatal : syntax error, unexpected $end
@@ -126,13 +126,13 @@ Hit fatal : syntax error, unexpected $end
 Hit a php exception : exception 'Exception' with message 'hello from eval' in %s/test/slow/ext_xdebug/remote/eval.php.test:30
 Stack trace:
 #0 (1): thrower()
-#1 %s/test/slow/ext_xdebug/remote/eval.php.test(45): include()
+#1 %s/test/slow/ext_xdebug/remote/eval.php.test(46): include()
 #2 {main}<?xml version="1.0" encoding="iso-8859-1"?>
 <response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="http://xdebug.org/dbgp/xdebug" command="eval" transaction_id="0"><error code="206"><message><![CDATA[error evaluating code
 Hit a php exception : exception 'Exception' with message 'hello from eval' %s
 Stack trace:
 #0 (1): thrower()
-#1 %s/eval.php.test(45): include()
+#1 %s/eval.php.test(46): include()
 #2 {main}]]></message></error></response>
 (cmd) run -i 0
 <?xml version="1.0" encoding="iso-8859-1"?>

--- a/hphp/test/slow/ext_xdebug/remote/eval.php.test
+++ b/hphp/test/slow/ext_xdebug/remote/eval.php.test
@@ -40,6 +40,8 @@ $bar = array_fill(0, 10, 2);
 $bar[1] = &$bar;
 var_dump($bar);
 
-$baz = fopen("/tmp/remote_eval.test", "w"); 
+$tempfile = tempnam(sys_get_temp_dir(), 'remote_eval.test');
+$baz = fopen($tempfile, "w");
 var_dump($baz);
 fclose($baz);
+unlink($tempfile);

--- a/hphp/test/slow/ext_xdebug/remote/eval.php.test.in
+++ b/hphp/test/slow/ext_xdebug/remote/eval.php.test.in
@@ -1,4 +1,4 @@
-breakpoint_set -i 0 -t line -f eval.php.test -n 45
+breakpoint_set -i 0 -t line -f eval.php.test -n 46
 run -i 0
 # 5 + 5 
 eval -i 0 -- NSs1


### PR DESCRIPTION
After creating the file /tmp/remote_eval.test it should be deleted.

Signed-off-by: Christoph Muellner <christoph.muellner@theobroma-systems.com>