### PR TITLE
memory leak check

### DIFF
--- a/hphp/util/cache/mmap-file.cpp
+++ b/hphp/util/cache/mmap-file.cpp
@@ -45,6 +45,8 @@ MmapFile::~MmapFile() {
 }
 
 bool MmapFile::init() {
+  CHECK(!initialized_) << ": already initialized. MmapFile::init will cause memory leak.";
+   
   int fd = open(path_.c_str(), O_RDONLY);
 
   if (fd < 0) {


### PR DESCRIPTION
Check for multiple mmap init calls.
When after successful init, it is called again, it will cause memory leak. Added appropriate error message for that case.