### PR TITLE
Add missing unicode include in icu.h

### DIFF
--- a/hphp/runtime/ext/icu/icu.h
+++ b/hphp/runtime/ext/icu/icu.h
@@ -21,6 +21,7 @@
 #include "hphp/runtime/vm/native-data.h"
 #include <unicode/utypes.h>
 #include <unicode/ucnv.h>
+#include <unicode/unistr.h>
 #include <unicode/ustring.h>
 #include "hphp/runtime/base/request-event-handler.h"
 #include "hphp/runtime/base/request-local.h"


### PR DESCRIPTION
Fix for missing include in icu.h as referenced in https://github.com/facebook/hhvm/issues/7843