### PR TITLE
correction for openssl_x509_parse vs. UTC

### DIFF
--- a/hphp/runtime/ext/openssl/ext_openssl.cpp
+++ b/hphp/runtime/ext/openssl/ext_openssl.cpp
@@ -2549,7 +2549,8 @@ static time_t asn1_time_to_time_t(ASN1_UTCTIME *timestr) {
   gmadjust = -(thetime.tm_isdst ?
                (long)timezone - 3600 : (long)timezone + 3600);
 #endif
-  ret += gmadjust;
+  /* no adjustment for UTC */
+  if (timezone) ret += gmadjust;
   free(strbuf);
   return ret;
 }


### PR DESCRIPTION
While testing HHVM on a different machine I noticed a regression failure in
hphp/test/zend/good/ext/openssl/tests/openssl_x509_parse_basic.php

side-by-side testing with gdb on the two systems working/not working shows that
down in the extension the certificate is parsed the same way until the final daylight
savings time adjustment.  The difference between the two systems was the timezone 
setting.  There should be no adjustment when the system setting is UTC.

BEFORE
======
# Change timezone to UTC 
root@xyzzy:/mnt/cdn/hhvm/hhvm# timedatectl set-timezone UTC 
root@xyzzy:/mnt/cdn/hhvm/hhvm# timedatectl
      Local time: Fri 2017-04-14 16:02:42 UTC 
  Universal time: Fri 2017-04-14 16:02:42 UTC 
        RTC time: Fri 2017-04-14 15:15:04
       Time zone: UTC (UTC, +0000)
 Network time on: yes 
NTP synchronized: yes 
 RTC in local TZ: no

# test FAILS
root@xyzzy:/mnt/cdn/hhvm/hhvm# /mnt/cdn/hhvm/hhvm/hphp/hhvm/hhvm /mnt/cdn/hhvm/hhvm/hphp/test/run  /mnt/cdn/hhvm/hhvm/hphp/test/zend/good/ext/openssl/tests/openssl_x509_parse_basic.php
Running 1 tests in 1 threads (0 in serial)

FAILED: hphp/test/zend/good/ext/openssl/tests/openssl_x509_parse_basic.php
041+   int(1214818123)

AFTER
=====
root@xyzzy:/mnt/cdn/hhvm/hhvm# /mnt/cdn/hhvm/hhvm/hphp/hhvm/hhvm /mnt/cdn/hhvm/hhvm/hphp/test/run  /mnt/cdn/hhvm/hhvm/hphp/test/zend/good/ext/openssl/tests/openssl_x509_parse_basic.php
Running 1 tests in 1 threads (0 in serial)

All tests passed.