### PR TITLE
jit: vasm-lower: Add ARM specific truncation for type values.

### DIFF
--- a/hphp/runtime/vm/jit/vasm-lower.cpp
+++ b/hphp/runtime/vm/jit/vasm-lower.cpp
@@ -189,15 +189,19 @@ void lower_vcall(Vunit& unit, Inst& inst, Vlabel b, size_t i) {
       static_assert(offsetof(TypedValue, m_type) == 8, "");
 
       if (dests.size() == 2) {
-        if (!(arch() == Arch::ARM)) {
-          v << copy2{rret(0), rret(1), dests[0], dests[1]};
-        } else {
-          //For ARM64 we are truncating the aux data
-          //from the type. That allows to use the resulting
-          //register values to be used in type comparisons
-          //without the need for truncation there.
-          v << copy{rret(0), dests[0]};
-          v << movtqb{rret(1), dests[1]};
+        switch(arch()) {
+          case Arch::X64: // fall through
+          case Arch::PPC64:
+            v << copy2{rret(0), rret(1), dests[0], dests[1]};
+            break;
+          case Arch::ARM:
+            // For ARM64 we are truncating the aux data
+            // from the type. That allows to use the resulting
+            // register values to be used in type comparisons
+            // without the need for truncation there.
+            v << copy{rret(0), dests[0]};
+            v << movtqb{rret(1), dests[1]};
+            break;
         }
       } else {
         // We have cases where we statically know the type but need the value
@@ -302,29 +306,37 @@ void lower(VLS& env, defvmretdata& inst, Vlabel b, size_t i) {
   env.unit.blocks[b].code[i] = copy{rret_data(), inst.data};
 }
 void lower(VLS& env, defvmrettype& inst, Vlabel b, size_t i) {
-  if (!(arch() == Arch::ARM)) {
-    env.unit.blocks[b].code[i] = copy{rret_type(), inst.type};
-  } else {
-    //For ARM64 we are truncating the aux data
-    //from the type. That allows to use the resulting
-    //register values to be used in type comparisons
-    //without the need for truncation there.
-    env.unit.blocks[b].code[i] = movtqb{rret_type(), inst.type};
+  switch(arch()) {
+    case Arch::X64: // fall through
+    case Arch::PPC64:
+      env.unit.blocks[b].code[i] = copy{rret_type(), inst.type};
+      break;
+    case Arch::ARM:
+      // For ARM64 we are truncating the aux data
+      // from the type. That allows to use the resulting
+      // register values to be used in type comparisons
+      // without the need for truncation there.
+      env.unit.blocks[b].code[i] = movtqb{rret_type(), inst.type};
+      break;
   }
 }
 void lower(VLS& env, syncvmret& inst, Vlabel b, size_t i) {
-  if (!(arch() == Arch::ARM)) {
-    env.unit.blocks[b].code[i] = copy2{inst.data,   inst.type,
-                                       rret_data(), rret_type()};
-  } else {
-    //For ARM64 we are truncating the aux data
-    //from the type. That allows to use the resulting
-    //register values to be used in type comparisons
-    //without the need for truncation there.
-    lower_impl(env.unit, b, i, [&] (Vout& v) {
-      v << copy{inst.data, rret_data()};
-      v << movtqb{inst.type, rret_type()};
-    });
+  switch(arch()) {
+    case Arch::X64: // fall through
+    case Arch::PPC64:
+      env.unit.blocks[b].code[i] = copy2{inst.data,   inst.type,
+                                         rret_data(), rret_type()};
+      break;
+    case Arch::ARM:
+      // For ARM64 we are truncating the aux data
+      // from the type. That allows to use the resulting
+      // register values to be used in type comparisons
+      // without the need for truncation there.
+      lower_impl(env.unit, b, i, [&] (Vout& v) {
+        v << copy{inst.data, rret_data()};
+        v << movtqb{inst.type, rret_type()};
+      });
+      break;
   }
 }
 void lower(VLS& env, vregrestrict& inst, Vlabel b, size_t i) {


### PR DESCRIPTION
When using 64-bit registers in cmpbi{} vasm instructions,
a preceding truncation to 8-bits is required in general.
This rule seems to be violated in some parts of the irlower
code. With the help of the arm64 backend, these locations
could be detected.

Note, that this patch is required in order to allow
a performance improvement patch for arm64 (drop emitting
uxtb instructions before cmpbi{} and cmpb{}).

Signed-off-by: Christoph Muellner <christoph.muellner@theobroma-systems.com>