### PR TITLE
Add missing vzeroupper to memset-avx2

### DIFF
--- a/hphp/util/memset-x64-avx2.S
+++ b/hphp/util/memset-x64-avx2.S
@@ -100,8 +100,8 @@ ETCH_LABEL(more_than_63bytes):
 	vmovdqu %ymm0, 0x20(%rcx)
 	addq	%rax, %rcx
 	subq	%rax, %rdx
-	je		ETCH_LABEL(EXIT_MEMSET)
-	
+	je		ETCH_LABEL(EXIT_MEMSET_VZEROUPPER)
+
 ETCH_ALIGN8
 ETCH_ALIGN4
 ETCH_LABEL(128byte_loop_data_guzzler):
@@ -112,6 +112,7 @@ ETCH_LABEL(128byte_loop_data_guzzler):
 	addq		$128, %rcx
 	subq		$128, %rdx
 	ja			ETCH_LABEL(128byte_loop_data_guzzler)
+ETCH_LABEL(EXIT_MEMSET_VZEROUPPER):
 	vzeroupper
 ETCH_LABEL(EXIT_MEMSET):
 	movq %r8, %rax


### PR DESCRIPTION
This diff ensures vzerouppper is executed when memset count
is >64 and <128 bytes.

The guidance from Intel is to use vzeroupper when transitioning from
AVX to SSE code in order to avoid transition penalties:

"When the upper 128 bits of the YMM registers are set to zero by the
vzeroupper instruction, the hardware does not need to save those values,
so the hardware assists do not occur. The vzeroupper instruction must be
used after 256-bit Intel AVX code and before Intel SSE code, which will
remove both the save and the restore operations. Zeroing out the YMM
registers with other methods, such as with XORs, will not prevent
AVX-SSE transition penalties."
https://software.intel.com/en-us/articles/avoiding-avx-sse-transition-penalties

No expensive transitions were detected when using the Intel SDE AVX/SSE
transition checker.