### PR TITLE
Fix var_dump of Imagick classes.

### DIFF
--- a/hphp/runtime/ext/imagick/ext_imagick.h
+++ b/hphp/runtime/ext/imagick/ext_imagick.h
@@ -119,6 +119,7 @@ void imagickThrow(const char* fmt, ...) {
 // WandResource
 template<typename Wand>
 struct WandResource : SweepableResourceData {
+
 private:
   DECLARE_RESOURCE_ALLOCATION(WandResource<Wand>);
 
@@ -129,6 +130,11 @@ public:
 
   ~WandResource() {
     clear();
+  }
+
+  CLASSNAME_IS("WandResource");
+  const String& o_getClassNameHook() const override {
+    return classnameof();
   }
 
   void clear() {

--- a/hphp/test/slow/ext_imagick/var_dump.php
+++ b/hphp/test/slow/ext_imagick/var_dump.php
@@ -1,0 +1,7 @@
+<?php
+
+$i = new Imagick();
+var_dump($i);
+
+$p = new ImagickPixel('black');
+var_dump($p);

--- a/hphp/test/slow/ext_imagick/var_dump.php.expect
+++ b/hphp/test/slow/ext_imagick/var_dump.php.expect
@@ -1,0 +1,12 @@
+object(Imagick)#1 (3) {
+  ["wand":"Imagick":private]=>
+  resource(4) of type (WandResource)
+  ["nextOutOfBound":"Imagick":private]=>
+  bool(false)
+  ["imagePending":"Imagick":private]=>
+  bool(false)
+}
+object(ImagickPixel)#2 (1) {
+  ["wand":"ImagickPixel":private]=>
+  resource(5) of type (WandResource)
+}


### PR DESCRIPTION
Previously it failed with "Fatal error: Resource did not provide a name".

Fixes #7693