### PR TITLE
avoid typechecker warning

### DIFF
--- a/hphp/test/slow/prepend-file/config.ini
+++ b/hphp/test/slow/prepend-file/config.ini
@@ -1,1 +1,2 @@
+hhvm.hack.lang.look_for_typechecker=0
 hhvm.prelude_path = "prelude-dir/prelude.inc"


### PR DESCRIPTION

Recently added regression tests are failing because hhvm is complaining
about missing type checker.