### PR TITLE
avoid typechecker warnings in regression tests.

### DIFF
--- a/hphp/test/slow/object/no-destructors-ok.php.ini
+++ b/hphp/test/slow/object/no-destructors-ok.php.ini
@@ -1,6 +1,3 @@
 hhvm.allow_object_destructors = false
 hhvm.php7.all=false
-hhvm.php7.all=false
-hhvm.php7.all=false
-hhvm.php7.all=false
 hhvm.hack.lang.look_for_typechecker=0

--- a/hphp/test/slow/object/no-destructors-ok.php.ini
+++ b/hphp/test/slow/object/no-destructors-ok.php.ini
@@ -3,3 +3,4 @@ hhvm.php7.all=false
 hhvm.php7.all=false
 hhvm.php7.all=false
 hhvm.php7.all=false
+hhvm.hack.lang.look_for_typechecker=0

--- a/hphp/test/slow/object/optional-destruct.php.ini
+++ b/hphp/test/slow/object/optional-destruct.php.ini
@@ -1,6 +1,3 @@
 hhvm.allow_object_destructors = false
 hhvm.php7.all=false
-hhvm.php7.all=false
-hhvm.php7.all=false
-hhvm.php7.all=false
 hhvm.hack.lang.look_for_typechecker=0

--- a/hphp/test/slow/object/optional-destruct.php.ini
+++ b/hphp/test/slow/object/optional-destruct.php.ini
@@ -3,3 +3,4 @@ hhvm.php7.all=false
 hhvm.php7.all=false
 hhvm.php7.all=false
 hhvm.php7.all=false
+hhvm.hack.lang.look_for_typechecker=0


### PR DESCRIPTION

These two regression tests have been failing some option sets since November 21 of last year.
Here's an example from last Friday's testing.

  Commit: be1887a17e111992c679dcb2189c6e097cccfcd5
  File | interp | interp -r | jit -a '-vEval.JitPGO=0' | jit -r -a '-vEval.JitPGO=0' | jit -a '-vEval.JitPGO=1' | jit -r -a '-vEval.JitPGO=1' | 
  hphp/test/slow/object/no-destructors-ok.php | F | . | F | . | F | . | 
  hphp/test/slow/object/optional-destruct.php | F | . | F | . | F | . | 

There doesn't appear to be anything Hack specific in the test, so it should be
Ok to turn off the type checker.

The tests pass all six option sets when this change is applied.
