### PR TITLE
[AArch64] Guarantees smashableMovq adjustment during relocation.

### DIFF
--- a/hphp/runtime/vm/jit/relocation-arm.cpp
+++ b/hphp/runtime/vm/jit/relocation-arm.cpp
@@ -590,6 +590,12 @@ size_t relocateImpl(Env& env) {
         // Do nothing, as the instruction word was initially copied above
       }
 
+      // If we just copied the first instruction of a smashableMovq, then it may
+      // with an internal reference that'll need to be adjusted below.
+      if (!literals.count(src) && isSmashableMovq(srcAddr)) {
+	env.updateInternalRefs = true;
+      }
+
       if (srcAddr == env.start) {
         /*
          * For the start of the range, we only want to overwrite the "after"

--- a/hphp/runtime/vm/jit/relocation-arm.cpp
+++ b/hphp/runtime/vm/jit/relocation-arm.cpp
@@ -591,9 +591,9 @@ size_t relocateImpl(Env& env) {
       }
 
       // If we just copied the first instruction of a smashableMovq, then it may
-      // with an internal reference that'll need to be adjusted below.
+      // have an internal reference that'll need to be adjusted below.
       if (!literals.count(src) && isSmashableMovq(srcAddr)) {
-	env.updateInternalRefs = true;
+        env.updateInternalRefs = true;
       }
 
       if (srcAddr == env.start) {


### PR DESCRIPTION
smashableMovqs often have an internal reference which needs to be
adjusted. While that adjustment code is present, it's only
triggered when the update internal reference flag is set. This
patch insures that the flag is set whenever a smashableMovq is
relocated.