### PR TITLE
AArch64 Fix getFrameRegs assertion during indirect fixup

### DIFF
--- a/hphp/runtime/base/array-data-defs.h
+++ b/hphp/runtime/base/array-data-defs.h
@@ -212,6 +212,7 @@ inline Variant ArrayData::getKey(ssize_t pos) const {
 
 ///////////////////////////////////////////////////////////////////////////////
 
+AARCH64_WALKABLE_FRAME
 inline void ArrayData::release() noexcept {
   assert(hasExactlyOneRef());
   return g_array_funcs.release[kind()](this);

--- a/hphp/runtime/base/array-data-defs.h
+++ b/hphp/runtime/base/array-data-defs.h
@@ -216,7 +216,6 @@ inline void ArrayData::release() noexcept {
   assert(hasExactlyOneRef());
   g_array_funcs.release[kind()](this);
   AARCH64_WALKABLE_FRAME();
-  return;
 }
 
 inline ArrayData* ArrayData::append(Cell v, bool copy) {

--- a/hphp/runtime/base/array-data-defs.h
+++ b/hphp/runtime/base/array-data-defs.h
@@ -212,10 +212,11 @@ inline Variant ArrayData::getKey(ssize_t pos) const {
 
 ///////////////////////////////////////////////////////////////////////////////
 
-AARCH64_WALKABLE_FRAME
 inline void ArrayData::release() noexcept {
   assert(hasExactlyOneRef());
-  return g_array_funcs.release[kind()](this);
+  g_array_funcs.release[kind()](this);
+  AARCH64_WALKABLE_FRAME();
+  return;
 }
 
 inline ArrayData* ArrayData::append(Cell v, bool copy) {

--- a/hphp/runtime/base/mixed-array.cpp
+++ b/hphp/runtime/base/mixed-array.cpp
@@ -468,7 +468,7 @@ ArrayData* MixedArray::MakeDictFromAPC(const APCArray* apc) {
 
 //=============================================================================
 // Destruction
-
+AARCH64_WALKABLE_FRAME
 NEVER_INLINE
 void MixedArray::Release(ArrayData* in) {
   assert(in->isRefCounted());

--- a/hphp/runtime/base/mixed-array.cpp
+++ b/hphp/runtime/base/mixed-array.cpp
@@ -468,7 +468,6 @@ ArrayData* MixedArray::MakeDictFromAPC(const APCArray* apc) {
 
 //=============================================================================
 // Destruction
-AARCH64_WALKABLE_FRAME
 NEVER_INLINE
 void MixedArray::Release(ArrayData* in) {
   assert(in->isRefCounted());
@@ -495,6 +494,7 @@ void MixedArray::Release(ArrayData* in) {
     }
   }
   MM().objFree(ad, ad->heapSize());
+  AARCH64_WALKABLE_FRAME();
 }
 
 NEVER_INLINE

--- a/hphp/runtime/base/mixed-array.cpp
+++ b/hphp/runtime/base/mixed-array.cpp
@@ -468,6 +468,7 @@ ArrayData* MixedArray::MakeDictFromAPC(const APCArray* apc) {
 
 //=============================================================================
 // Destruction
+
 NEVER_INLINE
 void MixedArray::Release(ArrayData* in) {
   assert(in->isRefCounted());

--- a/hphp/runtime/base/object-data.cpp
+++ b/hphp/runtime/base/object-data.cpp
@@ -192,6 +192,7 @@ static void tail_call_remove_live_bc_obj(ObjectData* obj) {
   return obj->releaseNoObjDestructCheck();
 }
 
+AARCH64_WALKABLE_FRAME
 void ObjectData::release() noexcept {
   assert(kindIsValid());
   if (UNLIKELY(RuntimeOption::EnableObjDestructCall && m_cls->getDtor())) {

--- a/hphp/runtime/base/object-data.cpp
+++ b/hphp/runtime/base/object-data.cpp
@@ -184,6 +184,7 @@ void ObjectData::releaseNoObjDestructCheck() noexcept {
     reinterpret_cast<char*>(stop) - reinterpret_cast<char*>(this);
   assert(size == sizeForNProps(nProps));
   MM().objFree(this, size);
+  AARCH64_WALKABLE_FRAME();
 }
 
 NEVER_INLINE
@@ -192,13 +193,15 @@ static void tail_call_remove_live_bc_obj(ObjectData* obj) {
   return obj->releaseNoObjDestructCheck();
 }
 
-AARCH64_WALKABLE_FRAME
 void ObjectData::release() noexcept {
   assert(kindIsValid());
   if (UNLIKELY(RuntimeOption::EnableObjDestructCall && m_cls->getDtor())) {
-    return tail_call_remove_live_bc_obj(this);
+    tail_call_remove_live_bc_obj(this);
+    AARCH64_WALKABLE_FRAME();
+    return;
   }
   releaseNoObjDestructCheck();
+  AARCH64_WALKABLE_FRAME();
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/hphp/runtime/base/packed-array.cpp
+++ b/hphp/runtime/base/packed-array.cpp
@@ -515,6 +515,7 @@ ArrayData* PackedArray::MakeVecFromAPC(const APCArray* apc) {
   return init.create();
 }
 
+AARCH64_WALKABLE_FRAME
 void PackedArray::Release(ArrayData* ad) {
   assert(checkInvariants(ad));
   assert(ad->isRefCounted());

--- a/hphp/runtime/base/packed-array.cpp
+++ b/hphp/runtime/base/packed-array.cpp
@@ -515,7 +515,6 @@ ArrayData* PackedArray::MakeVecFromAPC(const APCArray* apc) {
   return init.create();
 }
 
-AARCH64_WALKABLE_FRAME
 void PackedArray::Release(ArrayData* ad) {
   assert(checkInvariants(ad));
   assert(ad->isRefCounted());
@@ -528,6 +527,7 @@ void PackedArray::Release(ArrayData* ad) {
     free_strong_iterators(ad);
   }
   MM().objFreeIndex(ad, ad->m_aux16);
+  AARCH64_WALKABLE_FRAME();
 }
 
 NEVER_INLINE

--- a/hphp/runtime/base/ref-data.h
+++ b/hphp/runtime/base/ref-data.h
@@ -90,6 +90,7 @@ struct RefData final : Countable, type_scan::MarkScannableCountable<RefData> {
   /*
    * Deallocate a RefData.
    */
+  AARCH64_WALKABLE_FRAME
   void release() noexcept {
     assert(kindIsValid());
     auto& bits = aux<RefBits>();

--- a/hphp/runtime/base/ref-data.h
+++ b/hphp/runtime/base/ref-data.h
@@ -90,17 +90,18 @@ struct RefData final : Countable, type_scan::MarkScannableCountable<RefData> {
   /*
    * Deallocate a RefData.
    */
-  AARCH64_WALKABLE_FRAME
   void release() noexcept {
     assert(kindIsValid());
     auto& bits = aux<RefBits>();
     if (UNLIKELY(bits.cow)) {
       m_count = 1;
       bits.cow = bits.z = 0;
+      AARCH64_WALKABLE_FRAME();
       return;
     }
     this->~RefData();
     MM().freeSmallSize(this, sizeof(RefData));
+    AARCH64_WALKABLE_FRAME();
   }
 
   void releaseMem() const {

--- a/hphp/runtime/base/resource-data.h
+++ b/hphp/runtime/base/resource-data.h
@@ -163,6 +163,7 @@ struct ResourceData : type_scan::MarkCountable<ResourceData> {
                           req::ptr<T>>::type req::make(Args&&... args);
 };
 
+AARCH64_WALKABLE_FRAME
 inline void ResourceHdr::release() noexcept {
   assert(kindIsValid());
   delete data();

--- a/hphp/runtime/base/resource-data.h
+++ b/hphp/runtime/base/resource-data.h
@@ -163,10 +163,10 @@ struct ResourceData : type_scan::MarkCountable<ResourceData> {
                           req::ptr<T>>::type req::make(Args&&... args);
 };
 
-AARCH64_WALKABLE_FRAME
 inline void ResourceHdr::release() noexcept {
   assert(kindIsValid());
   delete data();
+  AARCH64_WALKABLE_FRAME();
 }
 
 inline ResourceData* safedata(ResourceHdr* hdr) {

--- a/hphp/runtime/base/set-array.cpp
+++ b/hphp/runtime/base/set-array.cpp
@@ -251,6 +251,7 @@ ArrayData* SetArray::AddToSet(ArrayData* ad, StringData* s, bool copy) {
 
 //////////////////////////////////////////////////////////////////////
 
+AARCH64_WALKABLE_FRAME
 void SetArray::Release(ArrayData* in) {
   assert(in->isRefCounted());
   assert(in->hasExactlyOneRef());

--- a/hphp/runtime/base/set-array.cpp
+++ b/hphp/runtime/base/set-array.cpp
@@ -251,7 +251,6 @@ ArrayData* SetArray::AddToSet(ArrayData* ad, StringData* s, bool copy) {
 
 //////////////////////////////////////////////////////////////////////
 
-AARCH64_WALKABLE_FRAME
 void SetArray::Release(ArrayData* in) {
   assert(in->isRefCounted());
   assert(in->hasExactlyOneRef());
@@ -277,6 +276,7 @@ void SetArray::Release(ArrayData* in) {
     }
   }
   MM().objFree(ad, ad->heapSize());
+  AARCH64_WALKABLE_FRAME();
 }
 
 void SetArray::ReleaseUncounted(ArrayData* in, size_t extra) {

--- a/hphp/runtime/base/string-data.cpp
+++ b/hphp/runtime/base/string-data.cpp
@@ -386,6 +386,7 @@ void StringData::releaseProxy() {
   MM().freeSmallSize(this, sizeof(StringData) + sizeof(Proxy));
 }
 
+AARCH64_WALKABLE_FRAME
 void StringData::release() noexcept {
   assert(isRefCounted());
   assert(checkSane());

--- a/hphp/runtime/base/string-data.cpp
+++ b/hphp/runtime/base/string-data.cpp
@@ -386,12 +386,16 @@ void StringData::releaseProxy() {
   MM().freeSmallSize(this, sizeof(StringData) + sizeof(Proxy));
 }
 
-AARCH64_WALKABLE_FRAME
 void StringData::release() noexcept {
   assert(isRefCounted());
   assert(checkSane());
-  if (UNLIKELY(!isFlat())) return releaseProxy();
+  if (UNLIKELY(!isFlat())) {
+    releaseProxy();
+    AARCH64_WALKABLE_FRAME();
+    return;
+  }
   MM().objFreeIndex(this, m_aux16);
+  AARCH64_WALKABLE_FRAME();
 }
 
 //////////////////////////////////////////////////////////////////////

--- a/hphp/util/portability.h
+++ b/hphp/util/portability.h
@@ -103,14 +103,13 @@
 
 
 /*
- * AARCH64 flag which creates a walkable stack frame for
+ * AARCH64 needs to create a walkable stack frame for
  * getFrameRegs() when a FixupEntry isIndirect()
  */
-#ifdef __AARCH64EL__
-#define AARCH64_WALKABLE_FRAME \
-  __attribute__ ((optimize("no-optimize-sibling-calls")))
+#ifdef __aarch64__
+#define AARCH64_WALKABLE_FRAME() asm("" ::: "memory");
 #else
-#define AARCH64_WALKABLE_FRAME
+#define AARCH64_WALKABLE_FRAME()
 #endif
 
 

--- a/hphp/util/portability.h
+++ b/hphp/util/portability.h
@@ -101,6 +101,19 @@
 # define DEBUG_ONLY UNUSED
 #endif
 
+
+/*
+ * AARCH64 flag which creates a walkable stack frame for
+ * getFrameRegs() when a FixupEntry isIndirect()
+ */
+#ifdef __AARCH64EL__
+#define AARCH64_WALKABLE_FRAME \
+  __attribute__ ((optimize("no-optimize-sibling-calls")))
+#else
+#define AARCH64_WALKABLE_FRAME
+#endif
+
+
 /*
  * We need to keep some unreferenced functions from being removed by
  * the linker. There is no compile time mechanism for doing this, but


### PR DESCRIPTION
On AA4ch64 plaforms when calling getFrameRegs() and an indirect
fixup is found, the RIP needs to be present at the correct
offset. It was not, because the destructor was compiled with a
tail-call. It needs to have a standard stack frame.

By disabling the tail-call via the compiler flag on all destructors
in g_destructors[], we can ensure that all destructors for AArch64
are walked correctly.

This bug occurred sometimes in OSS Mediawiki after a few minutes.
We tried to create a simplified unit test but were unsuccessful.

This patch introduces no new unit test failures for either DebugOpt
or Release build types on AArch64 platforms and doesn't affect x64
or PPC64 destructors.