### PR TITLE
[AArch64] Adjust cache sizes for PC relative branches

### DIFF
--- a/hphp/runtime/base/runtime-option.cpp
+++ b/hphp/runtime/base/runtime-option.cpp
@@ -1225,18 +1225,19 @@ void RuntimeOption::Load(
     using jit::CodeCache;
     Config::Bind(CodeCache::AHotSize, ini, config, "Eval.JitAHotSize",
                  ahotDefault());
-    Config::Bind(CodeCache::ASize, ini, config, "Eval.JitASize", 60 << 20);
+    Config::Bind(CodeCache::ASize, ini, config, "Eval.JitASize",
+                 (arch() == Arch::ARM) ? (50 << 20) : (60 << 20));
 
     if (RuntimeOption::EvalJitPGO) {
       Config::Bind(CodeCache::AProfSize, ini, config, "Eval.JitAProfSize",
-                   64 << 20);
+                   (arch() == Arch::ARM) ? (54 << 20) : (64 << 20));
     } else {
       // Avoid "Possible bad confg node" warning for unused keys.
       config["Eval.JitAProfSize"].configGetUInt64();
       CodeCache::AProfSize = 0;
     }
     Config::Bind(CodeCache::AColdSize, ini, config, "Eval.JitAColdSize",
-                 24 << 20);
+                 (arch() == Arch::ARM) ? (20 << 20) : (24 << 20));
     Config::Bind(CodeCache::AFrozenSize, ini, config, "Eval.JitAFrozenSize",
                  40 << 20);
     Config::Bind(CodeCache::GlobalDataSize, ini, config,

--- a/hphp/runtime/vm/jit/code-cache.cpp
+++ b/hphp/runtime/vm/jit/code-cache.cpp
@@ -80,6 +80,7 @@ CodeCache::CodeCache()
   m_totalSize = kAHotSize + kASize + kAColdSize + kAProfSize +
                 kAFrozenSize + kGDataSize + thread_local_size;
   m_codeSize = m_totalSize - kGDataSize;
+  auto kGCodeExeSize = kAHotSize + kASize + kAProfSize + kAColdSize;
 
   if ((kASize < (10 << 20)) ||
       (kAColdSize < (4 << 20)) ||
@@ -97,7 +98,14 @@ CodeCache::CodeCache()
     exit(1);
   }
 
-  auto enhugen = [&](void* base, int numMB) {
+  if (arch() == Arch::ARM && kGCodeExeSize > (128 << 20)) {
+    fprintf(stderr,"Combined size of AHotSize, ASize, AProfSize, and "
+                    "AColdSize must be <= 128MB to support PC relative "
+                    "branches \n");
+    exit(1);
+  }
+
+auto enhugen = [&](void* base, int numMB) {
     if (CodeCache::MapTCHuge) {
       assert((uintptr_t(base) & (kRoundUp - 1)) == 0);
       hintHugeDeleteData((char*)base, numMB << 20,


### PR DESCRIPTION
AArch64 supports up to +/-128MB PC relative branches with 26-bit
immediates in the B and BL instructions, so make Hot, Prof, Main,
and Cold caches 128MB (total).

No new failures in the 'all' unit test suite, nor in the oss-
perfomrance benchmarking suite. When combined with relocation, it
produces nice gains in oss.