### PR TITLE
correction to ocaml Aarch64 code gen

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ if (PATCHES)
   foreach(PATCH ${PATCHES})
     message(STATUS "Applying ${PATCH}")
     execute_process(
-      COMMAND patch -p1 --forward
+      COMMAND patch -p1 --forward --ignore-whitespace
       WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
       INPUT_FILE "${PATCH}"
       OUTPUT_VARIABLE OUTPUT

--- a/patches/ocaml2.patch
+++ b/patches/ocaml2.patch
@@ -1,0 +1,27 @@
+diff --git a/asmcomp/arm64/emit.mlp b/asmcomp/arm64/emit.mlp
+index 9cca60b..8a415e0 100644
+--- a/third-party/ocaml/src/asmcomp/arm64/emit.mlp
++++ b/third-party/ocaml/src/asmcomp/arm64/emit.mlp
+@@ -517,10 +517,18 @@ let assembly_code_for_allocation i ~n ~far =
+   if !fastcode_flag then begin
+     let lbl_redo = new_label() in
+     let lbl_call_gc = new_label() in
+-    `{emit_label lbl_redo}:`;
+-    `  sub     {emit_reg reg_alloc_ptr}, {emit_reg reg_alloc_ptr}, #{emit_int n}\n`;
+-    `  cmp     {emit_reg reg_alloc_ptr}, {emit_reg reg_alloc_limit}\n`;
+-    `  add     {emit_reg i.res.(0)}, {emit_reg reg_alloc_ptr}, #8\n`;
++    if n > 4096 then begin
++      `{emit_label lbl_redo}:`;
++      emit_intconst reg_tmp1 (Nativeint.of_int n);
++      `        sub     {emit_reg reg_alloc_ptr}, {emit_reg reg_alloc_ptr}, {emit_reg reg_tmp1}\n`;
++      `        cmp     {emit_reg reg_alloc_ptr}, {emit_reg reg_alloc_limit}\n`;
++      `        add     {emit_reg i.res.(0)}, {emit_reg reg_alloc_ptr}, #8\n`;
++    end else begin
++      `{emit_label lbl_redo}:`;
++      `        sub     {emit_reg reg_alloc_ptr}, {emit_reg reg_alloc_ptr}, #{emit_int n}\n`;
++      `        cmp     {emit_reg reg_alloc_ptr}, {emit_reg reg_alloc_limit}\n`;
++      `        add     {emit_reg i.res.(0)}, {emit_reg reg_alloc_ptr}, #8\n`;
++    end;
+     if not far then begin
+       `        b.lo    {emit_label lbl_call_gc}\n`
+     end else begin


### PR DESCRIPTION
This corrects an issue in the ocaml compiler where it tries to make
a invalid immediate operand for a subtraction instruction.

This change was tested by rebuilding from scratch and running the
standard regression tests.

I'm not sure why I had to add the --ignore-whitespace option to the patch
command line.
