### PR TITLE
Fix handling of b" in token_get_all()

### DIFF
--- a/hphp/parser/hphp.ll
+++ b/hphp/parser/hphp.ll
@@ -931,13 +931,13 @@ BACKQUOTE_CHARS     ("{"*([^$`\\{]|("\\"{ANY_CHAR}))|{BACKQUOTE_LITERAL_DOLLAR})
 
 <ST_VAR_OFFSET>"]" {
         yy_pop_state(yyscanner);
-        return ']';
+        RETSTEP(']');
 }
 
 <ST_VAR_OFFSET>{TOKENS}|[({}\"`] {
         /* Only '[' can be valid, but returning other tokens will allow
            a more explicit parse error */
-        return yytext[0];
+        RETSTEP(yytext[0]);
 }
 
 <ST_VAR_OFFSET>[ \n\r\t\\\'#] {
@@ -1098,7 +1098,7 @@ BACKQUOTE_CHARS     ("{"*([^$`\\{]|("\\"{ANY_CHAR}))|{BACKQUOTE_LITERAL_DOLLAR})
         int bprefix = (yytext[0] != '"') ? 1 : 0;
         _scanner->setToken(yytext, yyleng, yytext + bprefix, yyleng - bprefix);
         BEGIN(ST_DOUBLE_QUOTES);
-        return '\"';
+        RETSTEP('\"');
 }
 
 <ST_IN_SCRIPTING>b?"<<<"{TABS_AND_SPACES}({LABEL}|[']{LABEL}[']|["]{LABEL}["]){NEWLINE} {
@@ -1159,7 +1159,7 @@ BACKQUOTE_CHARS     ("{"*([^$`\\{]|("\\"{ANY_CHAR}))|{BACKQUOTE_LITERAL_DOLLAR})
 <ST_XHP_IN_TAG>"/>" {
   BEGIN(ST_XHP_END_SINGLETON_TAG);
   yyless(1);
-  return '/';
+  RETSTEP('/');
 }
 
 <ST_XHP_IN_TAG>{ANY_CHAR} {
@@ -1429,12 +1429,12 @@ doc_scan_done:
 
 <ST_DOUBLE_QUOTES>[\"] {
         BEGIN(ST_IN_SCRIPTING);
-        return '"';
+        RETSTEP('"');
 }
 
 <ST_BACKQUOTE>[\`] {
         BEGIN(ST_IN_SCRIPTING);
-        return '`';
+        RETSTEP('`');
 }
 
 <ST_COMMENT,ST_DOC_COMMENT><<EOF>> {

--- a/hphp/parser/scanner.h
+++ b/hphp/parser/scanner.h
@@ -263,7 +263,7 @@ public:
     incLoc(rawText, rawLeng, type);
   }
   void stepPos(const char *rawText, int rawLeng, int type = -1) {
-    if (shortTags()) {
+    if (full()) {
       m_token->setText(rawText, rawLeng);
     }
     incLoc(rawText, rawLeng, type);

--- a/hphp/runtime/ext/std/ext_std_misc.cpp
+++ b/hphp/runtime/ext/std/ext_std_misc.cpp
@@ -858,7 +858,7 @@ Array HHVM_FUNCTION(token_get_all, const String& source) {
   while ((tokid = scanner.getNextToken(tok, loc))) {
 loop_start: // For after seeing a T_INLINE_HTML, see below
     if (tokid < 256) {
-      res.append(String::FromChar((char)tokid));
+      res.append(String(tok.text()));
     } else {
       String value;
       int tokVal = get_user_token_id(tokid);

--- a/hphp/test/slow/ext_misc/token_get_all_bstring.php
+++ b/hphp/test/slow/ext_misc/token_get_all_bstring.php
@@ -1,0 +1,10 @@
+<?php
+
+$code = '<?php b"$foo";';
+foreach (token_get_all($code) as $token) {
+    if (is_string($token)) {
+        echo $token, "\n";
+    } else {
+        echo token_name($token[0]) . ": ", $token[1], "\n";
+    }
+}

--- a/hphp/test/slow/ext_misc/token_get_all_bstring.php.expect
+++ b/hphp/test/slow/ext_misc/token_get_all_bstring.php.expect
@@ -1,0 +1,5 @@
+T_OPEN_TAG: <?php 
+b"
+T_VARIABLE: $foo
+"
+;


### PR DESCRIPTION
In the best PHP tradition, "single-char" tokens can actually have
more than one character... In particular b" is considered a
single-char token and token_get_all() returns string "b\"" for it.
This change brings HHVM in line with PHP behavior. Previously
HHVM returned just "\"" in this case, dropping the "b" entirely.