### PR TITLE
Add lazy stat and readlink function

### DIFF
--- a/hphp/runtime/ext/fb/ext_fb.cpp
+++ b/hphp/runtime/ext/fb/ext_fb.cpp
@@ -1158,6 +1158,13 @@ static Variant do_lazy_stat(Function dostat, const String& filename) {
   return stat_impl(&sb);
 }
 
+Variant HHVM_FUNCTION(fb_lazy_stat, const String& filename) {
+  if (!FileUtil::checkPathAndWarn(filename, __FUNCTION__ + 2, 1)) {
+    return false;
+  }
+  return do_lazy_stat(StatCache::stat, filename);
+}
+
 Variant HHVM_FUNCTION(fb_lazy_lstat, const String& filename) {
   if (!FileUtil::checkPathAndWarn(filename, __FUNCTION__ + 2, 1)) {
     return false;
@@ -1171,6 +1178,14 @@ Variant HHVM_FUNCTION(fb_lazy_realpath, const String& filename) {
   }
 
   return StatCache::realpath(filename.c_str());
+}
+
+Variant HHVM_FUNCTION(fb_lazy_readlink, const String& filename) {
+  if (!FileUtil::checkPathAndWarn(filename, __FUNCTION__ + 2, 1)) {
+    return false;
+  }
+
+  return StatCache::readlink(filename.c_str());
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1210,8 +1225,10 @@ struct FBExtension : Extension {
     HHVM_FE(fb_output_compression);
     HHVM_FE(fb_set_exit_callback);
     HHVM_FE(fb_get_last_flush_size);
+    HHVM_FE(fb_lazy_stat);
     HHVM_FE(fb_lazy_lstat);
     HHVM_FE(fb_lazy_realpath);
+    HHVM_FE(fb_lazy_readlink);
     HHVM_FE(fb_call_user_func_safe);
     HHVM_FE(fb_call_user_func_safe_return);
     HHVM_FE(fb_call_user_func_array_safe);

--- a/hphp/runtime/ext/fb/ext_fb.h
+++ b/hphp/runtime/ext/fb/ext_fb.h
@@ -49,8 +49,10 @@ Variant HHVM_FUNCTION(fb_disable_code_coverage);
 bool HHVM_FUNCTION(fb_output_compression, bool new_value);
 void HHVM_FUNCTION(fb_set_exit_callback, const Variant& function);
 int64_t HHVM_FUNCTION(fb_get_last_flush_size);
+Variant HHVM_FUNCTION(fb_lazy_stat, const String& filename);
 Variant HHVM_FUNCTION(fb_lazy_lstat, const String& filename);
 Variant HHVM_FUNCTION(fb_lazy_realpath, const String& filename);
+Variant HHVM_FUNCTION(fb_lazy_readlink, const String& filename);
 
 Array HHVM_FUNCTION(fb_call_user_func_safe,
                     const Variant& function,

--- a/hphp/runtime/ext/fb/ext_fb.php
+++ b/hphp/runtime/ext/fb/ext_fb.php
@@ -179,6 +179,15 @@ function fb_set_exit_callback(mixed $function): void;
 <<__HipHopSpecific, __Native>>
 function fb_get_last_flush_size(): int;
 
+/* Gathers the statistics of the file named by filename, like stat(), except
+ * uses cached information from an internal inotify-based mechanism that may
+ * not be updated during the duration of a request.
+ * @param string $filename - Path to a file or a symbolic link.
+ * @return mixed - Same format as the normal php stat() function.
+ */
+<<__Native>>
+function fb_lazy_stat(string $filename): mixed;
+
 /* Gathers the statistics of the file named by filename, like lstat(), except
  * uses cached information from an internal inotify-based mechanism that may
  * not be updated during the duration of a request.
@@ -197,6 +206,15 @@ function fb_lazy_lstat(string $filename): mixed;
  */
 <<__Native>>
 function fb_lazy_realpath(string $filename): mixed;
+
+/* Returns the contents of the symbolic link path, like realpath(), 
+ * except uses cached information from an internal inotify-based mechanism 
+ * that may not be updated during the duration of a request.
+ * @param string $filename - The symbolic link path.
+ * @return string - Returns the contents of the symbolic link path.
+ */
+<<__Native>>
+function fb_lazy_readlink(string $filename): mixed;
 
 /* This function invokes $function with the arguments specified in its
  * parameter list. It returns an array of two elements, the first being a

--- a/hphp/test/slow/ext_fb/fb_lazy.php
+++ b/hphp/test/slow/ext_fb/fb_lazy.php
@@ -1,0 +1,13 @@
+<?php
+
+$stat = fb_lazy_stat(__FILE__);
+var_dump($stat == stat(__FILE__));
+
+$lstat = fb_lazy_lstat(__FILE__);
+var_dump($lstat == lstat(__FILE__));
+
+$path = fb_lazy_realpath(__FILE__);
+var_dump($path == realpath(__FILE__));
+
+$path = fb_lazy_readlink(__FILE__);
+var_dump($path == readlink(__FILE__));

--- a/hphp/test/slow/ext_fb/fb_lazy.php.expectf
+++ b/hphp/test/slow/ext_fb/fb_lazy.php.expectf
@@ -1,0 +1,6 @@
+bool(true)
+bool(true)
+bool(true)
+
+Warning: readlink(): No such file or directory %s/fb_lazy.php in %s/fb_lazy.php on line 13
+bool(true)

--- a/hphp/test/slow/ext_fb/fb_null_byte.php
+++ b/hphp/test/slow/ext_fb/fb_null_byte.php
@@ -4,3 +4,5 @@ $file = '/etc/passwd'.chr(0).'asdf';
 
 var_dump(fb_lazy_lstat($file));
 var_dump(fb_lazy_realpath($file));
+var_dump(fb_lazy_stat($file));
+var_dump(fb_lazy_readlink($file));

--- a/hphp/test/slow/ext_fb/fb_null_byte.php.expectf
+++ b/hphp/test/slow/ext_fb/fb_null_byte.php.expectf
@@ -4,3 +4,9 @@ bool(false)
 
 Warning: fb_lazy_realpath() expects parameter 1 to be a valid path, string given in %s/test/slow/ext_fb/fb_null_byte.php on line 6
 bool(false)
+
+Warning: fb_lazy_stat() expects parameter 1 to be a valid path, string given in %s/test/slow/ext_fb/fb_null_byte.php on line 7
+bool(false)
+
+Warning: fb_lazy_readlink() expects parameter 1 to be a valid path, string given in %s/test/slow/ext_fb/fb_null_byte.php on line 8
+bool(false)


### PR DESCRIPTION
Change-Id: Ifd99d64466657e0c0d0517312835fa8b0e173f2e

Add fb_lazy_stat() and fb_lazy_readlink() function, for faster access to file system information.