### PR TITLE
Aarch64 Sync I and D caches after modifying instructions

### DIFF
--- a/hphp/runtime/vm/jit/smashable-instr-arm.cpp
+++ b/hphp/runtime/vm/jit/smashable-instr-arm.cpp
@@ -334,8 +334,10 @@ bool optimizeSmashedCall(TCA inst) {
     CodeBlock callBlock;
     callBlock.init(inst, 8 /* bytes */, "optimizeSmashedCall");
     MacroAssembler a{callBlock};
+    auto const the_start = callBlock.frontier();
     a.nop();
     a.bl(offset >> kInstructionSizeLog2);
+    callBlock.sync(the_start);
     return true;
   }
 
@@ -356,8 +358,10 @@ bool optimizeSmashedJmp(TCA inst) {
     CodeBlock callBlock;
     callBlock.init(inst, 8 /* bytes */, "optimizeSmashedJmp");
     MacroAssembler a{callBlock};
+    auto const the_start = callBlock.frontier();
     a.nop();
     a.b(offset >> kInstructionSizeLog2);
+    callBlock.sync(the_start);
     return true;
   }
 
@@ -377,11 +381,13 @@ bool optimizeSmashedJcc(TCA inst) {
     CodeBlock callBlock;
     callBlock.init(inst, 12 /* bytes */, "optimizeSmashedJcc");
     MacroAssembler a{callBlock};
+    auto const the_start = callBlock.frontier();
     auto const cond = static_cast<Condition>(b->ConditionBranch());
     auto const invCond = InvertCondition(cond);
     a.b(offset >> kInstructionSizeLog2, invCond);
     a.nop();
     a.nop();
+    callBlock.sync(the_start);
     return true;
   }
 

--- a/hphp/runtime/vm/jit/vasm-arm.cpp
+++ b/hphp/runtime/vm/jit/vasm-arm.cpp
@@ -485,6 +485,8 @@ void Vgen::handleLiterals(Venv& env) {
     patchAddressActual->SetImmPCOffsetTarget(
       Instruction::Cast(literalAddress),
       Instruction::Cast(pl.patchAddress));
+    auto const pAA = reinterpret_cast<TCA>(patchAddressActual);
+    cb->syncDirect(pAA, pAA + kInstructionSize);
   }
 
   for (auto const& h : headers) {
@@ -495,7 +497,9 @@ void Vgen::handleLiterals(Venv& env) {
     assertx(env.fallThrus.count(h.second));
     // Write the jmp.
     Assembler a { cb };
+    auto const begin = cb.frontier();
     a.b(poolSize >> kInstructionSizeLog2);
+    cb.sync(begin);
   }
   env.meta.literalsToPool.swap(notEmitted);
 }


### PR DESCRIPTION
Summary:
When writing instructions on Aarch64, the I and D caches need to
be made cohorent, so call sync() and syncDirect().