### PR TITLE
Support numerical keys for Memcached::setMulti

### DIFF
--- a/hphp/runtime/ext/memcached/ext_memcached.php
+++ b/hphp/runtime/ext/memcached/ext_memcached.php
@@ -687,7 +687,10 @@ class Memcached {
                                 array<string, mixed> $items,
                                 int $expiration = 0): bool {
     foreach($items as $key => $value) {
-      if (!is_string($key)) {
+      if (is_int($key)) {
+        // numeric strings (e.g. '5') become integers as array keys
+        $key = (string)$key;
+      } elseif (!is_string($key)) {
         continue;
       }
       if (!$this->setByKey($server_key, $key, $value, $expiration)) {

--- a/hphp/test/slow/ext_memcached/setmulti.php
+++ b/hphp/test/slow/ext_memcached/setmulti.php
@@ -1,0 +1,35 @@
+<?php
+
+$m = new Memcached();
+$m->addServer('localhost', '11211');
+
+function matches_results($original, $compare)
+{
+    // get rid of $original keys that aren't in result
+    $order = array_intersect_key($original, $compare);
+
+    // fill values in original order
+    $result = array_replace($order, $compare);
+
+    return $original === $result;
+}
+
+$data = array(
+    'foo' => 'foo-data',
+    'bar' => 'bar-data',
+    '2' => '2-data',
+    '3' => '3-data',
+);
+
+$keys = array_keys($data);
+
+$null = null;
+$m->setMulti($data, 3600);
+
+/* Check that all keys were stored */
+var_dump(matches_results($data, $m->getMulti($keys)));
+
+/* ---- same tests for byKey variants ---- */
+$m->setMultiByKey("hi", $data, 3600);
+
+var_dump(matches_results($data, $m->getMultiByKey('hi', $keys)));

--- a/hphp/test/slow/ext_memcached/setmulti.php.expectf
+++ b/hphp/test/slow/ext_memcached/setmulti.php.expectf
@@ -1,0 +1,2 @@
+bool(true)
+bool(true)

--- a/hphp/test/slow/ext_memcached/setmulti.php.skipif
+++ b/hphp/test/slow/ext_memcached/setmulti.php.skipif
@@ -1,0 +1,9 @@
+<?php
+
+$memc = new Memcached();
+$memc->addServer('localhost', '11211');
+$version = $memc->getVersion();
+if ($version["localhost:11211"] == "255.255.255") {
+  echo "SKIP No Memcached running";
+}
+


### PR DESCRIPTION
Numerical keys, like '3252345', become integers
when used as array keys.
E.g.: ['123' => 'value'] becomes [123 => 'value']

PECL Memcached allows setting keys with such a
value.