### PR TITLE
[Aarch64] setcc/movzbl -> setcc peephole

### DIFF
--- a/hphp/runtime/vm/jit/vasm-simplify.cpp
+++ b/hphp/runtime/vm/jit/vasm-simplify.cpp
@@ -522,18 +522,31 @@ bool simplify(Env& env, const pop& inst, Vlabel b, size_t i) {
   });
 }
 
-bool simplify(Env& env, const movzbq& inst, Vlabel b, size_t i) {
+template<typename Movzb>
+bool simplify_movzb(Env& env, const Movzb& inst, Vlabel b, size_t i) {
   auto const def_op = env.def_insts[inst.s];
 
   if (def_op != Vinstr::setcc) return false;
   if (!(arch() == Arch::ARM &&
     width(def_op) != Width::Long)) return false;
 
-  // movzbq{} is redundant--operation on 32-bit registers clear the upper bits.
+  // movzbX{} is redundant--operation on 32-bit registers clear the upper bits.
   return simplify_impl(env, b, i, [&] (Vout& v) {
     v << copy{inst.s, inst.d};
     return 1;
   });
+}
+
+bool simplify(Env& env, const movzbl& inst, Vlabel b, size_t i) {
+  return simplify_movzb<movzbl>(env, inst, b, i);
+}
+
+bool simplify(Env& env, const movzbw& inst, Vlabel b, size_t i) {
+  return simplify_movzb<movzbw>(env, inst, b, i);
+}
+
+bool simplify(Env& env, const movzbq& inst, Vlabel b, size_t i) {
+  return simplify_movzb<movzbq>(env, inst, b, i);
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/hphp/runtime/vm/jit/vasm-simplify.cpp
+++ b/hphp/runtime/vm/jit/vasm-simplify.cpp
@@ -522,6 +522,20 @@ bool simplify(Env& env, const pop& inst, Vlabel b, size_t i) {
   });
 }
 
+bool simplify(Env& env, const movzbq& inst, Vlabel b, size_t i) {
+  auto const def_op = env.def_insts[inst.s];
+
+  if (def_op != Vinstr::setcc) return false;
+  if (!(arch() == Arch::ARM &&
+    width(def_op) != Width::Long)) return false;
+
+  // movzbq{} is redundant--operation on 32-bit registers clear the upper bits.
+  return simplify_impl(env, b, i, [&] (Vout& v) {
+    v << copy{inst.s, inst.d};
+    return 1;
+  });
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 
 /*


### PR DESCRIPTION

This improves JIT code generation for Aarch64 be removing unneeded zero extend
instructions.

Before
=====
    cset w0,rel
    uxtb x0,w0

After
=====
    cset W0,rel

The write to a 32-bit register clears the upper portion anyway, so the instruction is not needed.
This saved over 100 instructions in the vm-perf/center-of-mass.php benchmark.

The regression suite was run with 6 different option sets.  No new regressions were noted.

