### PR TITLE
add admin server type in runtime options

### DIFF
--- a/hphp/runtime/base/runtime-option.cpp
+++ b/hphp/runtime/base/runtime-option.cpp
@@ -320,6 +320,7 @@ bool RuntimeOption::UnserializationWhitelistCheckWarningOnly = true;
 int64_t RuntimeOption::UnserializationBigMapThreshold = 1 << 16;
 
 std::string RuntimeOption::TakeoverFilename;
+std::string RuntimeOption::AdminServerType;
 std::string RuntimeOption::AdminServerIP;
 int RuntimeOption::AdminServerPort = 0;
 int RuntimeOption::AdminThreadCount = 1;
@@ -1721,6 +1722,7 @@ void RuntimeOption::Load(
   }
   {
     // Admin Server
+    Config::Bind(AdminServerType, ini, config, "AdminServer.Type", ServerType);
     Config::Bind(AdminServerIP, ini, config, "AdminServer.IP", ServerIP);
     Config::Bind(AdminServerPort, ini, config, "AdminServer.Port", 0);
     // Single-threaded by default. If increasing the max thread count > 1, the

--- a/hphp/runtime/base/runtime-option.h
+++ b/hphp/runtime/base/runtime-option.h
@@ -303,6 +303,7 @@ struct RuntimeOption {
   static int64_t UnserializationBigMapThreshold;
 
   static std::string TakeoverFilename;
+  static std::string AdminServerType;
   static std::string AdminServerIP;
   static int AdminServerPort;
   static int AdminThreadCount;

--- a/hphp/runtime/server/http-server.cpp
+++ b/hphp/runtime/server/http-server.cpp
@@ -97,6 +97,8 @@ HttpServer::HttpServer()
 
   auto serverFactory = ServerFactoryRegistry::getInstance()->getFactory
       (RuntimeOption::ServerType);
+  auto adminServerFactory = ServerFactoryRegistry::getInstance()->getFactory
+      (RuntimeOption::AdminServerType);
   const std::string address = RuntimeOption::ServerFileSocket.empty()
     ? RuntimeOption::ServerIP : RuntimeOption::ServerFileSocket;
   ServerOptions options(address, RuntimeOption::ServerPort,
@@ -138,7 +140,7 @@ HttpServer::HttpServer()
                               RuntimeOption::AdminThreadCount);
   admin_options.m_queueToWorkerRatio =
     RuntimeOption::AdminServerQueueToWorkerRatio;
-  m_adminServer = serverFactory->createServer(admin_options);
+  m_adminServer = adminServerFactory->createServer(admin_options);
   m_adminServer->setRequestHandlerFactory<AdminRequestHandler>(
     RuntimeOption::RequestTimeoutSeconds);
 


### PR DESCRIPTION
Change-Id: Ie00658b19606c9238ee71c5ab66434481c22202d

We always use fastcgi server for compatibility, but we don't want the admin server to be fastcgi. It is not convenient to visit. So we add a patch to make admin server type different from page server type. 

In Baidu, we always use fastcgi for page server and http for admin server.

Just add this in you ini setting: `hhvm.admin_server.type=proxygen`

If this is not set, the default value is the same type as the page server.