### PR TITLE
recursive_substitutions2.php - Nothing hack specific in test

### DIFF
--- a/hphp/test/slow/ini/recursive_substitutions2.php
+++ b/hphp/test/slow/ini/recursive_substitutions2.php
@@ -1,3 +1,3 @@
-<?hh
+<?php
 var_dump(ini_get("hhvm.hot_func_count"));
 var_dump(ini_get("hhvm.env_variables"));


### PR DESCRIPTION
Regression test failing since last year.  It fails because
typechecker not running, but there's nothing hack specific
in the test.

Before
======
/home/swalk/master/hhvm/hphp/hhvm/hhvm   hphp/test/run -v hphp/test/slow/ini/recursive_substitutions2.php
You are using the binary located at: ./hphp/hhvm/hhvm
Running 1 tests in 1 threads (0 in serial)
hphp/test/slow/ini/recursive_substitutions2.php FAILED (15.95s)

After
=====
/home/swalk/master/hhvm/hphp/hhvm/hhvm   hphp/test/run -v hphp/test/slow/ini/recursive_substitutions2.php
You are using the binary located at: ./hphp/hhvm/hhvm
Running 1 tests in 1 threads (0 in serial)
hphp/test/slow/ini/recursive_substitutions2.php passed (11.73s)

