### PR TITLE
Allow array_map callback to be nullable

### DIFF
--- a/hphp/hack/hhi/stdlib/builtins_array.hhi
+++ b/hphp/hack/hhi/stdlib/builtins_array.hhi
@@ -114,7 +114,7 @@ function array_keys<Tk, Tv>(
  * Container<X>          -> R = array<arraykey, Tr>
  * X (unknown type)      -> R = Y (other unknown type)
  */
-function array_map($callback, $arr1, ...);
+function array_map(?$callback, $arr1, ...);
 function array_merge_recursive($array1, ...);
 function array_merge($array1, ...);
 function array_replace_recursive($array1, ...);


### PR DESCRIPTION
According to http://php.net/array_map the callback argument in array_map is nullable. (Example `#4`).

`An interesting use of this function is to construct an array of arrays, which can be easily performed by using NULL as the name of the callback function`

Currently `array_map(null, $arr1, $arr2)` produces a type error: 

```
Invalid argument (Typing[4110])
File "stdlib/builtins_array.hhi", line 117, characters 10-18:
This is a function
File "..."
It is incompatible with a nullable type
```