### PR TITLE
Fix smashable instructions in PPC64

### DIFF
--- a/hphp/ppc64-asm/asm-ppc64.cpp
+++ b/hphp/ppc64-asm/asm-ppc64.cpp
@@ -39,7 +39,7 @@ VMTOC::~VMTOC() {
 
 int64_t VMTOC::pushElem(int64_t elem, bool elemMayChange) {
   int64_t offset;
-  if(elemMayChange) {
+  if (elemMayChange) {
     offset = allocTOC(elem);
   }
   else {

--- a/hphp/ppc64-asm/asm-ppc64.h
+++ b/hphp/ppc64-asm/asm-ppc64.h
@@ -268,7 +268,6 @@ public:
   int64_t getIndex(uint64_t elem);
 
 private:
-  //int64_t allocTOC (int32_t target, bool align = false);
   int64_t allocTOC (int64_t target);
   void forceAlignment(HPHP::Address& addr);
 

--- a/hphp/ppc64-asm/decoded-instr-ppc64.cpp
+++ b/hphp/ppc64-asm/decoded-instr-ppc64.cpp
@@ -452,7 +452,7 @@ int64_t DecodedInstruction::decodeTOCOffset() const {
 bool DecodedInstruction::isSmashable(uint64_t elem) const {
   auto elemOffset = decodeTOCOffset();
   auto offset = VMTOC::getInstance().getIndex(elem);
-  return offset!=elemOffset;
+  return offset != elemOffset;
 }
 
 bool DecodedInstruction::fitsOnNearBranch(ptrdiff_t diff, bool uncond) const {
@@ -469,10 +469,7 @@ bool DecodedInstruction::isLimmediatePossible() const {
 }
 
 bool DecodedInstruction::isLoadingTOC() const {
-  if (m_dinfo.isLd(true) || m_dinfo.isLwz(true) || m_dinfo.isAddis(true)) {
-    return true;
-  }
-  return false;
+  return m_dinfo.isLd(true) || m_dinfo.isLwz(true) || m_dinfo.isAddis(true);
 }
 
 bool DecodedInstruction::isLi64Possible() const {

--- a/hphp/ppc64-asm/decoded-instr-ppc64.cpp
+++ b/hphp/ppc64-asm/decoded-instr-ppc64.cpp
@@ -75,13 +75,7 @@ bool DecodedInstruction::setImmediate(int64_t value) {
   HPHP::CodeCursor cursor { cb, m_ip };
   Assembler a{ cb };
 
-  a.limmediate(getLimmediateReg(), ssize_t(value),
-#ifdef USE_TOC_ON_BRANCH
-      ImmType::TocOnly
-#else
-      ImmType::AnyFixed
-#endif
-      );
+  a.limmediate(getLimmediateReg(), ssize_t(value), ImmType::TocOnly);
 
   // refresh m_imm and other parameters
   decode();
@@ -135,13 +129,7 @@ void DecodedInstruction::widenBranch(uint8_t* target) {
     cb.init(m_ip, block_size, "widenBranch relocation");
     HPHP::CodeCursor cursor { cb, m_ip };
     Assembler a { cb };
-    a.branchFar(target, bp,
-#ifdef USE_TOC_ON_BRANCH
-      ImmType::TocOnly
-#else
-      ImmType::AnyFixed
-#endif
-      );
+    a.branchFar(target, bp, ImmType::TocOnly, true);
 
     // refresh m_size and other parameters
     decode();
@@ -194,12 +182,14 @@ DecInfoOffset DecodedInstruction::getFarBranchLength(AllowCond ac) const {
     auto far_branch_instr = m_ip + ret.m_offset;
     ret.m_di = Decoder::GetDecoder().decode(far_branch_instr);
     if (ret.m_di.isRegisterBranch(ac)) return ret;
+    // If branch instruction found, stop searching.
+    if (ret.m_di.isRegisterBranch(AllowCond::Any)) break;
   }
   return DecInfoOffset();
 }
 
 bool DecodedInstruction::setFarBranchTarget(uint8_t* target,
-                                            bool /*smashable*/) {
+                                            bool smashable) {
   DecoderInfo di = getFarBranch();
   if (di.isInvalid()) return false;
 
@@ -210,13 +200,7 @@ bool DecodedInstruction::setFarBranchTarget(uint8_t* target,
   HPHP::CodeBlock cb;
   cb.init(m_ip, block_size, "setFarBranchTarget");
   Assembler a{ cb };
-  a.branchFar(target, bp,
-#ifdef USE_TOC_ON_BRANCH
-      ImmType::TocOnly
-#else
-      ImmType::AnyFixed
-#endif
-      );
+  a.branchFar(target, bp, ImmType::TocOnly, smashable);
 
   // Check if something was overwritten
   if ((a.frontier() - m_ip) > m_size) {
@@ -297,6 +281,12 @@ void DecodedInstruction::decode() {
   }
 }
 
+int64_t DecodedInstruction::calcIndex (int16_t indexBigTOC, 
+                                       int16_t indexTOC) const {
+  return static_cast<int64_t>(static_cast<int64_t>(indexTOC) +
+static_cast<int64_t>(indexBigTOC << 16));
+}
+
 /*
  * Reads back the immediate when emmited with (without nops) and return the
  * number of bytes read for this immediate decoding.
@@ -305,11 +295,6 @@ uint8_t DecodedInstruction::decodeImm() {
   // Functions that detect if @dinfo is exactly the instructions flavor that
   // our limmediate uses. Also the target register to be modified has to be
   // the same.
-
-  auto calcIndex = [&](int16_t indexBigTOC, int16_t indexTOC) {
-    return static_cast<int64_t>(static_cast<int64_t>(indexTOC) +
-              static_cast<int64_t>(indexBigTOC << 16));
-  };
 
   if (m_dinfo.isLd(true)) {
     m_imm = VMTOC::getInstance().getValue(calcIndex(0, m_dinfo.offsetDS()),
@@ -425,6 +410,51 @@ uint8_t DecodedInstruction::decodeImm() {
   return bytes_read;
 }
 
+uint64_t* DecodedInstruction::decodeTOCAddress() const{
+ if (m_dinfo.isLd(true)) {
+    return VMTOC::getInstance().getAddr(calcIndex(0, m_dinfo.offsetDS()));
+  } else if (m_dinfo.isLwz(true)) {
+    return VMTOC::getInstance().getAddr(calcIndex(0, m_dinfo.offsetD()));
+  } else if (m_dinfo.isAddis(true)) {
+    auto bigIndexTOC = m_dinfo.offsetD();
+    // Get next instruction
+    auto di = Decoder::GetDecoder().decode(m_ip+4);
+    if (di.isLd()) {
+      return VMTOC::getInstance().getAddr(calcIndex(bigIndexTOC,
+          di.offsetDS()));
+    } else if (di.isLwz()) {
+      return VMTOC::getInstance().getAddr(calcIndex(bigIndexTOC,
+          di.offsetD()));
+    }
+  }
+  return 0;
+}
+
+int64_t DecodedInstruction::decodeTOCOffset() const {
+ if (m_dinfo.isLd(true)) {
+    return calcIndex(0, m_dinfo.offsetDS());
+  } else if (m_dinfo.isLwz(true)) {
+    return calcIndex(0, m_dinfo.offsetD());
+  } else if (m_dinfo.isAddis(true)) {
+    auto bigIndexTOC = m_dinfo.offsetD();
+    // Get next instruction
+    auto di = Decoder::GetDecoder().decode(m_ip+4);
+    if (di.isLd()) {
+      return calcIndex(bigIndexTOC, di.offsetDS());
+    } else if (di.isLwz()) {
+      return calcIndex(bigIndexTOC, di.offsetD());
+    }
+  }
+  return 0;
+
+}
+
+bool DecodedInstruction::isSmashable(uint64_t elem) const {
+  auto elemOffset = decodeTOCOffset();
+  auto offset = VMTOC::getInstance().getIndex(elem);
+  return offset!=elemOffset;
+}
+
 bool DecodedInstruction::fitsOnNearBranch(ptrdiff_t diff, bool uncond) const {
   // is it b or bc? b can use offsets up to 26bits and bc only 16bits
   auto bitsize = uncond ? 26 : 16;
@@ -436,6 +466,13 @@ bool DecodedInstruction::isLimmediatePossible() const {
     return true;
   }
   return isLi64Possible();
+}
+
+bool DecodedInstruction::isLoadingTOC() const {
+  if (m_dinfo.isLd(true) || m_dinfo.isLwz(true) || m_dinfo.isAddis(true)) {
+    return true;
+  }
+  return false;
 }
 
 bool DecodedInstruction::isLi64Possible() const {

--- a/hphp/ppc64-asm/decoded-instr-ppc64.h
+++ b/hphp/ppc64-asm/decoded-instr-ppc64.h
@@ -114,6 +114,18 @@ struct DecodedInstruction {
   // Retrieve the register used by li32 instruction
   HPHP::jit::Reg64 getLi32Reg() const { return getLi64Reg(); }
 
+  // Check if is loading data from TOC
+  bool isLoadingTOC() const;
+
+  // Return the TOC addres of the immediate
+  uint64_t* decodeTOCAddress() const;
+
+  // Return the TOC offset of the immediate
+  int64_t decodeTOCOffset() const;
+
+  // Check if immediate is smashable (must not have reference).
+  bool isSmashable(uint64_t imm) const;
+
 private:
   // Initialize m_dinfo and m_size up to m_max_size
   void decode();
@@ -128,6 +140,9 @@ private:
   // Check if m_ip points to the beginning of a limmediate instruction (relaxed
   // constraint, only checks a part of it)
   bool isLimmediatePossible() const;
+
+  // Calculate the TOC index
+  int64_t calcIndex (int16_t indexBigTOC, int16_t indexTOC) const;
 
   uint8_t* m_ip;
   int64_t m_imm;

--- a/hphp/runtime/vm/jit/smashable-instr-ppc64.cpp
+++ b/hphp/runtime/vm/jit/smashable-instr-ppc64.cpp
@@ -49,7 +49,7 @@ using ppc64_asm::DecodedInstruction;
 
 TCA emitSmashableMovq(CodeBlock& cb, CGMeta& fixups, uint64_t imm,
                       PhysReg d) {
-  return EMIT_BODY(cb, fixups, limmediate, d, imm, ImmType::TocOnly);
+  return EMIT_BODY(cb, fixups, limmediate, d, imm, ImmType::TocOnly, true);
 }
 
 TCA emitSmashableCmpq(CodeBlock& cb, CGMeta& fixups, int32_t imm,
@@ -60,7 +60,7 @@ TCA emitSmashableCmpq(CodeBlock& cb, CGMeta& fixups, int32_t imm,
 
   // don't use cmpqim because of smashableCmpqImm implementation. A "load 32bits
   // immediate" is mandatory
-  a.limmediate (rfuncln(), imm, ImmType::TocOnly);
+  a.limmediate (rfuncln(), imm, ImmType::TocOnly, true);
   a.lwz  (rAsm, r[disp]); // base + displacement
   a.extsw(rAsm, rAsm);
   a.cmpd (rfuncln(), rAsm);
@@ -73,13 +73,15 @@ TCA emitSmashableCall(CodeBlock& cb, CGMeta& fixups, TCA target,
 }
 
 TCA emitSmashableJmp(CodeBlock& cb, CGMeta& fixups, TCA target) {
-  return EMIT_BODY(cb, fixups, branchFar, target);
+  return EMIT_BODY(cb, fixups, branchFar, target, ppc64_asm::BranchConditions::Always,
+                   ppc64_asm::LinkReg::DoNotTouch, ppc64_asm::ImmType::TocOnly, true);
 }
 
 TCA emitSmashableJcc(CodeBlock& cb, CGMeta& fixups, TCA target,
                      ConditionCode cc) {
   assertx(cc != CC_None);
-  return EMIT_BODY(cb, fixups, branchFar, target, cc);
+  return EMIT_BODY(cb, fixups, branchFar, target, cc, ppc64_asm::LinkReg::DoNotTouch,
+                   ppc64_asm::ImmType::TocOnly, true);
 }
 
 #undef EMIT_BODY
@@ -87,60 +89,43 @@ TCA emitSmashableJcc(CodeBlock& cb, CGMeta& fixups, TCA target,
 ///////////////////////////////////////////////////////////////////////////////
 
 void smashMovq(TCA inst, uint64_t imm) {
-  CodeBlock cb;
-  // Initialize code block cb pointing to li64
-  cb.init(inst, Assembler::kLi64Len, "smashing Movq");
-  CodeCursor cursor { cb, inst };
-  Assembler a { cb };
-
+  // Smash TOC value
   const DecodedInstruction di(inst);
-  Reg64 reg = di.getLimmediateReg();
-
-  a.limmediate(reg, imm, ImmType::TocOnly);
+  assertx(di.isLoadingTOC() && di.isSmashable(imm));
+  uint64_t* imm_address = di.decodeTOCAddress();
+  *imm_address = imm;
 }
 
 void smashCmpq(TCA inst, uint32_t imm) {
-  auto& cb = tc::code().blockFor(inst);
-  CodeCursor cursor { cb, inst };
-  Assembler a { cb };
-
-  // the first instruction is a vasm ldimml, which is a li32
+  // Smash TOC value
   const DecodedInstruction di(inst);
-  Reg64 reg = di.getLimmediateReg();
-
-  a.limmediate(reg, imm, ImmType::TocOnly);
+  assertx(di.isLoadingTOC() && di.isSmashable(imm));
+  uint64_t* imm_address = di.decodeTOCAddress();
+  *imm_address = imm;
 }
 
 void smashCall(TCA inst, TCA target) {
-  auto& cb = tc::code().blockFor(inst);
-  CodeCursor cursor { cb, inst };
-  Assembler a { cb };
-
+  // Smash TOC value
   const DecodedInstruction di(inst);
-  if (!di.isCall()) {
-    always_assert(false && "smashCall has unexpected block");
-  }
-
-  a.setFrontier(inst);
-
-  a.limmediate(rfuncentry(), reinterpret_cast<uint64_t>(target),
-      ImmType::TocOnly);
+  assertx(di.isLoadingTOC() && di.isSmashable(reinterpret_cast<uint64_t>(target)));
+  uint64_t* imm_address = di.decodeTOCAddress();
+  *imm_address = reinterpret_cast<uint64_t>(target);
 }
 
 void smashJmp(TCA inst, TCA target) {
-  auto& cb = tc::code().blockFor(inst);
-  CodeCursor cursor { cb, inst };
-  Assembler a { cb };
-
-  if (target > inst && target - inst <= smashableJmpLen()) {
-    a.emitNop(target - inst);
-  } else {
-    a.branchFar(target);
-  }
+  // Smash TOC value
+  const DecodedInstruction di(inst);
+  assertx(di.isLoadingTOC() && di.isSmashable(reinterpret_cast<uint64_t>(target)));
+  uint64_t* imm_address = di.decodeTOCAddress();
+  if(imm_address) *imm_address = reinterpret_cast<uint64_t>(target);
 }
 
 void smashJcc(TCA inst, TCA target) {
-  Assembler::patchBranch(inst, target);
+  // Smash TOC value
+  const DecodedInstruction di(inst);
+  assertx(di.isLoadingTOC() && di.isSmashable(reinterpret_cast<uint64_t>(target)));
+  uint64_t* imm_address = di.decodeTOCAddress();
+  *imm_address = reinterpret_cast<uint64_t>(target);
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/hphp/runtime/vm/jit/smashable-instr-ppc64.cpp
+++ b/hphp/runtime/vm/jit/smashable-instr-ppc64.cpp
@@ -73,14 +73,17 @@ TCA emitSmashableCall(CodeBlock& cb, CGMeta& fixups, TCA target,
 }
 
 TCA emitSmashableJmp(CodeBlock& cb, CGMeta& fixups, TCA target) {
-  return EMIT_BODY(cb, fixups, branchFar, target, ppc64_asm::BranchConditions::Always,
-                   ppc64_asm::LinkReg::DoNotTouch, ppc64_asm::ImmType::TocOnly, true);
+  return EMIT_BODY(cb, fixups, branchFar, target,
+                   ppc64_asm::BranchConditions::Always,
+                   ppc64_asm::LinkReg::DoNotTouch,
+                   ppc64_asm::ImmType::TocOnly, true);
 }
 
 TCA emitSmashableJcc(CodeBlock& cb, CGMeta& fixups, TCA target,
                      ConditionCode cc) {
   assertx(cc != CC_None);
-  return EMIT_BODY(cb, fixups, branchFar, target, cc, ppc64_asm::LinkReg::DoNotTouch,
+  return EMIT_BODY(cb, fixups, branchFar, target, cc,
+                   ppc64_asm::LinkReg::DoNotTouch,
                    ppc64_asm::ImmType::TocOnly, true);
 }
 
@@ -107,7 +110,8 @@ void smashCmpq(TCA inst, uint32_t imm) {
 void smashCall(TCA inst, TCA target) {
   // Smash TOC value
   const DecodedInstruction di(inst);
-  assertx(di.isLoadingTOC() && di.isSmashable(reinterpret_cast<uint64_t>(target)));
+  assertx(di.isLoadingTOC() &&
+          di.isSmashable(reinterpret_cast<uint64_t>(target)));
   uint64_t* imm_address = di.decodeTOCAddress();
   *imm_address = reinterpret_cast<uint64_t>(target);
 }
@@ -115,15 +119,17 @@ void smashCall(TCA inst, TCA target) {
 void smashJmp(TCA inst, TCA target) {
   // Smash TOC value
   const DecodedInstruction di(inst);
-  assertx(di.isLoadingTOC() && di.isSmashable(reinterpret_cast<uint64_t>(target)));
+  assertx(di.isLoadingTOC() &&
+          di.isSmashable(reinterpret_cast<uint64_t>(target)));
   uint64_t* imm_address = di.decodeTOCAddress();
-  if(imm_address) *imm_address = reinterpret_cast<uint64_t>(target);
+  if (imm_address) *imm_address = reinterpret_cast<uint64_t>(target);
 }
 
 void smashJcc(TCA inst, TCA target) {
   // Smash TOC value
   const DecodedInstruction di(inst);
-  assertx(di.isLoadingTOC() && di.isSmashable(reinterpret_cast<uint64_t>(target)));
+  assertx(di.isLoadingTOC() &&
+          di.isSmashable(reinterpret_cast<uint64_t>(target)));
   uint64_t* imm_address = di.decodeTOCAddress();
   *imm_address = reinterpret_cast<uint64_t>(target);
 }

--- a/hphp/runtime/vm/jit/vasm-ppc64.cpp
+++ b/hphp/runtime/vm/jit/vasm-ppc64.cpp
@@ -262,12 +262,7 @@ struct Vgen {
     a.lxvd2x(i.d, p);
   }
   void emit(const leap& i) {
-    // It can happen that when rellocating, the TOC will need to store the new
-    // pointer and it doesn't fit on a single instruction as the TOC is too big
-    // now. Therefore, emit this limmediate as fixed_size to avoid overlapping.
-    bool toc_may_grow = RuntimeOption::EvalJitRelocationSize != 0;
-    auto imm_type = toc_may_grow ? ImmType::TocOnly : ImmType::AnyCompact;
-    a.limmediate(i.d, i.s.r.disp, imm_type);
+    a.limmediate(i.d, i.s.r.disp, ImmType::TocOnly, true);
   }
   void emit(const lead& i) { a.limmediate(i.d, (int64_t)i.s.get()); }
   void emit(const mflr& i) { a.mflr(i.d); }
@@ -556,15 +551,12 @@ void Vgen::emit(const ldimml& i) {
 }
 
 void Vgen::emit(const ldimmq& i) {
-  // See leap to better understand the necessity of toc_may_grow
-  bool toc_may_grow = RuntimeOption::EvalJitRelocationSize != 0;
-  auto imm_type = toc_may_grow ? ImmType::TocOnly : ImmType::AnyCompact;
   auto val = i.s.q();
   if (i.d.isGP()) {
-    a.limmediate(i.d, val, imm_type);
+    a.limmediate(i.d, val, ImmType::TocOnly, true);
   } else {
     assertx(i.d.isSIMD());
-    a.limmediate(rAsm, val, imm_type);
+    a.limmediate(rAsm, val, ImmType::TocOnly, true);
     // no conversion necessary. The i.s already comes converted to FP
     emit(copy{rAsm, i.d});
   }


### PR DESCRIPTION
Currently on PPC64 architecture all immediate are loaded using up to 5
instructions, which makes the read not atomic.
The smashable instructions may have its immediate changed on the fly, i.e.,
while running or re-emitting the JITted code, which causes race condition,
if reading the immediate is composed with more than one instruction.
The race condition happen at two different moments:

1. The JITted code is being executed and the pipeline stop reading the
instructions group that reads the immediate in the middle (thread
preemption), then another thread smashes the instruction that uses the same
immediate.

2. The Decoder is reading the immediate used in a smashable instruction and
this thread stop being executed (thread preemption), then another thread
smashes the instruction that uses the same immediate.

For the reason above, this PR is being sent to enable the concept of TOC
(Table Of Contents) in the JITted code, where all immediate are save in
the "TOC" area, keeping the entire value in a slot of 64 bits, making the
read/write atomic, as only one operation is needed.
The TOC memory is an vector, where the pointer to it will be placed in the
R2 register, using up to two instructions to calculate its offset, which
keeps fixed, as only the position is TOC memory is changes when smashing.