### PR TITLE
Update .ini to avoid typecheck error

### DIFF
--- a/hphp/test/slow/ini/recursive_substitutions1.php.ini
+++ b/hphp/test/slow/ini/recursive_substitutions1.php.ini
@@ -1,1 +1,2 @@
+hhvm.hack.lang.look_for_typechecker=0
 hhvm.stats.slot_duration[:] = "hhvm.stats.slot_duration"

--- a/hphp/test/slow/ini/recursive_substitutions3.php.ini
+++ b/hphp/test/slow/ini/recursive_substitutions3.php.ini
@@ -1,3 +1,4 @@
+hhvm.hack.lang.look_for_typechecker=0
 hhvm.env_variables["MYBOOL"] = true
 hhvm.env_variables["MYINT"][:] = "hhvm.server_variables"
 hhvm.server_variables[:] = "hhvm.env_variables"


### PR DESCRIPTION
These two tests have been failing at least since last November.  With the updated
.ini files, the .expect files match the output produced.  I did not see anything in the
documentation that suggested the new initialization is not allowed.

Prior to this change, these two tests would fail with these option sets.

hphp/test/run -v -m interp -r
hphp/test/run -v -m jit -r -a '-vEval.JitPGO=0'
hphp/test/run -v -m jit -r -a '-vEval.JitPGO=1'

After this change, these tests pass six different option sets.

Evidence below.

swalk@xyzzy:~/master/hhvm$ egrep 'run |passed' my.Out1 | grep -v serially
/home/swalk/master/hhvm/hphp/hhvm/hhvm hphp/test/run -v -m interp hphp/test/slow/ini/recursive_substitutions1.php hphp/test/slow/ini/recursive_substitutions3.php
hphp/test/slow/ini/recursive_substitutions1.php passed (11.81s)
hphp/test/slow/ini/recursive_substitutions3.php passed (11.78s)
All tests passed.
/home/swalk/master/hhvm/hphp/hhvm/hhvm hphp/test/run -v -m interp -r hphp/test/slow/ini/recursive_substitutions1.php hphp/test/slow/ini/recursive_substitutions3.php
hphp/test/slow/ini/recursive_substitutions1.php passed (54.10s)
hphp/test/slow/ini/recursive_substitutions3.php passed (54.12s)
All tests passed.
/home/swalk/master/hhvm/hphp/hhvm/hhvm hphp/test/run -v -m jit -a '-vEval.JitPGO=0' hphp/test/slow/ini/recursive_substitutions1.php hphp/test/slow/ini/recursive_substitutions3.php
hphp/test/slow/ini/recursive_substitutions1.php passed (11.84s)
hphp/test/slow/ini/recursive_substitutions3.php passed (11.88s)
All tests passed.
/home/swalk/master/hhvm/hphp/hhvm/hhvm hphp/test/run -v -m jit -r -a '-vEval.JitPGO=0' hphp/test/slow/ini/recursive_substitutions1.php hphp/test/slow/ini/recursive_substitutions3.php
hphp/test/slow/ini/recursive_substitutions1.php passed (54.21s)
hphp/test/slow/ini/recursive_substitutions3.php passed (54.17s)
All tests passed.
/home/swalk/master/hhvm/hphp/hhvm/hhvm hphp/test/run -v -m jit -a '-vEval.JitPGO=1' hphp/test/slow/ini/recursive_substitutions1.php hphp/test/slow/ini/recursive_substitutions3.php
hphp/test/slow/ini/recursive_substitutions1.php passed (11.83s)
hphp/test/slow/ini/recursive_substitutions3.php passed (11.93s)
All tests passed.
/home/swalk/master/hhvm/hphp/hhvm/hhvm hphp/test/run -v -m jit -r -a '-vEval.JitPGO=1' hphp/test/slow/ini/recursive_substitutions1.php hphp/test/slow/ini/recursive_substitutions3.php
hphp/test/slow/ini/recursive_substitutions1.php passed (54.16s)
hphp/test/slow/ini/recursive_substitutions3.php passed (54.23s)
All tests passed.

I'm not sure why recursive_substitutions2.php could not be fixed in a similar fashion.
