### PR TITLE
[AArch64] Explicitly turn PIE off in the event that GCC has it on

### DIFF
--- a/CMake/HPHPCompiler.cmake
+++ b/CMake/HPHPCompiler.cmake
@@ -62,6 +62,9 @@ if (${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang" OR ${CMAKE_CXX_COMPILER_ID} STREQU
 
   # General options to pass to both C & C++ compilers
   set(GENERAL_OPTIONS)
+  list(APPEND GENERAL_OPTIONS
+    "fno-pie"
+  )
 
   # General options to pass to the C++ compiler
   set(GENERAL_CXX_OPTIONS)


### PR DESCRIPTION
Some GCC toolchains are being built with PIE defaulted to on.
PIE breaks the ability to use sbrk() to reserve low memory. This
patch ensures that PIE is off regardless of how it was configured.