### PR TITLE
test: Cleanup after creating /tmp/trace* files.

### DIFF
--- a/hphp/test/slow/ext_xdebug/tracing_0.php
+++ b/hphp/test/slow/ext_xdebug/tracing_0.php
@@ -8,3 +8,6 @@ start_trace();
 require(__DIR__ . '/tracing.inc');
 $file = xdebug_stop_trace();
 var_dump(file_get_contents($file));
+
+// Cleanup
+@array_map("unlink", glob("/tmp/trace*"));

--- a/hphp/test/slow/ext_xdebug/tracing_1.php
+++ b/hphp/test/slow/ext_xdebug/tracing_1.php
@@ -8,3 +8,6 @@ start_trace();
 require(__DIR__ . '/tracing.inc');
 $file = xdebug_stop_trace();
 var_dump(file_get_contents($file));
+
+// Cleanup
+@array_map("unlink", glob("/tmp/trace*"));

--- a/hphp/test/slow/ext_xdebug/tracing_2.php
+++ b/hphp/test/slow/ext_xdebug/tracing_2.php
@@ -8,3 +8,6 @@ start_trace();
 require(__DIR__ . '/tracing.inc');
 $file = xdebug_stop_trace();
 var_dump(file_get_contents($file));
+
+// Cleanup
+@array_map("unlink", glob("/tmp/trace*"));

--- a/hphp/test/slow/ext_xdebug/tracing_3.php
+++ b/hphp/test/slow/ext_xdebug/tracing_3.php
@@ -2,3 +2,6 @@
 require(__DIR__ . '/tracing.inc');
 $file = xdebug_stop_trace();
 var_dump(file_get_contents($file));
+
+// Cleanup
+@array_map("unlink", glob("/tmp/trace*"));

--- a/hphp/test/slow/ext_xdebug/tracing_4.php
+++ b/hphp/test/slow/ext_xdebug/tracing_4.php
@@ -6,3 +6,6 @@ xdebug_start_trace($file, XDEBUG_TRACE_APPEND | XDEBUG_TRACE_NAKED_FILENAME);
 require(__DIR__ . '/tracing.inc');
 xdebug_stop_trace();
 var_dump(file_get_contents($file));
+
+// Cleanup
+@array_map("unlink", glob("/tmp/trace*"));

--- a/hphp/test/slow/ext_xdebug/tracing_5.php
+++ b/hphp/test/slow/ext_xdebug/tracing_5.php
@@ -8,3 +8,6 @@ start_trace();
 require(__DIR__ . '/tracing.inc');
 $file = xdebug_stop_trace();
 var_dump(file_get_contents($file));
+
+// Cleanup
+@array_map("unlink", glob("/tmp/trace*"));

--- a/hphp/test/slow/ext_xdebug/tracing_6.php
+++ b/hphp/test/slow/ext_xdebug/tracing_6.php
@@ -8,3 +8,6 @@ start_trace();
 require(__DIR__ . '/tracing.inc');
 $file = xdebug_stop_trace();
 var_dump(file_get_contents($file));
+
+// Cleanup
+@array_map("unlink", glob("/tmp/trace*"));

--- a/hphp/test/slow/ext_xdebug/tracing_basic_0.php
+++ b/hphp/test/slow/ext_xdebug/tracing_basic_0.php
@@ -58,3 +58,6 @@ var_dump(xdebug_stop_trace());
 // Literal %
 var_dump(xdebug_start_trace("/tmp/trace-%%"));
 var_dump(xdebug_stop_trace());
+
+// Cleanup
+@array_map("unlink", glob("/tmp/trace*"));


### PR DESCRIPTION
This patch adds a cleanup step to the following tests,
which create files of the form /tmp/trace*:

 * tracing_0.php
 * tracing_1.php
 * tracing_2.php
 * tracing_3.php
 * tracing_4.php
 * tracing_5.php
 * tracing_6.php
 * tracing_basic_0.php

The cleanup step deletes all files which match the wildcard /tmp/trace*.

Signed-off-by: Christoph Muellner <christoph.muellner@theobroma-systems.com>