### PR TITLE
[easy] Add missing util/ dependency for compiler/ and parser/

### DIFF
--- a/hphp/compiler/CMakeLists.txt
+++ b/hphp/compiler/CMakeLists.txt
@@ -34,6 +34,7 @@ auto_source_group("hphp_analysis" "${CMAKE_CURRENT_SOURCE_DIR}"
   ${CXX_SOURCES} ${C_SOURCES} ${HEADER_SOURCES})
 target_link_libraries(hphp_analysis ${Boost_LIBRARIES})
 add_dependencies(hphp_analysis hphp_parser)
+add_dependencies(hphp_analysis hphp_util)
 if (ENABLE_COTIRE)
   cotire(hphp_analysis)
 endif()

--- a/hphp/parser/CMakeLists.txt
+++ b/hphp/parser/CMakeLists.txt
@@ -12,6 +12,7 @@ list(APPEND GROUP_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}" ${CXX_SOURCES}
   ${HEADER_SOURCES})
 
 add_library(hphp_parser STATIC ${CXX_SOURCES} ${HEADER_SOURCES})
+add_dependencies(hphp_parser hphp_util)
 set(COMPILER_HEADER "${HPHP_HOME}/hphp/compiler/parser/parser.h")
 auto_source_group("hphp_parser" ${GROUP_SOURCES} ${COMPILER_HEADER})
 set_target_properties(hphp_parser PROPERTIES COMPILE_FLAGS


### PR DESCRIPTION
Needed for low-ptr-defs.h

Test Plan:

For both compiler/ and parser/

```
$ rm ../util/low-ptr-def.h
$ make clean
$ make -j16 // fails
$ vim CMakeLists.txt // make this change
$ make clean
$ make -j16 // succeeds
```