### PR TITLE
test: Cleanup after running touch_date.php.

### DIFF
--- a/hphp/test/slow/ext_file/touch_date.php
+++ b/hphp/test/slow/ext_file/touch_date.php
@@ -26,3 +26,5 @@ touch($file, strtotime("@100200300"), strtotime("@100400500"));
 $fileInfo = new SplFileInfo($file);
 print($fileInfo->getMTime()."\n");
 print($fileInfo->getATime()."\n");
+
+@unlink($file);


### PR DESCRIPTION
After creating the file touch_date it should be deleted.

Signed-off-by: Christoph Muellner <christoph.muellner@theobroma-systems.com>