### PR TITLE
Modify `is_null` HHI signature to accept Disposable

### DIFF
--- a/hphp/hack/hhi/stdlib/builtins_variable.hhi
+++ b/hphp/hack/hhi/stdlib/builtins_variable.hhi
@@ -33,7 +33,7 @@ function is_object($var): bool;
 <<__Rx>>
 function is_resource($var): bool;
 <<__Rx>>
-function is_null($var): bool;
+function is_null(<<__AcceptDisposable>>$var): bool;
 <<__PHPStdLib, __Rx>>
 function gettype($v);
 <<__PHPStdLib, __Rx>>


### PR DESCRIPTION
A function with nullable Disposable argument[s] can't use them because
`is_null` trips Typing[4188].