### PR TITLE
Throw an exception when Redis returns an OOM error or aborts a transaction

### DIFF
--- a/hphp/system/php/redis/Redis.php
+++ b/hphp/system/php/redis/Redis.php
@@ -1097,7 +1097,8 @@ class Redis {
             throw new RedisException("Sync with master in progress");
           }
           if (!strncmp($line, 'OOM ', 4)) {
-            throw new RedisException("OOM command not allowed when used memory > 'maxmemory'");
+            throw new RedisException(
+              "OOM command not allowed when used memory > 'maxmemory'");
           }
           if (!strncmp($line, 'EXECABORT ', 10)) {
             throw new RedisException("Transaction discarded because of previous errors");

--- a/hphp/system/php/redis/Redis.php
+++ b/hphp/system/php/redis/Redis.php
@@ -1096,6 +1096,12 @@ class Redis {
           if (!strncmp($line, '-ERR SYNC ', 10)) {
             throw new RedisException("Sync with master in progress");
           }
+          if (!strncmp($line, 'OOM ', 4)) {
+            throw new RedisException("OOM command not allowed when used memory > 'maxmemory'");
+          }
+          if (!strncmp($line, 'EXECABORT ', 10)) {
+            throw new RedisException("Transaction discarded because of previous errors");
+          }
           return $line;
         case self::TYPE_INT:
         case self::TYPE_LINE:


### PR DESCRIPTION
## Summary

When Redis is out of memory, the hhvm Redis client blocks until the socket times out while executing a transaction.

The problem is that `exec` calls `flushCallbacks` which ignores the errors coming back from Redis and is stuck waiting to get the responses for the commands in the transaction, which are never going to come.

More specifically, when Redis is OOM:
1. When the client queues a command in a transaction, Redis returns - `OOM command not allowed when used memory > 'maxmemory'`.
2. When the client tries to execute this transaction, Redis returns - `Transaction discarded because of previous errors`. 

In this PR, both of these errors are thrown as exceptions so the caller knows that there is a problem with Redis.

## Notes 
1. I have used Redis errors as is when throwing exceptions. `Transaction discarded because of previous errors` does not look very intuitive as a standalone exception. Is there is a better way here? 

1. I could not find a test file for existing exception cases in this function. What's the best place to add tests for such exceptions? I will be happy to add more tests.  

1. Finally, this is my first submission to hhvm. If I am off somewhere, happy to change things.
 