### PR TITLE
Fix failing test cases, triggered by missing optional member-reflection data.

### DIFF
--- a/hphp/runtime/base/member-reflection.cpp
+++ b/hphp/runtime/base/member-reflection.cpp
@@ -46,7 +46,7 @@ bool init_member_reflection() {
   if (!get_embedded_data("member_reflection", &desc)) {
     // We might not be embedding the shared object, depending on platform, so
     // don't cry too loudly if we don't find it.
-    Logger::Verbose("init_member_reflection: Unable to find embedded data\n");
+    Logger::Verbose("init_member_reflection: Unable to find embedded data");
     return false;
   }
 
@@ -54,7 +54,7 @@ bool init_member_reflection() {
   auto const handle = dlopen_embedded_data(desc, tmp_filename);
   if (!handle) {
     Logger::Warning("init_member_reflection: "
-                    "Failed to dlopen embedded data\n");
+                    "Failed to dlopen embedded data");
     return false;
   }
 
@@ -63,7 +63,7 @@ bool init_member_reflection() {
       dlsym(handle, detail::kMemberReflectionTableName)
     );
   if (!g_member_reflection_vtable) {
-    Logger::Warning("init_member_reflection: dlsym failed: %s\n", dlerror());
+    Logger::Warning("init_member_reflection: dlsym failed: %s", dlerror());
     return false;
   }
 

--- a/hphp/test/slow/program_functions/config_overrides.php.expect
+++ b/hphp/test/slow/program_functions/config_overrides.php.expect
@@ -1,3 +1,0 @@
-string(2) "66"
-string(3) "222"
-string(7) "Verbose"

--- a/hphp/test/slow/program_functions/config_overrides.php.expectregex
+++ b/hphp/test/slow/program_functions/config_overrides.php.expectregex
@@ -1,0 +1,3 @@
+(init_member_reflection: Unable to find embedded data\n)?string\(2\) "66"
+string\(3\) "222"
+string\(7\) "Verbose"

--- a/hphp/test/slow/program_functions/tier_overrides_default.php.expect
+++ b/hphp/test/slow/program_functions/tier_overrides_default.php.expect
@@ -1,8 +1,0 @@
-string(7) "Verbose"
-string(10) "1073741824"
-string(7) "2323232"
-string(3) "120"
-string(5) "43200"
-string(1) "0"
-string(1) "1"
-bool(false)

--- a/hphp/test/slow/program_functions/tier_overrides_default.php.expectregex
+++ b/hphp/test/slow/program_functions/tier_overrides_default.php.expectregex
@@ -1,0 +1,8 @@
+(init_member_reflection: Unable to find embedded data\n)?string\(7\) "Verbose"
+string\(10\) "1073741824"
+string\(7\) "2323232"
+string\(3\) "120"
+string\(5\) "43200"
+string\(1\) "0"
+string\(1\) "1"
+bool\(false\)

--- a/hphp/test/slow/program_functions/tier_overrides_tier.php.expect
+++ b/hphp/test/slow/program_functions/tier_overrides_tier.php.expect
@@ -1,8 +1,0 @@
-string(7) "Verbose"
-string(9) "209715200"
-string(7) "2323232"
-string(3) "120"
-string(3) "360"
-string(9) "200000000"
-string(0) ""
-bool(false)

--- a/hphp/test/slow/program_functions/tier_overrides_tier.php.expectregex
+++ b/hphp/test/slow/program_functions/tier_overrides_tier.php.expectregex
@@ -1,0 +1,8 @@
+(init_member_reflection: Unable to find embedded data\n)?string\(7\) "Verbose"
+string\(9\) "209715200"
+string\(7\) "2323232"
+string\(3\) "120"
+string\(3\) "360"
+string\(9\) "200000000"
+string\(0\) ""
+bool\(false\)


### PR DESCRIPTION
There are three failing test cases (all archs, all build types), which are caused by
a warning message of the member-reflection module (in case the member-reflection
data is not embedded in HHVM):

* config_overrides.php
* tier_overrides_default.php
* tier_overrides_tier.php

This PR fixes those tests.