### PR TITLE
Do not reset redis dbNum on reconnect

### DIFF
--- a/hphp/system/php/redis/Redis.php
+++ b/hphp/system/php/redis/Redis.php
@@ -1064,9 +1064,7 @@ class Redis {
       if ($this->password) {
         $this->auth($this->password);
       }
-      if ($this->dbNumber) {
-        $this->select($this->dbNumber);
-      }
+      $this->select($this->dbNumber);
       return true;
     }
 
@@ -1708,10 +1706,13 @@ class Redis {
     $this->persistent = $persistent;
     $this->persistent_id = $persistent_id;
     $this->connection = $conn;
-    $this->dbNumber = 0;
     $this->commands = [];
     $this->multiHandler = [];
     $this->mode = self::ATOMIC;
+
+    if (is_null($this->dbNumber)) {
+      $this->dbNumber = 0;
+    }
 
     if (!$this->connection) {
       trigger_error(


### PR DESCRIPTION
Fixes #4802 by only assigning dbNum if it isn't already set on a reconnect try. Otherwise, dbNum will always be overwritten as 0.