### PR TITLE
[AArch64] Sign-extend before cmp instructions.

### DIFF
--- a/hphp/runtime/vm/jit/vasm-dead.cpp
+++ b/hphp/runtime/vm/jit/vasm-dead.cpp
@@ -88,9 +88,6 @@ bool effectful(Vinstr& inst) {
     case Vinstr::defvmsp:
     case Vinstr::divint:
     case Vinstr::divsd:
-    case Vinstr::extsb:
-    case Vinstr::extsw:
-    case Vinstr::extsl:
     case Vinstr::fcmpo:
     case Vinstr::fcmpu:
     case Vinstr::fctidz:
@@ -122,6 +119,11 @@ bool effectful(Vinstr& inst) {
     case Vinstr::mflr:
     case Vinstr::movb:
     case Vinstr::movl:
+    case Vinstr::movsbl:
+    case Vinstr::movswl:
+    case Vinstr::movsbq:
+    case Vinstr::movswq:
+    case Vinstr::movslq:
     case Vinstr::movtqb:
     case Vinstr::movtdb:
     case Vinstr::movtdq:

--- a/hphp/runtime/vm/jit/vasm-instr.cpp
+++ b/hphp/runtime/vm/jit/vasm-instr.cpp
@@ -170,7 +170,12 @@ Width width(Vinstr::Opcode op) {
     // restrict/unrestrict new virtuals
     case Vinstr::vregrestrict:
     case Vinstr::vregunrestrict:
-    // zero-extending/truncating copies
+    // sign/zero-extending/truncating copies
+    case Vinstr::movsbl:
+    case Vinstr::movswl:
+    case Vinstr::movsbq:
+    case Vinstr::movswq:
+    case Vinstr::movslq:
     case Vinstr::movzbw:
     case Vinstr::movzbl:
     case Vinstr::movzbq:
@@ -215,9 +220,6 @@ Width width(Vinstr::Opcode op) {
     case Vinstr::mrs:
     case Vinstr::msr:
     // ppc64 instructions
-    case Vinstr::extsb:
-    case Vinstr::extsw:
-    case Vinstr::extsl:
     case Vinstr::fcmpo:
     case Vinstr::fcmpu:
     case Vinstr::fctidz:

--- a/hphp/runtime/vm/jit/vasm-instr.h
+++ b/hphp/runtime/vm/jit/vasm-instr.h
@@ -248,6 +248,11 @@ struct Vunit;
   O(movtqb, Inone, UH(s,d), DH(d,s))\
   O(movtqw, Inone, UH(s,d), DH(d,s))\
   O(movtql, Inone, UH(s,d), DH(d,s))\
+  O(movsbl, Inone, UH(s,d), DH(d,s))\
+  O(movswl, Inone, UH(s,d), DH(d,s))\
+  O(movsbq, Inone, UH(s,d), DH(d,s))\
+  O(movswq, Inone, UH(s,d), DH(d,s))\
+  O(movslq, Inone, UH(s,d), DH(d,s))\
   /* loads/stores */\
   O(loadb, Inone, U(s), D(d))\
   O(loadw, Inone, U(s), D(d))\
@@ -314,9 +319,6 @@ struct Vunit;
   O(msr, I(s), U(r), Dn)\
   O(ubfmli, I(mr) I(ms), U(s), D(d))\
   /* ppc64 instructions */\
-  O(extsb, Inone, UH(s,d), DH(d,s))\
-  O(extsw, Inone, UH(s,d), DH(d,s))\
-  O(extsl, Inone, UH(s,d), DH(d,s))\
   O(fcmpo, Inone, U(s0) U(s1), D(sf))\
   O(fcmpu, Inone, U(s0) U(s1), D(sf))\
   O(fctidz, Inone, U(s), D(d) D(sf))\
@@ -1047,7 +1049,12 @@ struct movtdq { VregDbl s; Vreg64 d; };
 struct movtqb { Vreg64 s; Vreg8 d; };
 struct movtqw { Vreg64 s; Vreg16 d; };
 struct movtql { Vreg64 s; Vreg32 d; };
-
+// sign-extended s to d
+struct movsbl { Vreg8 s; Vreg32 d; };
+struct movswl { Vreg16 s; Vreg32 d; };
+struct movsbq { Vreg8 s; Vreg64 d; };
+struct movswq { Vreg16 s; Vreg64 d; };
+struct movslq { Vreg32 s; Vreg64 d; };
 
 /*
  * Loads and stores.
@@ -1149,9 +1156,6 @@ struct ubfmli { Immed mr, ms; Vreg32 s, d; };
 /*
  * ppc64 intrinsics.
  */
-struct extsb { Vreg8 s; Vreg64 d; };  // Extend byte sign
-struct extsw { Vreg16 s; Vreg64 d; }; // Extend word sign
-struct extsl { Vreg32 s; Vreg64 d; }; // Extend dword sign
 struct fcmpo { VregDbl s0; VregDbl s1; VregSF sf; };
 struct fcmpu { VregDbl s0; VregDbl s1; VregSF sf; };
 struct fctidz { VregDbl s; VregDbl d; VregSF sf; };

--- a/hphp/runtime/vm/jit/vasm-ppc64.cpp
+++ b/hphp/runtime/vm/jit/vasm-ppc64.cpp
@@ -212,9 +212,9 @@ struct Vgen {
   }
   void emit(const divint& i) { a.divd(i.d,  i.s0, i.s1, false); }
   void emit(const divsd& i) { a.fdiv(i.d, i.s1, i.s0); }
-  void emit(const extsb& i) { a.extsb(i.d, Reg64(i.s)); }
-  void emit(const extsw& i) { a.extsh(i.d, Reg64(i.s)); }
-  void emit(const extsl& i) { a.extsw(i.d, Reg64(i.s)); }
+  void emit(const movsbq& i) { a.extsb(i.d, Reg64(i.s)); }
+  void emit(const movswq& i) { a.extsh(i.d, Reg64(i.s)); }
+  void emit(const movslq& i) { a.extsw(i.d, Reg64(i.s)); }
   void emit(const fallthru& /*i*/) {}
   void emit(const fcmpo& i) {
     a.fcmpo(i.sf, i.s0, i.s1);
@@ -1033,8 +1033,8 @@ void lowerForPPC64(const VLS& e, Vout& v, vasm_src& inst) {             \
   else v << vasm_dst_imm{inst.s0, tmp3, inst.sf};                       \
 }
 
-X(testwim, testq, testqi, loadw, extsw)
-X(testlim, testq, testqi, loadl, extsl)
+X(testwim, testq, testqi, loadw, movswq)
+X(testlim, testq, testqi, loadl, movslq)
 #undef X
 
 // Very similar with the above case: handles MemoryRef and Immed, but also
@@ -1064,8 +1064,8 @@ void lowerForPPC64(const VLS& e, Vout& v, vasm_src& inst) {             \
   v << vasm_store{tmp3, p};                                             \
 }
 
-X(orwim,  orq,  loadw, storew, extsw)
-X(addlim, addq, load,  store, extsl)
+X(orwim,  orq,  loadw, storew, movswq)
+X(addlim, addq, load,  store, movslq)
 #undef X
 
 // Handles MemoryRef arguments and load the data input from memory, but these
@@ -1093,7 +1093,7 @@ void lowerForPPC64(const VLS& e, Vout& v, vasm_src& inst) {             \
   v << vasm_dst{operands tmp2, inst.sf};                                \
 }
 
-X(cmpwm,  cmpq,  loadw, ONE_R64(s0), extsw)
+X(cmpwm,  cmpq,  loadw, ONE_R64(s0), movswq)
 #undef X
 
 
@@ -1107,10 +1107,10 @@ void lowerForPPC64(const VLS& e, Vout& v, vasm_src& inst) {             \
 
 X(cmpb,  cmpq,  movzbq, NONE)
 X(cmpw,  cmpq,  movzwq, NONE)
-X(testb, testq, extsb,  NONE)
-X(testw, testq, extsw,  NONE)
-X(testl, testq, extsl,  NONE)
-X(subl,  subq,  extsl,  ONE_R64(d))
+X(testb, testq, movsbq, NONE)
+X(testw, testq, movswq, NONE)
+X(testl, testq, movslq, NONE)
+X(subl,  subq,  movslq, ONE_R64(d))
 
 #undef X
 
@@ -1123,10 +1123,10 @@ void lowerForPPC64(const VLS& e, Vout& v, vasm_src& inst) {             \
 
 X(cmpbi,  cmpqi,  movzbq, NONE)
 X(cmpwi,  cmpqi,  movzwq, NONE)
-X(subli,  subqi,  extsl,  ONE_R64(d))
-X(testbi, testqi, extsb,  NONE)
-X(testwi, testqi, extsw,  NONE)
-X(testli, testqi, extsl,  NONE)
+X(subli,  subqi,  movslq, ONE_R64(d))
+X(testbi, testqi, movsbq, NONE)
+X(testwi, testqi, movswq, NONE)
+X(testli, testqi, movslq, NONE)
 
 #undef X
 

--- a/hphp/util/immed.h
+++ b/hphp/util/immed.h
@@ -80,8 +80,9 @@ struct Immed {
   int64_t q() const { return m_int; }
   int32_t l() const { return safe_cast<int32_t>(m_int); }
   int16_t w() const { return safe_cast<int16_t>(m_int); }
+  uint16_t uw() const { return static_cast<uint16_t>(m_int); }
   int8_t  b() const { return safe_cast<int8_t>(m_int); }
-  uint8_t ub() const { return safe_cast<uint8_t>(m_int); }
+  uint8_t ub() const { return static_cast<uint8_t>(m_int); }
 
   bool fits(int sz) const { return deltaFits(m_int, sz); }
 


### PR DESCRIPTION
Additionally fix immediate casting. Immediates are stored in a
signed 32-bit int, which cannot be safe_casted to an unsigned int
using Boost.