### PR TITLE
[AArch64] Remove extra syncing of CodeBlock from base to frontier.

### DIFF
--- a/hphp/runtime/vm/jit/vasm-arm.cpp
+++ b/hphp/runtime/vm/jit/vasm-arm.cpp
@@ -219,7 +219,7 @@ struct Vgen {
     , catches(env.catches)
   {}
   ~Vgen() {
-    env.cb->sync();
+    env.cb->sync(base);
   }
 
   static void patch(Venv& env);


### PR DESCRIPTION
The VGen dtor was mistakenly syncing from the CodeBlock's base
repeatedly instead of just the new section emitted.