### PR TITLE
Support JSON_FB_HACK_ARRAYS when using json-c

### DIFF
--- a/hphp/runtime/ext/json/JSON_parser.cpp
+++ b/hphp/runtime/ext/json/JSON_parser.cpp
@@ -299,18 +299,6 @@ enum class Mode {
   ARRAY = 4
 };
 
-/**
- * These are the types of containers that can be returned
- * depending on the options used for json_decode.
- *
- * Objects are not included here.
- */
-enum class ContainerType {
-  PHP_ARRAYS = 1,
-  COLLECTIONS = 2,
-  HACK_ARRAYS = 3,
-};
-
 namespace {
 
 NEVER_INLINE
@@ -893,7 +881,7 @@ static void object_set(Variant &var,
                        const String& key,
                        const Variant& value,
                        int assoc,
-                       ContainerType container_type) {
+                       JSONContainerType container_type) {
   if (!assoc) {
     // We know it is stdClass, and everything is public (and dynamic).
     if (key.empty()) {
@@ -902,10 +890,10 @@ static void object_set(Variant &var,
       var.getObjectData()->o_set(key, value);
     }
   } else {
-    if (container_type == ContainerType::COLLECTIONS) {
+    if (container_type == JSONContainerType::COLLECTIONS) {
       auto keyTV = make_tv<KindOfString>(key.get());
       collections::set(var.getObjectData(), &keyTV, value.asCell());
-    } else if (container_type == ContainerType::HACK_ARRAYS) {
+    } else if (container_type == JSONContainerType::HACK_ARRAYS) {
       forceToDict(var).set(key, value);
     } else {
       forceToArray(var).set(key, value);
@@ -916,7 +904,7 @@ static void object_set(Variant &var,
 static void attach_zval(json_parser *json,
                         const String& key,
                         int assoc,
-                        ContainerType container_type) {
+                        JSONContainerType container_type) {
   if (json->top < 1) {
     return;
   }
@@ -926,7 +914,7 @@ static void attach_zval(json_parser *json,
   auto up_mode = json->stack[json->top - 1].mode;
 
   if (up_mode == Mode::ARRAY) {
-    if (container_type == ContainerType::COLLECTIONS) {
+    if (container_type == JSONContainerType::COLLECTIONS) {
       collections::append(root.getObjectData(), child.asCell());
     } else {
       root.toArrRef().append(child);
@@ -936,17 +924,17 @@ static void attach_zval(json_parser *json,
   }
 }
 
-ContainerType get_container_type_from_options(int64_t options) {
+JSONContainerType get_container_type_from_options(int64_t options) {
   if ((options & k_JSON_FB_STABLE_MAPS) ||
       (options & k_JSON_FB_COLLECTIONS)) {
-    return ContainerType::COLLECTIONS;
+    return JSONContainerType::COLLECTIONS;
   }
 
   if (options & k_JSON_FB_HACK_ARRAYS) {
-    return ContainerType::HACK_ARRAYS;
+    return JSONContainerType::HACK_ARRAYS;
   }
 
-  return ContainerType::PHP_ARRAYS;
+  return JSONContainerType::PHP_ARRAYS;
 }
 
 /**
@@ -1003,7 +991,7 @@ bool JSON_parser(Variant &z, const char *p, int length, bool const assoc,
 
   /*<fb>*/
   bool const loose = options & k_JSON_FB_LOOSE;
-  ContainerType const container_type = get_container_type_from_options(options);
+  JSONContainerType const container_type = get_container_type_from_options(options);
   int qchr = 0;
   int8_t const *byte_class;
   int8_t const (*next_state_table)[32];
@@ -1122,7 +1110,7 @@ bool JSON_parser(Variant &z, const char *p, int length, bool const assoc,
             top.unset();
           }
           /*<fb>*/
-          if (container_type == ContainerType::COLLECTIONS) {
+          if (container_type == JSONContainerType::COLLECTIONS) {
             // stable_maps is meaningless
             top = req::make<c_Map>();
           } else {
@@ -1130,7 +1118,7 @@ bool JSON_parser(Variant &z, const char *p, int length, bool const assoc,
             if (!assoc) {
               top = SystemLib::AllocStdClassObject();
             /* <fb> */
-            } else if (container_type == ContainerType::HACK_ARRAYS) {
+            } else if (container_type == JSONContainerType::HACK_ARRAYS) {
               top = Array::CreateDict();
             /* </fb> */
             } else {
@@ -1198,9 +1186,9 @@ bool JSON_parser(Variant &z, const char *p, int length, bool const assoc,
             top.unset();
           }
           /*<fb>*/
-          if (container_type == ContainerType::COLLECTIONS) {
+          if (container_type == JSONContainerType::COLLECTIONS) {
             top = req::make<c_Vector>();
-          } else if (container_type == ContainerType::HACK_ARRAYS) {
+          } else if (container_type == JSONContainerType::HACK_ARRAYS) {
             top = Array::CreateVec();
           } else {
             top = Array::Create();
@@ -1220,7 +1208,7 @@ bool JSON_parser(Variant &z, const char *p, int length, bool const assoc,
             Variant mval;
             json_create_zval(mval, *buf, type, options);
             auto& top = json->stack[json->top].val;
-            if (container_type == ContainerType::COLLECTIONS) {
+            if (container_type == JSONContainerType::COLLECTIONS) {
               collections::append(top.getObjectData(), mval.asCell());
             } else {
               top.toArrRef().append(mval);
@@ -1296,7 +1284,7 @@ bool JSON_parser(Variant &z, const char *p, int length, bool const assoc,
           case Mode::ARRAY:
             if (type != -1) {
               auto& top = json->stack[json->top].val;
-              if (container_type == ContainerType::COLLECTIONS) {
+              if (container_type == JSONContainerType::COLLECTIONS) {
                 collections::append(top.getObjectData(), mval.asCell());
               } else {
                 top.toArrRef().append(mval);

--- a/hphp/runtime/ext/json/JSON_parser.h
+++ b/hphp/runtime/ext/json/JSON_parser.h
@@ -22,6 +22,18 @@
 
 namespace HPHP {
 
+/**
+ * These are the types of containers that can be returned
+ * depending on the options used for json_decode.
+ *
+ * Objects are not included here.
+ */
+enum class JSONContainerType {
+  PHP_ARRAYS = 1,
+  COLLECTIONS = 2,
+  HACK_ARRAYS = 3,
+};
+
 struct StringBuffer;
 struct Variant;
 


### PR DESCRIPTION
fixes #8098

Also fix a bad use of FOLLY_FALLTHROUGH that makes clang sad.