### PR TITLE
Reduce false sharing in JIT performance counters

### DIFF
--- a/hphp/runtime/vm/jit/prof-data.h
+++ b/hphp/runtime/vm/jit/prof-data.h
@@ -95,6 +95,7 @@ struct ProfCounters {
   ProfCounters& operator=(const ProfCounters&) = delete;
 
   T get(uint32_t id) const {
+    assertx(kCountersPerChunk % 11);
     return id / kCountersPerChunk >= m_chunks.size()
       ? m_initVal
       : m_chunks[id / kCountersPerChunk][(id * 11) % kCountersPerChunk];
@@ -109,6 +110,7 @@ struct ProfCounters {
       m_chunks.emplace_back(chunk);
     }
     assertx(id / kCountersPerChunk < m_chunks.size());
+    assertx(kCountersPerChunk % 11);
     return &(m_chunks[id / kCountersPerChunk][(id * 11) % kCountersPerChunk]);
   }
 

--- a/hphp/runtime/vm/jit/prof-data.h
+++ b/hphp/runtime/vm/jit/prof-data.h
@@ -97,7 +97,7 @@ struct ProfCounters {
   T get(uint32_t id) const {
     return id / kCountersPerChunk >= m_chunks.size()
       ? m_initVal
-      : m_chunks[id / kCountersPerChunk][id % kCountersPerChunk];
+      : m_chunks[id / kCountersPerChunk][(id * 11) % kCountersPerChunk];
   }
 
   T* getAddr(uint32_t id) {
@@ -109,7 +109,7 @@ struct ProfCounters {
       m_chunks.emplace_back(chunk);
     }
     assertx(id / kCountersPerChunk < m_chunks.size());
-    return &(m_chunks[id / kCountersPerChunk][id % kCountersPerChunk]);
+    return &(m_chunks[id / kCountersPerChunk][(id * 11) % kCountersPerChunk]);
   }
 
   T getDefault() const { return m_initVal; }


### PR DESCRIPTION
The memory for JIT performance counters is currently allocated sequentially.  This
can lead to false sharing for small benchmarks and hosts with large cache lines.
This change slightly improves performance during the profiling interval.

The memory for the performance counter is currently referenced as a doubly indexed
array:  [id / kCountersPerChunk][id % kCountersPerChunk]
Since C/C++ uses row-major ordering the elements from the second index are next to
each other.

This change makes the memory less cache friendly to force the access around different
areas in memory. The second index is multiplied by a small prime and as long as the
modulus variable does not contain a factor there should be no issues.

The standard regression tests were run with 6 option sets.  No additional issues were observed.
