### PR TITLE
Fix a bunch of MacOS crashes

### DIFF
--- a/hphp/util/word-mem.h
+++ b/hphp/util/word-mem.h
@@ -26,6 +26,12 @@ extern "C" void* _memcpy16(void* dst, const void* src, size_t len);
 extern "C" void _bcopy32(void* dst, const void* src, size_t len);
 extern "C" void _bcopy_in_64(void* dst, const void* src, size_t lenIn64);
 
+#ifdef __APPLE__
+#define ASM_LOCAL_LABEL(x) "L" x
+#else
+#define ASM_LOCAL_LABEL(x) ".L" x
+#endif
+
 namespace HPHP {
 
 /*
@@ -98,7 +104,7 @@ inline void bcopy32_inline(void* dst, const void* src, size_t len) {
   assertx(len >= 32);
 #if defined(__x86_64__)
   __asm__ __volatile__("shr    $5, %0\n"
-                       ".LBCP32%=:\n"
+                       ASM_LOCAL_LABEL("BCP32%=") ":\n"
                        "movdqu (%1), %%xmm0\n"
                        "movdqu 16(%1), %%xmm1\n"
                        "add    $32, %1\n"
@@ -106,7 +112,7 @@ inline void bcopy32_inline(void* dst, const void* src, size_t len) {
                        "movdqu %%xmm1, 16(%2)\n"
                        "add    $32, %2\n"
                        "dec    %0\n"
-                       "jg     .LBCP32%=\n"
+                       "jg     " ASM_LOCAL_LABEL("BCP32%=") "\n"
                        : "+r"(len), "+r"(src), "+r"(dst)
                        :: "xmm0", "xmm1"
                       );
@@ -115,13 +121,13 @@ inline void bcopy32_inline(void* dst, const void* src, size_t len) {
   __asm__ __volatile__("lsr    %x0, %x0, #5\n"
                        "sub    %x1, %x1, #16\n"
                        "sub    %x2, %x2, #16\n"
-                       ".LBCP32%=:\n"
+                       ASM_LOCAL_LABEL("BCP32%=") ":\n"
                        "ldp    %x3, %x4, [%x1, #16]\n"
                        "ldp    %x5, %x6, [%x1, #32]!\n"
                        "stp    %x3, %x4, [%x2, #16]\n"
                        "stp    %x5, %x6, [%x2, #32]!\n"
                        "subs   %x0, %x0, #1\n"
-                       "bgt    .LBCP32%=\n"
+                       "bgt    " ASM_LOCAL_LOCAL("BCP32%=") "\n"
                        : "+r"(len), "+r"(src), "+r"(dst),
                          "=r"(t3), "=r"(t4), "=r"(t5), "=r"(t6), "=r"(t7)
                       );
@@ -136,8 +142,8 @@ inline void memcpy16_inline(void* dst, const void* src, size_t len) {
   __asm__ __volatile__("movdqu -16(%1, %0), %%xmm0\n"
                        "movdqu %%xmm0, -16(%2, %0)\n"
                        "shr    $5, %0\n"
-                       "jz     .LEND%=\n"
-                       ".LR32%=:\n"
+                       "jz     " ASM_LOCAL_LABEL("END%=") "\n"
+                       ASM_LOCAL_LABEL("R32%=") ":\n"
                        "movdqu (%1), %%xmm0\n"
                        "movdqu 16(%1), %%xmm1\n"
                        "add    $32, %1\n"
@@ -145,8 +151,8 @@ inline void memcpy16_inline(void* dst, const void* src, size_t len) {
                        "movdqu %%xmm1, 16(%2)\n"
                        "add    $32, %2\n"
                        "dec    %0\n"
-                       "jg     .LR32%=\n"
-                       ".LEND%=:\n"
+                       "jg     " ASM_LOCAL_LABEL("R32%=") "\n"
+                       ASM_LOCAL_LABEL("END%=") ":\n"
                        : "+r"(len), "+r"(src), "+r"(dst)
                        :: "xmm0", "xmm1"
                       );
@@ -159,17 +165,17 @@ inline void memcpy16_inline(void* dst, const void* src, size_t len) {
                        "add    %x2, %x2, %x0\n"
                        "stp    %x3, %x4, [%x2, #-16]!\n"
                        "lsr    %x0, %x0, #5\n"
-                       "cbz    %x0, .LEND%=\n"
+                       "cbz    %x0, " ASM_LOCAL_LABEL("END%=") "\n"
                        "sub    %x7, %x7, #16\n"
                        "sub    %x8, %x8, #16\n"
-                       ".LR32%=:\n"
+                       ASM_LOCAL_LABEL("R32%=") ":\n"
                        "ldp    %x3, %x4, [%x7, #16]\n"
                        "ldp    %x5, %x6, [%x7, #32]!\n"
                        "stp    %x3, %x4, [%x8, #16]\n"
                        "stp    %x5, %x6, [%x8, #32]!\n"
                        "subs   %x0, %x0, #1\n"
-                       "bgt    .LR32%=\n"
-                       ".LEND%=:\n"
+                       "bgt    " ASM_LOCAL_LABEL("R32%=") "\n"
+                       ASM_LOCAL_LABEL("END%=") ":\n"
                        : "+r"(len), "+r"(src), "+r"(dst),
                          "=r"(t3), "=r"(t4), "=r"(t5), "=r"(t6),
                          "=r"(s1), "=r"(d1), "=r"(d2)


### PR DESCRIPTION
Summary: clang generates noexcept frames for exported ASM labels - and it
has a different prefix for local labels, so our memcpy handler labels were
getting noexcept frames.

As our memcpy handlers are inlined, this meant that any C++ throws in the
same function as a call to one of our memcpy helpers would be uncaught.

Test Plan:

 - POC: https://gist.github.com/fredemmott/4d96ee4f5b7ce9be75af89eabb96759d
 - Hack test:

```Hack
<?hh

abstract final class Foo {
};

new Foo();
```

With this patch
---------------

```
fredemmott-pro:hhvm fredemmott$ ./hphp/hhvm/hhvm -d hhvm.jit=0 -d hhvm.hack.lang.look_for_typechecker=0 ~/test.php

Fatal error: Cannot instantiate abstract class Foo in /Users/fredemmott/test.php on line 6
fredemmott-pro:hhvm fredemmott$ ./hphp/hhvm/hhvm -d hhvm.jit=1 -d hhvm.hack.lang.look_for_typechecker=0 ~/test.php

Fatal error: Cannot instantiate abstract class Foo in /Users/fredemmott/test.php on line 6
```

Without this patch
------------------

```
libc++abi.dylib: terminating with uncaught exception of type HPHP::FatalErrorException: Cannot instantiate abstract class Foo
```