### PR TITLE
Fix DateTime constructor arguments

### DIFF
--- a/hphp/hack/hhi/stdlib/builtins_datetime.hhi
+++ b/hphp/hack/hhi/stdlib/builtins_datetime.hhi
@@ -100,7 +100,7 @@ class DateTime implements DateTimeInterface {
   const RFC3339 = '';
   const RSS = '';
   const W3C = '';
-  public function __construct(mixed $time = 'now', ?DateTimeZone $timezone = null);
+  public function __construct(string $time = 'now', ?DateTimeZone $timezone = null);
   public function add(DateInterval $interval);
   public function modify(string $modify);
   public function getOffset();


### PR DESCRIPTION
According to php documentation, first DateTime argument is a
nullable string, not mixed.  Update the prototype accordingly
so that non-strings passed into DateTime constructor will be
flagged by typechecker.