### PR TITLE
Revert avoid optimization to PPC64

### DIFF
--- a/CMake/HPHPCompiler.cmake
+++ b/CMake/HPHPCompiler.cmake
@@ -151,18 +151,11 @@ if (${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang" OR ${CMAKE_CXX_COMPILER_ID} STREQU
     )
     list(APPEND RELEASE_CXX_OPTIONS
       "-param max-inline-insns-auto=100"
+      "-param early-inlining-insns=200"
+      "-param max-early-inliner-iterations=50"
       "-param=inline-unit-growth=200"
       "-param=large-unit-insns=10000"
     )
-    # The params bellow causes problem on GCC 4.9 and 5.4 on PPC64
-    # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=72855
-    if(NOT IS_PPC64)
-      list(APPEND RELEASE_CXX_OPTIONS
-        "-param early-inlining-insns=200"
-        "-param max-early-inliner-iterations=50"
-       )
-    endif()
-
 
     # Fix problem with GCC 4.9, https://kb.isc.org/article/AA-01167
     if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 4.9 OR


### PR DESCRIPTION
Reverted change that removed optimization parameters for PPC64.