### PR TITLE
Fix retranslate all feature for PPC64

### DIFF
--- a/hphp/ppc64-asm/asm-ppc64.cpp
+++ b/hphp/ppc64-asm/asm-ppc64.cpp
@@ -636,7 +636,8 @@ Label::~Label() {
     assert(m_a && m_address && "Label had jumps but was never set");
   }
   for (auto& ji : m_toPatch) {
-    ji.a->patchBranch(ji.addr, m_address);
+    assert(ji.a->contains(ji.addr));
+    ji.a->patchBranch(ji.a->toDestAddress(ji.addr), m_address);
   }
 }
 

--- a/hphp/ppc64-asm/asm-ppc64.h
+++ b/hphp/ppc64-asm/asm-ppc64.h
@@ -317,6 +317,10 @@ struct Assembler {
     return codeBlock.contains(addr);
   }
 
+  CodeAddress toDestAddress(CodeAddress addr) const {
+    return codeBlock.toDestAddress(addr);
+  }
+
   bool empty() const {
     return codeBlock.empty();
   }

--- a/hphp/ppc64-asm/decoded-instr-ppc64.cpp
+++ b/hphp/ppc64-asm/decoded-instr-ppc64.cpp
@@ -35,7 +35,7 @@ namespace ppc64_asm {
 
 bool DecodedInstruction::couldBeNearBranch() {
   assert(isFarBranch());
-  ptrdiff_t diff = farBranchTarget() - m_ip;
+  ptrdiff_t diff = farBranchTarget() - m_base;
 
   // assert already stated it's a Far branch, but depending if it's conditional
   // or not, an additional range can be used.
@@ -44,13 +44,13 @@ bool DecodedInstruction::couldBeNearBranch() {
 
 uint8_t* DecodedInstruction::nearBranchTarget() const {
   assert(isNearBranch());
-  auto address = reinterpret_cast<uint64_t>(m_ip) + m_dinfo.branchOffset();
+  auto address = reinterpret_cast<uint64_t>(m_base) + m_dinfo.branchOffset();
   return reinterpret_cast<uint8_t*>(address);
 }
 
 bool DecodedInstruction::setNearBranchTarget(uint8_t* target) {
   if (!isNearBranch()) return false;
-  ptrdiff_t diff = target - m_ip;
+  ptrdiff_t diff = target - m_base;
   bool uncond = m_dinfo.isOffsetBranch(AllowCond::OnlyUncond);
   if (fitsOnNearBranch(diff, uncond)) {
     auto pinstr = reinterpret_cast<PPC64Instr*>(m_ip);
@@ -219,7 +219,7 @@ bool DecodedInstruction::setFarBranchTarget(uint8_t* target,
       );
 
   // Check if something was overwritten
-  if ((a.frontier() - m_ip) > m_size) {
+  if ((a.frontier() - m_base) > m_size) {
     return false;
   }
 

--- a/hphp/ppc64-asm/decoded-instr-ppc64.h
+++ b/hphp/ppc64-asm/decoded-instr-ppc64.h
@@ -38,6 +38,7 @@ struct DecInfoOffset {
 struct DecodedInstruction {
   explicit DecodedInstruction(PPC64Instr* ip, uint8_t max_size = 0)
     : m_ip(reinterpret_cast<uint8_t*>(ip))
+    , m_base(reinterpret_cast<uint8_t*>(ip))
     , m_imm(0)
     , m_dinfo(Decoder::GetDecoder().getInvalid())
     , m_size(instr_size_in_bytes)
@@ -48,6 +49,33 @@ struct DecodedInstruction {
   // 0 as @max_size means unlimited size
   explicit DecodedInstruction(uint8_t* ip, uint8_t max_size = 0)
     : m_ip(ip)
+    , m_base(ip)
+    , m_imm(0)
+    , m_dinfo(Decoder::GetDecoder().getInvalid())
+    , m_size(instr_size_in_bytes)
+    , m_max_size(max_size)
+  {
+    decode();
+  }
+
+  explicit DecodedInstruction(PPC64Instr* ip,
+                              PPC64Instr* base,
+                              uint8_t max_size = 0)
+    : m_ip(reinterpret_cast<uint8_t*>(ip))
+    , m_base(reinterpret_cast<uint8_t*>(base))
+    , m_imm(0)
+    , m_dinfo(Decoder::GetDecoder().getInvalid())
+    , m_size(instr_size_in_bytes)
+    , m_max_size(max_size)
+  {
+    decode();
+  }
+
+  explicit DecodedInstruction(uint8_t* ip,
+                             uint8_t* base,
+                             uint8_t max_size = 0)
+    : m_ip(ip)
+    , m_base(base)
     , m_imm(0)
     , m_dinfo(Decoder::GetDecoder().getInvalid())
     , m_size(instr_size_in_bytes)
@@ -130,6 +158,7 @@ private:
   bool isLimmediatePossible() const;
 
   uint8_t* m_ip;
+  uint8_t* m_base;
   int64_t m_imm;
   DecoderInfo m_dinfo;
   uint8_t m_size;

--- a/hphp/runtime/vm/jit/relocation-ppc64.cpp
+++ b/hphp/runtime/vm/jit/relocation-ppc64.cpp
@@ -45,6 +45,7 @@ struct JmpOutOfRange : std::exception {};
 size_t relocateImpl(RelocationInfo& rel,
                     CodeBlock& dest_block,
                     TCA start, TCA end,
+                    CodeBlock& src_block,
                     CGMeta& fixups,
                     TCA* exit_addr,
                     JmpSet& far_jmps,
@@ -58,12 +59,12 @@ size_t relocateImpl(RelocationInfo& rel,
   try {
     while (src != end) {
       assertx(src < end);
-      DecodedInstruction di(src);
+      DecodedInstruction di(src_block.toDestAddress(src), src);
       asm_count++;
 
       TCA dest = dest_block.frontier();
-      dest_block.bytes(di.size(), src);
-      DecodedInstruction d2(dest, di.size());
+      dest_block.bytes(di.size(), src_block.toDestAddress(src));
+      DecodedInstruction d2(dest_block.toDestAddress(dest), dest, di.size());
       if (di.isNearBranch()) {
         if (di.isBranch(ppc64_asm::AllowCond::OnlyUncond)) {
           jmp_dest = di.nearBranchTarget();
@@ -78,7 +79,7 @@ size_t relocateImpl(RelocationInfo& rel,
 
           // Near branch will be widen to Far branch. Update d2 in order to be
           // able to read more bytes than only the Near branch
-          d2 = DecodedInstruction(dest);
+          d2 = DecodedInstruction(dest_block.toDestAddress(dest), dest);
           d2.widenBranch(new_target);
 
           // widening a branch makes the dest instruction bigger
@@ -188,10 +189,10 @@ size_t relocateImpl(RelocationInfo& rel,
       src = start;
       bool ok = true;
       while (src != end) {
-        DecodedInstruction di(src);
+        DecodedInstruction di(src_block.toDestAddress(src), src);
         TCA dest = rel.adjustedAddressAfter(src);
         // Avoid set max_size as it would fail when a branch is widen.
-        DecodedInstruction d2(dest);
+        DecodedInstruction d2(dest_block.toDestAddress(dest), dest);
         if (di.isNearBranch()) {
           TCA old_target = di.nearBranchTarget();
           TCA adjusted_target = rel.adjustedAddressAfter(old_target);
@@ -353,8 +354,24 @@ void adjustForRelocation(RelocationInfo& rel, TCA srcStart, TCA srcEnd) {
   }
 }
 
-void adjustMetaDataForRelocation(RelocationInfo& /*rel*/, AsmInfo* /*asmInfo*/,
-                                 CGMeta& /*meta*/) {}
+void adjustMetaDataForRelocation(RelocationInfo& rel, AsmInfo* /*asmInfo*/,
+                                 CGMeta& meta) {
+  for (auto& li : meta.literals) {
+    if (auto adjusted = rel.adjustedAddressAfter((TCA)li.second)) {
+      li.second = (uint64_t*)adjusted;
+    }
+  }
+
+  decltype(meta.codePointers) updatedCP;
+  for (auto cp : meta.codePointers) {
+    if (auto adjusted = (TCA*)rel.adjustedAddressAfter((TCA)cp)) {
+      updatedCP.emplace(adjusted);
+    } else {
+      updatedCP.emplace(cp);
+    }
+  }
+  updatedCP.swap(meta.codePointers);
+}
 
 /*
  * Adjust potentially live references that point into the relocated
@@ -410,14 +427,14 @@ void findFixups(TCA start, TCA end, CGMeta& meta) {
 size_t relocate(RelocationInfo& rel,
                 CodeBlock& dest_block,
                 TCA start, TCA end,
-                CodeBlock&,
+                DataBlock& src_block,
                 CGMeta& fixups,
                 TCA* exit_addr,
                 AreaIndex) {
   JmpSet far_jmps, near_jmps;
   while (true) {
     try {
-      return relocateImpl(rel, dest_block, start, end,
+      return relocateImpl(rel, dest_block, start, end, src_block,
                           fixups, exit_addr, far_jmps, near_jmps);
     } catch (JmpOutOfRange& j) {
     }

--- a/hphp/runtime/vm/jit/vasm-ppc64.cpp
+++ b/hphp/runtime/vm/jit/vasm-ppc64.cpp
@@ -69,6 +69,19 @@ namespace {
 static_assert(folly::kIsLittleEndian,
   "Code contains little-endian specific optimizations.");
 
+static CodeAddress toReal(Venv& env, CodeAddress a) {
+  if (env.text.main().code.contains(a)) {
+    return env.text.main().code.toDestAddress(a);
+  }
+  if (env.text.cold().code.contains(a)) {
+    return env.text.cold().code.toDestAddress(a);
+  }
+  if (env.text.frozen().code.contains(a)) {
+    return env.text.frozen().code.toDestAddress(a);
+  }
+  return a;
+}
+
 struct Vgen {
   explicit Vgen(Venv& env)
     : env(env)
@@ -84,11 +97,11 @@ struct Vgen {
   static void patch(Venv& env) {
     for (auto& p : env.jmps) {
       assertx(env.addrs[p.target]);
-      Assembler::patchBranch(p.instr, env.addrs[p.target]);
+      Assembler::patchBranch(toReal(env, p.instr), env.addrs[p.target]);
     }
     for (auto& p : env.jccs) {
       assertx(env.addrs[p.target]);
-      Assembler::patchBranch(p.instr, env.addrs[p.target]);
+      Assembler::patchBranch(toReal(env, p.instr), env.addrs[p.target]);
     }
   }
 
@@ -712,7 +725,7 @@ void Vgen::emit(const mcprep& i) {
    */
   auto const mov_addr = emitSmashableMovq(a.code(), env.meta, 0, r64(i.d));
   auto const imm = reinterpret_cast<uint64_t>(mov_addr);
-  smashMovq(mov_addr, (imm << 1) | 1);
+  smashMovq(a.toDestAddress(mov_addr), (imm << 1) | 1);
 
   env.meta.addressImmediates.insert(reinterpret_cast<TCA>(~imm));
 }


### PR DESCRIPTION
The concept of resizable buffers was not added to PPC64 specific files,
which is used for the retranslate all feature.
The decoder was changed to receive the destination and buffer addresses,
and the calls for it, in the relocation method, was changed to add the
buffer address.
Also methods to obtain the buffer address, based on the destination code
address, were added.