### PR TITLE
[AArch64] Use the cbz instruction in imul vasm

### DIFF
--- a/hphp/runtime/vm/jit/vasm-arm.cpp
+++ b/hphp/runtime/vm/jit/vasm-arm.cpp
@@ -639,8 +639,7 @@ void Vgen::emit(const imul& i) {
 
       // If hi is all 0's or 1's, then check the sign, else overflow
       // (fallthrough).
-      a->Cmp(rAsm, 0);
-      a->B(&checkSign, vixl::eq);
+      a->Cbz(rAsm, &checkSign);
       a->Cmp(rAsm, -1);
       a->B(&checkSign, vixl::eq);
 


### PR DESCRIPTION
This patch updates the imul vasm to use the cbz instruction instead
of comparing against zero and branching if equal.

There are no new failures in the unit tests and OSS passes without
regressions. 17 new cbz instructions were detected in OSS's mediawiki.