### PR TITLE
Aarch64 - fold known ANDs

### DIFF
--- a/hphp/runtime/vm/jit/vasm-fold-imms.cpp
+++ b/hphp/runtime/vm/jit/vasm-fold-imms.cpp
@@ -422,9 +422,7 @@ struct ImmFolder {
 
   void fold(andq& in, Vinstr& out) {
     if (!uses[in.sf] && valid.test(in.s0) && valid.test(in.s1)) {
-      auto imm0 = vals[in.s0];
-      auto result = imm0 & vals[in.s1];
-      out = ldimmq{result, in.d};
+      out = ldimmq{vals[in.s0] & vals[in.s1], in.d};
       return;
     }
     int val;
@@ -438,9 +436,7 @@ struct ImmFolder {
   void fold(andqi& in, Vinstr& out) {
     if (uses[in.sf]) return;
     if (!valid.test(in.s1)) return;
-    auto imm64 = vals[in.s1];
-    auto result = imm64 & in.s0.q();
-    out = ldimmq{result, in.d};
+    out = ldimmq{vals[in.s1] & in.s0.q(), in.d};
   }
 
   void fold(storeb& in, Vinstr& out) {


### PR DESCRIPTION

This catches an annoying sequence  seen while working on PR#7894.  The values for
an and immediate are known and can be trivially folded at compile-time.  This was
seen 94 times in hphp/test/quick/all_type_comparison_test.php.

 Before
 ======
` B15: [profCount=1] (preds B14 B13)`
`  (64) RetCtrl<3> t1:StkPtr, t0:FramePtr, InitNull`
`     Main:   `
`    0x5340202c  910083bc              add x28, x29, #0x20 (32)`
`    0x53402030  b2609fe1              mov x1, #0xffffffff000000ff`
`    0x53402034  92400021              and x1, x1, #0x1 `   //<<---
`    0x53402038  a9407bbd              ldp x29, x30, [x29]`
`    0x5340203c  d65f03c0              ret  `

 After
 =====
` B15: [profCount=1] (preds B14 B13)`
`    (64) RetCtrl<3> t1:StkPtr, t0:FramePtr, InitNull`
`        Main:   `
`              0x3a000d24  910083bc              add x28, x29, #0x20 (32)`
`              0x3a000d28  d2800021              movz x1, #0x1`
`              0x3a000d2c  a9407bbd              ldp x29, x30, [x29]`
`              0x3a000d30  d65f03c0              ret `

The standard regression tests were run with six option sets.  No additional errors were
seen.
