### PR TITLE
Allow classname<T> in instanceof test

### DIFF
--- a/hphp/hack/src/typing/typing.ml
+++ b/hphp/hack/src/typing/typing.ml
@@ -4162,7 +4162,6 @@ and condition env tparamet =
         let env, obj_ty = Env.expand_type env obj_ty in
         match obj_ty with
         | _, Tabstract (AKgeneric _, _) ->
-          Errors.instanceof_generic_classname p;
           env, obj_ty
         | _, Tabstract (AKdependent (`this, []), Some (_, Tclass _)) ->
           let obj_ty =

--- a/hphp/hack/src/utils/errors.ml
+++ b/hphp/hack/src/utils/errors.ml
@@ -667,7 +667,6 @@ module Typing                               = struct
   let instanceof_always_false               = 4159 (* DONT MODIFY!!!! *)
   let instanceof_always_true                = 4160 (* DONT MODIFY!!!! *)
   let ambiguous_member                      = 4161 (* DONT MODIFY!!!! *)
-  let instanceof_generic_classname          = 4162 (* DONT MODIFY!!!! *)
   (* EXTEND HERE WITH NEW VALUES IF NEEDED *)
 end
 
@@ -2014,10 +2013,6 @@ let instanceof_always_false pos =
 let instanceof_always_true pos =
   add Typing.instanceof_always_true pos
     "This 'instanceof' test will always succeed"
-
-let instanceof_generic_classname pos =
-  add Typing.instanceof_generic_classname pos
-    "'instanceof' cannot be used on a generic classname because types are erased at runtime"
 
 
 (*****************************************************************************)

--- a/hphp/hack/src/utils/errors_sig.ml
+++ b/hphp/hack/src/utils/errors_sig.ml
@@ -321,8 +321,6 @@ module type S = sig
     -> (Pos.t * string) list -> unit
   val instanceof_always_false : Pos.t -> unit
   val instanceof_always_true : Pos.t -> unit
-  val instanceof_generic_classname : Pos.t -> unit
-
 
   val to_json : Pos.absolute error_ -> Hh_json.json
   val to_string : ?indent:bool -> Pos.absolute error_ -> string

--- a/hphp/hack/test/typecheck/classname/instanceof.php.exp
+++ b/hphp/hack/test/typecheck/classname/instanceof.php.exp
@@ -2,5 +2,4 @@ File "instanceof.php", line 8, characters 5-23:
   I
 File "instanceof.php", line 21, characters 7-19:
   T
-File "instanceof.php", line 20, characters 9-29:
-'instanceof' cannot be used on a generic classname because types are erased at runtime (Typing[4162])
+No errors

--- a/hphp/hack/test/typecheck/classname/instanceof_generic.php.exp
+++ b/hphp/hack/test/typecheck/classname/instanceof_generic.php.exp
@@ -1,4 +1,3 @@
 File "instanceof_generic.php", line 7, characters 3-13:
   T
-File "instanceof_generic.php", line 4, characters 8-27:
-'instanceof' cannot be used on a generic classname because types are erased at runtime (Typing[4162])
+No errors

--- a/hphp/hack/test/typecheck/instanceof_generic_instance.php.exp
+++ b/hphp/hack/test/typecheck/instanceof_generic_instance.php.exp
@@ -1,4 +1,3 @@
 File "instanceof_generic_instance.php", line 7, characters 3-13:
   T
-File "instanceof_generic_instance.php", line 4, characters 8-23:
-'instanceof' cannot be used on a generic classname because types are erased at runtime (Typing[4162])
+No errors


### PR DESCRIPTION
As far as I can tell, the commit https://github.com/facebook/hhvm/commit/e5e54bb597bc55249403011399eadc85772763cb is in error.

If `$y` is `classname<T>` (name of a class that is compatible with `T`) and `$x instanceof $y` is `true`, `$x` is necessarily compatible with `T`. I don't see the relevance to type erasure mentioned in the error message.

Fixes #7617