### PR TITLE
Add Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,3 @@
+# Code of Conduct
+
+Facebook has adopted a Code of Conduct that we expect project participants to adhere to. Please [read the full text](https://code.facebook.com/codeofconduct) so that you can understand what actions will and will not be tolerated.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,9 @@ If you want to help but don't know where to start, try fixing some of the ["prob
 
 All the open issues tagged [PHP5 incompatibility](https://github.com/facebook/hhvm/issues?labels=php5+incompatibility&page=1&state=open) are real issues reported by the community in existing PHP code and [frameworks](https://github.com/facebook/hhvm/wiki/OSS-PHP-Frameworks-Unit-Testing:-General) that could use some attention.
 
+## Code of Conduct
+The code of conduct is described in [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md)
+
 ## Submitting Pull Requests
 
 Before changes can be accepted a [Contributor Licensing Agreement](http://code.facebook.com/cla) must be completed. You will be prompted to accept the CLA when you submit your first pull request. If you prefer a hard copy, you can print the [pdf](https://github.com/facebook/hhvm/raw/master/hphp/doc/FB_Individual_CLA.pdf), sign it, scan it, and send it to <cla@fb.com>.


### PR DESCRIPTION
In the past Facebook didn't promote including a Code of Conduct when creating new projects, and many projects skipped this important document. Let's fix it. :)

**why make this change?:**
Facebook Open Source provides a Code of Conduct statement for all
projects to follow, to promote a welcoming and safe open source community.

Exposing the COC via a separate markdown file is a standard being
promoted by Github via the Community Profile in order to meet their Open
Source Guide's recommended community standards.

As you can see, adding this file will improve [the hhvm community profile](https://github.com/facebook/hhvm/community)
checklist and increase the visibility of our COC.

**test plan:**
Viewing it on my branch -
<img width="996" alt="screen shot 2017-12-03 at 4 41 27 pm" src="https://user-images.githubusercontent.com/1114467/33531921-fb447ce8-d848-11e7-914a-5968d8b1976f.png">
<img width="1027" alt="screen shot 2017-12-03 at 4 41 37 pm" src="https://user-images.githubusercontent.com/1114467/33531923-fb5f4c58-d848-11e7-97c3-063222085c95.png">

**issue:**
internal task t23481323