### PR TITLE
Refactors adjustMetaDataForRelocation to be common across platforms.

### DIFF
--- a/hphp/runtime/vm/jit/relocation-ppc64.h
+++ b/hphp/runtime/vm/jit/relocation-ppc64.h
@@ -23,9 +23,9 @@ namespace HPHP { namespace jit { namespace ppc64 {
 
 void adjustForRelocation(RelocationInfo&);
 void adjustForRelocation(RelocationInfo& rel, TCA srcStart, TCA srcEnd);
-void adjustCodeForRelocation(RelocationInfo& rel, CGMeta& fixups);
+void adjustCodeForRelocation(RelocationInfo& rel, CGMeta& meta);
 void adjustMetaDataForRelocation(RelocationInfo&, AsmInfo*, CGMeta&);
-void findFixups(TCA start, TCA end, CGMeta& fixups);
+void findFixups(TCA start, TCA end, CGMeta& meta);
 size_t relocate(RelocationInfo&, CodeBlock&, TCA, TCA, CodeBlock&, CGMeta&,
                 TCA*);
 

--- a/hphp/runtime/vm/jit/relocation-x64.cpp
+++ b/hphp/runtime/vm/jit/relocation-x64.cpp
@@ -37,39 +37,6 @@ constexpr int kJmpLen = 5;
 using WideJmpSet = hphp_hash_set<void*>;
 struct JmpOutOfRange : std::exception {};
 
-TcaRange fixupRange(const RelocationInfo& rel, const TcaRange& rng) {
-  /*
-   * We have to be careful with before/after here.
-   * If we relocate two consecutive regions of memory,
-   * but relocate them to two different destinations, then
-   * the end address of the first region is also the start
-   * address of the second region; so adjustedAddressBefore(end)
-   * gives us the relocated address of the end of the first
-   * region, while adjustedAddressAfter(end) gives us the
-   * relocated address of the start of the second region.
-   */
-  auto s = rel.adjustedAddressAfter(rng.begin());
-  auto e = rel.adjustedAddressBefore(rng.end());
-  if (s && e) {
-    return TcaRange(s, e);
-  }
-  if (s && !e) {
-    return TcaRange(s, s + rng.size());
-  }
-  if (!s && e) {
-    return TcaRange(e - rng.size(), e);
-  }
-  return rng;
-}
-
-void fixupRanges(AsmInfo* asmInfo, AreaIndex area, RelocationInfo& rel) {
-  asmInfo->clearBlockRangesForArea(area);
-  for (auto& ii : asmInfo->instRangesForArea(area)) {
-    ii.second = fixupRange(rel, ii.second);
-    asmInfo->updateForBlock(area, ii.first, ii.second);
-  }
-}
-
 size_t relocateImpl(RelocationInfo& rel,
                     CodeBlock& destBlock,
                     TCA start, TCA end,
@@ -334,115 +301,9 @@ void adjustForRelocation(RelocationInfo& rel, TCA srcStart, TCA srcEnd) {
   }
 }
 
-/*
- * Adjusts the addresses in asmInfo and fixups to match the new
- * location of the code.
- * This will not "hook up" the relocated code in any way, so is safe
- * to call before the relocated code is ready to run.
- */
 void adjustMetaDataForRelocation(RelocationInfo& rel,
                                  AsmInfo* asmInfo,
                                  CGMeta& meta) {
-  auto& ip = meta.inProgressTailJumps;
-  for (size_t i = 0; i < ip.size(); ++i) {
-    IncomingBranch& ib = const_cast<IncomingBranch&>(ip[i]);
-    if (TCA adjusted = rel.adjustedAddressAfter(ib.toSmash())) {
-      ib.adjust(adjusted);
-    }
-  }
-
-  for (auto watch : meta.watchpoints) {
-    if (auto const adjusted = rel.adjustedAddressBefore(*watch)) {
-      *watch = adjusted;
-    }
-  }
-
-  for (auto& fixup : meta.fixups) {
-    /*
-     * Pending fixups always point after the call instruction,
-     * so use the "before" address, since there may be nops
-     * before the next actual instruction.
-     */
-    if (TCA adjusted = rel.adjustedAddressBefore(fixup.first)) {
-      fixup.first = adjusted;
-    }
-  }
-
-  for (auto& ct : meta.catches) {
-    /*
-     * Similar to fixups - this is a return address so get
-     * the address returned to.
-     */
-    if (auto const adjusted = rel.adjustedAddressBefore(ct.first)) {
-      ct.first = adjusted;
-    }
-    /*
-     * But the target is an instruction, so skip over any nops
-     * that might have been inserted (eg for alignment).
-     */
-    if (auto const adjusted = rel.adjustedAddressAfter(ct.second)) {
-      ct.second = adjusted;
-    }
-  }
-
-  for (auto& jt : meta.jmpTransIDs) {
-    if (auto const adjusted = rel.adjustedAddressAfter(jt.first)) {
-      jt.first = adjusted;
-    }
-  }
-
-  if (!meta.bcMap.empty()) {
-    /*
-     * Most of the time we want to adjust to a corresponding "before" address
-     * with the exception of the start of the range where "before" can point to
-     * the end of a previous range.
-     */
-    auto const aStart = meta.bcMap[0].aStart;
-    auto const acoldStart = meta.bcMap[0].acoldStart;
-    auto const afrozenStart = meta.bcMap[0].afrozenStart;
-    auto adjustAddress = [&](TCA& address, TCA blockStart) {
-      if (TCA adjusted = (address == blockStart
-                            ? rel.adjustedAddressAfter(blockStart)
-                            : rel.adjustedAddressBefore(address))) {
-        address = adjusted;
-      }
-    };
-    for (auto& tbc : meta.bcMap) {
-      adjustAddress(tbc.aStart, aStart);
-      adjustAddress(tbc.acoldStart, acoldStart);
-      adjustAddress(tbc.afrozenStart, afrozenStart);
-    }
-  }
-
-  decltype(meta.addressImmediates) updatedAI;
-  for (auto addrImm : meta.addressImmediates) {
-    if (TCA adjusted = rel.adjustedAddressAfter(addrImm)) {
-      updatedAI.insert(adjusted);
-    } else if (TCA odd = rel.adjustedAddressAfter((TCA)~uintptr_t(addrImm))) {
-      // just for cgLdObjMethod
-      updatedAI.insert((TCA)~uintptr_t(odd));
-    } else {
-      updatedAI.insert(addrImm);
-    }
-  }
-  updatedAI.swap(meta.addressImmediates);
-
-  decltype(meta.alignments) updatedAF;
-  for (auto af : meta.alignments) {
-    if (TCA adjusted = rel.adjustedAddressAfter(af.first)) {
-      updatedAF.emplace(adjusted, af.second);
-    } else {
-      updatedAF.emplace(af);
-    }
-  }
-  updatedAF.swap(meta.alignments);
-
-  for (auto& af : meta.reusedStubs) {
-    if (TCA adjusted = rel.adjustedAddressAfter(af)) {
-      af = adjusted;
-    }
-  }
-
   for (auto& li : meta.literals) {
     if (auto adjusted = rel.adjustedAddressAfter((TCA)li.second)) {
       li.second = (uint64_t*)adjusted;
@@ -458,14 +319,6 @@ void adjustMetaDataForRelocation(RelocationInfo& rel,
     }
   }
   updatedCP.swap(meta.codePointers);
-
-  if (asmInfo) {
-    assert(asmInfo->validate());
-    fixupRanges(asmInfo, AreaIndex::Main, rel);
-    fixupRanges(asmInfo, AreaIndex::Cold, rel);
-    fixupRanges(asmInfo, AreaIndex::Frozen, rel);
-    assert(asmInfo->validate());
-  }
 }
 
 /*

--- a/hphp/runtime/vm/jit/relocation.cpp
+++ b/hphp/runtime/vm/jit/relocation.cpp
@@ -18,6 +18,7 @@
 #include "hphp/runtime/vm/jit/relocation-arm.h"
 #include "hphp/runtime/vm/jit/relocation-ppc64.h"
 #include "hphp/runtime/vm/jit/relocation-x64.h"
+#include "hphp/runtime/vm/jit/asm-info.h"
 
 #include "hphp/util/arch.h"
 
@@ -33,6 +34,39 @@ void RelocationInfo::recordRange(TCA start, TCA end,
 
 void RelocationInfo::recordAddress(TCA src, TCA dest, int range) {
   m_adjustedAddresses.emplace(src, std::make_pair(dest, dest + range));
+}
+
+TcaRange RelocationInfo::fixupRange(const TcaRange& rng) {
+  /*
+   * We have to be careful with before/after here.
+   * If we relocate two consecutive regions of memory,
+   * but relocate them to two different destinations, then
+   * the end address of the first region is also the start
+   * address of the second region; so adjustedAddressBefore(end)
+   * gives us the relocated address of the end of the first
+   * region, while adjustedAddressAfter(end) gives us the
+   * relocated address of the start of the second region.
+   */
+  auto s = adjustedAddressAfter(rng.begin());
+  auto e = adjustedAddressBefore(rng.end());
+  if (s && e) {
+    return TcaRange(s, e);
+  }
+  if (s && !e) {
+    return TcaRange(s, s + rng.size());
+  }
+  if (!s && e) {
+    return TcaRange(e - rng.size(), e);
+  }
+  return rng;
+}
+
+void RelocationInfo::fixupRanges(AsmInfo* asmInfo, AreaIndex area) {
+  asmInfo->clearBlockRangesForArea(area);
+  for (auto& ii : asmInfo->instRangesForArea(area)) {
+    ii.second = fixupRange(ii.second);
+    asmInfo->updateForBlock(area, ii.first, ii.second);
+  }
 }
 
 TCA RelocationInfo::adjustedAddressAfter(TCA addr) const {
@@ -95,6 +129,129 @@ void RelocationInfo::rewind(TCA start, TCA end) {
 //////////////////////////////////////////////////////////////////////
 
 /*
+ * Adjusts the addresses in asmInfo and fixups to match the new
+ * location of the code.
+ * This will not "hook up" the relocated code in any way, so is safe
+ * to call before the relocated code is ready to run.
+ */
+void adjustMetaDataForRelocation(RelocationInfo& rel,
+                                 AsmInfo* asmInfo,
+                                 CGMeta& meta  ) {
+  auto& ip = meta.inProgressTailJumps;
+  for (size_t i = 0; i < ip.size(); ++i) {
+    IncomingBranch& ib = const_cast<IncomingBranch&>(ip[i]);
+    if (TCA adjusted = rel.adjustedAddressAfter(ib.toSmash())) {
+      ib.adjust(adjusted);
+    }
+  }
+
+  for (auto watch : meta.watchpoints) {
+    if (auto const adjusted = rel.adjustedAddressBefore(*watch)) {
+      *watch = adjusted;
+    }
+  }
+
+  for (auto& fixup : meta.fixups) {
+    /*
+     * Pending fixups always point after the call instruction,
+     * so use the "before" address, since there may be nops
+     * before the next actual instruction.
+     */
+    if (TCA adjusted = rel.adjustedAddressBefore(fixup.first)) {
+      fixup.first = adjusted;
+    }
+  }
+
+  for (auto& ct : meta.catches) {
+    /*
+     * Similar to fixups - this is a return address so get
+     * the address returned to.
+     */
+    if (auto const adjusted = rel.adjustedAddressBefore(ct.first)) {
+      ct.first = adjusted;
+    }
+    /*
+     * But the target is an instruction, so skip over any nops
+     * that might have been inserted (eg for alignment).
+     */
+    if (auto const adjusted = rel.adjustedAddressAfter(ct.second)) {
+      ct.second = adjusted;
+    }
+  }
+
+  for (auto& jt : meta.jmpTransIDs) {
+    if (auto const adjusted = rel.adjustedAddressAfter(jt.first)) {
+      jt.first = adjusted;
+    }
+  }
+
+  if (!meta.bcMap.empty()) {
+    /*
+     * Most of the time we want to adjust to a corresponding "before" address
+     * with the exception of the start of the range where "before" can point to
+     * the end of a previous range.
+     */
+    auto const aStart = meta.bcMap[0].aStart;
+    auto const acoldStart = meta.bcMap[0].acoldStart;
+    auto const afrozenStart = meta.bcMap[0].afrozenStart;
+    auto adjustAddress = [&](TCA& address, TCA blockStart) {
+      if (TCA adjusted = (address == blockStart
+                            ? rel.adjustedAddressAfter(blockStart)
+                            : rel.adjustedAddressBefore(address))) {
+        address = adjusted;
+      }
+    };
+    for (auto& tbc : meta.bcMap) {
+      adjustAddress(tbc.aStart, aStart);
+      adjustAddress(tbc.acoldStart, acoldStart);
+      adjustAddress(tbc.afrozenStart, afrozenStart);
+    }
+  }
+
+  decltype(meta.addressImmediates) updatedAI;
+  for (auto addrImm : meta.addressImmediates) {
+    if (TCA adjusted = rel.adjustedAddressAfter(addrImm)) {
+      updatedAI.insert(adjusted);
+    } else if (TCA odd = rel.adjustedAddressAfter((TCA)~uintptr_t(addrImm))) {
+      // just for cgLdObjMethod
+      updatedAI.insert((TCA)~uintptr_t(odd));
+    } else {
+      updatedAI.insert(addrImm);
+    }
+  }
+  updatedAI.swap(meta.addressImmediates);
+
+  decltype(meta.alignments) updatedAF;
+  for (auto af : meta.alignments) {
+    if (TCA adjusted = rel.adjustedAddressAfter(af.first)) {
+      updatedAF.emplace(adjusted, af.second);
+    } else {
+      updatedAF.emplace(af);
+    }
+  }
+  updatedAF.swap(meta.alignments);
+
+  for (auto& af : meta.reusedStubs) {
+    if (TCA adjusted = rel.adjustedAddressAfter(af)) {
+      af = adjusted;
+    }
+  }
+
+  // Perform the platform-specific metadata adjustments
+  ARCH_SWITCH_CALL(adjustMetaDataForRelocation, rel, asmInfo, meta);
+
+  if (asmInfo) {
+    assert(asmInfo->validate());
+    rel.fixupRanges(asmInfo, AreaIndex::Main);
+    rel.fixupRanges(asmInfo, AreaIndex::Cold);
+    rel.fixupRanges(asmInfo, AreaIndex::Frozen);
+    assert(asmInfo->validate());
+  }
+}
+
+//////////////////////////////////////////////////////////////////////
+
+/*
  * Wrappers.
  */
 
@@ -106,11 +263,6 @@ void adjustForRelocation(RelocationInfo& rel, TCA srcStart, TCA srcEnd) {
 }
 void adjustCodeForRelocation(RelocationInfo& rel, CGMeta& fixups) {
   return ARCH_SWITCH_CALL(adjustCodeForRelocation, rel, fixups);
-}
-void adjustMetaDataForRelocation(RelocationInfo& rel,
-                                 AsmInfo* asmInfo,
-                                 CGMeta& fixups) {
-  return ARCH_SWITCH_CALL(adjustMetaDataForRelocation, rel, asmInfo, fixups);
 }
 void findFixups(TCA start, TCA end, CGMeta& fixups) {
   return ARCH_SWITCH_CALL(findFixups, start, end, fixups);

--- a/hphp/runtime/vm/jit/relocation.h
+++ b/hphp/runtime/vm/jit/relocation.h
@@ -27,6 +27,7 @@ namespace HPHP { namespace jit {
 
 struct AsmInfo;
 struct CGMeta;
+using TcaRange = folly::Range<TCA>;
 
 struct RelocationInfo {
   RelocationInfo() {}
@@ -34,6 +35,8 @@ struct RelocationInfo {
   void recordRange(TCA start, TCA end,
                    TCA destStart, TCA destEnd);
   void recordAddress(TCA src, TCA dest, int range);
+  TcaRange fixupRange(const TcaRange& rng);
+  void fixupRanges(AsmInfo* asmInfo, AreaIndex area);
   TCA adjustedAddressAfter(TCA addr) const;
   TCA adjustedAddressBefore(TCA addr) const;
   CTCA adjustedAddressAfter(CTCA addr) const {
@@ -75,16 +78,16 @@ struct RelocationInfo {
 
 void adjustForRelocation(RelocationInfo&);
 void adjustForRelocation(RelocationInfo& rel, TCA srcStart, TCA srcEnd);
-void adjustCodeForRelocation(RelocationInfo& rel, CGMeta& fixups);
+void adjustCodeForRelocation(RelocationInfo& rel, CGMeta& meta);
 void adjustMetaDataForRelocation(RelocationInfo& rel,
                                  AsmInfo* asmInfo,
-                                 CGMeta& fixups);
-void findFixups(TCA start, TCA end, CGMeta& fixups);
+                                 CGMeta& meta);
+void findFixups(TCA start, TCA end, CGMeta& meta);
 size_t relocate(RelocationInfo& rel,
                 CodeBlock& destBlock,
                 TCA start, TCA end,
                 DataBlock& srcBlock,
-                CGMeta& fixups,
+                CGMeta& meta,
                 TCA* exitAddr);
 
 }}


### PR DESCRIPTION
Each platform will still have an implementation of
adjustMetaDataForRelocation(), but it will be reserved for any
additional adjustments for that platform.