### PR TITLE
Emit note during cmake if aarch64 host supports crc instructions, but option not selected.

### DIFF
--- a/hphp/tools/gdb/gdbutils.py
+++ b/hphp/tools/gdb/gdbutils.py
@@ -126,7 +126,11 @@ def string_data_val(val, keep_case=True):
     else:
         data = val['m_data']
 
-    s = data.string('utf-8', 'ignore', val['m_len'])
+    try:
+        s = data.string('utf-8', 'ignore', val['m_len'])
+    except:
+        s = "Unknown"
+
     return s if keep_case else s.lower()
 
 
@@ -300,3 +304,11 @@ def deref(val):
         return val.cast(rawtype(val.type))
     else:
         return deref(p.referenced_value())
+
+def get_arch(self):
+    try:
+        arch = gdb.selected_frame().architecture().name()
+    except:
+        arch = re.search('\(currently (.*)\)', gdb.execute('show architecture', to_string=True)).group(1)
+    return arch
+

--- a/hphp/tools/gdb/stack.py
+++ b/hphp/tools/gdb/stack.py
@@ -79,7 +79,10 @@ The output backtrace has the following format:
 
         # Set fp = $rbp, rip = $rip.
         fp_type = T('uintptr_t').pointer()
-        fp = native_frame.read_register('rbp').cast(fp_type)
+        if get_arch(self) == 'aarch64':
+            fp = native_frame.read_register('x29').cast(fp_type)
+        else:
+            fp = native_frame.read_register('rbp').cast(fp_type)
         rip = native_frame.pc()
 
         if len(argv) == 1:
@@ -196,8 +199,13 @@ The output backtrace has the following format:
             return
 
         fp_type = T('uintptr_t').pointer()
-        fp = gdb.parse_and_eval('$rbp').cast(fp_type)
-        rip = gdb.parse_and_eval('$rip').cast(T('uintptr_t'))
+        if get_arch(self) == 'aarch64':
+            fp = gdb.parse_and_eval('x29').cast(fp_type)
+            rip = gdb.parse_and_eval('x30').cast(T('uintptr_t'))
+        else:
+            fp = gdb.parse_and_eval('$rbp').cast(fp_type)
+            rip = gdb.parse_and_eval('$rip').cast(T('uintptr_t'))
+        
 
         if len(argv) >= 1:
             fp = argv[0].cast(fp_type)


### PR DESCRIPTION
The ability to use the ARMv8 crc instructions was added by PR#7556.  They
are enabled only if an option is added to the cmake command line. 

This makes a minor change to the HPHPCompiler.cmake file to emit a note
if the build host supports the crc instruction and it has not been selected.

