### PR TITLE
test: Adding missing valid output variant to phpunit_mock.php.

### DIFF
--- a/hphp/test/slow/ext_phar/phpunit_mock.php.expectf
+++ b/hphp/test/slow/ext_phar/phpunit_mock.php.expectf
@@ -1,8 +1,0 @@
-#!/usr/bin/env php
-PHPUnit 3.7.22 by Sebastian Bergmann.
-
-.
-
-Time: %d second%A, Memory: %s
-
-OK (1 test, 1 assertion)

--- a/hphp/test/slow/ext_phar/phpunit_mock.php.expectregex
+++ b/hphp/test/slow/ext_phar/phpunit_mock.php.expectregex
@@ -1,0 +1,8 @@
+#\!\/usr\/bin\/env php
+PHPUnit 3.7.22 by Sebastian Bergmann.
+
+.
+
+(Time: \d+ second.*, Memory: [^\r\n]+|Time: \d+:\d+, Memory: [^\r\n]+)
+
+OK \(1 test, 1 assertion\)


### PR DESCRIPTION
phpunit_mock.php is expected to provide a string of this format:
Time: %d second%A, Memory: %s

However, it is possible that the test outputs this (observed on a debug
build on arm64 Ubuntu Xenial machine, which was under heavy load by
other tasks):
Time: 01:13, Memory: 22.92Mb

This leads to a failed test.
The reason is, that phpunit.phar:secondsToTimeString() creates several
time string variants (depending on the duration).
The expected test output assumes that the runtime is always below
one minute. As observed this assumption might not be always true.

This patch allows the test to take up to one hour, which should be
a reasonable timeframe.

Verification of this change has been achieved starting stress(1)
in background:
stress --cpu $(nproc) --io $(nproc) --vm $(nproc) --hdd $(nproc) --timeout 120s

Signed-off-by: Christoph Muellner <christoph.muellner@theobroma-systems.com>