### PR TITLE
arch64 - Improve instruction used in reuseImmq

### DIFF
--- a/hphp/runtime/vm/jit/vasm-reuse-imm.cpp
+++ b/hphp/runtime/vm/jit/vasm-reuse-imm.cpp
@@ -97,7 +97,11 @@ void reuseImmq(Env& env, const ldimmq& ld, Vlabel b, size_t i) {
 
     if (off.hasValue()) {
       reuseimm_impl(env.unit, b, i, [&] (Vout& v) {
-        v << addqi{off.value(), base, ld.d, v.makeReg()};
+        if (off.value() == 0) {
+          v << copy{base, ld.d};
+        } else {
+          v << addqi{off.value(), base, ld.d, v.makeReg()};
+        }
       });
       return;
     }


### PR DESCRIPTION
While examining the log file produced for zend/good/ext/intl/tests/grapheme.php
I noticed some code generation that could be improved.  There were several thousand
add instructions that really didn't contribute.

I traced it down to the reuseImmq optimization.  If there is no bias, a copy
instruction could be generated.  This would then later be elided after register
allocation.

Before
=====
```
    (18) DecRef<-> t3:Cell 
        Main:   
          0x44400284  d29fff02              movz x2, #0xfff8 
          0x44400288  f2a05fe2              movk x2, #0x2ff, lsl #16 
          0x4440028c  78626b63              ldrh w3, [x27, x2] 
          0x44400290  13003c63              sxth w3, w3
          0x44400294  3100047f              cmn w3, #0x1 (1) 
          0x44400298  1a9f07e3              cset w3, ne
          0x4440029c  91000042              add x2, x2, #0x0 (0)    //<<---
          0x444002a0  78626b64              ldrh w4, [x27, x2] 
          0x444002a4  0b030084              add w4, w4, w3
          0x444002a8  78226b64              strh w4, [x27, x2] 
          0x444002ac  7200003f              tst w1, #0x1
```

After
====
```
   (18) DecRef<-> t3:Cell 
      Main:   
          0x27000284  d29fff02              movz x2, #0xfff8 
          0x27000288  f2a05fe2              movk x2, #0x2ff, lsl #16
          0x2700028c  78626b63              ldrh w3, [x27, x2]
          0x27000290  13003c63              sxth w3, w3
          0x27000294  3100047f              cmn w3, #0x1 (1)
          0x27000298  1a9f07e3              cset w3, ne
          0x2700029c  78626b64              ldrh w4, [x27, x2]
          0x270002a0  0b030084              add w4, w4, w3
          0x270002a4  78226b64              strh w4, [x27, x2]
          0x270002a8  7200003f              tst w1, #0x1
```

The standard regression tests were run with 6 option sets.  No new issues were 
seen.

