### PR TITLE
Set a max amount of time per-request allowed in tc

### DIFF
--- a/hphp/runtime/base/runtime-option.h
+++ b/hphp/runtime/base/runtime-option.h
@@ -513,6 +513,7 @@ struct RuntimeOption {
   F(uint32_t, JitMaxTranslations,      10)                              \
   F(uint32_t, JitMaxProfileTranslations, 30)                            \
   F(uint64_t, JitGlobalTranslationLimit, -1)                            \
+  F(uint64_t, JitMaxRequestTranslationTime,   -1)                       \
   F(uint32_t, JitMaxRegionInstrs,      1347)                            \
   F(uint32_t, JitProfileInterpRequests, kDefaultProfileInterpRequests)  \
   F(bool, JitProfileWarmupRequests,    false)                           \

--- a/hphp/runtime/base/runtime-option.h
+++ b/hphp/runtime/base/runtime-option.h
@@ -513,7 +513,7 @@ struct RuntimeOption {
   F(uint32_t, JitMaxTranslations,      10)                              \
   F(uint32_t, JitMaxProfileTranslations, 30)                            \
   F(uint64_t, JitGlobalTranslationLimit, -1)                            \
-  F(uint64_t, JitMaxRequestTranslationTime,   -1)                       \
+  F(int64_t, JitMaxRequestTranslationTime, -1)                          \
   F(uint32_t, JitMaxRegionInstrs,      1347)                            \
   F(uint32_t, JitProfileInterpRequests, kDefaultProfileInterpRequests)  \
   F(bool, JitProfileWarmupRequests,    false)                           \

--- a/hphp/runtime/vm/jit/tc-internal.cpp
+++ b/hphp/runtime/vm/jit/tc-internal.cpp
@@ -138,8 +138,8 @@ bool shouldTranslate(const Func* func, TransKind kind) {
                           maxTransTime,
                           transCounter.wall_time_elapsed,
                           transCounter.count);
-      }
-      return false;
+    }
+    return false;
   }
 
   auto const main_under = code().main().used() < CodeCache::AMaxUsage;

--- a/hphp/runtime/vm/jit/tc-internal.cpp
+++ b/hphp/runtime/vm/jit/tc-internal.cpp
@@ -130,14 +130,14 @@ bool shouldTranslate(const Func* func, TransKind kind) {
   if (serverMode && maxTransTime >= 0 &&
       transCounter.wall_time_elapsed >= maxTransTime) {
 
-      if (Trace::moduleEnabledRelease(Trace::mcg, 1)) {
-        Trace::traceRelease("Skipping translation. "
-                            "Time budget of %" PRId64 " exceeded. "
-                            "%" PRId64 "us elapsed. "
-                            "%" PRId64 " translations completed\n",
-                            maxTransTime,
-                            transCounter.wall_time_elapsed,
-                            transCounter.count);
+    if (Trace::moduleEnabledRelease(Trace::mcg, 1)) {
+      Trace::traceRelease("Skipping translation. "
+                          "Time budget of %" PRId64 " exceeded. "
+                          "%" PRId64 "us elapsed. "
+                          "%" PRId64 " translations completed\n",
+                          maxTransTime,
+                          transCounter.wall_time_elapsed,
+                          transCounter.count);
       }
       return false;
   }

--- a/hphp/runtime/vm/jit/timer.h
+++ b/hphp/runtime/vm/jit/timer.h
@@ -94,6 +94,7 @@ struct Timer {
     int64_t total; // total CPU time, in nanoseconds
     int64_t count; // number of entries for this counter
     int64_t max;   // longest CPU time, in nanoseconds
+    int64_t wall_time_elapsed;   // Wall clock elapsed, in micros
 
     int64_t mean() const {
       return total / count;
@@ -120,6 +121,7 @@ struct Timer {
   Name m_name;
   bool m_finished;
   int64_t m_start;
+  int64_t m_start_wall;
   StructuredLogEntry* m_log_entry;
 };
 


### PR DESCRIPTION
Our application and deployment process doesn't lend itself well to
a warmup script, and especially in our developer/test environments
the jit costs are expensive. This sets a per-request jit budget
that amortizes the jit cost across requests.

Tested with the following config flags:

	hhvm.jit_max_request_translation_time = 50000
	hhvm.jit_timer = 1

Background:
We have a large and broad PHP application that we deploy to dozens of times per-day. Because of a variety of deployment constraints that are difficult for us to change in the near-term, it's difficult for us to run a warm-up script before traffic is served.

Because of this, we observe high tail-latencies on requests after a deployment. Because we have a vary large pool of hosts in the fleet that we serve round-robin and have some infrequently accessed pages, some users end up hitting the jit penalty repeatedly.

Desired change:
We'd like to set a per-request budget for the amount of time to spend in the jit, to amortize that cost across requests.  We'd like to tradeoff a longer time getting code to be fully JITted for a smoother response-time upper bound post-deploy.  We took a stab at adding the limit and our running it on our dev environments, and would like feedback.

Here's what we are seeing after restart for 100 requests, time-to-first-byte vs the size of the tc cache reported in the admin port:

![max-request-time-stock](https://cloud.githubusercontent.com/assets/43085/25233870/28bf43ea-2595-11e7-952b-956071986bc8.png)



With the translation limit set to 100ms:

![max-request-time-with-change](https://cloud.githubusercontent.com/assets/43085/25233878/2f56dc54-2595-11e7-8e2a-89467d128592.png)

Thanks, and we'd love feedback on the idea and implementation!
