### PR TITLE
aarch64 - correction for LSE Atomics

### DIFF
--- a/hphp/runtime/vm/jit/vasm-arm.cpp
+++ b/hphp/runtime/vm/jit/vasm-arm.cpp
@@ -735,8 +735,8 @@ void Vgen::emit(const decqmlock& i) {
   a->SetScratchRegisters(vixl::NoReg, vixl::NoReg);
   if (RuntimeOption::EvalJitArmLse) {
     a->Mov(rVixlScratch0, -1);
-    a->stadd(rVixlScratch0, adr);
-    a->Msr(NZCV, vixl::xzr);
+    a->ldaddal(rVixlScratch0, rVixlScratch0, adr);
+    a->Sub(rAsm, rVixlScratch0, 1, SetFlags);
   } else {
     vixl::Label again;
     a->bind(&again);

--- a/hphp/runtime/vm/jit/vasm-arm.cpp
+++ b/hphp/runtime/vm/jit/vasm-arm.cpp
@@ -736,6 +736,7 @@ void Vgen::emit(const decqmlock& i) {
   if (RuntimeOption::EvalJitArmLse) {
     a->Mov(rVixlScratch0, -1);
     a->stadd(rVixlScratch0, adr);
+    a->Msr(NZCV, vixl::xzr);
   } else {
     vixl::Label again;
     a->bind(&again);

--- a/hphp/vixl/a64/assembler-a64.cc
+++ b/hphp/vixl/a64/assembler-a64.cc
@@ -1136,11 +1136,11 @@ void Assembler::ldr(const FPRegister& ft, double imm) {
 }
 
 
-void Assembler::stadd(const Register& rt, const MemOperand& src) {
+void Assembler::ldaddal(const Register& rs, const Register& rt, const MemOperand& src) {
   assert(src.IsImmediateOffset() && (src.offset() == 0));
-  // ldadd alias
-  uint32_t op = rt.Is64Bits() ? LSELD_ADD_x : LSELD_ADD_w;
-  Emit(op | Rs(rt) | Rt(xzr) | RnSP(src.base()));
+  // aquire/release semantics
+  uint32_t op = rt.Is64Bits() ? LSELD_ADD_alx : LSELD_ADD_alw;
+  Emit(op | Rs(rs) | Rt(rt) | RnSP(src.base()));
 }
 
 

--- a/hphp/vixl/a64/assembler-a64.h
+++ b/hphp/vixl/a64/assembler-a64.h
@@ -1119,8 +1119,8 @@ class Assembler {
   void stnp(const CPURegister& rt, const CPURegister& rt2,
             const MemOperand& dst);
 
-  // Store Add - Large System Extension
-  void stadd(const Register& rt, const MemOperand& src);
+  // Load Add - Large System Extension
+  void ldaddal(const Register& rs, const Register& rt, const MemOperand& src);
 
   // Load literal to register.
   void ldr(const Register& rt, uint64_t imm);


### PR DESCRIPTION
Running a MOP on a larger lab machine exposed unexpected failures when -vEval.JitPGO=1 was used.  The issue was traced to the use of the LSE Atomic instructions.  The implementation of
PR#7857 was not complete.  The decqmlock Vinstr was expected to set the PSW.  Without this
change arbitrary PSW values were returned when the hardware supported the LSE instructions.

The hphp/test/quick/setg-dtor.php test reliably exposed the problem.

