### PR TITLE
[AArch64] Consider multiple smashables per target when relocating.

### DIFF
--- a/hphp/runtime/vm/jit/relocation-arm.cpp
+++ b/hphp/runtime/vm/jit/relocation-arm.cpp
@@ -191,11 +191,16 @@ bool relocateSmashable(Env& env, TCA srcAddr, TCA destAddr,
     // Look up the smashable (jmp, jcc, etc) from the target. Note this is
     // an actual address, and so we'll use the offset with the (potentially)
     // virtual srcAddr when we search through smashableLocation.
-    auto slActual =
-      getSmashableFromTargetAddr(srcAddrActual + kSmashJmpTargetOff);
-    auto sl = srcAddr + (slActual - srcAddrActual);
-    if (sl && env.meta.smashableLocations.count(sl)) {
-      target = nullptr;
+    auto smashableLocations =
+      getSmashablesFromTargetAddr(srcAddrActual + kSmashJmpTargetOff);
+    for (auto smashableLocation : smashableLocations) {
+      auto slAddrActual = reinterpret_cast<TCA>(smashableLocation);
+      auto slAddr = srcAddr + (slAddrActual - srcAddrActual);
+      if (env.meta.smashableLocations.count(slAddr)) {
+        FTRACE(3, "Can't optimize this smashable: {}.\n", slAddr);
+        target = nullptr;
+        break;
+      }
     }
   }
 

--- a/hphp/runtime/vm/jit/relocation-arm.cpp
+++ b/hphp/runtime/vm/jit/relocation-arm.cpp
@@ -67,7 +67,7 @@ TRACE_SET_MOD(mcg);
 
 //////////////////////////////////////////////////////////////////////
 
-using InstrSet = hphp_hash_set<Instruction*>;
+using InstrSet = std::unordered_set<Instruction*>;
 struct JmpOutOfRange : std::exception {};
 
 /*

--- a/hphp/runtime/vm/jit/smashable-instr-arm.cpp
+++ b/hphp/runtime/vm/jit/smashable-instr-arm.cpp
@@ -337,28 +337,29 @@ ConditionCode smashableJccCond(TCA inst) {
  *       sequence is a full jcc even though a jcc actually uses the same
  *       sequence as a jmp in its implementation.
  */
-hphp_hash_set<vixl::Instruction*> getSmashablesFromTargetAddr(TCA addr) {
-  using InstrSet = hphp_hash_set<vixl::Instruction*>;
+std::array<vixl::Instruction*, 3> getSmashablesFromTargetAddr(TCA addr) {
+  using InstrSet = std::unordered_set<vixl::Instruction*>;
   using namespace vixl;
 
-  InstrSet smashables;
+  std::array<vixl::Instruction*, 3> smashables;
+  auto i = 0;
 
   const uint32_t target32 = *reinterpret_cast<uint32_t*>(addr);
   auto target = reinterpret_cast<TCA>(target32);
 
   addr -= 3 << kInstructionSizeLog2;
   if (smashableJccTarget(addr) == target) {
-    smashables.insert(Instruction::Cast(addr));
+    smashables[i++] = Instruction::Cast(addr);
   }
 
   addr += kInstructionSize;
   if (smashableJmpTarget(addr) == target) {
-    smashables.insert(Instruction::Cast(addr));
+    smashables[i++] = Instruction::Cast(addr);
   }
 
   addr += kInstructionSize;
   if (smashableCallTarget(addr) == target) {
-    smashables.insert(Instruction::Cast(addr));
+    smashables[i++] = Instruction::Cast(addr);
   }
 
   return smashables;

--- a/hphp/runtime/vm/jit/smashable-instr-arm.h
+++ b/hphp/runtime/vm/jit/smashable-instr-arm.h
@@ -67,7 +67,7 @@ TCA smashableJmpTarget(TCA inst);
 TCA smashableJccTarget(TCA inst);
 ConditionCode smashableJccCond(TCA inst);
 
-hphp_hash_set<vixl::Instruction*> getSmashablesFromTargetAddr(TCA addr);
+std::array<vixl::Instruction*, 3> getSmashablesFromTargetAddr(TCA addr);
 
 constexpr size_t kSmashMovqImmOff = 8;
 constexpr size_t kSmashCmpqImmOff = 0;

--- a/hphp/runtime/vm/jit/smashable-instr-arm.h
+++ b/hphp/runtime/vm/jit/smashable-instr-arm.h
@@ -67,7 +67,7 @@ TCA smashableJmpTarget(TCA inst);
 TCA smashableJccTarget(TCA inst);
 ConditionCode smashableJccCond(TCA inst);
 
-TCA getSmashableFromTargetAddr(TCA addr);
+hphp_hash_set<vixl::Instruction*> getSmashablesFromTargetAddr(TCA addr);
 
 constexpr size_t kSmashMovqImmOff = 8;
 constexpr size_t kSmashCmpqImmOff = 0;


### PR DESCRIPTION
When finding the smashable from its target, we need to consider all possible smashables instead of just stopping at the first match. The rationale is that the first possible smashable that we find might not be an actual smashable. Consider a case where a smashable `jmp` is coincidentally preceded by a conditional branch. This can make it look like a smashable `jcc` which is the first possible smashable found. Without considered all possible smashables, we'd miss this `jmp`.