### PR TITLE
Fix PPC64 compilation

### DIFF
--- a/hphp/tools/tc-print/offline-ppc64-code.cpp
+++ b/hphp/tools/tc-print/offline-ppc64-code.cpp
@@ -33,11 +33,14 @@ namespace HPHP { namespace jit {
 
 #if defined(__powerpc64__)
 
+const char* OfflineCode::getArchName() { return "PPC64"; }
+
 TCA OfflineCode::collectJmpTargets(FILE *file,
                                    TCA fileStartAddr,
                                    TCA codeStartAddr,
                                    uint64_t codeLen,
                                    vector<TCA> *jmpTargets) {
+  return 0;
 }
 
 // Disassemble the code from the given raw file, whose initial address is given


### PR DESCRIPTION
After the PR https://github.com/facebook/hhvm/pull/7703, the method
getArchName was missing in the offline-ppc64-code.cpp file.
The missing method was added and the return value for collectJmpTargets as
well, in order to avoid warning when compiling.