### PR TITLE
Disable non-mac extensions by default on macos

### DIFF
--- a/CMake/Options.cmake
+++ b/CMake/Options.cmake
@@ -26,7 +26,11 @@ option(CPACK_GENERATOR "Enable build of distribution packages using CPack" OFF)
 
 option(ENABLE_COTIRE "Speed up the build by precompiling headers" OFF)
 option(ENABLE_ASYNC_MYSQL "Build the async_mysql extension" ON)
-option(ENABLE_MCROUTER "Build the mcrouter library and extension" ON)
+if (APPLE)
+  option(ENABLE_MCROUTER "Build the mcrouter library and extension" OFF)
+else()
+  option(ENABLE_MCROUTER "Build the mcrouter library and extension" ON)
+endif()
 option(ENABLE_PROXYGEN_SERVER "Build the Proxygen HTTP server" ON)
 
 option(ENABLE_SPLIT_DWARF "Reduce linker memory usage by putting debugging information into .dwo files" OFF)

--- a/hphp/runtime/ext/imap/config.cmake
+++ b/hphp/runtime/ext/imap/config.cmake
@@ -1,3 +1,7 @@
+if (APPLE)
+  option(ENABLE_EXTENSION_IMAP "Build the imap extension" OFF)
+endif()
+
 HHVM_DEFINE_EXTENSION("imap" IMPLICIT
   IS_ENABLED EXT_IMAP
   SOURCES

--- a/hphp/runtime/ext/mcrouter/config.cmake
+++ b/hphp/runtime/ext/mcrouter/config.cmake
@@ -1,3 +1,7 @@
+if (APPLE)
+  option(ENABLE_EXTENSION_MCROUTER "Build the imap extension" OFF)
+endif()
+
 HHVM_DEFINE_EXTENSION("mcrouter"
   SOURCES
     ext_mcrouter.cpp


### PR DESCRIPTION
Test plan:

did a mac build with no CMake arguments, it worked.