### PR TITLE
Warn about a GCC 4.9 bug

### DIFF
--- a/CMake/HPHPCompiler.cmake
+++ b/CMake/HPHPCompiler.cmake
@@ -167,6 +167,12 @@ if (${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang" OR ${CMAKE_CXX_COMPILER_ID} STREQU
        message(FATAL_ERROR "${PROJECT_NAME} requires g++ 4.9 or greater.")
     endif()
 
+    # Warn about a GCC 4.9 bug leading to an incorrect refcounting issue
+    # https://github.com/facebook/hhvm/issues/8011
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5.0)
+       message(WARNING "HHVM is known to trigger optimization bugs in GCC 4.9. Upgrading to GCC 5 is recommended. See https://github.com/facebook/hhvm/issues/8011 for more details.")
+    endif()
+
     if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 6.0 OR
        CMAKE_CXX_COMPILER_VERSION VERSION_EQUAL 6.0)
      message(WARNING "HHVM is primarily tested on GCC 4.9 and 5. Using other versions may produce unexpected results, or may not even build at all.")

--- a/hphp/test/slow/string/gcc-4.9-bug.php
+++ b/hphp/test/slow/string/gcc-4.9-bug.php
@@ -1,0 +1,17 @@
+<?php
+
+// https://github.com/facebook/hhvm/issues/8011
+
+class Test
+{
+    public function foo()
+    {
+        $x = ['foo', 'bar'];
+        // The actual operation isn't important, just need to do something to turn the literal
+        // strings into refcounted strings
+        $y = array_map(function($it) { return $it.$it; }, $x);
+        return array_unique($y, SORT_STRING);
+    }
+}
+
+var_dump((new Test())->foo());

--- a/hphp/test/slow/string/gcc-4.9-bug.php.expect
+++ b/hphp/test/slow/string/gcc-4.9-bug.php.expect
@@ -1,0 +1,6 @@
+array(2) {
+  [0]=>
+  string(6) "foofoo"
+  [1]=>
+  string(6) "barbar"
+}


### PR DESCRIPTION
Summary: HHVM triggers an optimization bug in GCC 4.9 which leads to an
incorrect refcounting issue when compiled with -O1 or greater.

Add a testcase from @fredemmott for the bug and add a warning in CMake
about the compiler version.

See: https://github.com/facebook/hhvm/issues/8011

Signed-off-by: Arthur Loiret <arthur.loiret@adeline.mobi>