### PR TITLE
Use HTTPS instead of HTTP

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to HHVM
 
-We'd love to have your help in making HHVM better. Before jumping into the code, please familiarize yourself with our [coding conventions](hphp/doc/coding-conventions.md). We're also working on a [Hacker's Guide to HHVM](hphp/doc/hackers-guide). It's still very incomplete, but if there's a specific topic you'd like to see addressed sooner rather than later, let us know. For documentation and any other problems, please open an [issue](http://github.com/facebook/hhvm/issues), or better yet, [fork us and send a pull request](https://github.com/facebook/hhvm/pulls). Join us on Freenode in [#hhvm](http://webchat.freenode.net/?channels=hhvm) for general discussion, or [#hhvm-dev](http://webchat.freenode.net/?channels=hhvm-dev) for development-oriented discussion.
+We'd love to have your help in making HHVM better. Before jumping into the code, please familiarize yourself with our [coding conventions](hphp/doc/coding-conventions.md). We're also working on a [Hacker's Guide to HHVM](hphp/doc/hackers-guide). It's still very incomplete, but if there's a specific topic you'd like to see addressed sooner rather than later, let us know. For documentation and any other problems, please open an [issue](https://github.com/facebook/hhvm/issues), or better yet, [fork us and send a pull request](https://github.com/facebook/hhvm/pulls). Join us on Freenode in [#hhvm](https://webchat.freenode.net/?channels=hhvm) for general discussion, or [#hhvm-dev](https://webchat.freenode.net/?channels=hhvm-dev) for development-oriented discussion.
 
 If you want to help but don't know where to start, try fixing some of the ["probably easy" issues](https://github.com/facebook/hhvm/issues?q=is%3Aopen+is%3Aissue+label%3A%22probably+easy%22); add a test to hphp/test/slow/something_appropriate, and run it with hphp/test/run.
 
@@ -11,7 +11,7 @@ The code of conduct is described in [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md)
 
 ## Submitting Pull Requests
 
-Before changes can be accepted a [Contributor Licensing Agreement](http://code.facebook.com/cla) must be completed. You will be prompted to accept the CLA when you submit your first pull request. If you prefer a hard copy, you can print the [pdf](https://github.com/facebook/hhvm/raw/master/hphp/doc/FB_Individual_CLA.pdf), sign it, scan it, and send it to <cla@fb.com>.
+Before changes can be accepted a [Contributor Licensing Agreement](https://code.facebook.com/cla) must be completed. You will be prompted to accept the CLA when you submit your first pull request. If you prefer a hard copy, you can print the [pdf](https://github.com/facebook/hhvm/raw/master/hphp/doc/FB_Individual_CLA.pdf), sign it, scan it, and send it to <cla@fb.com>.
 
 Please add appropriate test cases as you make changes, and make sure that they pass locally before submitting your pull request; see [here](hphp/test/README.md) for more information.  All the tests are run via Phabricator, however testing locally greatly speeds up the process of accepting your changes.
 
@@ -23,5 +23,5 @@ Then, submit another PR against the relevant stable branch(es) cherry-picking yo
 
 ## Quick Links
 
- * IRC: [#hhvm](http://webchat.freenode.net/?channels=hhvm) and [#hhvm-dev](http://webchat.freenode.net/?channels=hhvm-dev) on Freenode.
- * [Issue tracker](http://github.com/facebook/hhvm/issues)
+ * IRC: [#hhvm](https://webchat.freenode.net/?channels=hhvm) and [#hhvm-dev](https://webchat.freenode.net/?channels=hhvm-dev) on Freenode.
+ * [Issue tracker](https://github.com/facebook/hhvm/issues)

--- a/README.md
+++ b/README.md
@@ -1,36 +1,36 @@
 # HHVM
 
-[HHVM page](http://hhvm.com) |
-[HHVM documentation](http://docs.hhvm.com/hhvm/) |
+[HHVM page](https://hhvm.com) |
+[HHVM documentation](https://docs.hhvm.com/hhvm/) |
 [Hacklang page](http://hacklang.org) |
 [General group](https://www.facebook.com/groups/hhvm.general/) |
 [Dev group](https://www.facebook.com/groups/hhvm.dev/) |
-[Twitter](http://twitter.com/HipHopVM)
+[Twitter](https://twitter.com/HipHopVM)
 
 HHVM is an open-source virtual machine designed for executing programs written in [Hack](http://hacklang.org). HHVM uses a just-in-time (JIT) compilation approach to achieve superior performance while maintaining the development flexibility that PHP provides.
 
 HHVM is intended for [Hack](http://hacklang.org) projects, and also supports a large subset of PHP 7 that is required by common tools and libraries. We no longer recommend using HHVM for purely PHP projects.
 
-HHVM should be used together with a webserver like the built in, easy to deploy [Proxygen](http://docs.hhvm.com/hhvm/basic-usage/proxygen), or a [FastCGI](http://docs.hhvm.com/hhvm/advanced-usage/fastCGI)-based webserver on top of nginx or Apache.
+HHVM should be used together with a webserver like the built in, easy to deploy [Proxygen](https://docs.hhvm.com/hhvm/basic-usage/proxygen), or a [FastCGI](https://docs.hhvm.com/hhvm/advanced-usage/fastCGI)-based webserver on top of nginx or Apache.
 
 ## Installing
 
-If you're new, try our [getting started guide](http://docs.hhvm.com/hhvm/getting-started/getting-started).
+If you're new, try our [getting started guide](https://docs.hhvm.com/hhvm/getting-started/getting-started).
 
-You can install a [prebuilt package](http://docs.hhvm.com/hhvm/installation/introduction#prebuilt-packages) or [compile from source](http://docs.hhvm.com/hhvm/installation/building-from-source).
+You can install a [prebuilt package](https://docs.hhvm.com/hhvm/installation/introduction#prebuilt-packages) or [compile from source](https://docs.hhvm.com/hhvm/installation/building-from-source).
 
 ## Running
 
 You can run standalone programs just by passing them to hhvm: `hhvm my_script.php`.
 
 If you want to host a website:
-* Install your favorite webserver. [Proxygen](http://docs.hhvm.com/hhvm/basic-usage/proxygen) is built in to HHVM, fast and easy to deploy.
-* Install our [package](http://docs.hhvm.com/hhvm/installation/introduction#prebuilt-packages)
+* Install your favorite webserver. [Proxygen](https://docs.hhvm.com/hhvm/basic-usage/proxygen) is built in to HHVM, fast and easy to deploy.
+* Install our [package](https://docs.hhvm.com/hhvm/installation/introduction#prebuilt-packages)
 * Start your webserver
 * Run `sudo /etc/init.d/hhvm start`
 * Visit your site at `http://.../index.php`
 
-Our [getting started guide](http://docs.hhvm.com/hhvm/getting-started/getting-started) provides a slightly more detailed introduction as well as links to more information.
+Our [getting started guide](https://docs.hhvm.com/hhvm/getting-started/getting-started) provides a slightly more detailed introduction as well as links to more information.
 
 ## Contributing
 
@@ -59,6 +59,6 @@ is it eligible for a bounty under our program.
 
 ## FAQ
 
-Our [user FAQ](http://docs.hhvm.com/hhvm/FAQ/faq) has answers to many common questions about HHVM, from [general questions](http://docs.hhvm.com/hhvm/FAQ/faq#general) to questions geared towards those that want to [use](http://docs.hhvm.com/hhvm/FAQ/faq#users).
+Our [user FAQ](https://docs.hhvm.com/hhvm/FAQ/faq) has answers to many common questions about HHVM, from [general questions](https://docs.hhvm.com/hhvm/FAQ/faq#general) to questions geared towards those that want to [use](https://docs.hhvm.com/hhvm/FAQ/faq#users).
 
 There is also a FAQ for [contributors](https://github.com/facebook/hhvm/wiki/FAQ#contributors) to HHVM.

--- a/hphp/doc/profiling.md
+++ b/hphp/doc/profiling.md
@@ -22,7 +22,7 @@ Profiling PHP Code
 ## PHP Interface ##
 
 HHVM supports the whole Xhprof interface, as described
-[on php.net](http://php.net/manual/en/book.xhprof.php).
+[on php.net](https://php.net/manual/en/book.xhprof.php).
 
 Note that regardless of whether `XHPROF_FLAGS_NO_BUILTINS` is on, builtins will
 not be profiled if the config option `Eval.JitEnableRenameFunction` is off. That

--- a/hphp/hack/README.md
+++ b/hphp/hack/README.md
@@ -1,6 +1,6 @@
 # What is Hack?
 
-Hack is a programming language for [HHVM](http://hhvm.com) that interoperates
+Hack is a programming language for [HHVM](https://hhvm.com) that interoperates
 seamlessly with PHP.  Hack reconciles the fast development cycle of PHP with the
 discipline provided by static typing, while adding many features commonly found
 in other modern programming languages.

--- a/hphp/test/dso_test/README.md
+++ b/hphp/test/dso_test/README.md
@@ -1,6 +1,6 @@
 ## Purpose of dso_test
 This is a simple zend extension solely for testing, taken from
-    http://devzone.zend.com/303
+    https://devzone.zend.com/303
 and renamed "dso_test".
 
 This extension is intended to be compiled as a DSO, not statically linked
@@ -43,4 +43,3 @@ rapidly doing its relatively trivial work.
 ### Examine products:
 
     nm -u dso_test.so | c++filt
-


### PR DESCRIPTION
This PR can be extended to all header licenses, that current use `http://www.facebook.com` and `http://www.php.net/license/3_01.txt`, but I don't know if the core team is interesting on that :smile: 