### PR TITLE
Adds option for faster, estimated PGO counters.

### DIFF
--- a/hphp/runtime/base/runtime-option.cpp
+++ b/hphp/runtime/base/runtime-option.cpp
@@ -538,7 +538,8 @@ static inline uint32_t profileBCSizeDefault() {
 }
 
 static inline uint32_t resetProfCountersDefault() {
-  return RuntimeOption::EvalJitPGORacyProfiling ? UINT32_MAX
+  return RuntimeOption::EvalJitPGORacyProfiling
+    ? std::numeric_limits<uint32_t>::max()
     : RuntimeOption::EvalJitConcurrently ? 250 : 1000;
 }
 

--- a/hphp/runtime/base/runtime-option.cpp
+++ b/hphp/runtime/base/runtime-option.cpp
@@ -538,7 +538,8 @@ static inline uint32_t profileBCSizeDefault() {
 }
 
 static inline uint32_t resetProfCountersDefault() {
-  return RuntimeOption::EvalJitConcurrently ? 250 : 1000;
+  return RuntimeOption::EvalJitPGORacyProfiling ? UINT32_MAX
+    : RuntimeOption::EvalJitConcurrently ? 250 : 1000;
 }
 
 static inline int retranslateAllRequestDefault() {

--- a/hphp/runtime/base/runtime-option.h
+++ b/hphp/runtime/base/runtime-option.h
@@ -656,6 +656,7 @@ struct RuntimeOption {
   F(uint32_t, JitPGORelaxUncountedToGenPercent, 20)                     \
   F(uint32_t, JitPGORelaxCountedToGenPercent, 75)                       \
   F(bool,     JitPGODumpCallGraph,     false)                           \
+  F(bool,     JitPGOFastProfiling,     false)                           \
   F(uint64_t, FuncCountHint,           10000)                           \
   F(uint64_t, PGOFuncCountHint,        1000)                            \
   F(uint32_t, HotFuncCount,            4100)                            \

--- a/hphp/runtime/base/runtime-option.h
+++ b/hphp/runtime/base/runtime-option.h
@@ -656,7 +656,7 @@ struct RuntimeOption {
   F(uint32_t, JitPGORelaxUncountedToGenPercent, 20)                     \
   F(uint32_t, JitPGORelaxCountedToGenPercent, 75)                       \
   F(bool,     JitPGODumpCallGraph,     false)                           \
-  F(bool,     JitPGOFastProfiling,     false)                           \
+  F(bool,     JitPGORacyProfiling,     false)                           \
   F(uint64_t, FuncCountHint,           10000)                           \
   F(uint64_t, PGOFuncCountHint,        1000)                            \
   F(uint32_t, HotFuncCount,            4100)                            \

--- a/hphp/runtime/vm/jit/irlower-intrinsic.cpp
+++ b/hphp/runtime/vm/jit/irlower-intrinsic.cpp
@@ -191,7 +191,11 @@ void cgIncProfCounter(IRLS& env, const IRInstruction* inst) {
   auto const counterAddr = profData()->transCounterAddr(transID);
   auto& v = vmain(env);
 
-  v << decqmlock{v.cns(counterAddr)[0], v.makeReg()};
+  if (RuntimeOption::EvalJitPGOFastProfiling) {
+    v << decqm{v.cns(counterAddr)[0], v.makeReg()};
+  } else {
+    v << decqmlock{v.cns(counterAddr)[0], v.makeReg()};
+  }
 }
 
 void cgCheckCold(IRLS& env, const IRInstruction* inst) {

--- a/hphp/runtime/vm/jit/irlower-intrinsic.cpp
+++ b/hphp/runtime/vm/jit/irlower-intrinsic.cpp
@@ -191,7 +191,7 @@ void cgIncProfCounter(IRLS& env, const IRInstruction* inst) {
   auto const counterAddr = profData()->transCounterAddr(transID);
   auto& v = vmain(env);
 
-  if (RuntimeOption::EvalJitPGOFastProfiling) {
+  if (RuntimeOption::EvalJitPGORacyProfiling) {
     v << decqm{v.cns(counterAddr)[0], v.makeReg()};
   } else {
     v << decqmlock{v.cns(counterAddr)[0], v.makeReg()};

--- a/hphp/runtime/vm/jit/prof-data.h
+++ b/hphp/runtime/vm/jit/prof-data.h
@@ -358,8 +358,10 @@ struct ProfData {
   int64_t transCounter(TransID id) const {
     folly::SharedMutex::ReadHolder lock{m_transLock};
     assertx(id < m_transRecs.size());
-    auto const counter = m_counters.get(id);
+    auto counter = m_counters.get(id);
     auto const initVal = m_counters.getDefault();
+    if (RuntimeOption::EvalJitPGOFastProfiling &&
+	(counter > initVal)) counter = 0;
     assert_flog(initVal >= counter,
                 "transCounter({}) = {}, initVal = {}\n",
                 id, counter, initVal);

--- a/hphp/runtime/vm/jit/prof-data.h
+++ b/hphp/runtime/vm/jit/prof-data.h
@@ -358,12 +358,8 @@ struct ProfData {
   int64_t transCounter(TransID id) const {
     folly::SharedMutex::ReadHolder lock{m_transLock};
     assertx(id < m_transRecs.size());
-    auto counter = m_counters.get(id);
+    auto const counter = m_counters.get(id);
     auto const initVal = m_counters.getDefault();
-    // RacyProfiling can lead to counters underflowing, so reset to zero.
-    if (RuntimeOption::EvalJitPGORacyProfiling && (counter > initVal)) {
-      counter = 0;
-    }
     assert_flog(initVal >= counter,
                 "transCounter({}) = {}, initVal = {}\n",
                 id, counter, initVal);

--- a/hphp/runtime/vm/jit/prof-data.h
+++ b/hphp/runtime/vm/jit/prof-data.h
@@ -361,7 +361,7 @@ struct ProfData {
     auto counter = m_counters.get(id);
     auto const initVal = m_counters.getDefault();
     if (RuntimeOption::EvalJitPGOFastProfiling &&
-	(counter > initVal)) counter = 0;
+        (counter > initVal)) counter = 0;
     assert_flog(initVal >= counter,
                 "transCounter({}) = {}, initVal = {}\n",
                 id, counter, initVal);

--- a/hphp/runtime/vm/jit/prof-data.h
+++ b/hphp/runtime/vm/jit/prof-data.h
@@ -360,8 +360,10 @@ struct ProfData {
     assertx(id < m_transRecs.size());
     auto counter = m_counters.get(id);
     auto const initVal = m_counters.getDefault();
-    if (RuntimeOption::EvalJitPGOFastProfiling &&
-        (counter > initVal)) counter = 0;
+    // RacyProfiling can lead to counters underflowing, so reset to zero.
+    if (RuntimeOption::EvalJitPGORacyProfiling && (counter > initVal)) {
+      counter = 0;
+    }
     assert_flog(initVal >= counter,
                 "transCounter({}) = {}, initVal = {}\n",
                 id, counter, initVal);


### PR DESCRIPTION
Benchmarks with small amounts of code generate a lot of contention for that code's PGO counters. Using a `decqm` instead of a `decqmlock` removes the lock, easing the contentions but also leading to accuracy issues. This new switch (`Eval.JitPGORacyProfiling`) changes the counters to use `decqm` if accuracy isn't required.