### PR TITLE
fix segfault on include/require with registered user 'file' stream wrapper

### DIFF
--- a/hphp/runtime/base/unit-cache.cpp
+++ b/hphp/runtime/base/unit-cache.cpp
@@ -496,6 +496,7 @@ bool findFileWrapper(const String& file, void* ctx) {
       context->path = file;
       return true;
     }
+    return false;
   }
 
   // handle file://


### PR DESCRIPTION
I fixed issue #8089 by returning false in case "stat" from the user stream wrapper is unsuccessful.