### PR TITLE
Update XHP+namespace resolution in the typechecker to match the runtime.

### DIFF
--- a/hphp/hack/test/typecheck/namespace_fallback1.php
+++ b/hphp/hack/test/typecheck/namespace_fallback1.php
@@ -1,0 +1,11 @@
+<?hh // strict
+
+namespace {
+  class :my-xhp {}
+}
+
+namespace Foo {
+  function test(): :my-xhp {
+    return <my-xhp />;
+  }
+}

--- a/hphp/hack/test/typecheck/namespace_fallback1.php.exp
+++ b/hphp/hack/test/typecheck/namespace_fallback1.php.exp
@@ -1,0 +1,1 @@
+No errors

--- a/hphp/hack/test/typecheck/namespace_fallback2.php
+++ b/hphp/hack/test/typecheck/namespace_fallback2.php
@@ -1,0 +1,9 @@
+<?hh // strict
+
+namespace Foo {
+  class :my-xhp {}
+
+  function test(): :my-xhp {
+    return <my-xhp />;
+  }
+}

--- a/hphp/hack/test/typecheck/namespace_fallback2.php.exp
+++ b/hphp/hack/test/typecheck/namespace_fallback2.php.exp
@@ -1,0 +1,2 @@
+File "namespace_fallback2.php", line 6, characters 20-26:
+Unbound name: :my-xhp (an object type) (Naming[2049])


### PR DESCRIPTION
Right now (and, as far as I can tell, since the days of XHP as an extension of PHP), the runtime always looks for XHP classes in the "global" namespace. This means that defining an XHP class within in a namespace is a futile effort; even within that same namespace references to that class will fail.

The typechecker, on the other hand, has the exact opposite behavior: it always looks for XHP classes in the current namespace (like any other class). This mismatch means that using XHP in namespaced code is impossible in strict mode (though partial mode works perfectly fine; hh doesn't know what class the code is referencing but the runtime is happy to do what it's always done and resolve it globally). Since trying to `use` an XHP class is unsupported by the parser, partial mode is more-or-less the best that can be accomplished today.

This PR updates the typechecker to always assume an empty namespace context when resolving an XHP name. By doing so, we get the same behavior the runtime has (referencing XHP from a namespace will match the global class, but not a class in the same namespace). The included tests should hopefully demonstrate the behavioral change. If nothing else, having the typechecker match the runtime here allows for safer typing, since the typechecker will now be able to validate usages of XHP, and namespaced code that uses XHP can be converted to strict mode.

I have little faith that this will be accepted as-is--if not because this is my first foray into ocaml and I have no clue what I'm doing, then because I'm pretty sure this isn't the direction the HHVM team wants to go with XHP typing. Nonetheless, it's worth a try and IMO this is the right thing to do.