### PR TITLE
test: ext/openssl: Use SHA256 as default digest.

### DIFF
--- a/hphp/test/tools/import_zend_test.py
+++ b/hphp/test/tools/import_zend_test.py
@@ -1094,6 +1094,12 @@ def walk(filename, dest_subdir):
                 '__DIR__',
             )
 
+        if '/tests/zend/good/ext/openssl/tests/openssl.cnf' in full_dest_filename:
+            data = data.replace(
+                'default_bits',
+                'default_md = sha256\ndefault_bits',
+            )
+
         open(full_dest_filename, 'w').write(data)
 
         if full_dest_filename.endswith('.php'):

--- a/hphp/test/zend/good/ext/openssl/tests/openssl.cnf
+++ b/hphp/test/zend/good/ext/openssl/tests/openssl.cnf
@@ -5,7 +5,7 @@ distinguished_name	= req_distinguished_name
 attributes		= req_attributes
 x509_extensions	= v3_ca	# The extensions to add to the self signed cert
 string_mask = MASK:4294967295
-
+default_md		= sha256
 
 [ req_distinguished_name ]
 countryName			= Country Name (2 letter code)


### PR DESCRIPTION
RHEL, Fedora and CentOS ship openssl with a patch
(openssl-1.0.2a-no-md5-verify.patch) to disable
signature verification in case the certificate
uses MD5 as digest algorithm.

The patch also includes a workaround for this
behaviour: defining the environment variable
OPENSSL_ENABLE_MD5_VERIFY.

Since MD5 is cryptographically broken, this patch changes
openssl.cnf to use SHA256 as default digest algorithm.

Signed-off-by: Christoph Muellner <christoph.muellner@theobroma-systems.com>