### PR TITLE
aarch64 - setcc/movzbX peephole

### DIFF
--- a/hphp/runtime/vm/jit/vasm-simplify.cpp
+++ b/hphp/runtime/vm/jit/vasm-simplify.cpp
@@ -1049,6 +1049,33 @@ bool simplify(Env& env, const pop& inst, Vlabel b, size_t i) {
   });
 }
 
+template<typename Movzb>
+bool simplify_movzb(Env& env, const Movzb& inst, Vlabel b, size_t i) {
+  auto const def_op = env.def_insts[inst.s];
+
+  if (def_op != Vinstr::setcc) return false;
+  if (!(arch() == Arch::ARM &&
+    width(def_op) != Width::Long)) return false;
+
+  // movzbX{} is redundant--operation on 32-bit registers clear the upper bits.
+  return simplify_impl(env, b, i, [&] (Vout& v) {
+    v << copy{inst.s, inst.d};
+    return 1;
+  });
+}
+
+bool simplify(Env& env, const movzbl& inst, Vlabel b, size_t i) {
+  return simplify_movzb<movzbl>(env, inst, b, i);
+}
+
+bool simplify(Env& env, const movzbw& inst, Vlabel b, size_t i) {
+  return simplify_movzb<movzbw>(env, inst, b, i);
+}
+
+bool simplify(Env& env, const movzbq& inst, Vlabel b, size_t i) {
+  return simplify_movzb<movzbq>(env, inst, b, i);
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 
 // Try to do constant folding on Vptr operands.


### PR DESCRIPTION
The opportunity for removing unneeded zero extensions still exists.
This change was previously submitted as #7707, but was withdrawn due to cmullers
changes.  Approximately 200 instances were detected in the zend/bench.php benchmark.

Before
=====
 108241  B24: [profCount=1] (preds B17)
 108242     (53) t9:Bool = LtInt t7:Int, 1000000
 108243         Main:
 108244               0x586015f0  eb00003f              cmp x1, x0
 108245               0x586015f4  1a9fa7e0              cset w0, lt
 108246 
 108247     (54) StStk<IRSPOff -1> t1:StkPtr, t9:Bool
 108248         Main:
 108249               0x586015f8  52800421              movz w1, #0x21
 108250               0x586015fc  381b83a1              sturb w1, [x29, #-72]
 108251               0x58601600  d3401c00              uxtb x0, w0     //<<---
 108252               0x58601604  f81b03a0              stur x0, [x29, #-80]

After
====
 108239  B24: [profCount=1] (preds B17)
 108240     (53) t9:Bool = LtInt t7:Int, 1000000
 108241         Main:
 108242               0x298015f0  eb00003f              cmp x1, x0
 108243               0x298015f4  1a9fa7e0              cset w0, lt
 108244 
 108245     (54) StStk<IRSPOff -1> t1:StkPtr, t9:Bool
 108246         Main:
 108247               0x298015f8  52800421              movz w1, #0x21
 108248               0x298015fc  381b83a1              sturb w1, [x29, #-72]
 108249               0x29801600  f81b03a0              stur x0, [x29, #-80]

TRACE='printir:9,vasm:6' hphp/hhvm/hhvm -vEval.Jit=1 bench.php

The standard regression tests were run with 6 option sets.  No new regressions were observed.

