### PR TITLE
Fix race when calling `HH\facts_parse` in multiple requests

### DIFF
--- a/hphp/runtime/ext/factparse/ext_factparse.cpp
+++ b/hphp/runtime/ext/factparse/ext_factparse.cpp
@@ -137,6 +137,7 @@ struct ParseFactsWorker: public BaseWorker<T> {
     m_state = T::init_state();
   }
   void onThreadExit() override {
+    m_state = T::clear_state();
     hphp_context_exit();
     hphp_session_exit();
   }
@@ -208,6 +209,10 @@ struct HackCFactsExtractor {
 
   static state_type init_state() {
     return acquire_facts_parser();
+  }
+
+  static state_type clear_state() {
+    return std::unique_ptr<FactsParser>();
   }
 
   static void mark_failed(result_type& workerResult) {


### PR DESCRIPTION
Summary:

Problem:

 - each call tries to allocate pool_size workers
 - we allocate a hackc on thread enter
 - we deallocate the hackc when we deallocate the worker object
 - this happens after all threads are finished
 - this means that at some point, we must have the entire pool of hackc
 workers
 - if two requests get any, no-one gets all

Fix:
 - deallocate each hackc when the thread finishes its' work

Thanks to @vladima for the help fixing this.

Fixes #8259

Test plan:

```Hack
<?hh

HH\facts_parse('/', [__FILE__], /* force_hh = */ false, /* multithreaded = */ true);

echo "factsparse test\n";
```

```
 ~/code/hhvm/hphp/hhvm/hhvm --no-config -m server -p 8080
```

```
$ curl http://localhost:8080/test.php
factsparse test
$ ab -c 100 -n 1000 http://localhost:8080/test.php
```

This previously reliably deadlocked with `-c 2 -n 10`