### PR TITLE
Enabling hash functions that require SSE4.2 support

### DIFF
--- a/CMake/HPHPCompiler.cmake
+++ b/CMake/HPHPCompiler.cmake
@@ -209,6 +209,16 @@ if (${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang" OR ${CMAKE_CXX_COMPILER_ID} STREQU
     # X64
     if(IS_X64)
       list(APPEND GENERAL_CXX_OPTIONS "mcrc32")
+        if(ENABLE_SSE4_2)
+          list(APPEND GENERAL_CXX_OPTIONS
+          # SSE4.2 has been available on processors for quite some time now. This
+          # allows enabling CRC hash function code
+          "msse4.2"
+          )
+          # Also pass the right option to ASM files to avoid inconsistencies
+          # in CRC hash function handling
+          set(CMAKE_ASM_FLAGS  "${CMAKE_ASM_FLAGS} -msse4.2")
+        endif()
     endif()
 
     # ARM64

--- a/CMake/Options.cmake
+++ b/CMake/Options.cmake
@@ -6,6 +6,7 @@ option(STATIC_CXX_LIB "Statically link libstd++ and libgcc." OFF)
 option(ENABLE_AVX2 "Enable the use of AVX2 instructions" OFF)
 option(ENABLE_AARCH64_CRC "Enable the use of CRC instructions" OFF)
 option(ENABLE_FASTCGI "Enable the FastCGI interface." ON)
+option(ENABLE_SSE4_2 "Enable SSE4.2 supported code." OFF)
 
 option(EXECUTION_PROFILER "Enable the execution profiler" OFF)
 


### PR DESCRIPTION
Hash functions for HHVM are currently guarded by __SSE4_2__ flag which are not
enabled by default. The fallback versions for "hash int" functions are "C"
implementations leaving some room for performance. This change enables the SSE4.2
support by default allowing all the hash functions to take the corresponding
assembly routines. The change also leaves the ENABLE_SSE4_2 flag configurable so
it can be turned off in case run on really old processors.

This gives ~0.4% performance improvement on oss-performance/WordPress and Drupal7