### PR TITLE
jit: irlower-call: Do proper loading in cgCheckRefs to eliminate truncation

### DIFF
--- a/hphp/runtime/vm/jit/irlower-call.cpp
+++ b/hphp/runtime/vm/jit/irlower-call.cpp
@@ -475,20 +475,18 @@ void cgCheckRefs(IRLS& env, const IRInstruction* inst)  {
       if (vals64) cond = CC_E;
     } else {
       auto const bits = v.makeReg();
-      v << load{bitsPtr[bitsOff], bits};
-
-      auto const truncBits = v.makeReg();
       auto const maskedBits = v.makeReg();
 
       if (mask64 <= 0xff && vals64 <= 0xff) {
-        v << movtqb{bits, truncBits};
-        v << andbi{(int8_t)mask64, truncBits, maskedBits, v.makeReg()};
+        v << loadtqb{bitsPtr[bitsOff], bits};
+        v << andbi{(int8_t)mask64, bits, maskedBits, v.makeReg()};
         v << cmpbi{(int8_t)vals64, maskedBits, sf};
       } else if (mask64 <= 0xffffffff && vals64 <= 0xffffffff) {
-        v << movtql{bits, truncBits};
-        v << andli{(int32_t)mask64, truncBits, maskedBits, v.makeReg()};
+        v << loadtql{bitsPtr[bitsOff], bits};
+        v << andli{(int32_t)mask64, bits, maskedBits, v.makeReg()};
         v << cmpli{(int32_t)vals64, maskedBits, sf};
       } else {
+        v << load{bitsPtr[bitsOff], bits};
         v << andq{v.cns(mask64), bits, maskedBits, v.makeReg()};
         v << cmpq{v.cns(vals64), maskedBits, sf};
       }

--- a/hphp/runtime/vm/jit/vasm-arm.cpp
+++ b/hphp/runtime/vm/jit/vasm-arm.cpp
@@ -272,6 +272,7 @@ struct Vgen {
   void emit(const loadl& i) { a->Ldr(W(i.d), M(i.s)); }
   void emit(const loadsd& i) { a->Ldr(D(i.d), M(i.s)); }
   void emit(const loadtqb& i) { a->Ldrsb(W(i.d), M(i.s)); }
+  void emit(const loadtql& i) { a->Ldr(W(i.d), M(i.s)); }
   void emit(const loadups& i);
   void emit(const loadw& i) { a->Ldrsh(W(i.d), M(i.s)); }
   void emit(const loadzbl& i) { a->Ldrb(W(i.d), M(i.s)); }
@@ -1175,6 +1176,7 @@ Y(loadb, s)
 Y(loadl, s)
 Y(loadsd, s)
 Y(loadtqb, s)
+Y(loadtql, s)
 Y(loadups, s)
 Y(loadw, s)
 Y(loadzbl, s)

--- a/hphp/runtime/vm/jit/vasm-dead.cpp
+++ b/hphp/runtime/vm/jit/vasm-dead.cpp
@@ -105,6 +105,7 @@ bool effectful(Vinstr& inst) {
     case Vinstr::loadqp:
     case Vinstr::loadsd:
     case Vinstr::loadtqb:
+    case Vinstr::loadtql:
     case Vinstr::loadups:
     case Vinstr::loadw:
     case Vinstr::loadzbl:

--- a/hphp/runtime/vm/jit/vasm-fold-imms.cpp
+++ b/hphp/runtime/vm/jit/vasm-fold-imms.cpp
@@ -322,6 +322,7 @@ struct ImmFolder {
   void fold(loadzbl& in , Vinstr& out) { foldVptr(in.s); }
   void fold(loadzlq& in , Vinstr& out) { foldVptr(in.s); }
   void fold(loadtqb& in , Vinstr& out) { foldVptr(in.s); }
+  void fold(loadtql& in , Vinstr& out) { foldVptr(in.s); }
 };
 } // namespace x64
 

--- a/hphp/runtime/vm/jit/vasm-instr.cpp
+++ b/hphp/runtime/vm/jit/vasm-instr.cpp
@@ -262,6 +262,7 @@ Width width(Vinstr::Opcode op) {
     case Vinstr::movl:
     case Vinstr::loadl:
     case Vinstr::loadzbl:
+    case Vinstr::loadtql:
     case Vinstr::storel:
     case Vinstr::storeli:
       return Width::Long;

--- a/hphp/runtime/vm/jit/vasm-instr.h
+++ b/hphp/runtime/vm/jit/vasm-instr.h
@@ -251,6 +251,7 @@ struct Vunit;
   O(loadzbq, Inone, U(s), D(d))\
   O(loadzlq, Inone, U(s), D(d))\
   O(loadtqb, Inone, U(s), D(d))\
+  O(loadtql, Inone, U(s), D(d))\
   O(storeb, Inone, U(s) U(m), Dn)\
   O(storebi, I(s), U(m), Dn)\
   O(storew, Inone, U(s) U(m), Dn)\
@@ -1030,6 +1031,7 @@ struct loadzbq { Vptr s; Vreg64 d; };
 struct loadzlq { Vptr s; Vreg64 d; };
 // truncated s to d
 struct loadtqb { Vptr s; Vreg8 d; };
+struct loadtql { Vptr s; Vreg32 d; };
 // stores
 struct storeb { Vreg8 s; Vptr m; };
 struct storebi { Immed s; Vptr m; };

--- a/hphp/runtime/vm/jit/vasm-ppc64.cpp
+++ b/hphp/runtime/vm/jit/vasm-ppc64.cpp
@@ -393,6 +393,7 @@ struct Vgen {
   void emit(const loadtqb& i) { X(lbz, Reg64(i.d),  i.s); }
   void emit(const loadzbl& i) { X(lbz,  Reg64(i.d), i.s); }
   void emit(const loadzbq& i) { X(lbz,  i.d,        i.s); }
+  void emit(const loadtql& i) { X(lwz, Reg64(i.d),  i.s); }
   void emit(const loadzlq& i) { X(lwz,  i.d,        i.s); }
   void emit(const storeb& i)  { X(stb,  Reg64(i.s), i.m); }
   void emit(const storel& i)  { X(stw,  Reg64(i.s), i.m); }

--- a/hphp/runtime/vm/jit/vasm-x64.cpp
+++ b/hphp/runtime/vm/jit/vasm-x64.cpp
@@ -184,6 +184,7 @@ struct Vgen {
   void emit(const loadtqb& i) { a.loadb(i.s, i.d); }
   void emit(const loadb& i) { a.loadb(i.s, i.d); }
   void emit(const loadw& i) { a.loadw(i.s, i.d); }
+  void emit(const loadtql& i) { a.loadl(i.s, i.d); }
   void emit(const loadl& i) { a.loadl(i.s, i.d); }
   void emit(const loadqp& i) { a.loadq(i.s, i.d); }
   void emit(const loadqd& i) { a.loadq(rip[(intptr_t)i.s.get()], i.d); }


### PR DESCRIPTION
The vasm for CheckRefs distinguishes between 8-bit, 32-bit and 64-bit
masks. However it uses a 64-bit load for all cases in combination with
a movtqX. This patch changes this to use a load which does not require
a truncation for the cost of being little-endian specific (which is already
a requirement for the cgCheckRefs() function).

Testing the all set showed no regressions on ARM64.

Signed-off-by: Christoph Muellner <christoph.muellner@theobroma-systems.com>