### PR TITLE
test/slow/ext_shmop/ext_shmop.php is not a hack specific test

### DIFF
--- a/hphp/test/slow/ext_shmop/ext_shmop.php
+++ b/hphp/test/slow/ext_shmop/ext_shmop.php
@@ -1,4 +1,4 @@
-<?hh
+<?php
 
 // Most of the standard testing is in the zend shmop test.
 


### PR DESCRIPTION
This regression test is failing because the reference output doesn't match.
It cries not running the hack typechecker and suggests the option to add to
the command line.  There is nothing hack specfic in the test.