### PR TITLE
[AArch64] Shrinks embedded TCA targets to 32 bits.

### DIFF
--- a/hphp/runtime/vm/jit/abi-arm.h
+++ b/hphp/runtime/vm/jit/abi-arm.h
@@ -233,7 +233,8 @@ inline vixl::Register svcReqArgReg(unsigned index) {
 const vixl::Register rVixlScratch0(vixl::x16);
 const vixl::Register rVixlScratch1(vixl::x17);
 
-// x18 is used as assembler temporary
+// w18/x18 is used as assembler temporary. The 32-bit w18 is used
+// primarily to hold 32-bit branch targets.
 const vixl::Register rAsm(vixl::x18);
 const vixl::Register rAsm_w(vixl::w18);
 

--- a/hphp/runtime/vm/jit/abi-arm.h
+++ b/hphp/runtime/vm/jit/abi-arm.h
@@ -235,6 +235,7 @@ const vixl::Register rVixlScratch1(vixl::x17);
 
 // x18 is used as assembler temporary
 const vixl::Register rAsm(vixl::x18);
+const vixl::Register rAsm_w(vixl::w18);
 
 ///////////////////////////////////////////////////////////////////////////////
 

--- a/hphp/runtime/vm/jit/func-guard-arm.cpp
+++ b/hphp/runtime/vm/jit/func-guard-arm.cpp
@@ -69,11 +69,11 @@ void emitFuncGuard(const Func* func, CodeBlock& cb, CGMeta& fixups) {
   a.  Cmp   (vixl::x0, rAsm);
   a.  B     (&after_data, convertCC(CC_Z));
 
-  a.  Ldr   (rAsm, &target_data);
+  a.  Ldr   (rAsm_w, &target_data);
   a.  Br    (rAsm);
 
   a.  bind  (&target_data);
-  a.  dc64  (tc::ustubs().funcPrologueRedispatch);
+  a.  dc32  (makeTCA32(tc::ustubs().funcPrologueRedispatch));
   a.  bind  (&after_data);
 
   cb.sync(begin);
@@ -82,9 +82,9 @@ void emitFuncGuard(const Func* func, CodeBlock& cb, CGMeta& fixups) {
 TCA funcGuardFromPrologue(TCA prologue, const Func* /*func*/) {
   if (!isPrologueStub(prologue)) {
     // Typically a func guard is a smashable movq followed by an ldr, cmp, b.eq,
-    // ldr, br, and a 64 bit target. However, relocation can shorten the
-    // sequence, so search backwards until the smashable movq is found.
-    for (int length = 0; length <= (5 * 4) + 8; length += 4) {
+    // ldr, br, and a 32 bit target. However, relocation can shorten the sequence,
+    // so search backwards until the smashable movq is found.
+    for (int length = 0; length <= (5 * 4) + 4; length += 4) {
       TCA inst = prologue - (smashableMovqLen() + length);
       if (isSmashableMovq(inst)) return inst;
     }

--- a/hphp/runtime/vm/jit/func-guard-arm.cpp
+++ b/hphp/runtime/vm/jit/func-guard-arm.cpp
@@ -73,7 +73,7 @@ void emitFuncGuard(const Func* func, CodeBlock& cb, CGMeta& fixups) {
   a.  Br    (rAsm);
 
   a.  bind  (&target_data);
-  a.  dc32  (makeTCA32(tc::ustubs().funcPrologueRedispatch));
+  a.  dc32  (makeTarget32(tc::ustubs().funcPrologueRedispatch));
   a.  bind  (&after_data);
 
   cb.sync(begin);

--- a/hphp/runtime/vm/jit/relocation-arm.cpp
+++ b/hphp/runtime/vm/jit/relocation-arm.cpp
@@ -123,7 +123,7 @@ InstrSet findLiterals(Instruction* start, Instruction* end) {
   InstrSet literals;
   for (auto instr = start; instr < end; instr = instr->NextInstruction()) {
     if (literals.count(instr)) continue;
-    if (instr->IsLoadLiteral() && instr->Mask(LoadLiteralMask) == LDR_x_lit) {
+    if (instr->IsLoadLiteral()) {
       /*
        * Get the address of the literal instruction words. Add both words.
        * Also check if these instruction words are themselves LDR literals
@@ -134,17 +134,19 @@ InstrSet findLiterals(Instruction* start, Instruction* end) {
           if (!literals.count(lit)) {
             literals.insert(lit);
           }
-          if (lit->IsLoadLiteral() && lit->Mask(LoadLiteralMask) == LDR_x_lit) {
+          if (lit->IsLoadLiteral()) {
             auto oops = Instruction::Cast(lit->LiteralAddress());
             literals.erase(oops);
-            literals.erase(oops->NextInstruction());
+            if (lit->Mask(LoadLiteralMask) == LDR_x_lit)
+              literals.erase(oops->NextInstruction());
           }
         }
       };
 
       auto la = Instruction::Cast(instr->LiteralAddress());
       addLiteral(la);
-      addLiteral(la->NextInstruction());
+      if (instr->Mask(LoadLiteralMask) == LDR_x_lit)
+        addLiteral(la->NextInstruction());
     }
   }
   return literals;
@@ -717,23 +719,26 @@ size_t relocateImpl(Env& env) {
            *   MOV/MOVK
            */
           if (src->IsLoadLiteral()) {
-            auto addr = reinterpret_cast<TCA*>(dest->LiteralAddress());
-            auto target = *addr;
-            auto adjusted = env.rel.adjustedAddressAfter(target);
-
-            if (!adjusted) {
-              // Consider the case of a non-initialized mcprep smashableMovq
-              target = reinterpret_cast<TCA>((uint64_t(target) >> 1));
-              adjusted = env.rel.adjustedAddressAfter(target);
-              if (adjusted) {
-                adjusted = reinterpret_cast<TCA>((uint64_t(adjusted) << 1) | 1);
+            if (src->Mask(LoadLiteralMask) == LDR_w_lit) {
+              auto addr = reinterpret_cast<TCA32*>(dest->LiteralAddress());
+              auto target = *addr;
+              auto adjusted =
+		env.rel.adjustedAddressAfter(reinterpret_cast<TCA>(target));
+              if (adjusted) patchInstr(reinterpret_cast<TCA>(addr),
+				       makeTCA32(adjusted));
+            } else {
+              auto addr = reinterpret_cast<TCA*>(dest->LiteralAddress());
+              auto target = *addr;
+              auto adjusted = env.rel.adjustedAddressAfter(target);
+              if (!adjusted) {
+                // Consider the case of a non-initialized mcprep smashableMovq
+                target = reinterpret_cast<TCA>((uint64_t(target) >> 1));
+                adjusted = env.rel.adjustedAddressAfter(target);
+                if (adjusted) adjusted =
+				reinterpret_cast<TCA>((uint64_t(adjusted) << 1)
+						      | 1);
+                if (adjusted) patchInstr(reinterpret_cast<TCA>(addr), adjusted);
               }
-            }
-
-            if (adjusted) {
-              *addr = adjusted;
-              auto const begin = reinterpret_cast<TCA>(addr);
-              DataBlock::syncDirect(begin, begin + 8);
             }
           } else if (src->IsMovz()) {
             int length = 1;
@@ -869,13 +874,17 @@ void adjustInstruction(RelocationInfo& rel, Instruction* instr,
    *       assert when attempting to adjust MOV/MOVK when live.
    */
   if (instr->IsLoadLiteral()) {
-    auto addr = reinterpret_cast<TCA*>(instr->LiteralAddress());
-    auto target = *addr;
-    auto adjusted = rel.adjustedAddressAfter(target);
-    if (adjusted) {
-      *addr = adjusted;
-      auto const begin = reinterpret_cast<TCA>(addr);
-      DataBlock::syncDirect(begin, begin + 2 * kInstructionSize);
+    if (instr->Mask(LoadLiteralMask) == LDR_w_lit) {
+      auto addr = reinterpret_cast<TCA32*>(instr->LiteralAddress());
+      auto target = *addr;
+      auto adjusted = rel.adjustedAddressAfter(reinterpret_cast<TCA>(target));
+      if (adjusted) patchInstr(reinterpret_cast<TCA>(addr),
+			       makeTCA32(adjusted));
+    } else {
+      auto addr = reinterpret_cast<TCA*>(instr->LiteralAddress());
+      auto target = *addr;
+      auto adjusted = rel.adjustedAddressAfter(target);
+      if (adjusted) patchInstr(reinterpret_cast<TCA>(addr), adjusted);
     }
   } else if (instr->IsMovz()) {
     const auto rd = instr->Rd();

--- a/hphp/runtime/vm/jit/service-requests.cpp
+++ b/hphp/runtime/vm/jit/service-requests.cpp
@@ -232,14 +232,14 @@ namespace arm {
   //   ADD imm
   static constexpr int kLeaVmSpLen = 4;
   // The largest of vasm setcc, copy, or leap is emitted in 16 bytes.
-  //   AND imm, MOV, LDR + B + dc64, or ADRP + ADD imm
-  static constexpr int kMovLen = 16;
+  //   AND imm, MOV, LDR + B + dc32, or ADRP + ADD imm
+  static constexpr int kMovLen = 12;
   // The largest of vasm copy or leap is emitted in 16 bytes.
-  //   MOV, LDR + B + dc64, or ADRP + ADD imm
-  static constexpr int kPersist = 16;
-  // vasm copy and jmpi is emitted in 20 bytes.
-  //   MOV and 16
-  static constexpr int kSvcReqExit = 20;
+  //   MOV, LDR + B + dc32, or ADRP + ADD imm
+  static constexpr int kPersist = 12;
+  // vasm copy and jmpi is emitted in 16 bytes.
+  //   MOV + LDR + B + dc32
+  static constexpr int kSvcReqExit = 16;
 }
 
 namespace ppc64 {

--- a/hphp/runtime/vm/jit/smashable-instr-arm.cpp
+++ b/hphp/runtime/vm/jit/smashable-instr-arm.cpp
@@ -69,6 +69,8 @@ TCA emitSmashableCmpq(CodeBlock& /*cb*/, CGMeta& /*meta*/, int32_t /*imm*/,
   not_implemented();
 }
 
+// SmashableCalls don't embed the target at the end, because the
+// BLR must be the last instruction of the sequence.
 TCA emitSmashableCall(CodeBlock& cb, CGMeta& meta, TCA target) {
   align(cb, &meta, Alignment::SmashCall, AlignContext::Live);
 
@@ -104,12 +106,12 @@ TCA emitSmashableJmp(CodeBlock& cb, CGMeta& meta, TCA target) {
   meta.smashableLocations.insert(cb.frontier());
   auto const the_start = cb.frontier();
 
-  a.    Ldr  (rAsm, &target_data);
+  a.    Ldr  (rAsm_w, &target_data);
   a.    Br   (rAsm);
 
   // Emit the jmp target into the instruction stream.
   a.    bind (&target_data);
-  a.    dc64 (target);
+  a.    dc32 (makeTCA32(target));
 
   cb.sync(the_start);
   return the_start;
@@ -137,12 +139,12 @@ TCA emitSmashableJcc(CodeBlock& cb, CGMeta& meta, TCA target,
   a.    B    (&after_data, InvertCondition(arm::convertCC(cc)));
 
   // Emit the smashable jump
-  a.    Ldr  (rAsm, &target_data);
+  a.    Ldr  (rAsm_w, &target_data);
   a.    Br   (rAsm);
 
   // Emit the jmp target into the instruction stream.
   a.    bind (&target_data);
-  a.    dc64 (target);
+  a.    dc32 (makeTCA32(target));
 
   a.    bind (&after_data);
 
@@ -193,7 +195,7 @@ bool isSmashableJmp(TCA inst) {
   const auto rd = ldr->Rd();
 
   return (ldr->IsLoadLiteral() &&
-          ldr->Mask(LoadLiteralMask) == LDR_x_lit &&
+          ldr->Mask(LoadLiteralMask) == LDR_w_lit &&
           ldr->ImmPCOffsetTarget() == target &&
           br->Mask(UnconditionalBranchToRegisterMask) == BR &&
           br->Rn() == rd);
@@ -206,13 +208,13 @@ bool isSmashableJcc(TCA inst) {
   Instruction* ldr = b->NextInstruction();;
   Instruction* br = ldr->NextInstruction();
   Instruction* target = br->NextInstruction();
-  Instruction* after = target->NextInstruction()->NextInstruction();
+  Instruction* after = target->NextInstruction();
   const auto rd = ldr->Rd();
 
   return (b->IsCondBranchImm() &&
           b->ImmPCOffsetTarget() == after &&
           ldr->IsLoadLiteral() &&
-          ldr->Mask(LoadLiteralMask) == LDR_x_lit &&
+          ldr->Mask(LoadLiteralMask) == LDR_w_lit &&
           ldr->ImmPCOffsetTarget() == target &&
           br->Mask(UnconditionalBranchToRegisterMask) == BR &&
           br->Rn() == rd);
@@ -220,17 +222,9 @@ bool isSmashableJcc(TCA inst) {
 
 ///////////////////////////////////////////////////////////////////////////////
 
-template<typename T>
-static void smashInstr(TCA inst, T target, size_t sz) {
-  *reinterpret_cast<T*>(inst + sz - 8) = target;
-  auto const end = reinterpret_cast<TCA>(inst + sz);
-  auto const begin = end - 8;
-  DataBlock::syncDirect(begin, end);
-}
-
 void smashMovq(TCA inst, uint64_t target) {
   assertx(isSmashableMovq(inst));
-  smashInstr(inst, target, smashableMovqLen());
+  patchInstr(inst + smashableMovqLen() - sizeof(target), target);
 }
 
 void smashCmpq(TCA /*inst*/, uint32_t /*target*/) {
@@ -239,26 +233,27 @@ void smashCmpq(TCA /*inst*/, uint32_t /*target*/) {
 
 void smashCall(TCA inst, TCA target) {
   assertx(isSmashableCall(inst));
-  smashInstr(inst, target, (1 * 4) + 8);
+  // Note: The target is not at the end of the smashableCall.
+  patchInstr(inst + (1 * 4), target);
 }
 
 void smashJmp(TCA inst, TCA target) {
   assertx(isSmashableJmp(inst));
-
   // If the target is within the smashable jmp, then set the target to the
   // end. This mirrors logic in x86_64 with the exception that ARM cannot
   // replace the entire smashable jmp with nops.
   if (target > inst && target - inst <= smashableJmpLen()) {
     target = inst + smashableJmpLen();
   }
-  smashInstr(inst, target, smashableJmpLen());
+  auto const t32 = makeTCA32(target);
+  patchInstr(inst + smashableJmpLen() - sizeof(t32), t32);
 }
 
 void smashJcc(TCA inst, TCA target) {
   assertx(isSmashableJcc(inst));
-
   if (smashableJccTarget(inst) != target) {
-    smashInstr(inst, target, smashableJccLen());
+    auto const t32 = makeTCA32(target);
+    patchInstr(inst + smashableJccLen() - sizeof(t32), t32);
   }
 }
 
@@ -299,7 +294,9 @@ TCA smashableJmpTarget(TCA inst) {
 
   if (isSmashableJmp(inst)) {
     assertx((reinterpret_cast<uintptr_t>(target) & 3) == 0);
-    return *reinterpret_cast<TCA*>(target);
+    const uint32_t target32 = *reinterpret_cast<uint32_t*>(target);
+    const uint64_t target64 = target32;
+    return reinterpret_cast<TCA>(target64);
   }
   return nullptr;
 }
@@ -314,7 +311,9 @@ TCA smashableJccTarget(TCA inst) {
 
   if (isSmashableJcc(inst)) {
     assertx((reinterpret_cast<uintptr_t>(target) & 3) == 0);
-    return *reinterpret_cast<TCA*>(target);
+    const uint32_t target32 = *reinterpret_cast<uint32_t*>(target);
+    const uint64_t target64 = target32;
+    return reinterpret_cast<TCA>(target64);
   }
   return nullptr;
 }
@@ -345,7 +344,9 @@ ConditionCode smashableJccCond(TCA inst) {
 TCA getSmashableFromTargetAddr(TCA addr) {
   using namespace vixl;
 
-  auto target = *reinterpret_cast<TCA*>(addr);
+  const uint32_t target32 = *reinterpret_cast<uint32_t*>(addr);
+  const uint64_t target64 = target32;
+  auto target = reinterpret_cast<TCA>(target64);
 
   auto inst = addr - 3 * kInstructionSize;
   if (smashableJccTarget(inst) == target) return inst;

--- a/hphp/runtime/vm/jit/smashable-instr-arm.h
+++ b/hphp/runtime/vm/jit/smashable-instr-arm.h
@@ -42,7 +42,7 @@ namespace arm {
 constexpr size_t smashableMovqLen() { return 2 * 4 + 8; }
 constexpr size_t smashableCmpqLen() { return 0; }
 constexpr size_t smashableCallLen() { return 4 + 8 + 2 * 4; }
-constexpr size_t smashableJmpLen()  { return 2 * 4 + 8; }
+constexpr size_t smashableJmpLen()  { return 2 * 4 + 4; }
 constexpr size_t smashableJccLen()  { return 4 + smashableJmpLen(); }
 
 TCA emitSmashableMovq(CodeBlock& cb, CGMeta& meta, uint64_t imm,
@@ -76,6 +76,22 @@ constexpr size_t kSmashJmpTargetOff = 8;
 constexpr size_t kSmashJccTargetOff = 12;
 
 ///////////////////////////////////////////////////////////////////////////////
+
+template<typename T>
+static void patchInstr(TCA inst, T target) {
+  *reinterpret_cast<T*>(inst) = target;
+  auto const end = reinterpret_cast<TCA>(inst + sizeof(T));
+  auto const begin = end - sizeof(T);
+  DataBlock::syncDirect(begin, end);
+}
+
+using TCA32 = uint32_t;
+
+template <class T>
+static uint32_t makeTCA32(T t) {
+  assertx(!(reinterpret_cast<intptr_t>(t) >> 32));
+  return static_cast<TCA32>(reinterpret_cast<intptr_t>(t));
+}
 
 }}}
 

--- a/hphp/runtime/vm/jit/smashable-instr-arm.h
+++ b/hphp/runtime/vm/jit/smashable-instr-arm.h
@@ -77,20 +77,24 @@ constexpr size_t kSmashJccTargetOff = 12;
 
 ///////////////////////////////////////////////////////////////////////////////
 
-template<typename T>
-static void patchInstr(TCA inst, T target) {
-  *reinterpret_cast<T*>(inst) = target;
-  auto const end = reinterpret_cast<TCA>(inst + sizeof(T));
-  auto const begin = end - sizeof(T);
+template <class T>
+static uint32_t makeTarget32(T target) {
+  assertx(!(reinterpret_cast<intptr_t>(target) >> 32));
+  return static_cast<uint32_t>(reinterpret_cast<intptr_t>(target));
+}
+
+static void patchTarget32(TCA inst, TCA target) {
+  *reinterpret_cast<uint32_t*>(inst) = makeTarget32(target);
+  auto const begin = inst;
+  auto const end = begin + 4;
   DataBlock::syncDirect(begin, end);
 }
 
-using TCA32 = uint32_t;
-
-template <class T>
-static uint32_t makeTCA32(T t) {
-  assertx(!(reinterpret_cast<intptr_t>(t) >> 32));
-  return static_cast<TCA32>(reinterpret_cast<intptr_t>(t));
+static void patchTarget64(TCA inst, TCA target) {
+  *reinterpret_cast<uint64_t*>(inst) = reinterpret_cast<uint64_t>(target);
+  auto const begin = inst;
+  auto const end = begin + 8;
+  DataBlock::syncDirect(begin, end);
 }
 
 }}}

--- a/hphp/runtime/vm/jit/smashable-instr-arm.h
+++ b/hphp/runtime/vm/jit/smashable-instr-arm.h
@@ -78,19 +78,19 @@ constexpr size_t kSmashJccTargetOff = 12;
 ///////////////////////////////////////////////////////////////////////////////
 
 template <class T>
-static uint32_t makeTarget32(T target) {
+inline uint32_t makeTarget32(T target) {
   assertx(!(reinterpret_cast<intptr_t>(target) >> 32));
   return static_cast<uint32_t>(reinterpret_cast<intptr_t>(target));
 }
 
-static void patchTarget32(TCA inst, TCA target) {
+inline void patchTarget32(TCA inst, TCA target) {
   *reinterpret_cast<uint32_t*>(inst) = makeTarget32(target);
   auto const begin = inst;
   auto const end = begin + 4;
   DataBlock::syncDirect(begin, end);
 }
 
-static void patchTarget64(TCA inst, TCA target) {
+inline void patchTarget64(TCA inst, TCA target) {
   *reinterpret_cast<uint64_t*>(inst) = reinterpret_cast<uint64_t>(target);
   auto const begin = inst;
   auto const end = begin + 8;

--- a/hphp/runtime/vm/jit/unique-stubs-arm.cpp
+++ b/hphp/runtime/vm/jit/unique-stubs-arm.cpp
@@ -223,7 +223,7 @@ TCA emitCallToExit(CodeBlock& cb, DataBlock& /*data*/, const UniqueStubs& us) {
   a.Ldr(rAsm_w, &target_data);
   a.Br(rAsm);
   a.bind(&target_data);
-  a.dc32(makeTCA32(us.enterTCExit));
+  a.dc32(makeTarget32(us.enterTCExit));
 
   cb.sync(begin);
   return begin;

--- a/hphp/runtime/vm/jit/unique-stubs-arm.cpp
+++ b/hphp/runtime/vm/jit/unique-stubs-arm.cpp
@@ -24,6 +24,7 @@
 #include "hphp/runtime/vm/jit/code-gen-cf.h"
 #include "hphp/runtime/vm/jit/code-gen-helpers.h"
 #include "hphp/runtime/vm/jit/code-gen-tls.h"
+#include "hphp/runtime/vm/jit/smashable-instr-arm.h"
 #include "hphp/runtime/vm/jit/translator-inline.h"
 #include "hphp/runtime/vm/jit/unique-stubs.h"
 #include "hphp/runtime/vm/jit/unwind-itanium.h"
@@ -219,10 +220,10 @@ TCA emitCallToExit(CodeBlock& cb, DataBlock& /*data*/, const UniqueStubs& us) {
   auto const begin = cb.frontier();
 
   // Jump to enterTCExit
-  a.Ldr(rAsm, &target_data);
+  a.Ldr(rAsm_w, &target_data);
   a.Br(rAsm);
   a.bind(&target_data);
-  a.dc64(us.enterTCExit);
+  a.dc32(makeTCA32(us.enterTCExit));
 
   cb.sync(begin);
   return begin;

--- a/hphp/runtime/vm/jit/vasm-arm.cpp
+++ b/hphp/runtime/vm/jit/vasm-arm.cpp
@@ -440,24 +440,18 @@ static CodeAddress toReal(Venv& env, CodeAddress a) {
 
 void Vgen::patch(Venv& env) {
   for (auto& p : env.jmps) {
-    assertx(env.addrs[p.target]);
-    // 'jmp' is 2 instructions, load followed by branch
-    auto const begin = p.instr + 2 * 4;
-    auto const block = getBlock(env, begin);
-    assertx(block);
-    auto const addr = block->toDestAddress(begin);
-    *reinterpret_cast<TCA*>(addr) = env.addrs[p.target];
-    block->sync(begin, begin + sizeof(env.addrs[p.target]));
+    auto addr = toReal(env, p.instr);
+    auto target =  makeTCA32(env.addrs[p.target]);
+    assertx(target);
+    // Patch the 32 bit target following the LDR and BR
+    patchInstr(addr + 2 * 4, target);
   }
   for (auto& p : env.jccs) {
-    assertx(env.addrs[p.target]);
-    // 'jcc' is 3 instructions, b.!cc + load followed by branch
-    auto const begin = p.instr + 3 * 4;
-    auto const block = getBlock(env, begin);
-    assertx(block);
-    auto const addr = block->toDestAddress(begin);
-    *reinterpret_cast<TCA*>(addr) = env.addrs[p.target];
-    block->sync(begin, begin + sizeof(env.addrs[p.target]));
+    auto addr = toReal(env, p.instr);
+    auto target =  makeTCA32(env.addrs[p.target]);
+    assertx(target);
+    // Patch the 32 bit target following the B.<CC>, LDR, and BR
+    patchInstr(addr + 3 * 4, target);
   }
 }
 
@@ -764,10 +758,10 @@ void Vgen::emit(const jcc& i) {
     // Emit a sequence similar to a smashable for easy patching later.
     // Static relocation might be able to simplify the branch.
     a->B(&skip, vixl::InvertCondition(C(i.cc)));
-    a->Ldr(rAsm, &data);
+    a->Ldr(rAsm_w, &data);
     a->Br(rAsm);
     a->bind(&data);
-    a->dc64(a->code().toDestAddress(a->frontier()));
+    a->dc32(makeTCA32(a->frontier()));
     a->bind(&skip);
   }
   emit(jmp{i.targets[0]});
@@ -789,10 +783,10 @@ void Vgen::emit(const jmp& i) {
 
   // Emit a sequence similar to a smashable for easy patching later.
   // Static relocation might be able to simplify the branch.
-  a->Ldr(rAsm, &data);
+  a->Ldr(rAsm_w, &data);
   a->Br(rAsm);
   a->bind(&data);
-  a->dc64(a->code().toDestAddress(a->frontier()));
+  a->dc32(makeTCA32(a->frontier()));
 }
 
 void Vgen::emit(const jmpi& i) {
@@ -806,10 +800,10 @@ void Vgen::emit(const jmpi& i) {
   } else {
     // Cannot use simple a->Mov() since such a sequence cannot be
     // adjusted while live following a relocation.
-    a->Ldr(rAsm, &data);
+    a->Ldr(rAsm_w, &data);
     a->Br(rAsm);
     a->bind(&data);
-    a->dc64(i.target);
+    a->dc32(makeTCA32(i.target));
   }
 }
 
@@ -830,10 +824,10 @@ void Vgen::emit(const leap& i) {
 
   // Cannot use simple a->Mov() since such a sequence cannot be
   // adjusted while live following a relocation.
-  a->Ldr(X(i.d), &imm_data);
+  a->Ldr(W(i.d), &imm_data);
   a->B(&after_data);
   a->bind(&imm_data);
-  a->dc64(i.s.r.disp);
+  a->dc32(makeTCA32(i.s.r.disp));
   a->bind(&after_data);
 }
 

--- a/hphp/runtime/vm/jit/vasm-arm.cpp
+++ b/hphp/runtime/vm/jit/vasm-arm.cpp
@@ -441,17 +441,17 @@ static CodeAddress toReal(Venv& env, CodeAddress a) {
 void Vgen::patch(Venv& env) {
   for (auto& p : env.jmps) {
     auto addr = toReal(env, p.instr);
-    auto target =  makeTCA32(env.addrs[p.target]);
+    auto target = env.addrs[p.target];
     assertx(target);
     // Patch the 32 bit target following the LDR and BR
-    patchInstr(addr + 2 * 4, target);
+    patchTarget32(addr + 2 * 4, target);
   }
   for (auto& p : env.jccs) {
     auto addr = toReal(env, p.instr);
-    auto target =  makeTCA32(env.addrs[p.target]);
-    assertx(target);
+    auto target = env.addrs[p.target];
+    assertx(p.target);
     // Patch the 32 bit target following the B.<CC>, LDR, and BR
-    patchInstr(addr + 3 * 4, target);
+    patchTarget32(addr + 3 * 4, target);
   }
 }
 
@@ -761,7 +761,7 @@ void Vgen::emit(const jcc& i) {
     a->Ldr(rAsm_w, &data);
     a->Br(rAsm);
     a->bind(&data);
-    a->dc32(makeTCA32(a->frontier()));
+    a->dc32(makeTarget32(a->frontier()));
     a->bind(&skip);
   }
   emit(jmp{i.targets[0]});
@@ -786,7 +786,7 @@ void Vgen::emit(const jmp& i) {
   a->Ldr(rAsm_w, &data);
   a->Br(rAsm);
   a->bind(&data);
-  a->dc32(makeTCA32(a->frontier()));
+  a->dc32(makeTarget32(a->frontier()));
 }
 
 void Vgen::emit(const jmpi& i) {
@@ -803,7 +803,7 @@ void Vgen::emit(const jmpi& i) {
     a->Ldr(rAsm_w, &data);
     a->Br(rAsm);
     a->bind(&data);
-    a->dc32(makeTCA32(i.target));
+    a->dc32(makeTarget32(i.target));
   }
 }
 
@@ -827,7 +827,7 @@ void Vgen::emit(const leap& i) {
   a->Ldr(W(i.d), &imm_data);
   a->B(&after_data);
   a->bind(&imm_data);
-  a->dc32(makeTCA32(i.s.r.disp));
+  a->dc32(makeTarget32(i.s.r.disp));
   a->bind(&after_data);
 }
 

--- a/hphp/vixl/a64/assembler-a64.cc
+++ b/hphp/vixl/a64/assembler-a64.cc
@@ -1100,10 +1100,15 @@ void Assembler::str(const CPURegister& rt, const MemOperand& src) {
 
 
 void Assembler::ldr(const Register& rt, Label* label) {
-  assert(rt.Is64Bits());
-  Emit(LDR_x_lit
-       | ImmLLiteral(UpdateAndGetInstructionOffsetTo(label))
-       | Rt(rt));
+  if (rt.Is64Bits()) {
+    Emit(LDR_x_lit
+         | ImmLLiteral(UpdateAndGetInstructionOffsetTo(label))
+         | Rt(rt));
+  } else {
+    Emit(LDR_w_lit
+         | ImmLLiteral(UpdateAndGetInstructionOffsetTo(label))
+         | Rt(rt));
+  }
 }
 
 


### PR DESCRIPTION
Smashable jmps/jccs and patchable jmps/jccs embed the target in
the instruction stream. When using low memory for the translation
cache, those targets only need to use 32 bits to store the TCA as
a literal in the instruction stream. This reduces D$ pressure.