### PR TITLE
fix file_exists relative path bug

### DIFF
--- a/hphp/runtime/ext/std/ext_std_file.cpp
+++ b/hphp/runtime/ext/std/ext_std_file.cpp
@@ -193,7 +193,15 @@ static int accessSyscall(
         return -1;
       }
     }
-    return ::access(File::TranslatePathWithFileCache(path).data(), mode);
+    String filepath = path;
+    if (path.charAt(0) != '/') {
+      String cwd = g_context->getCwd();
+      filepath = cwd + "/" + path;
+      if (!cwd.empty() && cwd[cwd.length() - 1] == '/') {
+        filepath = cwd + path;
+      }
+      return ::access(filepath.data(),mode);
+    }
   }
   return w->access(uri_or_path, mode);
 }

--- a/hphp/test/slow/file/relative_path.php
+++ b/hphp/test/slow/file/relative_path.php
@@ -1,0 +1,9 @@
+<?php
+  error_reporting(-1);
+  $dir = "hhvm_file_exists_test";
+  mkdir($dir);
+  file_put_contents($dir."/a.txt","test");
+  var_dump(file_exists($dir."/b/../a.txt"));
+  unlink($dir."/a.txt");
+  rmdir($dir);
+?>

--- a/hphp/test/slow/file/relative_path.php.expectf
+++ b/hphp/test/slow/file/relative_path.php.expectf
@@ -1,0 +1,1 @@
+bool(false)


### PR DESCRIPTION
a.txt real location is a/a.txt

file_exists("a/b/../a.txt");

this code return value is false ,but hhvm process relative path,so this result is true,diff php,and then old way process relative path performance have problem,this modify way performance is improve 40%

replay case:

#3148