### PR TITLE
vixl: Backport 32-bit immediate handling.

### DIFF
--- a/hphp/vixl/a64/constants-a64.h
+++ b/hphp/vixl/a64/constants-a64.h
@@ -38,6 +38,8 @@ constexpr int kFirstCalleeSavedRegisterIndex = 19;
 constexpr int kNumberOfCalleeSavedFPRegisters = 8;
 constexpr int kFirstCalleeSavedFPRegisterIndex = 8;
 
+const int kWRegSizeInBits = 32;
+
 constexpr byte kSimulatorStackJunk = 0x8b;
 
 #define REGISTER_CODE_LIST(R)                                                  \


### PR DESCRIPTION
When using negative signed values as immediate for logical or
move operations (e.g. And, Eor, etc.) then the conversion to
uint64_t (argument type of the immedate defined by the vixl API)
might end up with the upper 32 bits set.

This is problematic when using W-registers (32 bit only).

The current arm64 code solves the problem by using the
MSKTOP() function, which seems to be derived from
upstream vixl. This patch puts the code to HHVM's vixl,
which allows to remove MSKTOP() in vasm-arm.cpp.

Signed-off-by: Christoph Muellner <christoph.muellner@theobroma-systems.com>