### PR TITLE
immed: Fix unsigned values retrieval.

### DIFF
--- a/hphp/util/immed.h
+++ b/hphp/util/immed.h
@@ -80,8 +80,9 @@ struct Immed {
   int64_t q() const { return m_int; }
   int32_t l() const { return safe_cast<int32_t>(m_int); }
   int16_t w() const { return safe_cast<int16_t>(m_int); }
+  uint16_t uw() const { return safe_cast<int16_t>(m_int); }
   int8_t  b() const { return safe_cast<int8_t>(m_int); }
-  uint8_t ub() const { return safe_cast<uint8_t>(m_int); }
+  uint8_t ub() const { return safe_cast<int8_t>(m_int); }
 
   bool fits(int sz) const { return deltaFits(m_int, sz); }
 


### PR DESCRIPTION
The Immed class offers a single constructor,
which assumes the immediate value to be int32_t.
All caller sides in HHVM decided therefore to
cast their values to int32_t. However that
causes safe_cast<uint8_t> to fail in 50% of
all possible values (i.e. 0x80-0xff).

This patch performs the correct cast sequence
for obtaining unsigned values from the Immed class
by performing a safe_cast<int8_t> and casting the
resulting 8-bit value then to uint8_t.

Signed-off-by: Christoph Muellner <christoph.muellner@theobroma-systems.com>