### PR TITLE
implement fastcgi_finish_request()

### DIFF
--- a/hphp/runtime/ext/phpfpm/config.cmake
+++ b/hphp/runtime/ext/phpfpm/config.cmake
@@ -1,0 +1,9 @@
+HHVM_DEFINE_EXTENSION("phpfpm"
+  SOURCES
+    ext_phpfpm.cpp
+  HEADERS
+    ext_phpfpm.h
+  SYSTEMLIB
+    ext_phpfpm.php
+  DEPENDS
+)

--- a/hphp/runtime/ext/phpfpm/ext_phpfpm.cpp
+++ b/hphp/runtime/ext/phpfpm/ext_phpfpm.cpp
@@ -1,0 +1,60 @@
+/*
+   +----------------------------------------------------------------------+
+   | HipHop for PHP                                                       |
+   +----------------------------------------------------------------------+
+   | Copyright (c) 2010-present Facebook, Inc. (http://www.facebook.com)  |
+   | Copyright (c) 1997-2010 The PHP Group                                |
+   +----------------------------------------------------------------------+
+   | This source file is subject to version 3.01 of the PHP license,      |
+   | that is bundled with this package in the file LICENSE, and is        |
+   | available through the world-wide-web at the following url:           |
+   | http://www.php.net/license/3_01.txt                                  |
+   | If you did not receive a copy of the PHP license and are unable to   |
+   | obtain it through the world-wide-web, please send a note to          |
+   | license@php.net so we can mail you a copy immediately.               |
+   +----------------------------------------------------------------------+
+*/
+
+#include "hphp/runtime/ext/phpfpm/ext_phpfpm.h"
+#include "hphp/runtime/base/execution-context.h"
+
+namespace HPHP {
+
+bool HHVM_FUNCTION(fastcgi_finish_request) {
+  auto context = g_context.getNoCheck();
+  auto transport = context->getTransport();
+  if (!transport) {
+      return false;
+  }
+  context->obFlushAll();
+  String content = context->obDetachContents();
+
+  // User may use fastcgi_finish_request in shutdown functions
+  // Shutdown functions will be invoked even if fatal error occurs
+  int errnum = g_context->getLastErrorNumber();
+  if (errnum == static_cast<int>(ErrorMode::FATAL_ERROR)){
+    if (RuntimeOption::ServerErrorMessage) {
+      String lastError = g_context->getLastError();
+      transport->sendString(lastError.data(),
+        500, false, false, "hphp_invoke");
+    } else {
+      transport->sendString(RuntimeOption::FatalErrorMessage,
+        500, false, false, "hphp_invoke");
+    }
+  } else {
+    transport->sendRaw((void*)content.data(), content.size());
+  }
+  transport->onSendEnd();
+  return true;
+}
+
+class PHPFpmExtension : public Extension {
+ public:
+  PHPFpmExtension() : Extension("cgi-fcgi", "1.0.0") {}
+  void moduleInit() override {
+    HHVM_FE(fastcgi_finish_request);
+    loadSystemlib("phpfpm");
+  }
+} s_phpfpm_extension;
+
+}

--- a/hphp/runtime/ext/phpfpm/ext_phpfpm.h
+++ b/hphp/runtime/ext/phpfpm/ext_phpfpm.h
@@ -1,0 +1,32 @@
+/*
+   +----------------------------------------------------------------------+
+   | HipHop for PHP                                                       |
+   +----------------------------------------------------------------------+
+   | Copyright (c) 2010-present Facebook, Inc. (http://www.facebook.com)  |
+   | Copyright (c) 1997-2010 The PHP Group                                |
+   +----------------------------------------------------------------------+
+   | This source file is subject to version 3.01 of the PHP license,      |
+   | that is bundled with this package in the file LICENSE, and is        |
+   | available through the world-wide-web at the following url:           |
+   | http://www.php.net/license/3_01.txt                                  |
+   | If you did not receive a copy of the PHP license and are unable to   |
+   | obtain it through the world-wide-web, please send a note to          |
+   | license@php.net so we can mail you a copy immediately.               |
+   +----------------------------------------------------------------------+
+*/
+
+#ifndef incl_HPHP_EXT_PHPFPM_H
+#define incl_HPHP_EXT_PHPFPM_H
+
+#include "hphp/runtime/ext/extension.h"
+
+namespace HPHP {
+///////////////////////////////////////////////////////////////////////////////
+
+bool HHVM_FUNCTION(fastcgi_finish_request);
+
+///////////////////////////////////////////////////////////////////////////////
+}
+
+#endif // incl_HPHP_EXT_PHPFPM_H
+

--- a/hphp/runtime/ext/phpfpm/ext_phpfpm.php
+++ b/hphp/runtime/ext/phpfpm/ext_phpfpm.php
@@ -1,0 +1,10 @@
+<?hh
+
+/**
+ * Flushes all response data to the client
+ *
+ * @return bool - Returns TRUE on success or FALSE on failure.
+ */
+<<__Native>>
+function fastcgi_finish_request(): bool;
+

--- a/hphp/runtime/server/fastcgi/fastcgi-transport.cpp
+++ b/hphp/runtime/server/fastcgi/fastcgi-transport.cpp
@@ -167,6 +167,9 @@ void FastCGITransport::sendResponseHeaders(IOBufQueue& queue, int code) {
 
 void FastCGITransport::sendImpl(const void* data, int size, int code,
                                 bool /*chunked*/, bool eom) {
+  if (m_sendEnded) {
+    return;  // Output after fastcgi_finish_request will be ignored
+  }
   if (!m_headersSent) {
     m_headersSent = true;
     sendResponseHeaders(m_txBuf, code);

--- a/hphp/runtime/server/proxygen/proxygen-transport.cpp
+++ b/hphp/runtime/server/proxygen/proxygen-transport.cpp
@@ -661,7 +661,6 @@ void ProxygenTransport::messageAvailable(ResponseMessage&& message) noexcept {
 void ProxygenTransport::sendImpl(const void *data, int size, int code,
                                  bool chunked, bool eom) {
   assert(data);
-  assert(!m_sendStarted || chunked);
   if (m_sendEnded) {
     // This should never happen, but when it does we have to bail out,
     // since there's no sensible way to send data at this point and
@@ -670,6 +669,7 @@ void ProxygenTransport::sendImpl(const void *data, int size, int code,
     // somewhere.
     return;
   }
+  assert(!m_sendStarted || chunked);
 
   VLOG(4) << "sendImpl called with data size=" << size << ", code=" << code
           << ", chunked=" << chunked << ", eom=" << eom;

--- a/hphp/test/server/fastcgi/server_root/test_fastcgi_finish_request.php
+++ b/hphp/test/server/fastcgi/server_root/test_fastcgi_finish_request.php
@@ -1,0 +1,14 @@
+<?php
+
+function test_fastcgi() {
+  echo "before\n";
+  fastcgi_finish_request();
+  echo "after\n";
+}
+
+if ($_GET['error']) {
+  register_shutdown_function('test_fastcgi');
+  func_not_exists();
+} else {
+  test_fastcgi();
+}

--- a/hphp/test/server/fastcgi/tests/fastcgi_finish_request.php
+++ b/hphp/test/server/fastcgi/tests/fastcgi_finish_request.php
@@ -1,0 +1,8 @@
+<?php
+
+require_once('test_base.inc');
+
+requestAll(array(
+    "test_fastcgi_finish_request.php?error=0",
+    "test_fastcgi_finish_request.php?error=1",
+));

--- a/hphp/test/server/fastcgi/tests/fastcgi_finish_request.php.expect
+++ b/hphp/test/server/fastcgi/tests/fastcgi_finish_request.php.expect
@@ -1,0 +1,4 @@
+Requesting 'test_fastcgi_finish_request.php?error=0'
+string(6) "before"
+Requesting 'test_fastcgi_finish_request.php?error=1'
+string(0) ""

--- a/hphp/util/hphp-config.h.in
+++ b/hphp/util/hphp-config.h.in
@@ -93,7 +93,7 @@ ${HHVM_COMPILES_DEFINE_STRING}
 #endif
 
 #ifdef USE_CMAKE
-# if ${HHVM_EXTENSION_COUNT} != 90
+# if ${HHVM_EXTENSION_COUNT} != 91
 #  error You need to update the config file for the new builtin extension, and add the define to the FB section
 # endif
 ${HHVM_EXTENSIONS_ENABLED_DEFINE_STRING}
@@ -155,6 +155,7 @@ ${HHVM_EXTENSIONS_ENABLED_DEFINE_STRING}
 # define ENABLE_EXTENSION_PDO_SQLITE 1
 /* #undef ENABLE_EXTENSION_PGSQL */
 # define ENABLE_EXTENSION_PHAR 1
+# define ENABLE_EXTENSION_PHPFPM 1
 # define ENABLE_EXTENSION_POSIX 1
 # define ENABLE_EXTENSION_PROCESS 1
 # define ENABLE_EXTENSION_RANDOM 1


### PR DESCRIPTION
Change-Id: I6a8322e7030060c619397cd39a94c660c1f214ce

This resolve #1230.

`fastcgi_finish_request()` is very useful to send response instantly and do the rest thing in background.

`register_postsend_function()` can do the same thing, but it is not compatible with Zend.