### PR TITLE
Extend register sign using VASM for PPC64

### DIFF
--- a/hphp/runtime/vm/jit/vasm-ppc64.cpp
+++ b/hphp/runtime/vm/jit/vasm-ppc64.cpp
@@ -1008,11 +1008,10 @@ X(addlm, addl, loadw, storew, ONE(s0))
 #define X(vasm_src, vasm_dst_reg, vasm_dst_imm, vasm_load)              \
 void lowerForPPC64(const VLS& e, Vout& v, vasm_src& inst) {             \
   Vptr p = inst.s1;                                                     \
-  Vreg tmp; if (!e.allow_vreg()) tmp = Vreg(PhysReg(rAsm));             \
+  Vreg tmp;                                                             \
   Vreg tmp2 = e.allow_vreg() ? v.makeReg() : Vreg(PhysReg(rAsm));       \
   v << vasm_load{p, tmp2};                                              \
-  if (patchImm(inst.s0, v, tmp))                                        \
-    v << vasm_dst_reg{tmp, tmp2, inst.sf};                              \
+  if (patchImm(inst.s0, v, tmp)) v << vasm_dst_reg{tmp, tmp2, inst.sf}; \
   else v << vasm_dst_imm{inst.s0, tmp2, inst.sf};                       \
 }
 
@@ -1025,13 +1024,12 @@ X(testqim, testq, testqi, load)
 #define X(vasm_src, vasm_dst_reg, vasm_dst_imm, vasm_load, vasm_exts)   \
 void lowerForPPC64(const VLS& e, Vout& v, vasm_src& inst) {             \
   Vptr p = inst.s1;                                                     \
-  Vreg tmp; if (!e.allow_vreg()) tmp = Vreg(PhysReg(rAsm));             \
-  Vreg tmp2 = e.allow_vreg() ? v.makeReg() : Vreg(PhysReg(rAsm));       \
+  Vreg tmp;                                                             \
+  Vreg tmp2 = v.makeReg();                                              \
   Vreg tmp3 = v.makeReg();                                              \
   v << vasm_load{p, tmp2};                                              \
   v << vasm_exts{tmp2, tmp3};                                           \
-  if (patchImm(inst.s0, v, tmp))                                        \
-    v << vasm_dst_reg{tmp, tmp3, inst.sf};                              \
+  if (patchImm(inst.s0, v, tmp)) v << vasm_dst_reg{tmp, tmp3, inst.sf}; \
   else v << vasm_dst_imm{inst.s0, tmp3, inst.sf};                       \
 }
 
@@ -1137,8 +1135,9 @@ X(testli, testqi, extsl,  NONE)
 #define X(vasm_src, vasm_dst_reg, operands)                             \
 void lowerForPPC64(const VLS& e, Vout& v, vasm_src& inst) {             \
   Vreg tmp;                                                             \
-  if (patchImm(inst.s0, v, tmp))                                        \
+  if (patchImm(inst.s0, v, tmp)){                                       \
     v << vasm_dst_reg{tmp, operands inst.sf};                           \
+  }                                                                     \
 }
 
 X(andqi, andq, TWO(s1, d))


### PR DESCRIPTION
The VASMs ```loadw``` and ```loadl``` was implicity extending the sign when
emitting the instruction. It was creating invalid VASM sequences, as right
after a ```loadw``` may appear a ```cmpq```, which uses different register sizes.
Another inconsistency was the ```loadb``` VASM instruction, which for ```PPC64``` by
default is not signed. When loading a byte and comparing with another
value, the invalid VASM sequence ```loadb```; ```cmpq``` was being created. It was
fixed lowering the ```loadb``` instruction to ```loadzbq```, in order to explicitly
extend the size.