### PR TITLE
Redis.php: remove explicit QUIT in close function

### DIFF
--- a/hphp/system/php/redis/Redis.php
+++ b/hphp/system/php/redis/Redis.php
@@ -84,7 +84,6 @@ class Redis {
   }
 
   public function close() {
-    $this->processCommand('QUIT');
     fclose($this->connection);
     $this->connection = null;
   }
@@ -835,6 +834,7 @@ class Redis {
     'popen' => [ 'alias' => 'pconnect' ],
     'ping' => [ 'return' => 'Raw' ],
     'echo' => [ 'format' => 's', 'return' => 'String' ],
+    'quit' => [ 'return' => 'Boolean' ],
 
     // Server
     'bgrewriteaof' => [ 'return' => 'Boolean' ],


### PR DESCRIPTION
The Redis QUIT always return "OK", but in Redis.php close()
function the TCP socket is closed immediately after sending
the command. This causes frequent TCP RST returned by HHVM
to the Redis server when the latter sends the "OK" response.

To fix the issue the QUIT command is removed from the close()
function and added as function ('quit', via __call). This allows
users to "quit() and close()" if needed.

The same issue has been discussed/fixed in phpredis:
https://github.com/phpredis/phpredis/issues/562