### PR TITLE
array_column allows a null $column_key

### DIFF
--- a/hphp/hack/hhi/stdlib/builtins_array.hhi
+++ b/hphp/hack/hhi/stdlib/builtins_array.hhi
@@ -66,7 +66,7 @@ function array_combine($keys, $values);
 function array_count_values($input);
 function array_column<Tk as arraykey, Tv>(
   array<array<Tk, Tv>> $array,
-  Tk $column_key,
+  ?Tk $column_key,
   ?Tk $index_key = null,
 ): array;
 function array_fill_keys($keys, $value);


### PR DESCRIPTION
According to php docs: http://php.net/manual/en/function.array-column.php

column_key
The column of values to return. This value may be an integer key of the column you wish to retrieve, or it may be a string key name for an associative array or property name. It may also be NULL to return complete arrays or objects (this is useful together with index_key to reindex the array).