### PR TITLE
optimize File::TranslatePathWithFileCache when FileCache is empty

### DIFF
--- a/hphp/runtime/base/file.cpp
+++ b/hphp/runtime/base/file.cpp
@@ -124,8 +124,9 @@ String File::TranslatePathWithFileCache(const String& filename) {
   // canonicalize asserts that we don't have nulls
   String canonicalized = FileUtil::canonicalize(filename);
   String translated = TranslatePath(canonicalized);
-  if (!translated.empty() && access(translated.data(), F_OK) < 0 &&
-      StaticContentCache::TheFileCache) {
+  if (!translated.empty() && 
+      StaticContentCache::TheFileCache &&
+      access(translated.data(), F_OK) < 0) {
     if (StaticContentCache::TheFileCache->exists(canonicalized.data(),
                                                  false)) {
       // we use file cache's file name to make stat() work


### PR DESCRIPTION
Change-Id: I7c6d98db13ea0dece449597347f31761486f1aa7

When StaticContentCache::TheFileCache is empty, it is no need to call access().

This will save 30% cost of some file system functions such as file_exist(), is_file(), etc.