### PR TITLE
test: Make session IDs unique.

### DIFF
--- a/hphp/test/zend/good/ext/session/tests/003.php
+++ b/hphp/test/zend/good/ext/session/tests/003.php
@@ -6,7 +6,7 @@ class foo {
 	function method() { $this->yes++; }
 }
 
-session_id("abtest");
+session_id(uniqid("abtest"));
 session_start();
 session_decode('baz|O:3:"foo":2:{s:3:"bar";s:2:"ok";s:3:"yes";i:1;}arr|a:1:{i:3;O:3:"foo":2:{s:3:"bar";s:2:"ok";s:3:"yes";i:1;}}');
 

--- a/hphp/test/zend/good/ext/session/tests/006.php
+++ b/hphp/test/zend/good/ext/session/tests/006.php
@@ -1,7 +1,7 @@
 <?php
 error_reporting(E_ALL);
 
-session_id("abtest");
+session_id(uniqid("abtest"));
 session_start();
 
 class a {

--- a/hphp/test/zend/good/ext/session/tests/013.php
+++ b/hphp/test/zend/good/ext/session/tests/013.php
@@ -1,10 +1,10 @@
 <?php
 error_reporting(E_ALL);
 
-session_id("abtest");
+session_id(uniqid("abtest"));
 session_start();
 session_destroy();
-session_id("abtest2");
+session_id(uniqid("abtest2"));
 session_start();
 session_destroy();
 

--- a/hphp/test/zend/good/ext/session/tests/014.php
+++ b/hphp/test/zend/good/ext/session/tests/014.php
@@ -1,7 +1,7 @@
 <?php
 error_reporting(E_ALL);
 
-session_id("abtest");
+session_id(uniqid("abtest"));
 session_start();
 
 ?>

--- a/hphp/test/zend/good/ext/session/tests/023.php
+++ b/hphp/test/zend/good/ext/session/tests/023.php
@@ -6,7 +6,7 @@ class foo {
 	function method() { $this->yes++; }
 }
 
-session_id("abtest");
+session_id(uniqid("abtest"));
 session_start();
 session_decode('baz|O:3:"foo":2:{s:3:"bar";s:2:"ok";s:3:"yes";i:1;}arr|a:1:{i:3;O:3:"foo":2:{s:3:"bar";s:2:"ok";s:3:"yes";i:1;}}');
 $baz = $_SESSION['baz'];

--- a/hphp/test/zend/good/ext/session/tests/030.php
+++ b/hphp/test/zend/good/ext/session/tests/030.php
@@ -1,10 +1,10 @@
 <?php
 error_reporting(E_ALL);
 
-session_id("abtest");
+session_id(uniqid("abtest"));
 session_start();
 session_destroy();
-session_id("abtest2");
+session_id(uniqid("abtest2"));
 session_start();
 session_destroy();
 


### PR DESCRIPTION
The session ID is used to create a filename of a new created file in /tmp.
If that is not unique, warning of the following form can be observed:

Warning: open(/tmp/sess_abtest, O_RDWR) failed: Permission denied (13)

This patch make the session ID unique, by calling uniqid() with the
defined string.

Signed-off-by: Christoph Muellner <christoph.muellner@theobroma-systems.com>