### PR TITLE
Allow nullable types in PHP mode

### DIFF
--- a/hphp/parser/hphp.y
+++ b/hphp/parser/hphp.y
@@ -3496,8 +3496,7 @@ array_typelist:
 hh_type:
     /* double-optional types will be rejected by the typechecker; we
      * already allow plenty of nonsense types anyway */
-    '?' hh_type                        { only_in_hh_syntax(_p);
-                                         _p->onTypeSpecialization($2, '?');
+    '?' hh_type                        { _p->onTypeSpecialization($2, '?');
                                          $$ = $2; }
   | '@' hh_type                        { only_in_hh_syntax(_p);
                                          _p->onTypeSpecialization($2, '@');


### PR DESCRIPTION
PHP 7.1 adds nullable types* using a HackLang compatable syntax.
Remove the "only in hack" check and allow in PHP mode.

100% Guaranteed USDA untested code.
Ain't nobody got time to wait for HHVM to compile on a laptop.

* http://php.net/manual/en/migration71.new-features.php