### PR TITLE
aarch64 - slight improvement to ffs64

### DIFF
--- a/hphp/util/bitops.h
+++ b/hphp/util/bitops.h
@@ -161,11 +161,18 @@ inline size_t ffs64(size_t x) {
            : "r"(x)    // Inputs.
            );
   return ret;
+#elif defined(__aarch64__)
+  size_t ret;
+  __asm__ ("rbit %0, %1\n\t"
+           "clz %0, %0"
+           : "=r"(ret) // Outputs.
+           : "r"(x)    // Inputs.
+           );
+  return ret;
 #else
   return __builtin_ffsll(x) - 1;
 #endif
 }
-
 } // HPHP
 
 #endif


### PR DESCRIPTION

This adds the Aarch64 equivalent code that was seen at the bottom of  commit 1c338be.
This takes advantage of the assert to save 2 instructions per instance.

The standard regression tests were run with 6 option sets.  No new problems were observed.
The generated assembly code was as expected.

Before
=====
0000000005e8b574 <_ZN4HPHP5ffs64Em>:
...
 5e8b5e4:       52801382        mov     w2, #0x9c                       // #156
 5e8b5e8:       97dc48c9        bl      559d90c <_ZN4HPHP11assert_failEPKcS1_jS1_RKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE>
 5e8b5ec:       f94017a0        ldr     x0, [x29,#40]
 5e8b5f0:       f100001f        cmp     x0, #0x0        //<<---
 5e8b5f4:       dac00000        rbit    x0, x0          //<<---
 5e8b5f8:       dac01000        clz     x0, x0          //<<---
 5e8b5fc:       9a8007e0        csinc   x0, xzr, x0, eq //<<---
 5e8b600:       51000400        sub     w0, w0, #0x1

After
====
0000000005e8b574 <_ZN4HPHP5ffs64Em>:
...
 5e8b5e4:       52801382        mov     w2, #0x9c                       // #156
 5e8b5e8:       97dc48c9        bl      559d90c <_ZN4HPHP11assert_failEPKcS1_jS1_RKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE>
 5e8b5ec:       f94017a0        ldr     x0, [x29,#40]
 5e8b5f0:       dac00000        rbit    x0, x0          //<<---
 5e8b5f4:       dac01000        clz     x0, x0          //<<---
 5e8b5f8:       f90023a0        str     x0, [x29,#64]
 5e8b5fc:       f94023a0        ldr     x0, [x29,#64]