### PR TITLE
Correction for tc-print build

### DIFF
--- a/hphp/tools/tc-print/CMakeLists.txt
+++ b/hphp/tools/tc-print/CMakeLists.txt
@@ -3,15 +3,25 @@ if(IS_X64)
   if (LibXed_INCLUDE_DIR AND LibXed_LIBRARY)
     include_directories(${LibXed_INCLUDE_DIR})
     add_definitions("-DHAVE_LIBXED")
+    add_executable(tc-print "mappers.cpp" "offline-trans-data.cpp"
+                            "offline-code.cpp"
+                            "offline-x86-code.cpp"  "perf-events.cpp"
+                            "repo-wrapper.cpp"  "tc-print.cpp"
+                            "../../hhvm/process-init.cpp")
+    link_object_libraries(tc-print ${HHVM_WHOLE_ARCHIVE_LIBRARIES})
+    target_link_libraries(tc-print ${HHVM_LINK_LIBRARIES})
+    embed_all_systemlibs(tc-print "${CMAKE_CURRENT_BINARY_DIR}/../.."
+                                  "${CMAKE_CURRENT_BINARY_DIR}/tc-print")
   endif()
 endif()
-add_executable(tc-print "mappers.cpp" "offline-trans-data.cpp"
-                        "offline-code.cpp"  "perf-events.cpp"
-                        "offline-arm-code.cpp" "offline-ppc64-code.cpp"
-                        "offline-x86-code.cpp"
-                        "repo-wrapper.cpp"  "tc-print.cpp"
-                        "../../hhvm/process-init.cpp")
-link_object_libraries(tc-print ${HHVM_WHOLE_ARCHIVE_LIBRARIES})
-target_link_libraries(tc-print ${HHVM_LINK_LIBRARIES})
-embed_all_systemlibs(tc-print "${CMAKE_CURRENT_BINARY_DIR}/../.."
-                              "${CMAKE_CURRENT_BINARY_DIR}/tc-print")
+if(NOT IS_X64)
+  add_executable(tc-print "mappers.cpp" "offline-trans-data.cpp"
+                          "offline-code.cpp"  "perf-events.cpp"
+                          "offline-arm-code.cpp" "offline-ppc64-code.cpp"
+                          "repo-wrapper.cpp"  "tc-print.cpp"
+                          "../../hhvm/process-init.cpp")
+  link_object_libraries(tc-print ${HHVM_WHOLE_ARCHIVE_LIBRARIES})
+  target_link_libraries(tc-print ${HHVM_LINK_LIBRARIES})
+  embed_all_systemlibs(tc-print "${CMAKE_CURRENT_BINARY_DIR}/../.."
+                                "${CMAKE_CURRENT_BINARY_DIR}/tc-print")
+endif()

--- a/hphp/tools/tc-print/offline-x86-code.cpp
+++ b/hphp/tools/tc-print/offline-x86-code.cpp
@@ -240,7 +240,7 @@ void OfflineCode::disasm(FILE* file,
 }
 #else
   // cmake should prevent this.
-  error "tc-print on x86_64 requires libxed"
+#error "tc-print on x86_64 requires libxed"
 #endif
 #endif
 


### PR DESCRIPTION
Correction for #7703 for case where libxed is NOT installed on x86_64 machine.

This was tested on Aarch64, and x86_64 with/without libxed.
