### PR TITLE
Patch MySQL client to skip non-backported session tracking types.

### DIFF
--- a/patches/webscalesql-skip-session-tracking-types.patch
+++ b/patches/webscalesql-skip-session-tracking-types.patch
@@ -1,0 +1,52 @@
+From b4ae418dbbd4913cbf0d523569a3d4ec9ba85343 Mon Sep 17 00:00:00 2001
+From: Manuel Ung <mung@fb.com>
+Date: Thu, 1 Feb 2018 11:26:32 -0800
+Subject: [PATCH] Safely skip over unsupported session tracking types
+
+Summary:
+When we backported session tracking from 5.7, we did not backport all types, which is fine. However, we weren't skipping over them properly, since we just break out prematurely.
+
+The fix is to move the cases down with the default cases where they will safely get skipped. Note that the assert won't fire because we still have all the enums defined properly.
+
+Closes https://github.com/facebook/mysql-5.6/pull/781
+Closes https://github.com/facebook/mysql-5.6/issues/766
+
+Reviewed By: jkedgar
+
+Differential Revision: D6874150
+---
+ sql-common/client.c | 11 +++++------
+ 1 file changed, 5 insertions(+), 6 deletions(-)
+
+diff --git a/third-party/webscalesqlclient/src/sql-common/client.c b/third-party/webscalesqlclient/src/sql-common/client.c
+index 3cfe0d8ddb..e10f15d89b 100644
+--- a/third-party/webscalesqlclient/src/sql-common/client.c
++++ b/third-party/webscalesqlclient/src/sql-common/client.c
+@@ -780,12 +780,6 @@ void read_ok_ex(MYSQL *mysql, ulong length)
+ 
+           switch (type)
+           {
+-          case SESSION_TRACK_SYSTEM_VARIABLES:
+-          case SESSION_TRACK_SCHEMA:
+-          case SESSION_TRACK_TRANSACTION_CHARACTERISTICS:
+-          case SESSION_TRACK_TRANSACTION_STATE:
+-            /* not backported */
+-           break;
+           case SESSION_TRACK_GTIDS:
+             if (!my_multi_malloc(MYF(0),
+               &element, sizeof(LIST),
+@@ -858,6 +852,11 @@ void read_ok_ex(MYSQL *mysql, ulong length)
+             }
+ 
+             break;
++          case SESSION_TRACK_SYSTEM_VARIABLES:
++          case SESSION_TRACK_SCHEMA:
++          case SESSION_TRACK_TRANSACTION_CHARACTERISTICS:
++          case SESSION_TRACK_TRANSACTION_STATE:
++            /* not backported */
+           default:
+             DBUG_ASSERT(type <= SESSION_TRACK_END);
+             /*
+-- 
+2.13.5
+


### PR DESCRIPTION
This is
https://github.com/facebook/mysql-5.6/commit/b4ae418dbbd4913cbf0d523569a3d4ec9ba85343
by @lth

I'm adding this to patches/ instead of updating the submodule so that
this diff is cherry-pickable to release branches of HHVM.

fixes facebook/hhvm#8050