### PR TITLE
Aarch64 - improve after lea lowering

### DIFF
--- a/hphp/runtime/vm/jit/vasm-simplify-arm.cpp
+++ b/hphp/runtime/vm/jit/vasm-simplify-arm.cpp
@@ -99,6 +99,25 @@ bool simplify(Env& env, const loadb& inst, Vlabel b, size_t i) {
 
 ///////////////////////////////////////////////////////////////////////////////
 
+bool simplify(Env& env, const ldimmq& inst, Vlabel b, size_t i) {
+  return if_inst<Vinstr::lea>(env, b, i + 1, [&] (const lea& ea) {
+    // ldimmq{s, tmp}; lea{tmp, d} -> subqi{s, d}
+    if (!(env.use_counts[inst.d] == 1 &&
+          inst.s.q() <= -1  &&
+          inst.s.q() >= -4095 &&
+          ea.s.disp == 0 &&
+          ea.s.base.isValid())) return false;
+
+    return simplify_impl(env, b, i, [&] (Vout& v) {
+      auto sf = env.unit.makeReg();
+      v << subqi{-inst.s.l(), ea.s.base, ea.d, sf};
+      return 2;
+    });
+  });
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
 bool simplify(Env& env, const movzbl& inst, Vlabel b, size_t i) {
   // movzbl{s, d}; shrli{2, s, d} --> ubfmli{2, 7, s, d}
   return if_inst<Vinstr::shrli>(env, b, i + 1, [&](const shrli& sh) {

--- a/hphp/runtime/vm/jit/vasm-simplify-arm.cpp
+++ b/hphp/runtime/vm/jit/vasm-simplify-arm.cpp
@@ -110,8 +110,9 @@ bool simplify(Env& env, const ldimmq& inst, Vlabel b, size_t i) {
           ea.s.base.isValid())) return false;
 
     return simplify_impl(env, b, i, [&] (Vout& v) {
-      auto sf = env.unit.makeReg();
-      v << subqi{-inst.s.l(), ea.s.base, ea.d, sf};
+      // eXtend ea - lowerVptr() too conservative.
+      Vptr xea{ea.s.base, inst.s.l()};
+      v << lea{xea, ea.d};
       return 2;
     });
   });

--- a/hphp/runtime/vm/jit/vasm-simplify-arm.cpp
+++ b/hphp/runtime/vm/jit/vasm-simplify-arm.cpp
@@ -105,6 +105,7 @@ bool simplify(Env& env, const ldimmq& inst, Vlabel b, size_t i) {
     if (!(env.use_counts[inst.d] == 1 &&
           inst.s.q() <= -1  &&
           inst.s.q() >= -4095 &&
+          inst.d == ea.s.index &&
           ea.s.disp == 0 &&
           ea.s.base.isValid())) return false;
 


### PR DESCRIPTION
This change improves the sequence generated when lowering the Vptr element of the lea
Vinstr by taking advantage of the sub immediate instruction.  This saves 1 instruction 
per instance.

Before
=====
    (07) StLocRange<[0, 108)> t0:FramePtr, Uninit
        Main:   
            0x52c0035c  d10043a0              sub x0, x29, #0x10 (16)
            0x52c00360  9280d9e1              movn x1, #0x6cf
            0x52c00364  8b0103a1              add x1, x29, x1 
            0x52c00368  3900201f              strb wzr, [x0, #8]

After
====
    (07) StLocRange<[0, 108)> t0:FramePtr, Uninit
        Main:   
            0x50400404  d10043a0              sub x0, x29, #0x10 (16)
            0x50400408  d11b43a1              sub x1, x29, #0x6d0 (1744)  //<<---
            0x5040040c  3900201f              strb wzr, [x0, #8]

This was seen approximately 300 times in hphp/test/quick/all_type_comparison_test.php
and around 1000 times in hphp/test/zend/good/ext/intl/tests/grapheme.php

The standard regression tests were run with six option sets.  No new failures were observed.
