### PR TITLE
tests: Increase VMStackElms in stack-overflow tests.

### DIFF
--- a/hphp/test/slow/stack-overflow/catch-trace-rematerialize.php.opts
+++ b/hphp/test/slow/stack-overflow/catch-trace-rematerialize.php.opts
@@ -1,1 +1,1 @@
--vEval.VMStackElms=512
+-vEval.VMStackElms=8192

--- a/hphp/test/slow/stack-overflow/reenter.php.opts
+++ b/hphp/test/slow/stack-overflow/reenter.php.opts
@@ -1,1 +1,1 @@
--vEval.VMStackElms=512
+-vEval.VMStackElms=8192


### PR DESCRIPTION
Fedora on aarch64 uses a default page size of 64k.
This setting breaks two stack-overflow tests, which set
the VMStackElms variable to 512 (0x200).

The error message, which comes from hphp/runtime/vm/bytecode.cpp, is:
Uncaught exception: VM stack size of 0x200 is below the minimum of 0x2000

This patch fixes the two stack-overflow tests by setting the value
of VMStackElms to 8192 (0x2000).

Signed-off-by: Christoph Muellner <christoph.muellner@theobroma-systems.com>