### PR TITLE
Allow getopt to return optind by reference.

### DIFF
--- a/hphp/runtime/ext/std/ext_std_options.cpp
+++ b/hphp/runtime/ext/std/ext_std_options.cpp
@@ -595,7 +595,8 @@ static req::vector<opt_struct> parse_opts(const char *opts, int opts_len) {
 }
 
 static Array HHVM_FUNCTION(getopt, const String& options,
-                                   const Variant& longopts /*=null */) {
+                                   const Variant& longopts /*=null */,
+                                   OutputArg optind /*= null */) {
   auto opt_vec = parse_opts(options.data(), options.size());
 
   if (!longopts.isNull()) {
@@ -726,6 +727,9 @@ static Array HHVM_FUNCTION(getopt, const String& options,
     php_optarg = nullptr;
   }
 
+  if (optind.get()) {
+    *(optind->var()) = php_optind;
+  }
   return ret;
 }
 

--- a/hphp/runtime/ext/std/ext_std_options.php
+++ b/hphp/runtime/ext/std/ext_std_options.php
@@ -167,7 +167,8 @@ function getmyuid(): mixed;
  */
 <<__Native>>
 function getopt(string $options,
-                mixed $longopts = null): array;
+                mixed $longopts = null,
+                int &$optind = null): array;
 
 /* This is an interface to getrusage(2). It gets data returned from the system
  * call.

--- a/hphp/test/quick/getopt_006.php
+++ b/hphp/test/quick/getopt_006.php
@@ -1,0 +1,20 @@
+<?php
+$argv = [$argv[0], '--arg', 'val', 'hello'];
+var_dump(getopt("a:", array("arg:"), $optind));
+var_dump($optind);
+$argv = [$argv[0]];
+var_dump(getopt("a:", array("arg:"), $optind));
+var_dump($optind);
+$argv = [$argv[0], '--invalid'];
+var_dump(getopt("a:", array("arg:"), $optind));
+var_dump($optind);
+$argv = [$argv[0], '-i', '3'];
+var_dump(getopt("a:", array("arg:"), $optind));
+var_dump($optind);
+$argv = [$argv[0], '-a', '3'];
+var_dump(getopt("a:", array("arg:"), $optind));
+var_dump($optind);
+$argv = [$argv[0], '-a', '3', 'extra'];
+var_dump(getopt("a:", array("arg:"), $optind));
+var_dump($optind);
+?>

--- a/hphp/test/quick/getopt_006.php.expectf
+++ b/hphp/test/quick/getopt_006.php.expectf
@@ -1,0 +1,24 @@
+array(1) {
+  ["arg"]=>
+  string(3) "val"
+}
+int(3)
+array(0) {
+}
+int(1)
+array(0) {
+}
+int(2)
+array(0) {
+}
+int(2)
+array(1) {
+  ["a"]=>
+  string(1) "3"
+}
+int(3)
+array(1) {
+  ["a"]=>
+  string(1) "3"
+}
+int(3)

--- a/hphp/test/quick/getopt_006.php.ini
+++ b/hphp/test/quick/getopt_006.php.ini
@@ -1,0 +1,2 @@
+register_argc_argv=On
+variables_order=GPS


### PR DESCRIPTION
PHP 7.1 changed the signature of getopt by adding a third parameter
returning the index where parameter parsing stopped.

`function getopt(string $options, array $longopts = null, int &$optind = null)`

Haven't added getopt_006-009 from php-src yet,
waiting to see if the new parameter is a feature that could be accepted
into HHVM.

This is useful for parsing CLI arguments in standalone scripts
without relying on third party libraries.

See http://php.net/getopt