### PR TITLE
aarch64 - loadb/movsbl->loadsbl peephole

### DIFF
--- a/hphp/runtime/vm/jit/vasm-arm.cpp
+++ b/hphp/runtime/vm/jit/vasm-arm.cpp
@@ -339,6 +339,7 @@ struct Vgen {
   void emit(const loadzbl& i) { a->Ldrb(W(i.d), M(i.s)); }
   void emit(const loadzbq& i) { a->Ldrb(W(i.d), M(i.s)); }
   void emit(const loadsbq& i) { a->Ldrsb(X(i.d), M(i.s)); }
+  void emit(const loadsbl& i) { a->Ldrsb(W(i.d), M(i.s)); }
   void emit(const loadzlq& i) { a->Ldr(W(i.d), M(i.s)); }
   void emit(const movb& i) { if (i.d != i.s) a->Mov(W(i.d), W(i.s)); }
   void emit(const movw& i) { if (i.d != i.s) a->Mov(W(i.d), W(i.s)); }

--- a/hphp/runtime/vm/jit/vasm-dead.cpp
+++ b/hphp/runtime/vm/jit/vasm-dead.cpp
@@ -116,6 +116,7 @@ bool effectful(Vinstr& inst) {
     case Vinstr::loadzbl:
     case Vinstr::loadzbq:
     case Vinstr::loadzlq:
+    case Vinstr::loadsbl:
     case Vinstr::loadsbq:
     case Vinstr::mflr:
     case Vinstr::movb:

--- a/hphp/runtime/vm/jit/vasm-instr.cpp
+++ b/hphp/runtime/vm/jit/vasm-instr.cpp
@@ -302,6 +302,7 @@ Width width(Vinstr::Opcode op) {
     case Vinstr::movl:
     case Vinstr::loadl:
     case Vinstr::loadzbl:
+    case Vinstr::loadsbl:
     case Vinstr::loadtql:
     case Vinstr::storel:
     case Vinstr::storeli:

--- a/hphp/runtime/vm/jit/vasm-instr.h
+++ b/hphp/runtime/vm/jit/vasm-instr.h
@@ -271,6 +271,7 @@ struct Vunit;
   O(loadsd, Inone, U(s), D(d))\
   O(loadzbl, Inone, U(s), D(d))\
   O(loadzbq, Inone, U(s), D(d))\
+  O(loadsbl, Inone, U(s), D(d))\
   O(loadsbq, Inone, U(s), D(d))\
   O(loadzlq, Inone, U(s), D(d))\
   O(loadtqb, Inone, U(s), D(d))\
@@ -1119,6 +1120,7 @@ struct loadzbl { Vptr8 s; Vreg32 d; };
 struct loadzbq { Vptr8 s; Vreg64 d; };
 struct loadzlq { Vptr32 s; Vreg64 d; };
 // sign-extended s to d
+struct loadsbl { Vptr8 s; Vreg32 d; };
 struct loadsbq { Vptr8 s; Vreg64 d; };
 // truncated s to d
 struct loadtqb { Vptr64 s; Vreg8 d; };

--- a/hphp/runtime/vm/jit/vasm-simplify-arm.cpp
+++ b/hphp/runtime/vm/jit/vasm-simplify-arm.cpp
@@ -85,7 +85,7 @@ bool simplify(Env& env, const cmovq& inst, Vlabel b, size_t i) {
 ///////////////////////////////////////////////////////////////////////////////
 
 template<Vinstr::Opcode op>
-bool is_next(const Env& env, Vlabel b, size_t i)
+bool is_inst(const Env& env, Vlabel b, size_t i)
 {
   auto const& code = env.unit.blocks[b].code;
   if (i > code.size()) return false;
@@ -93,7 +93,7 @@ bool is_next(const Env& env, Vlabel b, size_t i)
 }
 
 bool simplify(Env& env, const loadb& inst, Vlabel b, size_t i) {
-  if (is_next<Vinstr::movzbl>(env, b, i + 1)) {
+  if (is_inst<Vinstr::movzbl>(env, b, i + 1)) {
     return if_inst<Vinstr::movzbl>(env, b, i + 1, [&] (const movzbl& mov) {
       // loadb{s, tmp}; movzbl{tmp, d}; -> loadzbl{s, d};
       if (!(env.use_counts[inst.d] == 1 &&
@@ -104,7 +104,7 @@ bool simplify(Env& env, const loadb& inst, Vlabel b, size_t i) {
         return 2;
       }); });
   }
-  if (is_next<Vinstr::movsbl>(env, b, i + 1)) {
+  if (is_inst<Vinstr::movsbl>(env, b, i + 1)) {
     return if_inst<Vinstr::movsbl>(env, b, i + 1, [&] (const movsbl& mov) {
       // loadb{s, tmp}; movsbl{tmp, d}; -> loadsbl{s, d};
       if (!(env.use_counts[inst.d] == 1 &&

--- a/hphp/runtime/vm/jit/vasm-simplify-arm.cpp
+++ b/hphp/runtime/vm/jit/vasm-simplify-arm.cpp
@@ -87,27 +87,23 @@ bool simplify(Env& env, const cmovq& inst, Vlabel b, size_t i) {
 bool simplify(Env& env, const loadb& inst, Vlabel b, size_t i) {
   if (if_inst<Vinstr::movzbl>(env, b, i + 1, [&] (const movzbl& mov) {
       // loadb{s, tmp}; movzbl{tmp, d}; -> loadzbl{s, d};
-      if (!(env.use_counts[inst.d] == 1 &&
-            inst.d == mov.s)) return false;
+      if (!(env.use_counts[inst.d] == 1 && inst.d == mov.s)) return false;
 
       return simplify_impl(env, b, i, [&] (Vout& v) {
         v << loadzbl{inst.s, mov.d};
         return 2;
-      }); })
-    ) return true;
+      }); })) {
+      return true;
+    }
 
-  if (if_inst<Vinstr::movsbl>(env, b, i + 1, [&] (const movsbl& mov) {
+  return if_inst<Vinstr::movsbl>(env, b, i + 1, [&] (const movsbl& mov) {
       // loadb{s, tmp}; movsbl{tmp, d}; -> loadsbl{s, d};
-      if (!(env.use_counts[inst.d] == 1 &&
-            inst.d == mov.s)) return false;
+      if (!(env.use_counts[inst.d] == 1 && inst.d == mov.s)) return false;
 
       return simplify_impl(env, b, i, [&] (Vout& v) {
         v << loadsbl{inst.s, mov.d};
         return 2;
-      }); })
-  ) return true;
-
-  return false;
+      }); });
 }
 
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
While examining the tracefile for mediawiki, I saw an opportunity to remove
some sign-extension instructions.  There is a form of the load byte instruction
which sign-extends the value.  

Before
======
```
    (01) t1:StkPtr = DefSP<FPInvOff 2> t0:FramePtr
    (04) CheckLoc<Uninit,1> t0:FramePtr -> B2<Unlikely>
        Main:        
               0xf6002b4  385e83a0              ldurb w0, [x29, #-24]
               0xf6002b8  13001c00              sxtb w0, w0  //<<---
               0xf6002bc  7100001f              cmp w0, #0x0 (0) 
               0xf6002c0  540003a1              b.ne #+0x74
```

After
=====
```
    (01) t1:StkPtr = DefSP<FPInvOff 2> t0:FramePtr
    (04) CheckLoc<Uninit,1> t0:FramePtr -> B2<Unlikely>
        Main:  
               0xf601a5c  38de83a0              ldursb w0, [x29, #-24]  //<<---
               0xf601a60  7100001f              cmp w0, #0x0 (0) 
               0xf601a64  540003a1              b.ne #+0x74 
```

The standard regression tests were run with 6 option sets.  No new regressions were
observed.  The oss-performance mediawiki test was run before/after.  A (very) small
improvement was seen.
