### PR TITLE
Fix more MacOS crashes due to non-portable local labels

### DIFF
--- a/hphp/runtime/base/hash-table-inl.h
+++ b/hphp/runtime/base/hash-table-inl.h
@@ -44,10 +44,10 @@ void HashTableCommon::InitHash(int32_t* hash, uint32_t scale) {
   uint64_t offset = scale * 16;
   __asm__ __volatile__(
     "pcmpeqd    %%xmm0, %%xmm0\n"          // xmm0 <- 11111....
-    ".l%=:\n"
+    ASM_LOCAL_LABEL("%=") ":\n"
     "sub        $0x10, %0\n"
     "movdqu     %%xmm0, (%1, %0)\n"
-    "ja         .l%=\n"
+    "ja         " ASM_LOCAL_LABEL("%=") "\n"
     : "+r"(offset) : "r"(hash) : "xmm0"
   );
 #elif defined(__aarch64__)
@@ -58,10 +58,10 @@ void HashTableCommon::InitHash(int32_t* hash, uint32_t scale) {
   uint64_t ones = -1;
   auto hash2 = hash;
   __asm__ __volatile__(
-    ".l%=:\n"
+    ASM_LOCAL_LABEL("%=") ":\n"
     "stp        %x2, %x2, [%x1], #16\n"
     "subs       %x0, %x0, #16\n"
-    "bhi        .l%=\n"
+    "bhi        " ASM_LOCAL_LABEL("%=") "\n"
     : "+r"(offset), "+r"(hash2) : "r"(ones) : "cc"
   );
 #elif defined(__powerpc__)
@@ -71,10 +71,10 @@ void HashTableCommon::InitHash(int32_t* hash, uint32_t scale) {
   uint64_t offset = scale * 16;
   __asm__ __volatile__(
     "vspltisw   0, -1       \n"
-    ".l%=:                  \n"
+    ASM_LOCAL_LABEL("%=") ":\n"
     "subic.     %0, %0, 0x10\n"
     "stxvd2x    32, %1, %0   \n"
-    "bgt        .l%=        \n"
+    "bgt        " ASM_LOCAL_LABEL("%=") "\n"
     : "+b"(offset) : "b"(hash) : "v0");
 #else
   static_assert(Empty == -1, "Cannot use wordfillones().");

--- a/hphp/util/etch-helpers.h
+++ b/hphp/util/etch-helpers.h
@@ -36,7 +36,7 @@
 #define ETCH_SECTION(x)   .text
 #define ETCH_SIZE(x)      /* not used on OSX */
 #define ETCH_NAME(x)      _##x
-#define ETCH_LABEL(x)     .L##_##x
+#define ETCH_LABEL(x)     L##_##x /* not .L */
 #define ETCH_TYPE(x, y)   /* not used on OSX */
 #define ETCH_NAME_REL(x)  _##x@GOTPCREL(%rip)
 #define ETCH_ARG1         %rdi

--- a/hphp/util/portability.h
+++ b/hphp/util/portability.h
@@ -274,4 +274,10 @@
 # define MSVC_NO_STD_CHRONO_DURATION_DOUBLE_ADD 1
 #endif
 
+#ifdef __APPLE__
+#define ASM_LOCAL_LABEL(x) "L" x
+#else
+#define ASM_LOCAL_LABEL(x) ".L" x
+#endif
+
 #endif

--- a/hphp/util/word-mem.h
+++ b/hphp/util/word-mem.h
@@ -20,17 +20,12 @@
 #include <folly/Portability.h>
 
 #include "hphp/util/assertions.h"
+#include "hphp/util/portability.h"
 
 extern "C" void* _memcpy8(void* dst, const void* src, size_t len);
 extern "C" void* _memcpy16(void* dst, const void* src, size_t len);
 extern "C" void _bcopy32(void* dst, const void* src, size_t len);
 extern "C" void _bcopy_in_64(void* dst, const void* src, size_t lenIn64);
-
-#ifdef __APPLE__
-#define ASM_LOCAL_LABEL(x) "L" x
-#else
-#define ASM_LOCAL_LABEL(x) ".L" x
-#endif
 
 namespace HPHP {
 


### PR DESCRIPTION
Isolated repro of the problem: https://gist.github.com/fredemmott/e3b7f6f1b41be02e5980416677dd05a6

fixes #8276