### PR TITLE
[AArch64] - capture n:immr:imms encoding for AND (immediate)

### DIFF
--- a/hphp/runtime/vm/jit/vasm-arm.cpp
+++ b/hphp/runtime/vm/jit/vasm-arm.cpp
@@ -294,6 +294,7 @@ struct Vgen {
   void emit(const andli& i) { a->And(W(i.d), W(i.s1), i.s0.l(), UF(i.fl)); }
   void emit(const andq& i) { a->And(X(i.d), X(i.s1), X(i.s0), UF(i.fl)); }
   void emit(const andqi& i) { a->And(X(i.d), X(i.s1), i.s0.q(), UF(i.fl)); }
+  void emit(const andzi& i) { a->And(X(i.d), X(i.s1), i.s0.Q(), UF(i.fl)); }
   void emit(const cmovb& i) { a->Csel(W(i.d), W(i.t), W(i.f), C(i.cc)); }
   void emit(const cmovw& i) { a->Csel(W(i.d), W(i.t), W(i.f), C(i.cc)); }
   void emit(const cmovl& i) { a->Csel(W(i.d), W(i.t), W(i.f), C(i.cc)); }

--- a/hphp/runtime/vm/jit/vasm-arm.cpp
+++ b/hphp/runtime/vm/jit/vasm-arm.cpp
@@ -294,7 +294,7 @@ struct Vgen {
   void emit(const andli& i) { a->And(W(i.d), W(i.s1), i.s0.l(), UF(i.fl)); }
   void emit(const andq& i) { a->And(X(i.d), X(i.s1), X(i.s0), UF(i.fl)); }
   void emit(const andqi& i) { a->And(X(i.d), X(i.s1), i.s0.q(), UF(i.fl)); }
-  void emit(const andzi& i) { a->And(X(i.d), X(i.s1), i.s0.Q(), UF(i.fl)); }
+  void emit(const andqi64& i) { a->And(X(i.d), X(i.s1), i.s0.q(), UF(i.fl)); }
   void emit(const cmovb& i) { a->Csel(W(i.d), W(i.t), W(i.f), C(i.cc)); }
   void emit(const cmovw& i) { a->Csel(W(i.d), W(i.t), W(i.f), C(i.cc)); }
   void emit(const cmovl& i) { a->Csel(W(i.d), W(i.t), W(i.f), C(i.cc)); }

--- a/hphp/runtime/vm/jit/vasm-dead.cpp
+++ b/hphp/runtime/vm/jit/vasm-dead.cpp
@@ -48,6 +48,7 @@ bool effectful(Vinstr& inst) {
     case Vinstr::andli:
     case Vinstr::andq:
     case Vinstr::andqi:
+    case Vinstr::andzi:
     case Vinstr::cloadq:
     case Vinstr::cmovb:
     case Vinstr::cmovw:

--- a/hphp/runtime/vm/jit/vasm-dead.cpp
+++ b/hphp/runtime/vm/jit/vasm-dead.cpp
@@ -48,7 +48,7 @@ bool effectful(Vinstr& inst) {
     case Vinstr::andli:
     case Vinstr::andq:
     case Vinstr::andqi:
-    case Vinstr::andzi:
+    case Vinstr::andqi64:
     case Vinstr::cloadq:
     case Vinstr::cmovb:
     case Vinstr::cmovw:

--- a/hphp/runtime/vm/jit/vasm-fold-imms.cpp
+++ b/hphp/runtime/vm/jit/vasm-fold-imms.cpp
@@ -354,7 +354,7 @@ struct ImmFolder {
     return true;
   }
 
-  bool logical_BitMask(Vreg r, uint64_t& out) {
+  bool logical_bmsk(Vreg r, uint64_t& out) {
     if (!valid.test(r)) return false;
     auto imm64 = vals[r];
     if (!vixl::Assembler::IsImmLogical(imm64, vixl::kXRegSize)) return false;
@@ -422,13 +422,11 @@ struct ImmFolder {
 
   void fold(andq& in, Vinstr& out) {
     int val;
+    uint64_t bm;
     if (logical_imm(in.s0, val)) { out = andqi{val, in.s1, in.d, in.sf}; }
     else if (logical_imm(in.s1, val)) { out = andqi{val, in.s0, in.d, in.sf}; }
-    else {
-      uint64_t bm;
-      if (logical_BitMask(in.s0, bm)) { out = andzi{bm, in.s1, in.d, in.sf}; }
-      else if (logical_BitMask(in.s1, bm)) { out = andzi{bm, in.s0, in.d, in.sf}; }
-    }
+    else if (logical_bmsk(in.s0, bm)) { out = andqi64{bm, in.s1, in.d, in.sf}; }
+    else if (logical_bmsk(in.s1, bm)) { out = andqi64{bm, in.s0, in.d, in.sf}; }
   }
 
   void fold(storeb& in, Vinstr& out) {

--- a/hphp/runtime/vm/jit/vasm-fold-imms.cpp
+++ b/hphp/runtime/vm/jit/vasm-fold-imms.cpp
@@ -354,6 +354,14 @@ struct ImmFolder {
     return true;
   }
 
+  bool logical_BitMask(Vreg r, uint64_t& out) {
+    if (!valid.test(r)) return false;
+    auto imm64 = vals[r];
+    if (!vixl::Assembler::IsImmLogical(imm64, vixl::kXRegSize)) return false;
+    out = imm64;
+    return true;
+  }
+
   bool zero_imm(Vreg r) {
     if (!valid.test(r)) return false;
     return vals[r] == 0;
@@ -403,7 +411,6 @@ struct ImmFolder {
   void fold(addq& in, Vinstr& out) { return fold_arith<addqi>(in, out); }
   void fold(andb& in, Vinstr& out) { return fold_logical<andbi>(in, out); }
   void fold(andl& in, Vinstr& out) { return fold_logical<andli>(in, out); }
-  void fold(andq& in, Vinstr& out) { return fold_logical<andqi>(in, out); }
   void fold(orq& in, Vinstr& out) { return fold_logical<orqi>(in, out); }
 
   void fold(testb& in, Vinstr& out) { return fold_test<testbi>(in, out); }
@@ -412,6 +419,17 @@ struct ImmFolder {
   void fold(cmpb& in, Vinstr& out) { return fold_cmp<cmpbi>(in, out); }
   void fold(cmpl& in, Vinstr& out) { return fold_cmp<cmpli>(in, out); }
   void fold(cmpq& in, Vinstr& out) { return fold_cmp<cmpqi>(in, out); }
+
+  void fold(andq& in, Vinstr& out) {
+    int val;
+    if (logical_imm(in.s0, val)) { out = andqi{val, in.s1, in.d, in.sf}; }
+    else if (logical_imm(in.s1, val)) { out = andqi{val, in.s0, in.d, in.sf}; }
+    else {
+      uint64_t bm;
+      if (logical_BitMask(in.s0, bm)) { out = andzi{bm, in.s1, in.d, in.sf}; }
+      else if (logical_BitMask(in.s1, bm)) { out = andzi{bm, in.s0, in.d, in.sf}; }
+    }
+  }
 
   void fold(storeb& in, Vinstr& out) {
     if (zero_imm(in.s)) out = storeb{PhysReg(vixl::wzr), in.m};

--- a/hphp/runtime/vm/jit/vasm-instr.cpp
+++ b/hphp/runtime/vm/jit/vasm-instr.cpp
@@ -297,6 +297,7 @@ Width width(Vinstr::Opcode op) {
     case Vinstr::addqim:
     case Vinstr::andq:
     case Vinstr::andqi:
+    case Vinstr::andzi:
     case Vinstr::decq:
     case Vinstr::decqm:
     case Vinstr::decqmlock:

--- a/hphp/runtime/vm/jit/vasm-instr.cpp
+++ b/hphp/runtime/vm/jit/vasm-instr.cpp
@@ -297,7 +297,7 @@ Width width(Vinstr::Opcode op) {
     case Vinstr::addqim:
     case Vinstr::andq:
     case Vinstr::andqi:
-    case Vinstr::andzi:
+    case Vinstr::andqi64:
     case Vinstr::decq:
     case Vinstr::decqm:
     case Vinstr::decqmlock:

--- a/hphp/runtime/vm/jit/vasm-instr.h
+++ b/hphp/runtime/vm/jit/vasm-instr.h
@@ -146,6 +146,7 @@ struct Vunit;
   O(andli, I(s0) I(fl), UH(s1,d), DH(d,s1) D(sf)) \
   O(andq, I(fl), U(s0) U(s1), D(d) D(sf)) \
   O(andqi, I(s0) I(fl), UH(s1,d), DH(d,s1) D(sf)) \
+  O(andzi, I(s0) I(fl), UH(s1,d), DH(d,s1) D(sf)) \
   O(decl, I(fl), UH(s,d), DH(d,s) D(sf))\
   O(declm, I(fl), U(m), D(sf))\
   O(decq, I(fl), UH(s,d), DH(d,s) D(sf))\
@@ -1109,6 +1110,7 @@ struct shlq { Vreg64 s, d; VregSF sf; Vflags fl; }; // uses rcx
 /*
  * arm intrinsics.
  */
+struct andzi { Immed64 s0; Vreg64 s1, d; VregSF sf; Vflags fl; };
 struct csincb { ConditionCode cc; VregSF sf; Vreg8 f, t, d; };
 struct csincw { ConditionCode cc; VregSF sf; Vreg16 f, t, d; };
 struct csincl { ConditionCode cc; VregSF sf; Vreg32 f, t, d; };

--- a/hphp/runtime/vm/jit/vasm-instr.h
+++ b/hphp/runtime/vm/jit/vasm-instr.h
@@ -146,7 +146,7 @@ struct Vunit;
   O(andli, I(s0) I(fl), UH(s1,d), DH(d,s1) D(sf)) \
   O(andq, I(fl), U(s0) U(s1), D(d) D(sf)) \
   O(andqi, I(s0) I(fl), UH(s1,d), DH(d,s1) D(sf)) \
-  O(andzi, I(s0) I(fl), UH(s1,d), DH(d,s1) D(sf)) \
+  O(andqi64, I(s0) I(fl), UH(s1,d), DH(d,s1) D(sf)) \
   O(decl, I(fl), UH(s,d), DH(d,s) D(sf))\
   O(declm, I(fl), U(m), D(sf))\
   O(decq, I(fl), UH(s,d), DH(d,s) D(sf))\
@@ -1110,7 +1110,7 @@ struct shlq { Vreg64 s, d; VregSF sf; Vflags fl; }; // uses rcx
 /*
  * arm intrinsics.
  */
-struct andzi { Immed64 s0; Vreg64 s1, d; VregSF sf; Vflags fl; };
+struct andqi64 { Immed64 s0; Vreg64 s1, d; VregSF sf; Vflags fl; };
 struct csincb { ConditionCode cc; VregSF sf; Vreg8 f, t, d; };
 struct csincw { ConditionCode cc; VregSF sf; Vreg16 f, t, d; };
 struct csincl { ConditionCode cc; VregSF sf; Vreg32 f, t, d; };

--- a/hphp/util/immed.h
+++ b/hphp/util/immed.h
@@ -107,7 +107,6 @@ struct Immed64 {
   {}
 
   int64_t q() const { return m_long; }
-  uint64_t Q() const { return m_long; }
   int32_t l() const { return safe_cast<int32_t>(m_long); }
   int16_t w() const { return safe_cast<int16_t>(m_long); }
   int8_t  b() const { return safe_cast<int8_t>(m_long); }

--- a/hphp/util/immed.h
+++ b/hphp/util/immed.h
@@ -107,6 +107,7 @@ struct Immed64 {
   {}
 
   int64_t q() const { return m_long; }
+  uint64_t Q() const { return m_long; }
   int32_t l() const { return safe_cast<int32_t>(m_long); }
   int16_t w() const { return safe_cast<int16_t>(m_long); }
   int8_t  b() const { return safe_cast<int8_t>(m_long); }


### PR DESCRIPTION
This sequence was seen multiple times in several of the regression tests
particularly hphp/test/quick/all_type_comparison_test.php

    b2609ff3              mov x19, #0xffffffff000000ff
    8a130021              and x1, x1, x19

Some ARMv8 instructions utilize BitMask encoding to represent both
32 and 64-bit values.  The AND (immediate) form of the instruction can represent
the  immediate value above and  the constant can be propagated.  The  mov instruction 
is removed as dead.

    92609c21              and x1, x1, #0xffffffff000000ff

This immediate value is hard-coded in the lowering of vcall, vinvoke, syncvmret, and
defvmretdata on ARM hosts.

The current implementation of Vinstr::andqi can only support 32-bit values.  This
change will catch the BitMask encoding ( n:immr:imms) into a new ARM specific intrinsic.

The standard regression tests were run with six option sets.  No additional failures were
observed.




