### PR TITLE
add dynamic syntax log and monitor

### DIFF
--- a/hphp/runtime/base/execution-context.cpp
+++ b/hphp/runtime/base/execution-context.cpp
@@ -2007,6 +2007,16 @@ typedef RankedCHM<StringData*, HPHP::Unit*,
         StringDataHashCompare,
         RankEvaledUnits> EvaledUnitsMap;
 static EvaledUnitsMap s_evaledUnits;
+static std::atomic<int64_t> s_createfuncs;
+
+int64_t getEvaledUnits() {
+  return s_evaledUnits.size();
+}
+
+int64_t getCreateFuncs() {
+  return s_createfuncs.load(std::memory_order_acquire);
+}
+
 Unit* ExecutionContext::compileEvalString(
     StringData* code,
     const char* evalFilename /* = nullptr */) {
@@ -2015,6 +2025,11 @@ Unit* ExecutionContext::compileEvalString(
   // across requests.
   code = makeStaticString(code);
   if (s_evaledUnits.insert(acc, code)) {
+    if (RuntimeOption::EnableDynamicFuncWarn) {
+       Logger::Warning("Don't recommended call eval(), "
+         "maybe effect performance "
+          "in %s on %d", getContainingFileName()->data(), getLine());
+    }
     acc->second = compile_string(
       code->data(),
       code->size(),
@@ -2034,6 +2049,12 @@ StrNR ExecutionContext::createFunction(const String& args,
   }
 
   VMRegAnchor _;
+  s_createfuncs.fetch_add(1, std::memory_order_acq_rel);
+  if (RuntimeOption::EnableDynamicFuncWarn) {
+    Logger::Warning("Don't recommended call eval(), "
+      "maybe effect performance "
+       "in %s on %d", getContainingFileName()->data(), getLine());
+  }
   auto const ar = GetCallerFrame();
   // It doesn't matter if there's a user function named __lambda_func; we only
   // use this name during parsing, and then change it to an impossible name

--- a/hphp/runtime/base/execution-context.h
+++ b/hphp/runtime/base/execution-context.h
@@ -66,6 +66,9 @@ enum class InclOpFlags {
   Relative = 16,
 };
 
+int64_t getEvaledUnits();
+int64_t getCreateFuncs();
+
 inline InclOpFlags operator|(const InclOpFlags& l, const InclOpFlags& r) {
   return static_cast<InclOpFlags>(static_cast<int>(l) | static_cast<int>(r));
 }

--- a/hphp/runtime/base/runtime-option.cpp
+++ b/hphp/runtime/base/runtime-option.cpp
@@ -107,6 +107,7 @@ bool RuntimeOption::CheckFlushOnUserClose = true;
 bool RuntimeOption::EvalAuthoritativeMode = false;
 bool RuntimeOption::IntsOverflowToInts = false;
 bool RuntimeOption::AutoprimeGenerators = true;
+bool RuntimeOption::EnableDynamicFuncWarn = false;
 
 #ifdef FACEBOOK
 bool RuntimeOption::UseThriftLogger = false;
@@ -1138,6 +1139,8 @@ void RuntimeOption::Load(
   }
   {
     // Eval
+    Config::Bind(EnableDynamicFuncWarn, ini, config, "Eval.EnableDynamicFuncWarn",
+                 EnableDynamicFuncWarn);
     Config::Bind(EnableHipHopSyntax, ini, config, "Eval.EnableHipHopSyntax",
                  EnableHipHopSyntax);
     Config::Bind(EnableHipHopExperimentalSyntax, ini,

--- a/hphp/runtime/base/runtime-option.h
+++ b/hphp/runtime/base/runtime-option.h
@@ -379,6 +379,7 @@ struct RuntimeOption {
   // is the following prefix followed by the pid of the hphp process.
   static std::string LightProcessFilePrefix;
   static int LightProcessCount;
+  static bool EnableDynamicFuncWarn;
 
   // Eval options
   static bool EnableHipHopSyntax;

--- a/hphp/runtime/server/admin-request-handler.cpp
+++ b/hphp/runtime/server/admin-request-handler.cpp
@@ -1013,6 +1013,8 @@ bool AdminRequestHandler::handleCheckRequest(const std::string &cmd,
     appendStat("fixups", jit::FixupMap::size());
     appendStat("units", numLoadedUnits());
     appendStat("funcs", Func::nextFuncId());
+    appendStat("EvaledUnits", getEvaledUnits());
+    appendStat("CreateFuncs", getCreateFuncs());
     appendStat("named-entities", NamedEntity::tableSize());
     for (auto& pair : NamedEntity::tableStats()) {
       appendStat(folly::sformat("named-entities-{}", pair.first), pair.second);


### PR DESCRIPTION
(1)add eval and create_function compile num monitor (call check-health command),monitor name is EvaledUnits(eval num) and CreateFuncs(create_function num) in check-health command
(2)add option Eval.EnableDynamicFuncWarn (default is False),print warning log use eval and create_function call compile code will print warning log when option set Eval.EnableDynamicFuncWarn is True

Add monitoring and logging, mainly to avoid performance loss.
