### PR TITLE
vasm-simplify: Eliminate masking values with -1. 

### DIFF
--- a/hphp/runtime/vm/jit/vasm-arm.cpp
+++ b/hphp/runtime/vm/jit/vasm-arm.cpp
@@ -1209,8 +1209,8 @@ void lower(const VLS& e, vasm_opc& i, Vlabel b, size_t z) { \
 
 Y(addli, addl, ldimml, ISAR, i.s0, U2(i.s1, i.d))
 Y(addqi, addq, ldimmq, ISAR, Immed64(value), U2(i.s1, i.d))
-Y(andbi, andb, ldimmb, ISLG(32), i.s0, U2(i.s1, i.d))
-Y(andli, andl, ldimml, ISLG(32), i.s0, U2(i.s1, i.d))
+Y(andbi, andb, ldimmb, (ISLG(32) || (safe_cast<int8_t>(value) == -1)), i.s0, U2(i.s1, i.d))
+Y(andli, andl, ldimml, (ISLG(32) || (safe_cast<int32_t>(value) == -1)), i.s0, U2(i.s1, i.d))
 Y(andqi, andq, ldimmq, ISLG(64), Immed64(value), U2(i.s1, i.d))
 Y(cmpli, cmpl, ldimml, ISAR, i.s0, i.s1)
 Y(cmpqi, cmpq, ldimmq, ISAR, Immed64(value), i.s1)

--- a/hphp/runtime/vm/jit/vasm-simplify.cpp
+++ b/hphp/runtime/vm/jit/vasm-simplify.cpp
@@ -473,6 +473,29 @@ bool simplify(Env& env, const pop& inst, Vlabel b, size_t i) {
   });
 }
 
+/*
+ * Eliminate masking values with -1 in andXi.
+ * andbi s0=0xff s1=val0 d=val1 -> copy s=val0 d=val1
+ * andli s0=0xffffffff s1=val0 d=val1 -> copy s=val0 d=val1
+ */
+template<typename andi>
+bool simplify_andi(Env& env, const andi& inst, Vlabel b, size_t i) {
+  if (inst.s0.l() != -1 ||
+      env.use_counts[inst.sf] != 0) return false;
+  return simplify_impl(env, b, i, [&] (Vout& v) {
+    v << copy{inst.s1, inst.d};
+    return 1;
+  });
+}
+
+bool simplify(Env& env, const andbi& andbi, Vlabel b, size_t i) {
+  return simplify_andi(env, andbi, b, i);
+}
+
+bool simplify(Env& env, const andli& andli, Vlabel b, size_t i) {
+  return simplify_andi(env, andli, b, i);
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 
 /*


### PR DESCRIPTION
Masking 8/32-bit values with 0xff/0xffffffff is
not necessary. This patch eliminates that.

```
Before:
      load       [%129 + 0x48] => %147              # (14) CheckRefs<0,255,192> t2:Func, 64 -> B10<Unlikely>
      movtqb     %147 => %150
      movzbq     %150 => %151
      movtqb     %151 => %148
      andbi      -1, %148 => %149, %152
      cmpbi      -64, %149 => %145

After:
      load       [%129 + 0x48] => %147              # (14) CheckRefs<0,255,192> t2:Func, 64 -> B10<Unlikely>
      movtqb     %147 => %150
      movzbq     %150 => %151
      movtqb     %151 => %148
      movb       %148 => %149
      cmpbi      -64, %149 => %145
```

Or in ARM64 assembly (already with #7744 applied (uxtb instead of sxtb for movtqb)):

```
Before:
              0x24c0c9d0  f9402400              ldr x0, [x0, #72]
              //movtqb w0 <- w0
              0x24c0c9d4  53001c00              uxtb w0, w0
              //andbi w0 <- w0, 255
              0x24c0c9d8  12800001              movn w1, #0x0
              0x24c0c9dc  0a010000              and w0, w0, w1
              //cmpi w0, 192
              0x24c0c9e0  53001c00              uxtb w0, w0
              0x24c0c9e4  128007e1              movn w1, #0x3f
              0x24c0c9e8  6b01001f              cmp w0, w1

After:
              0x48c0c86c  f9402400              ldr x0, [x0, #72]
              //movtqb w0 <- w0
              0x48c0c870  13001c00              uxtb w0, w0
              //andbi w0 <- w0, 255
              0x48c0c874  2a0003e0              mov w0, w0
              //cmpi w0, 192
              0x48c0c878  53001c00              uxtb w0, w0
              0x48c0c87c  128007e1              movn w1, #0x3f
              0x48c0c880  6b01001f              cmp w0, w1
```

This is another optimisation derived from #7767.

Note, that this PR contains a second commit, which prevents
that `andbi/andli -1` gets lowered in vasm-arm.cpp (before simplify()).

@mxw : please review
@dave-estes @jim-saxman @swalk-cavium : please test if possible
Notification also for @ptomsich