### PR TITLE
Allow "EXPLAIN..." queries to be recorded properly as well

### DIFF
--- a/hphp/runtime/ext/mysql/mysql_common.cpp
+++ b/hphp/runtime/ext/mysql/mysql_common.cpp
@@ -1518,11 +1518,11 @@ MySQLQueryReturn php_mysql_do_query(const String& query, const Variant& link_id,
 
     Variant matches;
     preg_match("/^(?:\\(|\\s)*(?:"
-               "(insert).*?\\s+(?:into\\s+)?([^\\s\\(,]+)|"
-               "(update|set|show)\\s+([^\\s\\(,]+)|"
-               "(replace).*?\\s+into\\s+([^\\s\\(,]+)|"
-               "(delete).*?\\s+from\\s+([^\\s\\(,]+)|"
-               "(select).*?[\\s`]+from\\s+([^\\s\\(,]+)|"
+               "(?:explain\\s|describe\\s)?(insert).*?\\s+(?:into\\s+)?([^\\s\\(,]+)|"
+               "(?:explain\\s|describe\\s)?(update|set|show)\\s+([^\\s\\(,]+)|"
+               "(?:explain\\s|describe\\s)?(replace).*?\\s+into\\s+([^\\s\\(,]+)|"
+               "(?:explain\\s|describe\\s)?(delete).*?\\s+from\\s+([^\\s\\(,]+)|"
+               "(?:explain\\s|describe\\s)?(select).*?[\\s`]+from\\s+([^\\s\\(,]+)|"
                "(create|alter|drop).*?\\s+table\\s+([^\\s\\(,]+))/is",
                q, &matches);
     auto marray = matches.toArray();


### PR DESCRIPTION
Similar to #3760 and #3761, EXPLAIN queries are not being properly gathered by the stats collector. Add them as an optional non-capturing part of the query for all CRUD operations.

cc @lavagetto who reported & fixed the original issues referenced.