### PR TITLE
jit: Removal of vasm instructions subb and subbi

### DIFF
--- a/hphp/runtime/vm/jit/vasm-arm.cpp
+++ b/hphp/runtime/vm/jit/vasm-arm.cpp
@@ -319,7 +319,6 @@ struct Vgen {
   void emit(const storeups& i);
   void emit(const storew& i) { a->Strh(W(i.s), M(i.m)); }
   void emit(const subb& i) { a->Sub(W(i.d), W(i.s1), W(i.s0), UF(i.fl)); }
-  void emit(const subbi& i) { a->Sub(W(i.d), W(i.s1), i.s0.l(), UF(i.fl)); }
   void emit(const subl& i) { a->Sub(W(i.d), W(i.s1), W(i.s0), UF(i.fl)); }
   void emit(const subli& i) { a->Sub(W(i.d), W(i.s1), i.s0.l(), UF(i.fl)); }
   void emit(const subq& i) { a->Sub(X(i.d), X(i.s1), X(i.s0), UF(i.fl)); }
@@ -1220,7 +1219,6 @@ Y(andqi, andq, ldimmq, ISLG(64), Immed64(value), U2(i.s1, i.d))
 Y(cmpli, cmpl, ldimml, ISAR, i.s0, i.s1)
 Y(cmpqi, cmpq, ldimmq, ISAR, Immed64(value), i.s1)
 Y(orqi, orq, ldimmq, ISLG(64), Immed64(value), U2(i.s1, i.d))
-Y(subbi, subb, ldimmb, ISAR, i.s0, U2(i.s1, i.d))
 Y(subli, subl, ldimml, ISAR, i.s0, U2(i.s1, i.d))
 Y(subqi, subq, ldimmq, ISAR, Immed64(value), U2(i.s1, i.d))
 Y(testli, testl, ldimml, ISLG(32), i.s0, i.s1)

--- a/hphp/runtime/vm/jit/vasm-arm.cpp
+++ b/hphp/runtime/vm/jit/vasm-arm.cpp
@@ -318,7 +318,6 @@ struct Vgen {
   void emit(const storesd& i) { emit(store{i.s, i.m}); }
   void emit(const storeups& i);
   void emit(const storew& i) { a->Strh(W(i.s), M(i.m)); }
-  void emit(const subb& i) { a->Sub(W(i.d), W(i.s1), W(i.s0), UF(i.fl)); }
   void emit(const subl& i) { a->Sub(W(i.d), W(i.s1), W(i.s0), UF(i.fl)); }
   void emit(const subli& i) { a->Sub(W(i.d), W(i.s1), i.s0.l(), UF(i.fl)); }
   void emit(const subq& i) { a->Sub(X(i.d), X(i.s1), X(i.s0), UF(i.fl)); }

--- a/hphp/runtime/vm/jit/vasm-copy.cpp
+++ b/hphp/runtime/vm/jit/vasm-copy.cpp
@@ -459,7 +459,6 @@ void analyze_virt_disp(Env& env, RegState& state,
       V(addli)    \
       V(addqi)
 #define VASM_SUBS \
-      V(subbi)    \
       V(subli)    \
       V(subqi)
 

--- a/hphp/runtime/vm/jit/vasm-dead.cpp
+++ b/hphp/runtime/vm/jit/vasm-dead.cpp
@@ -146,7 +146,6 @@ bool effectful(Vinstr& inst) {
     case Vinstr::shrqi:
     case Vinstr::sqrtsd:
     case Vinstr::srem:
-    case Vinstr::subb:
     case Vinstr::subl:
     case Vinstr::subli:
     case Vinstr::subq:

--- a/hphp/runtime/vm/jit/vasm-dead.cpp
+++ b/hphp/runtime/vm/jit/vasm-dead.cpp
@@ -147,7 +147,6 @@ bool effectful(Vinstr& inst) {
     case Vinstr::sqrtsd:
     case Vinstr::srem:
     case Vinstr::subb:
-    case Vinstr::subbi:
     case Vinstr::subl:
     case Vinstr::subli:
     case Vinstr::subq:

--- a/hphp/runtime/vm/jit/vasm-instr.cpp
+++ b/hphp/runtime/vm/jit/vasm-instr.cpp
@@ -204,7 +204,6 @@ Width width(Vinstr::Opcode op) {
     case Vinstr::notb:
     case Vinstr::orbim:
     case Vinstr::subb:
-    case Vinstr::subbi:
     case Vinstr::xorb:
     case Vinstr::xorbi:
     case Vinstr::cmpb:

--- a/hphp/runtime/vm/jit/vasm-instr.cpp
+++ b/hphp/runtime/vm/jit/vasm-instr.cpp
@@ -203,7 +203,6 @@ Width width(Vinstr::Opcode op) {
     case Vinstr::andbim:
     case Vinstr::notb:
     case Vinstr::orbim:
-    case Vinstr::subb:
     case Vinstr::xorb:
     case Vinstr::xorbi:
     case Vinstr::cmpb:

--- a/hphp/runtime/vm/jit/vasm-instr.h
+++ b/hphp/runtime/vm/jit/vasm-instr.h
@@ -175,7 +175,6 @@ struct Vunit;
   O(shrli, I(s0) I(fl), UH(s1,d), DH(d,s1) D(sf))\
   O(shrqi, I(s0) I(fl), UH(s1,d), DH(d,s1) D(sf))\
   O(subb, I(fl), UA(s0) U(s1), D(d) D(sf))\
-  O(subbi, I(s0) I(fl), UH(s1,d), DH(d,s1) D(sf))\
   O(subl, I(fl), UA(s0) U(s1), D(d) D(sf))\
   O(subli, I(s0) I(fl), UH(s1,d), DH(d,s1) D(sf))\
   O(subq, I(fl), UA(s0) U(s1), D(d) D(sf))\
@@ -927,7 +926,6 @@ struct shrli { Immed s0; Vreg32 s1, d; VregSF sf; Vflags fl; };
 struct shrqi { Immed s0; Vreg64 s1, d; VregSF sf; Vflags fl; };
 // sub: s1 - s0 => d, sf
 struct subb { Vreg8 s0; Vreg8 s1, d; VregSF sf; Vflags fl; };
-struct subbi { Immed s0; Vreg8 s1, d; VregSF sf; Vflags fl; };
 struct subl { Vreg32 s0, s1, d; VregSF sf; Vflags fl; };
 struct subli { Immed s0; Vreg32 s1, d; VregSF sf; Vflags fl; };
 struct subq { Vreg64 s0, s1, d; VregSF sf; Vflags fl; };

--- a/hphp/runtime/vm/jit/vasm-instr.h
+++ b/hphp/runtime/vm/jit/vasm-instr.h
@@ -174,7 +174,6 @@ struct Vunit;
   O(shlqi, I(s0) I(fl), UH(s1,d), DH(d,s1) D(sf))\
   O(shrli, I(s0) I(fl), UH(s1,d), DH(d,s1) D(sf))\
   O(shrqi, I(s0) I(fl), UH(s1,d), DH(d,s1) D(sf))\
-  O(subb, I(fl), UA(s0) U(s1), D(d) D(sf))\
   O(subl, I(fl), UA(s0) U(s1), D(d) D(sf))\
   O(subli, I(s0) I(fl), UH(s1,d), DH(d,s1) D(sf))\
   O(subq, I(fl), UA(s0) U(s1), D(d) D(sf))\
@@ -925,7 +924,6 @@ struct shlqi { Immed s0; Vreg64 s1, d; VregSF sf; Vflags fl; };
 struct shrli { Immed s0; Vreg32 s1, d; VregSF sf; Vflags fl; };
 struct shrqi { Immed s0; Vreg64 s1, d; VregSF sf; Vflags fl; };
 // sub: s1 - s0 => d, sf
-struct subb { Vreg8 s0; Vreg8 s1, d; VregSF sf; Vflags fl; };
 struct subl { Vreg32 s0, s1, d; VregSF sf; Vflags fl; };
 struct subli { Immed s0; Vreg32 s1, d; VregSF sf; Vflags fl; };
 struct subq { Vreg64 s0, s1, d; VregSF sf; Vflags fl; };

--- a/hphp/runtime/vm/jit/vasm-ppc64.cpp
+++ b/hphp/runtime/vm/jit/vasm-ppc64.cpp
@@ -1088,7 +1088,6 @@ void lowerForPPC64(Vout& v, vasm_src& inst) {                           \
 }
 
 X(cmpbi,  cmpqi,  movzbq, NONE)
-X(subbi,  subqi,  extsb,  ONE_R64(d))
 X(subli,  subqi,  extsl,  ONE_R64(d))
 X(testbi, testqi, extsb,  NONE)
 X(testli, testqi, extsl,  NONE)

--- a/hphp/runtime/vm/jit/vasm-x64.cpp
+++ b/hphp/runtime/vm/jit/vasm-x64.cpp
@@ -238,7 +238,6 @@ struct Vgen {
   void emit(const storesd& i) { a.movsd(i.s, i.m); }
   void emit(const storew& i) { a.storew(i.s, i.m); }
   void emit(const storewi& i) { a.storew(i.s, i.m); }
-  void emit(subbi i) { binary(i); a.subb(i.s0, i.d); }
   void emit(subl i) { noncommute(i); a.subl(i.s0, i.d); }
   void emit(subli i) { binary(i); a.subl(i.s0, i.d); }
   void emit(subq i) { noncommute(i); a.subq(i.s0, i.d); }


### PR DESCRIPTION
I wanted to verify the correctness of aarch64's emit function for subb and subbi, when I realised that both instructions are not emitted at all. With this PR I propose the elimination of them. Note that subb was not even implemented for x86_64 and ppc64.

The all set showed no regressions on ARM64.

@mxw please review.