### PR TITLE
Fix tc-print linking error

### DIFF
--- a/hphp/tools/tc-print/CMakeLists.txt
+++ b/hphp/tools/tc-print/CMakeLists.txt
@@ -6,8 +6,8 @@ if(IS_X64)
     add_executable(tc-print "mappers.cpp" "offline-trans-data.cpp"
                             "offline-code.cpp"
                             "offline-x86-code.cpp"  "perf-events.cpp"
-                            "repo-wrapper.cpp"  "tc-print.cpp"
-                            "../../hhvm/process-init.cpp")
+                            "repo-wrapper.cpp"  "std-logger.cpp"
+                            "tc-print.cpp"  "../../hhvm/process-init.cpp")
     link_object_libraries(tc-print ${HHVM_WHOLE_ARCHIVE_LIBRARIES})
     target_link_libraries(tc-print ${HHVM_LINK_LIBRARIES})
     embed_all_systemlibs(tc-print "${CMAKE_CURRENT_BINARY_DIR}/../.."
@@ -18,8 +18,8 @@ if(NOT IS_X64)
   add_executable(tc-print "mappers.cpp" "offline-trans-data.cpp"
                           "offline-code.cpp"  "perf-events.cpp"
                           "offline-arm-code.cpp" "offline-ppc64-code.cpp"
-                          "repo-wrapper.cpp"  "tc-print.cpp"
-                          "../../hhvm/process-init.cpp")
+                          "repo-wrapper.cpp"  "std-logger.cpp"
+                          "tc-print.cpp"  "../../hhvm/process-init.cpp")
   link_object_libraries(tc-print ${HHVM_WHOLE_ARCHIVE_LIBRARIES})
   target_link_libraries(tc-print ${HHVM_LINK_LIBRARIES})
   embed_all_systemlibs(tc-print "${CMAKE_CURRENT_BINARY_DIR}/../.."


### PR DESCRIPTION
Update tc-print/CMakeLists.txt and add std-logger.cpp to the tc-print target.