### PR TITLE
set_error_handler(null) incompatibility fix

### DIFF
--- a/hphp/runtime/base/execution-context.cpp
+++ b/hphp/runtime/base/execution-context.cpp
@@ -572,6 +572,10 @@ void ExecutionContext::popUserErrorHandler() {
   }
 }
 
+void ExecutionContext::clearUserErrorHandlers() {
+  while (!m_userErrorHandlers.empty()) m_userErrorHandlers.pop_back();
+}
+
 void ExecutionContext::popUserExceptionHandler() {
   if (!m_userExceptionHandlers.empty()) {
     m_userExceptionHandlers.pop_back();

--- a/hphp/runtime/base/execution-context.h
+++ b/hphp/runtime/base/execution-context.h
@@ -241,6 +241,7 @@ public:
   Variant pushUserExceptionHandler(const Variant& function);
   void popUserErrorHandler();
   void popUserExceptionHandler();
+  void clearUserErrorHandlers();
   bool errorNeedsHandling(int errnum,
                           bool callUserHandler,
                           ErrorThrowMode mode);

--- a/hphp/runtime/ext/std/ext_std_errorfunc.cpp
+++ b/hphp/runtime/ext/std/ext_std_errorfunc.cpp
@@ -227,7 +227,12 @@ bool HHVM_FUNCTION(restore_exception_handler) {
 
 Variant HHVM_FUNCTION(set_error_handler, const Variant& error_handler,
                                          int error_types /* = k_E_ALL */) {
-  return g_context->pushUserErrorHandler(error_handler, error_types);
+  if (!is_null(error_handler)) {
+    return g_context->pushUserErrorHandler(error_handler, error_types);
+  } else {
+    g_context->clearUserErrorHandlers();
+    return init_null_variant;
+  }
 }
 
 Variant HHVM_FUNCTION(set_exception_handler, const Variant& exception_handler) {

--- a/hphp/test/slow/error_handler/7613.php
+++ b/hphp/test/slow/error_handler/7613.php
@@ -1,0 +1,6 @@
+<?php
+// `set_error_handler(null)` should clear the error handler and reset it back
+// to the default error handler.
+set_error_handler(function() { print("Custom handler"); });
+set_error_handler(null);
+trigger_error("ack");

--- a/hphp/test/slow/error_handler/7613.php.expectf
+++ b/hphp/test/slow/error_handler/7613.php.expectf
@@ -1,0 +1,2 @@
+
+Notice: ack in %s on line %d


### PR DESCRIPTION
Per the PHP documentation passing null to the `set_error_handler` function should clear any existing error handlers, resetting the VM back to using the default error handler.

Fixes #7613