### PR TITLE
[easy] cherry-pick wangle fix for segmentation fault if SSL misconfigured

### DIFF
--- a/patches/wangle-ssl-segfault-if-misconfigured.patch
+++ b/patches/wangle-ssl-segfault-if-misconfigured.patch
@@ -1,0 +1,120 @@
+commit ab7a6f191c1150fb4aa95f325023b88ae4201850
+Author: Neel Goyal <ngoyal@fb.com>
+Date:   Mon Dec 11 18:48:49 2017 -0800
+
+    Fix case where ssl cert does not match key
+    
+    Summary: In some cases, SSLContextManager seg faults if a cert and key do not match.  This guards against that case when strictSSL = false, and throws a more useful error in the cases when SSL is required.
+    
+    Reviewed By: xybu
+    
+    Differential Revision: D6513964
+
+diff --git a/third-party/wangle/src/wangle/ssl/SSLContextManager.cpp b/third-party/wangle/src/wangle/ssl/SSLContextManager.cpp
+index c0b7e0d..b4e97c8 100644
+--- a/third-party/wangle/src/wangle/ssl/SSLContextManager.cpp
++++ b/third-party/wangle/src/wangle/ssl/SSLContextManager.cpp
+@@ -76,7 +76,9 @@ X509* getX509(SSL_CTX* ctx) {
+   SSL* ssl = SSL_new(ctx);
+   SSL_set_connect_state(ssl);
+   X509* x509 = SSL_get_certificate(ssl);
+-  X509_up_ref(x509);
++  if (x509) {
++    X509_up_ref(x509);
++  }
+   SSL_free(ssl);
+   return x509;
+ }
+@@ -270,21 +272,43 @@ void SSLContextManager::addSSLContextConfig(
+       std::make_shared<ServerSSLContext>(ctxConfig.sslVersion);
+   for (const auto& cert : ctxConfig.certificates) {
+     try {
+-      loadCertificate(sslCtx.get(), ctxConfig, cert.certPath);
++      if (ctxConfig.isLocalPrivateKey ||
++          ctxConfig.keyOffloadParams.offloadType.empty()) {
++        // The private key lives in the same process
++        // This needs to be called before loadPrivateKey().
++        if (!cert.passwordPath.empty()) {
++          auto sslPassword = std::make_shared<PasswordInFile>(
++              cert.passwordPath);
++          sslCtx->passwordCollector(std::move(sslPassword));
++        }
++        sslCtx->loadCertKeyPairFromFiles(
++          cert.certPath.c_str(),
++          cert.keyPath.c_str(),
++          "PEM",
++          "PEM");
++      } else {
++        loadCertificate(sslCtx.get(), ctxConfig, cert.certPath);
++        enableAsyncCrypto(sslCtx, ctxConfig, cert.certPath);
++      }
+     } catch (const std::exception& ex) {
+-      // The exception isn't very useful without the certificate path name,
+-      // so throw a new exception that includes the path to the certificate.
+-      string msg = folly::to<string>("error loading SSL certificate ",
+-                                     cert.certPath, ": ",
+-                                     folly::exceptionStr(ex));
+-      LOG(ERROR) << msg;
+-      throw std::runtime_error(msg);
++        // The exception isn't very useful without the certificate path name,
++        // so throw a new exception that includes the path to the certificate.
++        string msg = folly::to<string>("error loading SSL certificate ",
++                                       cert.certPath, ": ",
++                                       folly::exceptionStr(ex));
++        LOG(ERROR) << msg;
++        throw std::runtime_error(msg);
+     }
+ 
+     // Verify that the Common Name and (if present) Subject Alternative Names
+     // are the same for all the certs specified for the SSL context.
+     numCerts++;
+     X509* x509 = getX509(sslCtx->getSSLCtx());
++    if (!x509) {
++      throw std::runtime_error(
++          folly::to<std::string>(
++              "Certificate: ", cert.certPath, " is invalid"));
++    }
+     auto guard = folly::makeGuard([x509] { X509_free(x509); });
+     auto cn = SSLUtil::getCommonName(x509);
+     if (!cn) {
+@@ -323,30 +347,6 @@ void SSLContextManager::addSSLContextConfig(
+       }
+     }
+     lastCertPath = cert.certPath;
+-
+-    if (ctxConfig.isLocalPrivateKey
+-        || ctxConfig.keyOffloadParams.offloadType.empty()) {
+-      // The private key lives in the same process
+-      // This needs to be called before loadPrivateKey().
+-      if (!cert.passwordPath.empty()) {
+-        auto sslPassword = std::make_shared<PasswordInFile>(cert.passwordPath);
+-        sslCtx->passwordCollector(sslPassword);
+-      }
+-
+-      try {
+-        sslCtx->loadPrivateKey(cert.keyPath.c_str());
+-      } catch (const std::exception& ex) {
+-        // Throw an error that includes the key path, so the user can tell
+-        // which key had a problem.
+-        string msg = folly::to<string>("error loading private SSL key ",
+-                                       cert.keyPath, ": ",
+-                                       folly::exceptionStr(ex));
+-        LOG(ERROR) << msg;
+-        throw std::runtime_error(msg);
+-      }
+-    } else {
+-      enableAsyncCrypto(sslCtx, ctxConfig, cert.certPath);
+-    }
+   }
+ 
+   overrideConfiguration(sslCtx, ctxConfig);
+@@ -596,6 +596,9 @@ SSLContextManager::insert(shared_ptr<ServerSSLContext> sslCtx,
+                           bool defaultFallback,
+                           SslContexts& contexts) {
+   X509* x509 = getX509(sslCtx->getSSLCtx());
++  if (!x509) {
++    throw std::runtime_error("SSLCtx is invalid");
++  }
+   auto guard = folly::makeGuard([x509] { X509_free(x509); });
+   auto cn = SSLUtil::getCommonName(x509);
+   if (!cn) {


### PR DESCRIPTION
fixes #8061

This is https://github.com/facebook/wangle/commit/ab7a6f191c1150fb4aa95f325023b88ae4201850

Applying this in patches/ instead of updating third-party/ so it's
safely cherry-pickable to the 3.24 branch. Will be separately updating
third-party in the near future.

Test plan:

3.24.1
------

```
$ hhvm -m server -d hhvm.server.enable_ssl=true -d hhvm.server.ssl_port=8443 -p 8080
...
Invalid certificate file or key file
...
Core dumped: Segmentation fault: 11
Stack trace in /tmp/stacktrace.62287.log
Segmentation fault: 11
$
```

With This Patch
---------------

```
$ ./hhvm -m server -d hhvm.server.enable_ssl=true -d hhvm.server.ssl_port=8443 -p 8080
...
Invalid certificate file or key file
...
E0206 10:21:37.443305 3073762112 SSLContextManager.cpp:432] Error adding certificate : St13runtime_error: SSLCtx is invalid
I0206 10:21:37.443473 3073762112 Acceptor.cpp:89] Failed to configure TLS. This is not a fatal error. Error adding certificate : St13runtime_error: SSLCtx is invalid
...
```