### PR TITLE
Fix pgsql prepared statement memory leak

### DIFF
--- a/hphp/runtime/ext/pgsql/pq.h
+++ b/hphp/runtime/ext/pgsql/pq.h
@@ -39,9 +39,11 @@ struct Result {
   }
 
   Result& operator=(Result&& other) {
-    clear();
-    m_res = other.m_res;
-    other.m_res = nullptr;
+    if (this != &other) {
+      clear();
+      m_res = other.m_res;
+      other.m_res = nullptr;
+    }
     return *this;
   }
 

--- a/hphp/runtime/ext/pgsql/pq.h
+++ b/hphp/runtime/ext/pgsql/pq.h
@@ -39,6 +39,7 @@ struct Result {
   }
 
   Result& operator=(Result&& other) {
+    clear();
     m_res = other.m_res;
     other.m_res = nullptr;
     return *this;


### PR DESCRIPTION
The pgsql Result struct mishandled PGresult resources when the
move assignment operator was used, resulting in PGresult leakage.

Fixes Issue #7716.