### PR TITLE
Move stream context http header processing

### DIFF
--- a/hphp/runtime/base/http-client.h
+++ b/hphp/runtime/base/http-client.h
@@ -49,6 +49,12 @@ struct HttpClient {
   void setStreamContextOptions(const Array &opts) {
     m_stream_context_options = opts;
   }
+
+  /**
+   * Get StreamContext http header map.
+   */
+  HeaderMap streamContextHttpHeader();
+
   /**
    * require SLS/TLS
    * (default) CURLUSESSL_NONE, CURLUSESSL_TRY, CURLUSESSL_CONTROL,

--- a/hphp/runtime/base/http-stream-wrapper.cpp
+++ b/hphp/runtime/base/http-stream-wrapper.cpp
@@ -19,7 +19,6 @@
 #include "hphp/runtime/base/comparisons.h"
 #include "hphp/runtime/base/ini-setting.h"
 #include "hphp/runtime/base/runtime-option.h"
-#include "hphp/runtime/base/string-util.h"
 #include "hphp/runtime/base/thread-info.h"
 #include "hphp/runtime/base/url-file.h"
 #include "hphp/runtime/ext/stream/ext_stream.h"
@@ -34,7 +33,6 @@ const StaticString
   s_GET("GET"),
   s_method("method"),
   s_http("http"),
-  s_header("header"),
   s_ignore_errors("ignore_errors"),
   s_max_redirects("max_redirects"),
   s_timeout("timeout"),
@@ -71,21 +69,6 @@ req::ptr<File> HttpStreamWrapper::open(const String& filename,
     Array opts = context->getOptions()[s_http].toArray();
     if (opts.exists(s_method)) {
       method = opts[s_method].toString();
-    }
-    if (opts.exists(s_header)) {
-      Array lines;
-      if (opts[s_header].isString()) {
-        lines = StringUtil::Explode(
-          opts[s_header].toString(), "\r\n").toArray();
-      } else if (opts[s_header].isArray()) {
-        lines = opts[s_header];
-      }
-
-      for (ArrayIter it(lines); it; ++it) {
-        Array parts = StringUtil::Explode(
-          it.second().toString(), ":", 2).toArray();
-        headers.set(parts.rvalAt(0).unboxed().tv(), parts.rvalAt(1).tv());
-      }
     }
     if (opts.exists(s_user_agent) && !headers.exists(s_User_Agent)) {
       headers.set(s_User_Agent, opts[s_user_agent]);

--- a/hphp/runtime/base/url-file.cpp
+++ b/hphp/runtime/base/url-file.cpp
@@ -89,10 +89,8 @@ bool UrlFile::open(const String& input_url, const String& mode) {
     http.proxy(m_proxyHost, m_proxyPort, m_proxyUsername, m_proxyPassword);
   }
 
-  HeaderMap *pHeaders = nullptr;
-  HeaderMap requestHeaders;
+  HeaderMap requestHeaders = http.streamContextHttpHeader();
   if (!m_headers.empty()) {
-    pHeaders = &requestHeaders;
     for (ArrayIter iter(m_headers); iter; ++iter) {
       requestHeaders[std::string(iter.first().toString().data())].
         push_back(iter.second().toString().data());
@@ -114,11 +112,11 @@ bool UrlFile::open(const String& input_url, const String& mode) {
   int code;
   req::vector<String> responseHeaders;
   if (m_get) {
-    code = http.get(url.c_str(), m_response, pHeaders, &responseHeaders);
+    code = http.get(url.c_str(), m_response, &requestHeaders, &responseHeaders);
   } else {
     code = http.request(m_method,
                         url.c_str(), m_postData.data(), m_postData.size(),
-                        m_response, pHeaders, &responseHeaders);
+                        m_response, &requestHeaders, &responseHeaders);
   }
 
   m_responseHeaders.reset();

--- a/hphp/runtime/ext/soap/ext_soap.cpp
+++ b/hphp/runtime/ext/soap/ext_soap.cpp
@@ -2812,7 +2812,10 @@ Variant HHVM_METHOD(SoapClient, __dorequest,
   USE_SOAP_GLOBAL;
   SoapClientScope ss(this_);
 
-  HeaderMap headers;
+  HttpClient http(data->m_connection_timeout, data->m_max_redirect,
+                  data->m_use11, true);
+  http.setStreamContextOptions(data->m_stream_context_options);
+  HeaderMap headers = http.streamContextHttpHeader();
 
   String buffer(buf);
 
@@ -2855,8 +2858,6 @@ Variant HHVM_METHOD(SoapClient, __dorequest,
   }
 
   // post the request
-  HttpClient http(data->m_connection_timeout, data->m_max_redirect,
-                  data->m_use11, true);
   if (!data->m_proxy_host.empty() && data->m_proxy_port) {
     http.proxy(data->m_proxy_host.data(), data->m_proxy_port,
                data->m_proxy_login.data(), data->m_proxy_password.data());
@@ -2864,7 +2865,6 @@ Variant HHVM_METHOD(SoapClient, __dorequest,
   if (!data->m_login.empty()) {
     http.auth(data->m_login.data(), data->m_password.data(), !data->m_digest);
   }
-  http.setStreamContextOptions(data->m_stream_context_options);
 
   if(data->m_ssl_method > -1) {
     http.setUseSSL(CURLUSESSL_ALL);

--- a/hphp/runtime/ext/soap/sdl.cpp
+++ b/hphp/runtime/ext/soap/sdl.cpp
@@ -163,7 +163,7 @@ static void load_wsdl_ex(char *struri, sdlCtx *ctx, bool include,
 
   xmlDocPtr wsdl;
   if (http) {
-    HeaderMap headers;
+    HeaderMap headers = http->streamContextHttpHeader();
     StringBuffer response;
     int code = http->get(struri, response, &headers);
     if (code != 200) {


### PR DESCRIPTION
Commit eec9da990e7344af985735ec53d73325579931eb appended the http header from
the stream context to the curl list of headers. This was done to allow a
SoapClient to be constructed with a stream context that contained http headers.
It created issues #7684 and #8046.

HttpClient::request() has a requestHeaders argument that should be
used instead. Because there are three places that use HttpClient with a
StreamContext object, this commit adds HttpClient.streamContextHttpHeader()
and moves all processing of stream context http headers there.

Places that use HttpClient.setStreamContextOptions()
* SoapClient::__construct(), -> sdl.cpp load_wsdl_ex()
* SoapClient::__dorequest()
* UrlFile->open()

Closes #5553
Closes #7684
Closes #8046
Closes #8047