### PR TITLE
ext_watchman.php test should skip if watchman not installed

### DIFF
--- a/hphp/test/slow/ext_watchman/ext_watchman.php.skipif
+++ b/hphp/test/slow/ext_watchman/ext_watchman.php.skipif
@@ -1,0 +1,3 @@
+<?php
+if (!extension_loaded("watchman")) die("skip");
+?>


### PR DESCRIPTION
Per comment on issue #7649, this test should skip if
watchman extension is not installed.
