### PR TITLE
Fix compilation error (numa_node_set undefined) for non-NUMA builds

### DIFF
--- a/hphp/util/alloc.cpp
+++ b/hphp/util/alloc.cpp
@@ -373,6 +373,7 @@ static BumpMapper* getHugeMapperWithFallback(unsigned n1GPages,
     } else if (use2MFallback) {
       mapper = new Bump2MMapper;
     }
+#ifdef HAVE_NUMA
   } else {
     fallback = new Bump4KMapper(numa_node_set);
     if (n1GPages) {
@@ -380,6 +381,7 @@ static BumpMapper* getHugeMapperWithFallback(unsigned n1GPages,
     } else {
       mapper = new Bump2MMapper(numa_node_set);
     }
+#endif
   }
   if (mapper) {
     mapper->append(fallback);


### PR DESCRIPTION
Fixes compilation error for non-NUMA builds which was introduced with afa3f0811556226a202b724aab8d41c94ae55675.