### PR TITLE
Pass to reuse ldimmq immediate values

### DIFF
--- a/hphp/runtime/base/runtime-option.h
+++ b/hphp/runtime/base/runtime-option.h
@@ -459,6 +459,7 @@ struct RuntimeOption {
   F(int, JitConcurrently,              1)                               \
   F(int, JitThreads,                   4)                               \
   F(int, JitWorkerThreads,             Process::GetCPUCount() / 2)      \
+  F(int, JitLdimmqSpan,                8)                               \
   F(bool, RecordSubprocessTimes,       false)                           \
   F(bool, AllowHhas,                   false)                           \
   F(string, UseExternalEmitter,        "")                              \

--- a/hphp/runtime/vm/jit/vasm-arm.cpp
+++ b/hphp/runtime/vm/jit/vasm-arm.cpp
@@ -1641,12 +1641,13 @@ void optimizeARM(Vunit& unit, const Abi& abi, bool regalloc) {
   simplify(unit);
 
   lowerForARM(unit);
-  reuseImmq(unit);
+
   simplify(unit);
 
   if (!unit.constToReg.empty()) {
     foldImms<arm::ImmFolder>(unit);
   }
+  reuseImmq(unit);
 
   optimizeCopies(unit, abi);
 

--- a/hphp/runtime/vm/jit/vasm-arm.cpp
+++ b/hphp/runtime/vm/jit/vasm-arm.cpp
@@ -1641,7 +1641,7 @@ void optimizeARM(Vunit& unit, const Abi& abi, bool regalloc) {
   simplify(unit);
 
   lowerForARM(unit);
-
+  reuseImmq(unit);
   simplify(unit);
 
   if (!unit.constToReg.empty()) {

--- a/hphp/runtime/vm/jit/vasm-instr.cpp
+++ b/hphp/runtime/vm/jit/vasm-instr.cpp
@@ -72,6 +72,26 @@ bool isBlockEnd(const Vinstr& inst) {
   }
 }
 
+bool isCall(const Vinstr& inst) {
+  switch (inst.op) {
+    case Vinstr::call:
+    case Vinstr::callarray:
+    case Vinstr::callfaststub:
+    case Vinstr::callm:
+    case Vinstr::callphp:
+    case Vinstr::callr:
+    case Vinstr::calls:
+    case Vinstr::callstub:
+    case Vinstr::calltc:
+    case Vinstr::tailcallphp:
+    case Vinstr::vcall:
+    case Vinstr::vinvoke:
+      return true;
+    default:
+      return false;
+  }
+}
+
 Width width(Vinstr::Opcode op) {
   switch (op) {
     // service requests

--- a/hphp/runtime/vm/jit/vasm-instr.cpp
+++ b/hphp/runtime/vm/jit/vasm-instr.cpp
@@ -84,7 +84,9 @@ bool isCall(const Vinstr& inst) {
     case Vinstr::callstub:
     case Vinstr::calltc:
     case Vinstr::tailcallphp:
+    case Vinstr::tailcallstub:
     case Vinstr::vcall:
+    case Vinstr::vcallarray:
     case Vinstr::vinvoke:
       return true;
     default:

--- a/hphp/runtime/vm/jit/vasm-instr.h
+++ b/hphp/runtime/vm/jit/vasm-instr.h
@@ -1266,6 +1266,11 @@ VASM_OPCODES
 bool isBlockEnd(const Vinstr& inst);
 
 /*
+ * Whether `inst' is a call instruction.
+ */
+bool isCall(const Vinstr& inst);
+
+/*
  * The register width specification of `op'.
  *
  * If `op' is an instruction whose non-flags register arguments are all a

--- a/hphp/runtime/vm/jit/vasm-reuseimm.cpp
+++ b/hphp/runtime/vm/jit/vasm-reuseimm.cpp
@@ -24,6 +24,7 @@
 #include "hphp/runtime/vm/jit/vasm-unit.h"
 #include "hphp/runtime/vm/jit/vasm-util.h"
 
+#include "hphp/util/arch.h"
 #include "hphp/util/assertions.h"
 
 #include <cstdlib>
@@ -50,12 +51,11 @@ struct Env {
 bool isMultiword(int64_t imm) {
   switch(arch()) {
   case Arch::X64:
+  case Arch::PPC64:
     break;
   case Arch::ARM:
     uint64_t val = std::abs(imm);
     if (val > (1 << 16)) return true;
-    break;
-  case Arch::PPC64:
     break;
   }
   return false;

--- a/hphp/runtime/vm/jit/vasm-reuseimm.cpp
+++ b/hphp/runtime/vm/jit/vasm-reuseimm.cpp
@@ -139,11 +139,6 @@ void reuseImmq(Vunit& unit) {
 
   auto const labels = sortBlocks(unit);
 
-  // required for initial size of vector
-  for (auto i = 0; i < RuntimeOption::EvalJitLdimmqSpan; i++) {
-    env.immStateVec.push_back(ImmState{});
-  }
-
   for (auto const b : labels) {
     for (auto& elem : env.immStateVec) elem.reset();
     for (size_t i = 0; i < blocks[b].code.size(); ++i) {

--- a/hphp/runtime/vm/jit/vasm-reuseimm.cpp
+++ b/hphp/runtime/vm/jit/vasm-reuseimm.cpp
@@ -137,7 +137,7 @@ void reuseImmq(Vunit& unit) {
 
   if (RuntimeOption::EvalJitLdimmqSpan <= 0) return;
 
-  Env env {unit};
+  Env env { unit };
   env.immStateVec.resize(RuntimeOption::EvalJitLdimmqSpan);
 
   auto const labels = sortBlocks(unit);

--- a/hphp/runtime/vm/jit/vasm-reuseimm.cpp
+++ b/hphp/runtime/vm/jit/vasm-reuseimm.cpp
@@ -1,0 +1,182 @@
+/*
+   +----------------------------------------------------------------------+
+   | HipHop for PHP                                                       |
+   +----------------------------------------------------------------------+
+   | Copyright (c) 2010-present Facebook, Inc. (http://www.facebook.com)  |
+   +----------------------------------------------------------------------+
+   | This source file is subject to version 3.01 of the PHP license,      |
+   | that is bundled with this package in the file LICENSE, and is        |
+   | available through the world-wide-web at the following url:           |
+   | http://www.php.net/license/3_01.txt                                  |
+   | If you did not receive a copy of the PHP license and are unable to   |
+   | obtain it through the world-wide-web, please send a note to          |
+   | license@php.net so we can mail you a copy immediately.               |
+   +----------------------------------------------------------------------+
+*/
+
+#include <cstdlib>
+
+#include "hphp/runtime/vm/jit/vasm.h"
+
+#include "hphp/runtime/vm/jit/vasm-gen.h"
+#include "hphp/runtime/vm/jit/vasm-instr.h"
+#include "hphp/runtime/vm/jit/vasm-print.h"
+#include "hphp/runtime/vm/jit/vasm-reg.h"
+#include "hphp/runtime/vm/jit/vasm-unit.h"
+#include "hphp/runtime/vm/jit/vasm-util.h"
+
+#include "hphp/util/assertions.h"
+
+TRACE_SET_MOD(vasm);
+
+namespace HPHP { namespace jit {
+
+struct qTrack {
+  Immed64 val;
+  Vreg base;
+  int  ttl;
+};
+
+struct Env {
+  Vunit& unit;
+  int tick;
+  std::deque<qTrack> qdeque; // leaky bucket of recent immediates
+};
+
+static bool isMultiword(int64_t imm) {
+  uint64_t val = abs(imm);
+  if (val > (1 << 16)) return true;
+  return false;
+}
+
+// candidate around +/- uimm12
+static bool reuseCandidate(Env& env, int64_t p, Vreg& reg, int& delta)
+{
+  delta = 0;
+  for (const auto& itr : env.qdeque) {
+    int64_t q = itr.val.q();
+    if ((p >= q) && (p < (q+4095))) {
+      delta = safe_cast<int>(p-q);
+      reg = itr.base;
+      return true;
+    }
+    if ((p < q) && (q < (p+4095))) {
+      delta = safe_cast<int>(q-p);
+      delta = -delta;
+      reg = itr.base;
+      return true;
+    }
+  }
+  return false;
+}
+
+template <typename Inst>
+void reuseImmq(Env& env, const Inst& inst, Vlabel b, size_t i) { return; }
+
+// purge table across any instruction with RegSet or flow change
+#define Y(vasm_opc) \
+void reuseImmq(Env& env, const vasm_opc& c, Vlabel b, size_t i) { \
+  env.qdeque.clear(); \
+  return; \
+} 
+
+Y(fallthru)
+Y(call)
+Y(callarray)
+Y(callfaststub)
+Y(callm)
+Y(callr)
+Y(calls)
+Y(callstub)
+Y(calltc)
+Y(contenter)
+Y(jcc)
+Y(jcci)
+Y(jmpi)
+Y(jmpm)
+Y(jmpr)
+Y(landingpad)
+Y(leavetc)
+Y(nothrow)
+Y(phpret)
+Y(ret)
+Y(syncpoint)
+Y(ud2)
+Y(unwind)
+
+#undef Y
+
+
+template<typename ReuseImm>
+void reuseImm_impl(Vunit& unit, Vlabel b, size_t i, ReuseImm reuse) {
+  vmodify(unit, b, i, [&] (Vout& v) { reuse(v); return 1; });
+}
+
+void reuseImmq(Env& env, const ldimmq& ld, Vlabel b, size_t i) {
+  if (isMultiword(ld.s.q())) {
+    int off;
+    Vreg base;
+    if (reuseCandidate(env, ld.s.q(), base, off)) {
+     if (off >= 0 ) {
+       reuseImm_impl(env.unit, b, i, [&] (Vout& v) {
+         v << addqi{off, base, ld.d, v.makeReg()};
+        });
+     } else {
+       reuseImm_impl(env.unit, b, i, [&] (Vout& v) {
+         v << subqi{-off, base, ld.d, v.makeReg()};
+        });
+      }
+    return;
+    }
+  }
+  env.qdeque.push_front(
+      qTrack{ld.s, ld.d, (env.tick + RuntimeOption::EvalJitLdimmqSpan)}
+    ); 
+}
+
+void reuseImmq(Env& env, Vlabel b, size_t i) {
+  assertx(i <= env.unit.blocks[b].code.size());
+  auto const& inst = env.unit.blocks[b].code[i];
+
+  switch (inst.op) {
+#define O(name, ...)                      \
+    case Vinstr::name:                    \
+      reuseImmq(env, inst.name##_, b, i); \
+      return;
+
+  VASM_OPCODES
+#undef O
+  }
+  not_reached();
+}
+
+// Opportunistically reuse immediate q values
+void reuseImmq(Vunit& unit) {
+  assertx(check(unit));
+  auto& blocks = unit.blocks;
+
+  Env env {unit};
+
+  auto const labels = sortBlocks(unit);
+
+  for (auto const b : labels) {
+    env.tick = 0;
+    env.qdeque.clear();
+
+    for (size_t i = 0; i < blocks[b].code.size(); ++i) {
+      reuseImmq(env, b, i);
+      env.tick++;
+      if (!env.qdeque.empty()) {
+        auto& p = env.qdeque.back();
+        if (p.ttl < env.tick) {
+          env.qdeque.pop_back(); 
+        }
+      }
+    }
+  }
+
+  printUnit(kVasmSimplifyLevel, "after vasm reuse immq", unit);
+}
+
+}}
+

--- a/hphp/runtime/vm/jit/vasm.h
+++ b/hphp/runtime/vm/jit/vasm.h
@@ -114,6 +114,7 @@ void optimizeJmps(Vunit&);
 void optimizePhis(Vunit&);
 void removeDeadCode(Vunit&);
 void removeTrivialNops(Vunit&);
+void reuseImmq(Vunit&);
 template<typename Folder> void foldImms(Vunit&);
 void simplify(Vunit&);
 


### PR DESCRIPTION
This adds a quick pass for ARM targets which attempts to reuse immediate values
generated by the ldimmq Vinstr.  This pass only operates on single blocks.  The span
of this optimization is tunable so that it does not increase register pressure.  The
default for the new option is 8,  (-vEval.JitLdimmqSpan=8).

Here is an example of the pass firing on test/zend/good/ext/intl/tests/grapheme.php

Without
=====

    36918     (38) DecRef<-> t7:Str
    36919         Main:
    36920               0x468005f4  d29ffe40              movz x0, #0xfff2
    36921               0x468005f8  f2a05fe0              movk x0, #0x2ff, lsl #16 
    36922               0x468005fc  78e06b61              ldrsh w1, [x27, x0] 
    36923               0x46800600  11000421              add w1, w1, #0x1 (1) 
    36924               0x46800604  78206b61              strh w1, [x27, x0] 
    36925               0x46800608  d29ffe80              movz x0, #0xfff4         //<<--+
    36926               0x4680060c  f2a05fe0              movk x0, #0x2ff, lsl #16 //<<--+
    36927               0x46800610  78e06b61              ldrsh w1, [x27, x0] 
    36928               0x46800614  11000421              add w1, w1, #0x1 (1) 
    36929               0x46800618  78206b61              strh w1, [x27, x0] 

With
===

    36929     (38) DecRef<-> t7:Str
    36930         Main:
    36931               0x200005f0  d29ffe40              movz x0, #0xfff2
    36932               0x200005f4  f2a05fe0              movk x0, #0x2ff, lsl #16 
    36933               0x200005f8  78e06b61              ldrsh w1, [x27, x0] 
    36934               0x200005fc  11000421              add w1, w1, #0x1 (1) 
    36935               0x20000600  78206b61              strh w1, [x27, x0] 
    36936               0x20000604  91000800              add x0, x0, #0x2 (2)  //<<---
    36937               0x20000608  78e06b61              ldrsh w1, [x27, x0] 
    36938               0x2000060c  11000421              add w1, w1, #0x1 (1) 
    36939               0x20000610  78206b61              strh w1, [x27, x0] 

This was tested by running the regression tests with 6 different option sets.
No regressions were introduced.

Performance testing is pending.
