### PR TITLE
Aarch64 Make rvmsp() a reserved register

### DIFF
--- a/hphp/hack/src/utils/disk/realDisk.ml
+++ b/hphp/hack/src/utils/disk/realDisk.ml
@@ -2,7 +2,10 @@ include Disk_sig.Types
 
 let cat (filename : string) : string =
   let ic = open_in_bin filename in
-  let len = in_channel_length ic in
+  let len =
+    try
+      in_channel_length ic
+    with Sys_error _ -> 0 in
   (* in_channel_length returns 0 for non-regular files; try reading it
     using a fixed-sized buffer if it appears to be empty.
     NOTE: JaneStreet's Core Sys module defines a function is_file which

--- a/hphp/runtime/vm/jit/abi-arm.cpp
+++ b/hphp/runtime/vm/jit/abi-arm.cpp
@@ -54,7 +54,7 @@ const RegSet kGPCalleeSaved =
 
 const RegSet kGPReserved =
   rVixlScratch0 | rVixlScratch1 | rAsm | rvmtl() |
-  rvmfp() | rlr() | vixl::xzr | rsp();
+  rvmsp() | rvmfp() | rlr() | vixl::xzr | rsp();
   // ARM machines really only have 32 GP regs.  However, vixl has 33 separate
   // register codes, because it treats the zero register and stack pointer
   // (which are really both register 31) separately.  Rather than lose this


### PR DESCRIPTION
While reviewing 09b20a1d I saw the rvmsp() register is not in the kGPReserved RegSet.  I think it should be reserved. @mxw can you please review? 

There are no new regressions in the unit test suite run in the various configurations {Jit,RepoAuth,Pgo}. 
