### PR TITLE
AARCH64 - movzbl/shrli -> ubfmr2m6 peephole

### DIFF
--- a/hphp/runtime/vm/jit/vasm-arm.cpp
+++ b/hphp/runtime/vm/jit/vasm-arm.cpp
@@ -340,7 +340,7 @@ struct Vgen {
   void emit(const fcvtzs& i) { a->Fcvtzs(X(i.d), D(i.s)); }
   void emit(const mrs& i) { a->Mrs(X(i.r), vixl::SystemRegister(i.s.l())); }
   void emit(const msr& i) { a->Msr(vixl::SystemRegister(i.s.l()), X(i.r)); }
-  void emit(const ubfm2r7ml& i) { a->ubfm(W(i.d), W(i.s), 2, 7); }
+  void emit(const ubfmli& i) { a->ubfm(W(i.d), W(i.s), i.mr.w(), i.ms.w()); }
 
   void emit_nop() { a->Nop(); }
 

--- a/hphp/runtime/vm/jit/vasm-arm.cpp
+++ b/hphp/runtime/vm/jit/vasm-arm.cpp
@@ -340,6 +340,7 @@ struct Vgen {
   void emit(const fcvtzs& i) { a->Fcvtzs(X(i.d), D(i.s)); }
   void emit(const mrs& i) { a->Mrs(X(i.r), vixl::SystemRegister(i.s.l())); }
   void emit(const msr& i) { a->Msr(vixl::SystemRegister(i.s.l()), X(i.r)); }
+  void emit(const ubfm2r7ml& i) { a->ubfm(W(i.d), W(i.s), 2, 7); }
 
   void emit_nop() { a->Nop(); }
 

--- a/hphp/runtime/vm/jit/vasm-dead.cpp
+++ b/hphp/runtime/vm/jit/vasm-dead.cpp
@@ -164,7 +164,7 @@ bool effectful(Vinstr& inst) {
     case Vinstr::testwim:
     case Vinstr::ucomisd:
     case Vinstr::unpcklpd:
-    case Vinstr::ubfm2r7ml:
+    case Vinstr::ubfmli:
     case Vinstr::xorb:
     case Vinstr::xorbi:
     case Vinstr::xorl:

--- a/hphp/runtime/vm/jit/vasm-dead.cpp
+++ b/hphp/runtime/vm/jit/vasm-dead.cpp
@@ -164,6 +164,7 @@ bool effectful(Vinstr& inst) {
     case Vinstr::testwim:
     case Vinstr::ucomisd:
     case Vinstr::unpcklpd:
+    case Vinstr::ubfm2r7ml:
     case Vinstr::xorb:
     case Vinstr::xorbi:
     case Vinstr::xorl:

--- a/hphp/runtime/vm/jit/vasm-instr.cpp
+++ b/hphp/runtime/vm/jit/vasm-instr.cpp
@@ -264,6 +264,7 @@ Width width(Vinstr::Opcode op) {
     case Vinstr::loadtql:
     case Vinstr::storel:
     case Vinstr::storeli:
+    case Vinstr::ubfm2r7ml:
       return Width::Long;
 
     case Vinstr::addq:

--- a/hphp/runtime/vm/jit/vasm-instr.cpp
+++ b/hphp/runtime/vm/jit/vasm-instr.cpp
@@ -264,7 +264,7 @@ Width width(Vinstr::Opcode op) {
     case Vinstr::loadtql:
     case Vinstr::storel:
     case Vinstr::storeli:
-    case Vinstr::ubfm2r7ml:
+    case Vinstr::ubfmli:
       return Width::Long;
 
     case Vinstr::addq:

--- a/hphp/runtime/vm/jit/vasm-instr.h
+++ b/hphp/runtime/vm/jit/vasm-instr.h
@@ -298,6 +298,7 @@ struct Vunit;
   O(fcvtzs, Inone, U(s), D(d))\
   O(mrs, I(s), Un, D(r))\
   O(msr, I(s), U(r), Dn)\
+  O(ubfm2r7ml, Inone, U(s), D(d))\
   /* ppc64 instructions */\
   O(extsb, Inone, UH(s,d), DH(d,s))\
   O(extsl, Inone, UH(s,d), DH(d,s))\
@@ -1107,6 +1108,7 @@ struct shlq { Vreg64 s, d; VregSF sf; Vflags fl; }; // uses rcx
 struct fcvtzs { VregDbl s; Vreg64 d;};
 struct mrs { Immed s; Vreg64 r; };
 struct msr { Vreg64 r; Immed s; };
+struct ubfm2r7ml { Vreg32 s, d; VregSF sf; Vflags fl; };
 
 /*
  * ppc64 intrinsics.

--- a/hphp/runtime/vm/jit/vasm-instr.h
+++ b/hphp/runtime/vm/jit/vasm-instr.h
@@ -298,7 +298,7 @@ struct Vunit;
   O(fcvtzs, Inone, U(s), D(d))\
   O(mrs, I(s), Un, D(r))\
   O(msr, I(s), U(r), Dn)\
-  O(ubfm2r7ml, Inone, U(s), D(d))\
+  O(ubfmli, I(mr) I(ms), U(s), D(d))\
   /* ppc64 instructions */\
   O(extsb, Inone, UH(s,d), DH(d,s))\
   O(extsl, Inone, UH(s,d), DH(d,s))\
@@ -1108,7 +1108,7 @@ struct shlq { Vreg64 s, d; VregSF sf; Vflags fl; }; // uses rcx
 struct fcvtzs { VregDbl s; Vreg64 d;};
 struct mrs { Immed s; Vreg64 r; };
 struct msr { Vreg64 r; Immed s; };
-struct ubfm2r7ml { Vreg32 s, d; VregSF sf; Vflags fl; };
+struct ubfmli { Immed mr, ms; Vreg32 s, d; VregSF sf; Vflags fl; };
 
 /*
  * ppc64 intrinsics.

--- a/hphp/runtime/vm/jit/vasm-instr.h
+++ b/hphp/runtime/vm/jit/vasm-instr.h
@@ -1108,7 +1108,7 @@ struct shlq { Vreg64 s, d; VregSF sf; Vflags fl; }; // uses rcx
 struct fcvtzs { VregDbl s; Vreg64 d;};
 struct mrs { Immed s; Vreg64 r; };
 struct msr { Vreg64 r; Immed s; };
-struct ubfmli { Immed mr, ms; Vreg32 s, d; VregSF sf; Vflags fl; };
+struct ubfmli { Immed mr, ms; Vreg32 s, d; };
 
 /*
  * ppc64 intrinsics.

--- a/hphp/runtime/vm/jit/vasm-simplify-arm.cpp
+++ b/hphp/runtime/vm/jit/vasm-simplify-arm.cpp
@@ -48,6 +48,24 @@ bool simplify(Env& env, const loadb& inst, Vlabel b, size_t i) {
 
 ///////////////////////////////////////////////////////////////////////////////
 
+bool simplify(Env& env, const movzbl& inst, Vlabel b, size_t i) {
+  // movzbl{s, d}; shrli{2, s, d} --> ubfmli{2, 7, s, d}
+  return if_inst<Vinstr::shrli>(env, b, i + 1, [&](const shrli& sh) {
+    if (!(sh.s0.l() == 2 &&
+      env.use_counts[inst.d] == 1 &&
+      env.use_counts[sh.sf] == 0 &&
+      inst.d == sh.s1)) return false;
+
+    return simplify_impl(env, b, i, [&] (Vout& v) {
+      v << copy{inst.s, inst.d};
+      v << ubfmli{2, 7, inst.d, sh.d};
+      return 2;
+    });
+  });
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
 }
 
 bool simplify(Env& env, Vlabel b, size_t i) {

--- a/hphp/runtime/vm/jit/vasm-simplify.cpp
+++ b/hphp/runtime/vm/jit/vasm-simplify.cpp
@@ -321,25 +321,6 @@ bool simplify(Env& env, const pop& inst, Vlabel b, size_t i) {
 
 ///////////////////////////////////////////////////////////////////////////////
 
-bool simplify(Env& env, const movzbl& inst, Vlabel b, size_t i) {
-  // movzbl{s, d}; shrli{2, s, d} --> ubfmli{2, 7, s, d}
-  return if_inst<Vinstr::shrli>(env, b, i + 1, [&](const shrli& sh) {
-    if (!(arch() == Arch::ARM &&
-      sh.s0.l() == 2 &&
-      env.use_counts[inst.d] == 1 &&
-      env.use_counts[sh.sf] == 0 &&
-      inst.d == sh.s1)) return false;
-
-    return simplify_impl(env, b, i, [&] (Vout& v) {
-      v << copy{inst.s, inst.d};
-      v << ubfmli{2, 7, inst.d, sh.d};
-      return 2;
-    });
-  });
-}
-
-///////////////////////////////////////////////////////////////////////////////
-
 /*
  * Perform peephole simplification at instruction `i' of block `b'.
  *

--- a/hphp/runtime/vm/jit/vasm-simplify.cpp
+++ b/hphp/runtime/vm/jit/vasm-simplify.cpp
@@ -327,12 +327,13 @@ bool simplify(Env& env, const movzbl& inst, Vlabel b, size_t i) {
     if (!(arch() == Arch::ARM &&
       sh.s0.l() == 2 &&
       env.use_counts[inst.d] == 1 &&
+      env.use_counts[sh.sf] == 0 &&
       inst.d == sh.s1)) return false;
 
-  return simplify_impl(env, b, i, [&] (Vout& v) {
-    v << copy{inst.s, inst.d};
-    v << ubfmli{2, 7, inst.d, sh.d, sh.sf, sh.fl};
-    return 2;
+    return simplify_impl(env, b, i, [&] (Vout& v) {
+      v << copy{inst.s, inst.d};
+      v << ubfmli{2, 7, inst.d, sh.d};
+      return 2;
     });
   });
 }

--- a/hphp/runtime/vm/jit/vasm-simplify.cpp
+++ b/hphp/runtime/vm/jit/vasm-simplify.cpp
@@ -321,6 +321,24 @@ bool simplify(Env& env, const pop& inst, Vlabel b, size_t i) {
 
 ///////////////////////////////////////////////////////////////////////////////
 
+bool simplify(Env& env, const movzbl& inst, Vlabel b, size_t i) {
+  // movzbl{s, d}; shrli{2, s, d} --> ubfm2r7ml{s, d}
+  return if_inst<Vinstr::shrli>(env, b, i + 1, [&](const shrli& sh) {
+    if (!(arch() == Arch::ARM &&
+      sh.s0.l() == 2 &&
+      env.use_counts[inst.d] == 1 &&
+      inst.d == sh.s1)) return false;
+
+  return simplify_impl(env, b, i, [&] (Vout& v) {
+    v << copy{inst.s, inst.d};
+    v << ubfm2r7ml{inst.d, sh.d, sh.sf, sh.fl};
+    return 2;
+    });
+  });
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
 /*
  * Perform peephole simplification at instruction `i' of block `b'.
  *

--- a/hphp/runtime/vm/jit/vasm-simplify.cpp
+++ b/hphp/runtime/vm/jit/vasm-simplify.cpp
@@ -322,7 +322,7 @@ bool simplify(Env& env, const pop& inst, Vlabel b, size_t i) {
 ///////////////////////////////////////////////////////////////////////////////
 
 bool simplify(Env& env, const movzbl& inst, Vlabel b, size_t i) {
-  // movzbl{s, d}; shrli{2, s, d} --> ubfm2r7ml{s, d}
+  // movzbl{s, d}; shrli{2, s, d} --> ubfmli{2, 7, s, d}
   return if_inst<Vinstr::shrli>(env, b, i + 1, [&](const shrli& sh) {
     if (!(arch() == Arch::ARM &&
       sh.s0.l() == 2 &&
@@ -331,7 +331,7 @@ bool simplify(Env& env, const movzbl& inst, Vlabel b, size_t i) {
 
   return simplify_impl(env, b, i, [&] (Vout& v) {
     v << copy{inst.s, inst.d};
-    v << ubfm2r7ml{inst.d, sh.d, sh.sf, sh.fl};
+    v << ubfmli{2, 7, inst.d, sh.d, sh.sf, sh.fl};
     return 2;
     });
   });


### PR DESCRIPTION
This creates an ARMv8 specific Vinstr to represent a commonly used form of the
ubfm/ubfx instruction and the peephole to detect it.  This pattern was seen
in several of the regression tests.  It is generated during the lowering of the callm
instruction.

Before
=====
              0x434009c4  53001c21              uxtb w1, w1
              0x434009c8  53027c21              lsr w1, w1, #2
              0x434009cc  d37df021              lsl x1, x1, #3
              0x434009d0  d297c302              movz x2, #0xbe18 
              0x434009d4  f2a1c322              movk x2, #0xe19, lsl #16 
              0x434009d8  f8626821              ldr x1, [x1, x2]
              0x434009dc  d63f0020              blr x1  

After
=====
              0x40400994  53021c21              ubfx w1, w1, #2, #6
              0x40400998  d37df021              lsl x1, x1, #3
              0x4040099c  d2965e02              movz x2, #0xb2f0 
              0x404009a0  f2a081a2              movk x2, #0x40d, lsl #16 
              0x404009a4  f8626821              ldr x1, [x1, x2]
              0x404009a8  d63f0020              blr x1  

This was seen 169 times in hphp/test/quick/all_type_comparison_test.php and
230 times in hphp/test/zend/good/ext/intl/tests/grapheme.php.

The standard regression tests were run with 6 option sets.  No new regressions seen.
