### PR TITLE
Aarch64 - Prevent unnecessary cache syncs

### DIFF
--- a/hphp/util/data-block.h
+++ b/hphp/util/data-block.h
@@ -284,7 +284,7 @@ struct DataBlock {
   }
 
   static void syncDirect(Address begin,  Address end) {
-    if (arch() == Arch::ARM) {
+    if (arch() == Arch::ARM && begin < end) {
       __builtin___clear_cache(reinterpret_cast<char*>(begin),
                               reinterpret_cast<char*>(end));
 


### PR DESCRIPTION
Summary:
On Aarch64, ___builtin__clear_cache() is used to ensure I and D
cache coherency when writing out JIT'd instructions. Sometimes (6%)
Vgen is destroyed with no modified code, however the expensive
___builtin__clear_cache() function is still called. This patch
prevents unncessary cache syncs when no bytes have been written to
the data-block.

There are no new unit test case regressions with this patch, and
the time to run the unit test suite is reduced.