### PR TITLE
RedisSessionModule.php: Correcting type error

### DIFF
--- a/hphp/system/php/redis/RedisSessionModule.php
+++ b/hphp/system/php/redis/RedisSessionModule.php
@@ -113,7 +113,7 @@ class RedisSessionModule implements SessionHandlerInterface {
 
     $redis = new Redis;
     $func = ($r['persistent']) ? 'pconnect' : 'connect';
-    if (!$redis->{$func}($r['host'], $r['port'], $r['timeout'])) {
+    if (!$redis->{$func}($r['host'], $r['port'], (float)$r['timeout'])) {
       return false;
     }
     if (($r['auth'] !== '') &&


### PR DESCRIPTION
Correcting a type error if using redis as sessionhandler and having hhvm.php7.all=true.
Error message was:
Fatal error: Uncaught TypeError: Argument 5 passed to fsockopen() must be an instance of float, int given

Did a test build and now it´s working like it should