### PR TITLE
Enable runtime/test build for OSS.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,8 @@ hphp.log
 /hphp/runtime/ext/*/CMakeLists.txt
 /hphp/runtime/ext/*/*.so
 
+/hphp/runtime/test/hphp_runtime_test
+
 /hphp/runtime/tmp/string
 
 /hphp/hhvm/gen

--- a/hphp/CMakeLists.txt
+++ b/hphp/CMakeLists.txt
@@ -126,6 +126,13 @@ add_subdirectory(parser)
 
 add_subdirectory(runtime)
 add_subdirectory(runtime/ext)
+
+# The runtime/test binary require GTest and GMock to be installed globally
+option(RUNTIME_TEST_BIN "Create the HHVM runtime/test binary" OFF)
+if (RUNTIME_TEST_BIN)
+  add_subdirectory(runtime/test)
+endif ()
+
 if (ENABLE_ZEND_COMPAT)
   add_subdirectory(runtime/ext_zend_compat)
 endif()

--- a/hphp/runtime/test/CMakeLists.txt
+++ b/hphp/runtime/test/CMakeLists.txt
@@ -1,0 +1,24 @@
+enable_testing()
+find_package(GTest REQUIRED)
+include_directories(${GTEST_INCLUDE_DIRS})
+
+set(CXX_SOURCES)
+auto_sources(files "*.cpp" "RECURSE" "${CMAKE_CURRENT_SOURCE_DIR}")
+list(APPEND CXX_SOURCES ${files} )
+
+set(HEADER_SOURCES)
+auto_sources(files "*.h" "RECURSE" "${CMAKE_CURRENT_SOURCE_DIR}")
+list(APPEND HEADER_SOURCES ${files} "${CMAKE_CURRENT_SOURCE_DIR}/../../hhvm/process-init.cpp")
+
+add_executable(hphp_runtime_test ${CXX_SOURCES} ${HEADER_SOURCES})
+link_object_libraries(hphp_runtime_test ${HHVM_WHOLE_ARCHIVE_LIBRARIES})
+target_link_libraries(hphp_runtime_test ${HHVM_LINK_LIBRARIES} gtest gtest_main gmock gmock_main)
+embed_all_systemlibs(hphp_runtime_test "${CMAKE_CURRENT_BINARY_DIR}/../.."
+                              "${CMAKE_CURRENT_BINARY_DIR}/hphp_runtime_test")
+
+auto_source_group("hphp_runtime_test" "${CMAKE_CURRENT_SOURCE_DIR}"
+  ${CXX_SOURCES} ${HEADER_SOURCES})
+add_dependencies(hphp_runtime_test hphp_system)
+if (ENABLE_COTIRE)
+  cotire(hphp_runtime_test)
+endif()

--- a/hphp/runtime/test/CMakeLists.txt
+++ b/hphp/runtime/test/CMakeLists.txt
@@ -1,18 +1,17 @@
-enable_testing()
 find_package(GTest REQUIRED)
 include_directories(${GTEST_INCLUDE_DIRS})
 
 set(CXX_SOURCES)
 auto_sources(files "*.cpp" "RECURSE" "${CMAKE_CURRENT_SOURCE_DIR}")
-list(APPEND CXX_SOURCES ${files} )
+list(APPEND CXX_SOURCES ${files} "${CMAKE_CURRENT_SOURCE_DIR}/../../hhvm/process-init.cpp")
 
 set(HEADER_SOURCES)
 auto_sources(files "*.h" "RECURSE" "${CMAKE_CURRENT_SOURCE_DIR}")
-list(APPEND HEADER_SOURCES ${files} "${CMAKE_CURRENT_SOURCE_DIR}/../../hhvm/process-init.cpp")
+list(APPEND HEADER_SOURCES ${files})
 
 add_executable(hphp_runtime_test ${CXX_SOURCES} ${HEADER_SOURCES})
 link_object_libraries(hphp_runtime_test ${HHVM_WHOLE_ARCHIVE_LIBRARIES})
-target_link_libraries(hphp_runtime_test ${HHVM_LINK_LIBRARIES} gtest gtest_main gmock gmock_main)
+target_link_libraries(hphp_runtime_test ${HHVM_LINK_LIBRARIES} gtest gmock)
 embed_all_systemlibs(hphp_runtime_test "${CMAKE_CURRENT_BINARY_DIR}/../.."
                               "${CMAKE_CURRENT_BINARY_DIR}/hphp_runtime_test")
 


### PR DESCRIPTION
The GTest based tests under hphp/runtime/test were previously not
built under the OSS build. This patch adds the CMake support which
is enabled with -DRUNTIME_TEST_BIN=on. The results is a binary,
hphp_runtime_test.

Additionally the tests were ported to ARM.