### PR TITLE
Reflection: Fix nullable types  when in PHP7 scalar type mode

### DIFF
--- a/hphp/runtime/ext/reflection/ext_reflection.cpp
+++ b/hphp/runtime/ext/reflection/ext_reflection.cpp
@@ -821,6 +821,13 @@ static int64_t HHVM_METHOD(ReflectionFunctionAbstract, getNumberOfParameters) {
   return func->numParams();
 }
 
+// If we are in <?php and in PHP 7 mode w.r.t. scalar types
+ALWAYS_INLINE static bool isPhpTypeHintEnabled(const Func* func) {
+  return (!(func->unit()->isHHFile() || RuntimeOption::EnableHipHopSyntax) &&
+    RuntimeOption::PHP7_ScalarTypes
+  );
+}
+
 ALWAYS_INLINE
 static Array get_function_param_info(const Func* func) {
   const Func::ParamInfoVec& params = func->params();
@@ -845,6 +852,13 @@ static Array get_function_param_info(const Func* func) {
       ? fpi.userType
       : staticEmptyString();
     param.set(s_type_hint, make_tv<KindOfPersistentString>(typeHint));
+
+    std::string phpTypeHint(typeHint->toCppString());
+    if (isPhpTypeHintEnabled(func) && phpTypeHint[0] == '?') {
+      phpTypeHint = phpTypeHint.substr(1);
+      param.set(s_type_hint, phpTypeHint);
+    }
+
     // callable typehint considered builtin; stdclass typehint is not
     if (
       fpi.typeConstraint.isCallable() ||
@@ -856,12 +870,9 @@ static Array get_function_param_info(const Func* func) {
       // If we are in <?php and in PHP 7 mode w.r.t. scalar types, then we want
       // the types to come back as PHP 7 style scalar types, not HH\ style
       // scalar types.
-      if (!(func->unit()->isHHFile() || RuntimeOption::EnableHipHopSyntax) &&
-          RuntimeOption::PHP7_ScalarTypes &&
-          boost::starts_with(typeHint->toCppString(), "HH\\")) {
-        String no_hh_type_hint(typeHint->toCppString());
-        no_hh_type_hint = no_hh_type_hint.substr(3);
-        param.set(s_type_hint, no_hh_type_hint);
+      if (isPhpTypeHintEnabled(func) && boost::starts_with(phpTypeHint, "HH\\")) {
+        phpTypeHint = phpTypeHint.substr(3);
+        param.set(s_type_hint, phpTypeHint);
       }
     } else {
       param.set(s_type_hint_builtin, false_varNR.tv());
@@ -946,9 +957,13 @@ static Array HHVM_METHOD(ReflectionFunctionAbstract, getRetTypeInfo) {
     auto retType = func->returnTypeConstraint();
     if (retType.isNullable()) {
       retTypeInfo.set(s_type_hint_nullable, true_varNR.tv());
+      if (isPhpTypeHintEnabled(func)) {
+        name = name.substr(1); //removes '?' - e.g. ?int -> int
+      }
     } else {
       retTypeInfo.set(s_type_hint_nullable, false_varNR.tv());
     }
+
     if (
       retType.isCallable() || // callable type hint is considered builtin
       (retType.underlyingDataType() &&
@@ -959,10 +974,8 @@ static Array HHVM_METHOD(ReflectionFunctionAbstract, getRetTypeInfo) {
       // If we are in <?php and in PHP 7 mode w.r.t. scalar types, then we want
       // the types to come back as PHP 7 style scalar types, not HH\ style
       // scalar types.
-      if (!(func->unit()->isHHFile() || RuntimeOption::EnableHipHopSyntax) &&
-          RuntimeOption::PHP7_ScalarTypes &&
-          boost::starts_with(name.toCppString(), "HH\\")) {
-          name = name.substr(3);
+      if (isPhpTypeHintEnabled(func) && boost::starts_with(name.toCppString(), "HH\\")) {
+        name = name.substr(3);
       }
     } else {
       retTypeInfo.set(s_type_hint_builtin, false_varNR.tv());

--- a/hphp/runtime/ext/reflection/ext_reflection.cpp
+++ b/hphp/runtime/ext/reflection/ext_reflection.cpp
@@ -853,8 +853,9 @@ static Array get_function_param_info(const Func* func) {
       : staticEmptyString();
     param.set(s_type_hint, make_tv<KindOfPersistentString>(typeHint));
 
-    std::string phpTypeHint(typeHint->toCppString());
-    if (isPhpTypeHintEnabled(func) && phpTypeHint[0] == '?') {
+    std::string phpTypeHint(isPhpTypeHintEnabled(func) ? typeHint->toCppString() : "");
+
+    if (!phpTypeHint.empty() && phpTypeHint[0] == '?') {
       phpTypeHint = phpTypeHint.substr(1);
       param.set(s_type_hint, phpTypeHint);
     }
@@ -870,7 +871,7 @@ static Array get_function_param_info(const Func* func) {
       // If we are in <?php and in PHP 7 mode w.r.t. scalar types, then we want
       // the types to come back as PHP 7 style scalar types, not HH\ style
       // scalar types.
-      if (isPhpTypeHintEnabled(func) && boost::starts_with(phpTypeHint, "HH\\")) {
+      if (!phpTypeHint.empty() && boost::starts_with(phpTypeHint, "HH\\")) {
         phpTypeHint = phpTypeHint.substr(3);
         param.set(s_type_hint, phpTypeHint);
       }

--- a/hphp/test/slow/reflection/ReflectionType-basic-explicit-php7.php
+++ b/hphp/test/slow/reflection/ReflectionType-basic-explicit-php7.php
@@ -1,26 +1,31 @@
 <?php
 
 function foo(int $a): bool {}
+function nfoo(?int $a): ?bool {}
 
-$rf = new ReflectionFunction('foo');
+$rp = null;
 
-echo "--Parameter--\n\n";
+foreach(['nfoo','foo'] as $fName) {
+  $rf = new ReflectionFunction($fName);
 
-$rp = $rf->getParameters()[0];
-var_dump($rp->hasType());
-$rt = $rp->getType();
-var_dump($rt->isBuiltin());
-var_dump($rt->__toString());
-var_dump($rt->allowsNull());
+  echo "--Function $fName - Parameter--\n\n";
 
-echo "\n--Return--\n\n";
+  $rp = $rf->getParameters()[0];
+  var_dump($rp->hasType());
+  $rt = $rp->getType();
+  var_dump($rt->isBuiltin());
+  var_dump($rt->__toString());
+  var_dump($rt->allowsNull());
 
-var_dump($rf->hasReturnType());
-$rt = $rf->getReturnType();
-var_dump($rt->isBuiltin());
-var_dump($rt->__toString());
-var_dump($rt->allowsNull());
+  echo "\n--Function $fName - Return--\n\n";
 
+  var_dump($rf->hasReturnType());
+  $rt = $rf->getReturnType();
+  var_dump($rt->isBuiltin());
+  var_dump($rt->__toString());
+  var_dump($rt->allowsNull());
+  echo "\n";
+}
 
 echo "\n--Call Constructor Directly--\n\n";
 

--- a/hphp/test/slow/reflection/ReflectionType-basic-explicit-php7.php.expectf
+++ b/hphp/test/slow/reflection/ReflectionType-basic-explicit-php7.php.expectf
@@ -1,16 +1,31 @@
---Parameter--
+--Function nfoo - Parameter--
+
+bool(true)
+bool(true)
+string(3) "int"
+bool(true)
+
+--Function nfoo - Return--
+
+bool(true)
+bool(true)
+string(4) "bool"
+bool(true)
+
+--Function foo - Parameter--
 
 bool(true)
 bool(true)
 string(3) "int"
 bool(false)
 
---Return--
+--Function foo - Return--
 
 bool(true)
 bool(true)
 string(4) "bool"
 bool(false)
+
 
 --Call Constructor Directly--
 

--- a/hphp/test/slow/reflection/ReflectionType-detailed-explicit-php7.php
+++ b/hphp/test/slow/reflection/ReflectionType-detailed-explicit-php7.php
@@ -2,18 +2,26 @@
 function foo(stdClass $a, array $b, callable $c, stdClass $d = null,
              $e = null, string $f, bool $g, int $h, float $i,
              NotExisting $j) { }
+function nfoo(?stdClass $a, ?array $b, ?callable $c, ?stdClass $d = null,
+            $e = null, ?string $f, ?bool $g, ?int $h, ?float $i,
+            ?NotExisting $j) { }
 function bar(): stdClass { return new stdClass; }
 class c extends stdClass {
   function bar(self $x): int { return 1; }
+  function nbar(?self $x): ?int { return 1; }
   function pbar(parent $x): int { return 1; }
   function factory(): self { return new c; }
+  function nfactory(): ?self { return new c; }
   function pfactory(): parent { return new stdClass; }
 }
 $closure = function (Test $a): Test { return $a; };
+$nclosure = function (?Test $a): ?Test { return $a; };
 echo "*** functions\n";
 foreach ([
   new ReflectionFunction('foo'),
+  new ReflectionFunction('nfoo'),
   new ReflectionFunction($closure),
+  new ReflectionFunction($nclosure),
 ] as $idx => $rf) {
   foreach ($rf->getParameters() as $idx2 => $rp) {
     echo "** Function $idx - Parameter $idx2\n";
@@ -30,8 +38,10 @@ echo "\n*** methods\n";
 foreach ([
   new ReflectionMethod('SplObserver', 'update'),
   new ReflectionMethod('c', 'bar'),
+  new ReflectionMethod('c', 'nbar'),
   new ReflectionMethod('c', 'pbar'),
   new ReflectionMethod($closure, '__invoke'),
+  new ReflectionMethod($nclosure, '__invoke'),
 ] as $idx => $rm) {
   foreach ($rm->getParameters() as $idx2 => $rp) {
     echo "** Method $idx - parameter $idx2\n";
@@ -49,10 +59,14 @@ foreach ([
   new ReflectionMethod('SplObserver', 'update'),
   new ReflectionFunction('bar'),
   new ReflectionMethod('c', 'bar'),
+  new ReflectionMethod('c', 'nbar'),
   new ReflectionMethod('c', 'factory'),
+  new ReflectionMethod('c', 'nfactory'),
   new ReflectionMethod('c', 'pfactory'),
   new ReflectionFunction($closure),
   new ReflectionMethod($closure, '__invoke'),
+  new ReflectionFunction($nclosure),
+  new ReflectionMethod($nclosure, '__invoke'),
 ] as $idx => $rf) {
   echo "** Function/method return type $idx\n";
   var_dump($rf->hasReturnType());

--- a/hphp/test/slow/reflection/ReflectionType-detailed-explicit-php7.php.expectf
+++ b/hphp/test/slow/reflection/ReflectionType-detailed-explicit-php7.php.expectf
@@ -48,7 +48,59 @@ bool(false)
 string(11) "NotExisting"
 ** Function 1 - Parameter 0
 bool(true)
+bool(true)
 bool(false)
+string(8) "stdClass"
+** Function 1 - Parameter 1
+bool(true)
+bool(true)
+bool(true)
+string(5) "array"
+** Function 1 - Parameter 2
+bool(true)
+bool(true)
+bool(true)
+string(8) "callable"
+** Function 1 - Parameter 3
+bool(true)
+bool(true)
+bool(false)
+string(8) "stdClass"
+** Function 1 - Parameter 4
+bool(false)
+** Function 1 - Parameter 5
+bool(true)
+bool(true)
+bool(true)
+string(6) "string"
+** Function 1 - Parameter 6
+bool(true)
+bool(true)
+bool(true)
+string(4) "bool"
+** Function 1 - Parameter 7
+bool(true)
+bool(true)
+bool(true)
+string(3) "int"
+** Function 1 - Parameter 8
+bool(true)
+bool(true)
+bool(true)
+string(5) "float"
+** Function 1 - Parameter 9
+bool(true)
+bool(true)
+bool(false)
+string(11) "NotExisting"
+** Function 2 - Parameter 0
+bool(true)
+bool(false)
+bool(false)
+string(4) "Test"
+** Function 3 - Parameter 0
+bool(true)
+bool(true)
 bool(false)
 string(4) "Test"
 
@@ -65,12 +117,22 @@ bool(false)
 string(4) "self"
 ** Method 2 - parameter 0
 bool(true)
+bool(true)
 bool(false)
-bool(false)
-string(6) "parent"
+string(4) "self"
 ** Method 3 - parameter 0
 bool(true)
 bool(false)
+bool(false)
+string(6) "parent"
+** Method 4 - parameter 0
+bool(true)
+bool(false)
+bool(false)
+string(4) "Test"
+** Method 5 - parameter 0
+bool(true)
+bool(true)
 bool(false)
 string(4) "Test"
 
@@ -89,21 +151,41 @@ bool(true)
 string(3) "int"
 ** Function/method return type 3
 bool(true)
-bool(false)
-bool(false)
-string(4) "self"
+bool(true)
+bool(true)
+string(3) "int"
 ** Function/method return type 4
 bool(true)
 bool(false)
 bool(false)
-string(6) "parent"
+string(4) "self"
 ** Function/method return type 5
+bool(true)
+bool(true)
+bool(false)
+string(4) "self"
+** Function/method return type 6
+bool(true)
+bool(false)
+bool(false)
+string(6) "parent"
+** Function/method return type 7
 bool(true)
 bool(false)
 bool(false)
 string(4) "Test"
-** Function/method return type 6
+** Function/method return type 8
 bool(true)
 bool(false)
+bool(false)
+string(4) "Test"
+** Function/method return type 9
+bool(true)
+bool(true)
+bool(false)
+string(4) "Test"
+** Function/method return type 10
+bool(true)
+bool(true)
 bool(false)
 string(4) "Test"


### PR DESCRIPTION
Summary:
it reflects nullable types like PHP7  when in PHP7 scalar type mode
e.g.: ?int --> int , ?FooClass --> FooClass

fixes: #7968