### PR TITLE
Avoid race condition of PPC64 decoder

### DIFF
--- a/hphp/ppc64-asm/decoder-ppc64.cpp
+++ b/hphp/ppc64-asm/decoder-ppc64.cpp
@@ -656,11 +656,11 @@ const DecoderInfo Decoder::decode(const PPC64Instr* const ip) {
 
     // If instruction found, return it.
     if (position != -1) {
-      auto pdi = m_decoder_table[position];
-      assert(pdi->opcode() == decoded_instr);
-      pdi->instruction_image(*ip);
-      pdi->setIp(ip);
-      return *pdi;
+      DecoderInfo pdi = *m_decoder_table[position];
+      assert(pdi.opcode() == decoded_instr);
+      pdi.instruction_image(*ip);
+      pdi.setIp(ip);
+      return pdi;
     }
   }
 


### PR DESCRIPTION
Avoided change data from m_decoder_table, where multiple threads are able
to make changes at the same time.