### PR TITLE
jit: irlower: Mask type with kDataTypeMask before comparing.

### DIFF
--- a/hphp/runtime/vm/jit/irlower-internal-inl.h
+++ b/hphp/runtime/vm/jit/irlower-internal-inl.h
@@ -189,15 +189,14 @@ void emitTypeTest(Vout& v, IRLS& env, Type type,
 
   auto const cc = [&] {
 
-    auto const mask_cmp = [&] (int mask, int bits, ConditionCode cc) {
+    auto const mask_cmp = [&] (int mask, int kind, ConditionCode cc) {
       auto const masked = emitMaskTVType(v, mask, typeSrc);
-      emitCmpTVType(v, sf, bits, masked);
+      emitCmpTVType(v, sf, kind, masked);
       return cc;
     };
 
-    auto const cmp = [&] (DataType kind, ConditionCode cc) {
-      emitCmpTVType(v, sf, kind, typeSrc);
-      return cc;
+    auto const cmp = [&] (int kind, ConditionCode cc) {
+      return mask_cmp(kDataTypeMask, kind, cc);
     };
 
     auto const test = [&] (int bits, ConditionCode cc) {

--- a/hphp/runtime/vm/jit/irlower-refcount.cpp
+++ b/hphp/runtime/vm/jit/irlower-refcount.cpp
@@ -88,7 +88,8 @@ void ifRefCountedType(Vout& v, Vout& vtaken, Type ty, Vloc loc, Then then) {
     cond = CC_E;
   } else {
     assert(ty <= TGen);
-    emitCmpTVType(v, sf, KindOfRefCountThreshold, loc.reg(1));
+    auto const masked = emitMaskTVType(v, (int)kDataTypeMask, loc.reg(1));
+    emitCmpTVType(v, sf, KindOfRefCountThreshold, masked);
   }
   unlikelyIfThen(v, vtaken, cond, sf, then);
 }
@@ -435,7 +436,8 @@ void cgDecRef(IRLS& env, const IRInstruction *inst) {
       auto const type = srcLoc(env, inst, 0).reg(1);
 
       auto const sf = v.makeReg();
-      emitCmpTVType(v, sf, KindOfRefCountThreshold, type);
+      auto const masked = emitMaskTVType(v, (int)kDataTypeMask, type);
+      emitCmpTVType(v, sf, KindOfRefCountThreshold, masked);
 
       unlikelyIfThen(v, vcold(env), CC_NLE, sf, [&] (Vout& v) {
         auto const stub = tc::ustubs().decRefGeneric;


### PR DESCRIPTION
When using 64-bit registers in cmpbi{} vasm instructions,
a preceding truncation to 8-bits is required in general.
This rule seems to be violated in some parts of the irlower
code. With the help of the arm64 backend, these locations
could be detected.

This patch uses masking with KindOfRefCountThreshold (0x7f)
to address this issue.

No regressions with the 'all' test set on arm64.

Note, that this patch is required in order to allow
a performance improvement patch for arm64 (drop emitting
uxtb instructions before cmpbi{} and cmpb{}).

Signed-off-by: Christoph Muellner <christoph.muellner@theobroma-systems.com>