### PR TITLE
[AArch64] Remove ARM specific optimization disablers

### DIFF
--- a/hphp/runtime/vm/jit/inlining-decider.cpp
+++ b/hphp/runtime/vm/jit/inlining-decider.cpp
@@ -169,9 +169,6 @@ bool InliningDecider::canInlineAt(SrcKey callSK, const Func* callee) const {
     return false;
   }
 
-  // TODO(#3331014): We have this hack until more ARM codegen is working.
-  if (arch() == Arch::ARM) return false;
-
   // We can only inline at normal FCalls.
   if (callSK.op() != Op::FCall &&
       callSK.op() != Op::FCallD) {

--- a/hphp/runtime/vm/jit/translate-region.cpp
+++ b/hphp/runtime/vm/jit/translate-region.cpp
@@ -296,8 +296,8 @@ bool shouldTrySingletonInline(const RegionDesc& region,
                               TransFlags trflags) {
   if (!RuntimeOption::RepoAuthoritative) return false;
 
-  // I don't really want to inline my arm, thanks.
-  if (arch() != Arch::X64) return false;
+  // I don't really want to inline PPC64, yet.
+  if (arch() == Arch::PPC64) return false;
 
   // Don't inline if we're retranslating due to a side-exit from an
   // inlined call.


### PR DESCRIPTION
Remove ARM specific optimization disablers. These conditionals are no longer necessary. 

No new failures were observed when running all of the unit tests. OSS-Performance suite scores also increased slightly across the board. 