### PR TITLE
Aarch64 - improve emitter for shl

### DIFF
--- a/hphp/runtime/vm/jit/vasm-arm.cpp
+++ b/hphp/runtime/vm/jit/vasm-arm.cpp
@@ -1080,9 +1080,8 @@ void Vgen::emit(const vasm_opc& i) {                         \
   } else {                                                   \
     checkSF(i, StatusFlags::NotV);                           \
     if (!flagRequired(i.fl, StatusFlags::C)) {               \
-      /* Perform the shift and set N and Z. */               \
-      a->arm_opc(gpr_w(i.d), gpr_w(i.s1), i.s0.l());         \
-      a->Bic(vixl::zr, gpr_w(i.d), vixl::zr, SetFlags);      \
+      /* Equivalent to shift and test, set N and Z. */       \
+      a->Tst(gpr_w(i.s1), Operand(~(-1LL << (sz - i.s0.l())))); \
     } else {                                                 \
       /* Use VIXL's macroassembler scratch regs. */          \
       a->SetScratchRegisters(vixl::NoReg, vixl::NoReg);      \


### PR DESCRIPTION
This improves the emitter for the shift left instructions in the case
where only the condition code is needed.  An immediate can be  calculated
at compile time which checks only the equivalent bits.  This saves 1 instruction 
per instance.

This happened to show up 82 times in the all_type_comparison_test.php
regression test.

Before
======
` 196: Lt `
`    (30) t9:Bool = ConvDblToBool t5:Dbl`
`      Main:   `
`          0x51001ec8  d37ff800              lsl x0, x0, #1`
 `         0x51001ecc  ea3f001f              bics xzr, x0, xzr `

After
=====
` 196: Lt `
`    (30) t9:Bool = ConvDblToBool t5:Dbl`
`      Main:   `
`          0x534023e8  f240f81f              tst x0, #0x7fffffffffffffff`

The standard regression tests were run with six option sets.  No new regressions
were seen.

