### PR TITLE
build: make boost dependency failure more explicit

### DIFF
--- a/CMake/HPHPFindLibs.cmake
+++ b/CMake/HPHPFindLibs.cmake
@@ -29,6 +29,9 @@ endif()
 
 # boost checks
 find_package(Boost 1.51.0 COMPONENTS system program_options filesystem context REQUIRED)
+if(NOT Boost_FOUND)
+  message(FATAL_ERROR "boost[>=1.51.0] is required to build HHVM")
+endif()
 include_directories(${Boost_INCLUDE_DIRS})
 link_directories(${Boost_LIBRARY_DIRS})
 add_definitions("-DHAVE_BOOST1_49")


### PR DESCRIPTION
Previously, if boost was not found, we would fail with a developer
warning rather than a proper error message.  Add an explicit check to
ensure that boost is found when configuring.

  Make Error: The following variables are used in this project, but they are set to NOTFOUND.
  Please set them or make sure they are set and tested correctly in the CMake files:
  Boost_INCLUDE_DIR (ADVANCED)
     used as include directory in directory /Users/compnerd/Source/hhvm/third-party
     used as include directory in directory /Users/compnerd/Source/hhvm/third-party
  LIBGLOG_INCLUDE_DIR (ADVANCED)
     used as include directory in directory /Users/compnerd/Source/hhvm/third-party
     used as include directory in directory /Users/compnerd/Source/hhvm/third-party