### PR TITLE
Survive EINTR while invoking external compiler.

### DIFF
--- a/hphp/runtime/vm/extern-compiler.cpp
+++ b/hphp/runtime/vm/extern-compiler.cpp
@@ -559,7 +559,19 @@ std::string readline(FILE* f) {
   ssize_t len = 0;
   SCOPE_EXIT { free(line); };
 
-  if ((len = getline(&line, &mx, f)) < 0) {
+  for (auto tries = 0; tries < 10; tries++) {
+    if ((len = getline(&line, &mx, f)) >= 0) {
+      break;
+    }
+    if (errno == EINTR){
+      // Signal. Maybe Xenon? Just try again within reason.
+      continue;
+    }
+    // Non-EINTR error.
+    break;
+  }
+
+  if (len < 0) {
     throwErrno("error reading line");
   }
 


### PR DESCRIPTION
When using the Xenon sampling profiler, HHVM will periodically thwack
itself with SIGVTALRM, causing blocking system calls to fail with EINTR.
This included reads over the pipe to the HackC child compiler, which
led to runtime failures.

With this patch we are able to run for long periods of time with the
Xenon profiler on, and `hh_single_compile` singly compiling its little
heart out. Xenon in non-RepoAuth is a major improvement to our
production and dev inspectability.