### PR TITLE
Aarch64 peephole using csinc

### DIFF
--- a/hphp/runtime/vm/jit/vasm-arm.cpp
+++ b/hphp/runtime/vm/jit/vasm-arm.cpp
@@ -252,6 +252,10 @@ struct Vgen {
   void emit(const cmpq& i) { a->Cmp(X(i.s1), X(i.s0)); }
   void emit(const cmpqi& i) { a->Cmp(X(i.s1), i.s0.q()); }
   void emit(const cmpsd& i);
+  void emit(const csoneb& i) { a->Csinc(W(i.d), W(i.t), vixl::wzr, C(i.cc)); }
+  void emit(const csonew& i) { a->Csinc(W(i.d), W(i.t), vixl::wzr, C(i.cc)); }
+  void emit(const csonel& i) { a->Csinc(W(i.d), W(i.t), vixl::wzr, C(i.cc)); }
+  void emit(const csoneq& i) { a->Csinc(X(i.d), X(i.t), vixl::xzr, C(i.cc)); }
   void emit(const cvtsi2sd& i) { a->Scvtf(D(i.d), X(i.s)); }
   void emit(const decl& i) { a->Sub(W(i.d), W(i.s), 1, UF(i.fl)); }
   void emit(const decq& i) { a->Sub(X(i.d), X(i.s), 1, UF(i.fl)); }

--- a/hphp/runtime/vm/jit/vasm-arm.cpp
+++ b/hphp/runtime/vm/jit/vasm-arm.cpp
@@ -252,10 +252,10 @@ struct Vgen {
   void emit(const cmpq& i) { a->Cmp(X(i.s1), X(i.s0)); }
   void emit(const cmpqi& i) { a->Cmp(X(i.s1), i.s0.q()); }
   void emit(const cmpsd& i);
-  void emit(const csoneb& i) { a->Csinc(W(i.d), W(i.t), vixl::wzr, C(i.cc)); }
-  void emit(const csonew& i) { a->Csinc(W(i.d), W(i.t), vixl::wzr, C(i.cc)); }
-  void emit(const csonel& i) { a->Csinc(W(i.d), W(i.t), vixl::wzr, C(i.cc)); }
-  void emit(const csoneq& i) { a->Csinc(X(i.d), X(i.t), vixl::xzr, C(i.cc)); }
+  void emit(const csincb& i) { a->Csinc(W(i.d), W(i.t), W(i.f), C(i.cc)); }
+  void emit(const csincw& i) { a->Csinc(W(i.d), W(i.t), W(i.f), C(i.cc)); }
+  void emit(const csincl& i) { a->Csinc(W(i.d), W(i.t), W(i.f), C(i.cc)); }
+  void emit(const csincq& i) { a->Csinc(X(i.d), X(i.t), X(i.f), C(i.cc)); }
   void emit(const cvtsi2sd& i) { a->Scvtf(D(i.d), X(i.s)); }
   void emit(const decl& i) { a->Sub(W(i.d), W(i.s), 1, UF(i.fl)); }
   void emit(const decq& i) { a->Sub(X(i.d), X(i.s), 1, UF(i.fl)); }

--- a/hphp/runtime/vm/jit/vasm-dead.cpp
+++ b/hphp/runtime/vm/jit/vasm-dead.cpp
@@ -71,6 +71,10 @@ bool effectful(Vinstr& inst) {
     case Vinstr::copy:
     case Vinstr::copy2:
     case Vinstr::copyargs:
+    case Vinstr::csoneb:
+    case Vinstr::csonew:
+    case Vinstr::csonel:
+    case Vinstr::csoneq:
     case Vinstr::cvtsi2sd:
     case Vinstr::cvtsi2sdm:
     case Vinstr::cvttsd2siq:

--- a/hphp/runtime/vm/jit/vasm-dead.cpp
+++ b/hphp/runtime/vm/jit/vasm-dead.cpp
@@ -71,10 +71,10 @@ bool effectful(Vinstr& inst) {
     case Vinstr::copy:
     case Vinstr::copy2:
     case Vinstr::copyargs:
-    case Vinstr::csoneb:
-    case Vinstr::csonew:
-    case Vinstr::csonel:
-    case Vinstr::csoneq:
+    case Vinstr::csincb:
+    case Vinstr::csincw:
+    case Vinstr::csincl:
+    case Vinstr::csincq:
     case Vinstr::cvtsi2sd:
     case Vinstr::cvtsi2sdm:
     case Vinstr::cvttsd2siq:

--- a/hphp/runtime/vm/jit/vasm-instr.cpp
+++ b/hphp/runtime/vm/jit/vasm-instr.cpp
@@ -214,6 +214,7 @@ Width width(Vinstr::Opcode op) {
     case Vinstr::testbi:
     case Vinstr::testbim:
     case Vinstr::cmovb:
+    case Vinstr::csoneb:
     case Vinstr::setcc:
     case Vinstr::movb:
     case Vinstr::loadb:
@@ -226,6 +227,7 @@ Width width(Vinstr::Opcode op) {
     case Vinstr::incwm:
     case Vinstr::orwim:
     case Vinstr::cmovw:
+    case Vinstr::csonew:
     case Vinstr::cmpwim:
     case Vinstr::cmpwm:
     case Vinstr::testwim:
@@ -251,6 +253,7 @@ Width width(Vinstr::Opcode op) {
     case Vinstr::subli:
     case Vinstr::xorl:
     case Vinstr::cmovl:
+    case Vinstr::csonel:
     case Vinstr::cmpl:
     case Vinstr::cmpli:
     case Vinstr::cmplm:
@@ -304,6 +307,7 @@ Width width(Vinstr::Opcode op) {
     case Vinstr::testqim:
     case Vinstr::cloadq:
     case Vinstr::cmovq:
+    case Vinstr::csoneq:
     case Vinstr::lea:
     case Vinstr::leap:
     case Vinstr::lead:

--- a/hphp/runtime/vm/jit/vasm-instr.cpp
+++ b/hphp/runtime/vm/jit/vasm-instr.cpp
@@ -214,7 +214,7 @@ Width width(Vinstr::Opcode op) {
     case Vinstr::testbi:
     case Vinstr::testbim:
     case Vinstr::cmovb:
-    case Vinstr::csoneb:
+    case Vinstr::csincb:
     case Vinstr::setcc:
     case Vinstr::movb:
     case Vinstr::loadb:
@@ -227,7 +227,7 @@ Width width(Vinstr::Opcode op) {
     case Vinstr::incwm:
     case Vinstr::orwim:
     case Vinstr::cmovw:
-    case Vinstr::csonew:
+    case Vinstr::csincw:
     case Vinstr::cmpwim:
     case Vinstr::cmpwm:
     case Vinstr::testwim:
@@ -253,7 +253,7 @@ Width width(Vinstr::Opcode op) {
     case Vinstr::subli:
     case Vinstr::xorl:
     case Vinstr::cmovl:
-    case Vinstr::csonel:
+    case Vinstr::csincl:
     case Vinstr::cmpl:
     case Vinstr::cmpli:
     case Vinstr::cmplm:
@@ -307,7 +307,7 @@ Width width(Vinstr::Opcode op) {
     case Vinstr::testqim:
     case Vinstr::cloadq:
     case Vinstr::cmovq:
-    case Vinstr::csoneq:
+    case Vinstr::csincq:
     case Vinstr::lea:
     case Vinstr::leap:
     case Vinstr::lead:

--- a/hphp/runtime/vm/jit/vasm-instr.h
+++ b/hphp/runtime/vm/jit/vasm-instr.h
@@ -295,6 +295,10 @@ struct Vunit;
   O(sarq, I(fl), UH(s,d), DH(d,s) D(sf))\
   O(shlq, I(fl), UH(s,d), DH(d,s) D(sf))\
   /* arm instructions */\
+  O(csoneb, I(cc), U(sf) U(t), D(d))\
+  O(csonew, I(cc), U(sf) U(t), D(d))\
+  O(csonel, I(cc), U(sf) U(t), D(d))\
+  O(csoneq, I(cc), U(sf) U(t), D(d))\
   O(fcvtzs, Inone, U(s), D(d))\
   O(mrs, I(s), Un, D(r))\
   O(msr, I(s), U(r), Dn)\
@@ -1105,6 +1109,10 @@ struct shlq { Vreg64 s, d; VregSF sf; Vflags fl; }; // uses rcx
 /*
  * arm intrinsics.
  */
+struct csoneb { ConditionCode cc; VregSF sf; Vreg8 t, d; };
+struct csonew { ConditionCode cc; VregSF sf; Vreg16 t, d; };
+struct csonel { ConditionCode cc; VregSF sf; Vreg32 t, d; };
+struct csoneq { ConditionCode cc; VregSF sf; Vreg64 t, d; };
 struct fcvtzs { VregDbl s; Vreg64 d;};
 struct mrs { Immed s; Vreg64 r; };
 struct msr { Vreg64 r; Immed s; };

--- a/hphp/runtime/vm/jit/vasm-instr.h
+++ b/hphp/runtime/vm/jit/vasm-instr.h
@@ -295,10 +295,10 @@ struct Vunit;
   O(sarq, I(fl), UH(s,d), DH(d,s) D(sf))\
   O(shlq, I(fl), UH(s,d), DH(d,s) D(sf))\
   /* arm instructions */\
-  O(csoneb, I(cc), U(sf) U(t), D(d))\
-  O(csonew, I(cc), U(sf) U(t), D(d))\
-  O(csonel, I(cc), U(sf) U(t), D(d))\
-  O(csoneq, I(cc), U(sf) U(t), D(d))\
+  O(csincb, I(cc), U(sf) U(f) U(t), D(d))\
+  O(csincw, I(cc), U(sf) U(f) U(t), D(d))\
+  O(csincl, I(cc), U(sf) U(f) U(t), D(d))\
+  O(csincq, I(cc), U(sf) U(f) U(t), D(d))\
   O(fcvtzs, Inone, U(s), D(d))\
   O(mrs, I(s), Un, D(r))\
   O(msr, I(s), U(r), Dn)\
@@ -1109,10 +1109,10 @@ struct shlq { Vreg64 s, d; VregSF sf; Vflags fl; }; // uses rcx
 /*
  * arm intrinsics.
  */
-struct csoneb { ConditionCode cc; VregSF sf; Vreg8 t, d; };
-struct csonew { ConditionCode cc; VregSF sf; Vreg16 t, d; };
-struct csonel { ConditionCode cc; VregSF sf; Vreg32 t, d; };
-struct csoneq { ConditionCode cc; VregSF sf; Vreg64 t, d; };
+struct csincb { ConditionCode cc; VregSF sf; Vreg8 f, t, d; };
+struct csincw { ConditionCode cc; VregSF sf; Vreg16 f, t, d; };
+struct csincl { ConditionCode cc; VregSF sf; Vreg32 f, t, d; };
+struct csincq { ConditionCode cc; VregSF sf; Vreg64 f, t, d; };
 struct fcvtzs { VregDbl s; Vreg64 d;};
 struct mrs { Immed s; Vreg64 r; };
 struct msr { Vreg64 r; Immed s; };

--- a/hphp/runtime/vm/jit/vasm-simplify-arm.cpp
+++ b/hphp/runtime/vm/jit/vasm-simplify-arm.cpp
@@ -65,23 +65,19 @@ bool cmov_fold_one(Env& env, const Inst& inst, Vlabel b, size_t i) {
 }
 
 bool simplify(Env& env, const cmovb& inst, Vlabel b, size_t i) {
-  if (cmov_fold_one<csincb>(env, inst, b, i)) return true;
-  return false;
+  return cmov_fold_one<csincb>(env, inst, b, i);
 }
 
 bool simplify(Env& env, const cmovw& inst, Vlabel b, size_t i) {
-  if (cmov_fold_one<csincw>(env, inst, b, i)) return true;
-  return false;
+  return cmov_fold_one<csincw>(env, inst, b, i);
 }
 
 bool simplify(Env& env, const cmovl& inst, Vlabel b, size_t i) {
-  if (cmov_fold_one<csincl>(env, inst, b, i)) return true;
-  return false;
+  return cmov_fold_one<csincl>(env, inst, b, i);
 }
 
 bool simplify(Env& env, const cmovq& inst, Vlabel b, size_t i) {
-  if (cmov_fold_one<csincq>(env, inst, b, i)) return true;
-  return false;
+  return cmov_fold_one<csincq>(env, inst, b, i);
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/hphp/runtime/vm/jit/vasm-simplify.cpp
+++ b/hphp/runtime/vm/jit/vasm-simplify.cpp
@@ -120,8 +120,10 @@ bool simplify(Env& env, const setcc& vsetcc, Vlabel b, size_t i) {
   });
 }
 
-// Fold a cmov of a certain width into a copy if both values are the same
-// register or have the same known constant value.
+/*
+ * Fold a cmov of a certain width into a copy if both values are the same
+ * register or have the same known constant value.
+ */
 template <typename Inst>
 bool cmov_fold_impl(Env& env, const Inst& inst, Vlabel b, size_t i) {
   auto const equivalent = [&]{

--- a/hphp/runtime/vm/jit/vasm-simplify.cpp
+++ b/hphp/runtime/vm/jit/vasm-simplify.cpp
@@ -124,6 +124,40 @@ bool simplify(Env& env, const setcc& vsetcc, Vlabel b, size_t i) {
  * Fold a cmov of a certain width into a copy if both values are the same
  * register or have the same known constant value.
  */
+=======
+template <typename Reg>
+bool operand_one(Env& env, Reg op) {
+  auto const op_it = env.unit.regToConst.find(op);
+  if (op_it == env.unit.regToConst.end()) return false;
+
+  auto const op_const = op_it->second;
+  if (op_const.isUndef) return false;
+  if (op_const.val != 1) return false;
+  return true;
+}
+
+// Reduce use of immediate one possibly removing def as dead code.
+// Specific to ARM using hard-coded zero register.
+template <typename Out, typename Inst>
+bool cmov_fold_one(Env& env, const Inst& inst, Vlabel b, size_t i) {
+  if (arch() != Arch::ARM) return false;
+  if (operand_one(env, inst.f)) {
+    return simplify_impl(env, b, i, [&] (Vout& v) {
+      v << Out{inst.cc, inst.sf, inst.t, inst.d};
+      return 1;
+      }); 
+  }
+  if (operand_one(env, inst.t)) {
+    return simplify_impl(env, b, i, [&] (Vout& v) {
+      v << Out{ccNegate(inst.cc), inst.sf, inst.f, inst.d};
+      return 1;
+      }); 
+  }
+  return false;
+}
+
+// Fold a cmov of a certain width into a copy if both values are the same
+// register or have the same known constant value.
 template <typename Inst>
 bool cmov_fold_impl(Env& env, const Inst& inst, Vlabel b, size_t i) {
   auto const equivalent = [&]{
@@ -205,6 +239,7 @@ bool cmov_setcc_impl(Env& env, const Inst& inst, Vlabel b,
 
 bool simplify(Env& env, const cmovb& inst, Vlabel b, size_t i) {
   if (cmov_fold_impl(env, inst, b, i)) return true;
+  if (cmov_fold_one<csoneb>(env, inst, b, i)) return true;
   return cmov_setcc_impl(
     env, inst, b, i,
     [](Vout& v, Vreg8 src, Vreg dest) { v << copy{src, dest}; }
@@ -213,6 +248,7 @@ bool simplify(Env& env, const cmovb& inst, Vlabel b, size_t i) {
 
 bool simplify(Env& env, const cmovw& inst, Vlabel b, size_t i) {
   if (cmov_fold_impl(env, inst, b, i)) return true;
+  if (cmov_fold_one<csonew>(env, inst, b, i)) return true;
   return cmov_setcc_impl(
     env, inst, b, i,
     [](Vout& v, Vreg8 src, Vreg dest) { v << movzbw{src, dest}; }
@@ -221,6 +257,7 @@ bool simplify(Env& env, const cmovw& inst, Vlabel b, size_t i) {
 
 bool simplify(Env& env, const cmovl& inst, Vlabel b, size_t i) {
   if (cmov_fold_impl(env, inst, b, i)) return true;
+  if (cmov_fold_one<csonel>(env, inst, b, i)) return true;
   return cmov_setcc_impl(
     env, inst, b, i,
     [](Vout& v, Vreg8 src, Vreg dest) { v << movzbl{src, dest}; }
@@ -229,6 +266,7 @@ bool simplify(Env& env, const cmovl& inst, Vlabel b, size_t i) {
 
 bool simplify(Env& env, const cmovq& inst, Vlabel b, size_t i) {
   if (cmov_fold_impl(env, inst, b, i)) return true;
+  if (cmov_fold_one<csoneq>(env, inst, b, i)) return true;
   return cmov_setcc_impl(
     env, inst, b, i,
     [](Vout& v, Vreg8 src, Vreg dest) { v << movzbq{src, dest}; }

--- a/hphp/vixl/a64/macro-assembler-a64.h
+++ b/hphp/vixl/a64/macro-assembler-a64.h
@@ -401,7 +401,6 @@ class MacroAssembler : public Assembler {
     assert(allow_macro_instructions_);
     assert(!rd.IsZero());
     assert(!rn.IsZero());
-    assert(!rm.IsZero());
     assert((cond != al) && (cond != nv));
     csel(rd, rn, rm, cond);
   }
@@ -422,7 +421,6 @@ class MacroAssembler : public Assembler {
     assert(allow_macro_instructions_);
     assert(!rd.IsZero());
     assert(!rn.IsZero());
-    assert(!rm.IsZero());
     assert((cond != al) && (cond != nv));
     csinc(rd, rn, rm, cond);
   }

--- a/hphp/vixl/a64/macro-assembler-a64.h
+++ b/hphp/vixl/a64/macro-assembler-a64.h
@@ -420,7 +420,6 @@ class MacroAssembler : public Assembler {
              Condition cond) {
     assert(allow_macro_instructions_);
     assert(!rd.IsZero());
-    assert(!rn.IsZero());
     assert((cond != al) && (cond != nv));
     csinc(rd, rn, rm, cond);
   }


### PR DESCRIPTION
This change introduces an Aarch64 specific pseudo instruction which
is a variation of the conditional move.  One pattern seen in the OOPSLA'14
benchmark tests involved the expression  like this in C

    (cond) ? exp : 1;

The hard-coded zero register can be used with the csinc instruction to
create the 1.

Before
======
     0x146010d0  39c0e361             ldrsb w1, [x27, #56]
     0x146010d4  72001c3f             tst w1, #0xff
     0x146010d8  52800022             movz w2, #0x1   //<<---
     0x146010dc  1a810041             csel w1, w2, w1, eq

After
=====
      0x362011d0  38e16b61              ldrsb w1, [x27, x1] 
      0x362011d4  72001c3f              tst w1, #0xff
      0x362011d8  1a9f1421              csinc w1, w1, wzr, ne  

This saves 1 instruction per instance.

The standard regression suite was run with 6 option sets.  No new regressions
were introduced.

