### PR TITLE
Use `find_library` to find libatomic, instead of explicit -latomic

### DIFF
--- a/CMake/HPHPFindLibs.cmake
+++ b/CMake/HPHPFindLibs.cmake
@@ -561,7 +561,6 @@ macro(hphp_link target)
 
   if (LINUX)
     target_link_libraries(${target} -Wl,--wrap=pthread_create -Wl,--wrap=pthread_exit -Wl,--wrap=pthread_join)
-    target_link_libraries(${target} atomic)
   endif()
 
   if (MSVC)

--- a/CMake/HPHPFindLibs.cmake
+++ b/CMake/HPHPFindLibs.cmake
@@ -566,4 +566,26 @@ macro(hphp_link target)
   if (MSVC)
     target_link_libraries(${target} dbghelp.lib dnsapi.lib)
   endif()
+
+# Check whether atomic operations require -latomic or not
+# See https://github.com/facebook/hhvm/issues/5217
+  include(CheckCXXSourceCompiles)
+  set(OLD_CMAKE_REQUIRED_FLAGS ${CMAKE_REQUIRED_FLAGS})
+  set(CMAKE_REQUIRED_FLAGS "-std=c++1y")
+  CHECK_CXX_SOURCE_COMPILES("
+#include <atomic>
+#include <stdint.h>
+int main() {
+    struct Test { int64_t val1; int64_t val2; };
+    std::atomic<Test> s;
+    s.is_lock_free();
+}
+  " NOT_REQUIRE_ATOMIC_LINKER_FLAG)
+
+  if(NOT "${NOT_REQUIRE_ATOMIC_LINKER_FLAG}")
+      message(STATUS "-latomic is required to link hhvm")
+      find_library(ATOMIC_LIBRARY NAMES atomic libatomic.so.1)
+      target_link_libraries(${target} ${ATOMIC_LIBRARY})
+  endif()
+  set(CMAKE_REQUIRED_FLAGS ${OLD_CMAKE_REQUIRED_FLAGS})
 endmacro()

--- a/hphp/hhvm/CMakeLists.txt
+++ b/hphp/hhvm/CMakeLists.txt
@@ -51,28 +51,6 @@ if (ENABLE_SPLIT_DWARF)
   target_link_libraries(hhvm debug "-Wl,--gdb-index")
 endif()
 
-# Check whether atomic operations require -latomic or not
-# See https://github.com/facebook/hhvm/issues/5217
-INCLUDE(CheckCXXSourceCompiles)
-set(OLD_CMAKE_REQUIRED_FLAGS ${CMAKE_REQUIRED_FLAGS})
-set(CMAKE_REQUIRED_FLAGS "-std=c++1y")
-CHECK_CXX_SOURCE_COMPILES("
-#include <atomic>
-#include <stdint.h>
-int main() {
-    struct Test { int64_t val1; int64_t val2; };
-    std::atomic<Test> s;
-    s.is_lock_free();
-}
-" NOT_REQUIRE_ATOMIC_LINKER_FLAG)
-
-if(NOT "${NOT_REQUIRE_ATOMIC_LINKER_FLAG}")
-    message(STATUS "-latomic is required to link hhvm")
-    find_library(ATOMIC_LIBRARY NAMES atomic libatomic.so.1)
-    target_link_libraries(hhvm ${ATOMIC_LIBRARY})
-endif()
-set(CMAKE_REQUIRED_FLAGS ${OLD_CMAKE_REQUIRED_FLAGS})
-
 embed_all_systemlibs(hhvm "${CMAKE_CURRENT_BINARY_DIR}/.." "${CMAKE_CURRENT_BINARY_DIR}/hhvm")
 add_dependencies(hhvm systemlib)
 

--- a/hphp/hhvm/CMakeLists.txt
+++ b/hphp/hhvm/CMakeLists.txt
@@ -68,7 +68,8 @@ int main() {
 
 if(NOT "${NOT_REQUIRE_ATOMIC_LINKER_FLAG}")
     message(STATUS "-latomic is required to link hhvm")
-    target_link_libraries(hhvm atomic)
+    find_library(ATOMIC_LIBRARY NAMES atomic libatomic.so.1)
+    target_link_libraries(hhvm ${ATOMIC_LIBRARY})
 endif()
 set(CMAKE_REQUIRED_FLAGS ${OLD_CMAKE_REQUIRED_FLAGS})
 


### PR DESCRIPTION
This allows overriding it on platforms where we build a custom GCC, and
need to point it at libatomic.a, such as Ubuntu Trusty

Test Plan:

- built Trusty package with this, hardcoded to our custom libatomci.a
- built Artful package with this, autodetecting libatomic.so.1