### PR TITLE
Issue 8211: Format block comments with tabs correctly

### DIFF
--- a/hphp/hack/src/hackfmt/hack_format.ml
+++ b/hphp/hack/src/hackfmt/hack_format.ml
@@ -3060,7 +3060,7 @@ and transform_trivia ~is_leading trivia =
         let prefix_space_count str =
           let len = String.length str in
           let rec aux i =
-            if i = len || str.[i] <> ' '
+            if i = len || (str.[i] <> ' ' && str.[i] <> '\t')
             then 0
             else 1 + (aux (i + 1))
           in


### PR DESCRIPTION
This PR fixes issue #8211. We tested it on a few different files, with only tabs, only spaces, and mixed tabs and spaces.

The asterisks aren't aligned in the block comment, but this is also currently true for files indented with only spaces. 