### PR TITLE
arm: Stop emitting moves for `movb/movl rN rN`

### DIFF
--- a/hphp/runtime/vm/jit/vasm-arm.cpp
+++ b/hphp/runtime/vm/jit/vasm-arm.cpp
@@ -277,8 +277,8 @@ struct Vgen {
   void emit(const loadzbl& i) { a->Ldrb(W(i.d), M(i.s)); }
   void emit(const loadzbq& i) { a->Ldrb(W(i.d), M(i.s)); }
   void emit(const loadzlq& i) { a->Ldr(W(i.d), M(i.s)); }
-  void emit(const movb& i) { a->Mov(W(i.d), W(i.s)); }
-  void emit(const movl& i) { a->Mov(W(i.d), W(i.s)); }
+  void emit(const movb& i) { if (i.d != i.s) a->Mov(W(i.d), W(i.s)); }
+  void emit(const movl& i) { if (i.d != i.s) a->Mov(W(i.d), W(i.s)); }
   void emit(const movtqb& i) { a->Sxtb(W(i.d), W(i.s)); }
   void emit(const movtql& i) { a->Mov(W(i.d), W(i.s)); }
   void emit(const movzbl& i) { a->Uxtb(W(i.d), W(i.s)); }


### PR DESCRIPTION
In aarch64 the following vasm can be eliminated:

  movb VregN_8, VregN_8
  movl VregN_32, VergN_32

Signed-off-by: Christoph Muellner <christoph.muellner@theobroma-systems.com>