### PR TITLE
Add hackfmt support for single line if statements

### DIFF
--- a/hphp/hack/test/hackfmt/tests/allow_single_line_ifs.php
+++ b/hphp/hack/test/hackfmt/tests/allow_single_line_ifs.php
@@ -1,0 +1,89 @@
+<?hh // strict
+
+// Should be on a single line
+if (true) print("hi");
+
+// Should not be on a single line
+if (true)
+print("hi");
+
+if (true)
+  print("hi");
+
+if (true) {
+print("this is a");
+print("multi line if");
+}
+
+if (true)
+print("this is not a");
+print("multi line if");
+
+// Should all have the if body on a new line
+if (true) this_is_a_very_long_function_call_that_really_exceeds_the_line_length_lorem_ipsum_dolor_sit_amet_consectetur_adipiscing_elit();
+
+if (true)
+this_is_a_very_long_function_call_that_really_exceeds_the_line_length_lorem_ipsum_dolor_sit_amet_consectetur_adipiscing_elit();
+
+if (true)
+  this_is_a_very_long_function_call_that_really_exceeds_the_line_length_lorem_ipsum_dolor_sit_amet_consectetur_adipiscing_elit();
+
+// Should preserve the single line if
+f(g($a, $b), () ==> {
+  if (true) print('hi');
+  if (true)
+  print('hi');
+});
+
+if (true) {
+print('hi');
+if (true) print('hi');
+}
+
+if ($a)
+f();
+elseif ($b)
+g();
+else
+h();
+
+if ($a) f();
+else if ($b) g();
+else h();
+
+if ($a)
+f();
+elseif ($b) {
+g();
+} else
+h();
+
+if ($a)
+f();
+else if ($b) {
+g();
+} else{
+h();
+}
+
+if ($a)
+f();
+elseif ($b) {
+g();
+g2();
+} else
+h();
+
+if ($a) f();
+else if ($b) {
+g();
+g2();
+} else h();
+
+if ($this->head->isEmpty()) return new MyQueue($this->head->push($item), $this->tail);
+else return new MyQueue($this->head, $this->tail->push($item));
+
+if ($this->head->isEmpty())
+return new MyQueue($this->head->push($item), $this->tail);
+else
+return new MyQueue($this->head, $this->tail->push($item));

--- a/hphp/hack/test/hackfmt/tests/allow_single_line_ifs.php.exp
+++ b/hphp/hack/test/hackfmt/tests/allow_single_line_ifs.php.exp
@@ -1,0 +1,94 @@
+<?hh // strict
+
+// Should be on a single line
+if (true) print("hi");
+
+// Should not be on a single line
+if (true)
+  print("hi");
+
+if (true)
+  print("hi");
+
+if (true) {
+  print("this is a");
+  print("multi line if");
+}
+
+if (true)
+  print("this is not a");
+print("multi line if");
+
+// Should all have the if body on a new line
+if (true)
+  this_is_a_very_long_function_call_that_really_exceeds_the_line_length_lorem_ipsum_dolor_sit_amet_consectetur_adipiscing_elit();
+
+if (true)
+  this_is_a_very_long_function_call_that_really_exceeds_the_line_length_lorem_ipsum_dolor_sit_amet_consectetur_adipiscing_elit();
+
+if (true)
+  this_is_a_very_long_function_call_that_really_exceeds_the_line_length_lorem_ipsum_dolor_sit_amet_consectetur_adipiscing_elit();
+
+// Should preserve the single line if
+f(
+  g($a, $b),
+  () ==> {
+    if (true) print('hi');
+    if (true)
+      print('hi');
+  },
+);
+
+if (true) {
+  print('hi');
+  if (true) print('hi');
+}
+
+if ($a)
+  f();
+elseif ($b)
+  g();
+else
+  h();
+
+if ($a) f();
+else if ($b) g();
+else h();
+
+if ($a)
+  f();
+elseif ($b) {
+  g();
+} else
+  h();
+
+if ($a)
+  f();
+else if ($b) {
+  g();
+} else {
+  h();
+}
+
+if ($a)
+  f();
+elseif ($b) {
+  g();
+  g2();
+} else
+  h();
+
+if ($a) f();
+else if ($b) {
+  g();
+  g2();
+} else h();
+
+if ($this->head->isEmpty())
+  return new MyQueue($this->head->push($item), $this->tail);
+else return new MyQueue($this->head, $this->tail->push($item));
+
+if ($this->head->isEmpty())
+  return new MyQueue($this->head->push($item), $this->tail);
+else
+  return new MyQueue($this->head, $this->tail->push($item));


### PR DESCRIPTION
Currently, a single line if statement will be split into 2 lines after hackfmt is run. For example,
```
if (true) print("Hello, world!");
```
becomes
```
if (true)
  print("Hello, world!");
```

This PR changes hackfmt so it keeps single line if statements, as long as the line isn't too long. If the line exceeds the specified limit, then it'll be split into 2 lines.

This was tested on a file with both single line if statements (of various lengths) and multi-line if statements.