### PR TITLE
fragile test compares beyond FP precision

### DIFF
--- a/hphp/test/zend/good/ext/date/tests/timezone_location_get.php.expectf
+++ b/hphp/test/zend/good/ext/date/tests/timezone_location_get.php.expectf
@@ -2,7 +2,7 @@ array(4) {
   ["country_code"]=>
   string(2) "NO"
   ["latitude"]=>
-  float(59.91666)
+  float(59.9166%d)
   ["longitude"]=>
   float(10.75)
   ["comments"]=>


### PR DESCRIPTION

After updating tzdata I went back and checked the few failing regression tests.
```
hhvm/hphp/test/zend/good/ext/date/tests/timezone_location_get.php
```

has been failing all option sets tested since at least January 2nd of this year.  It is expecting 
an exact representation for a floating point number.  The last digit is different due to rounding.
This is the same problem that was present in issue 8271.

Before
=====
```
hphp/test/run  hphp/test/zend/good/ext/date/tests/timezone_location_get.php
Running 1 tests in 1 threads (0 in serial)
FAILED: hphp/test/zend/good/ext/date/tests/timezone_location_get.php
005+   float(59.91667)
005-   float\(59\.91666\)
```
After
====
```
hphp/test/run  hphp/test/zend/good/ext/date/tests/timezone_location_get.php 
Running 1 tests in 1 threads (0 in serial)

All tests passed.
```

This website is useful for checking ieee-754 representations.
https://babbage.cs.qc.cuny.edu/IEEE-754.old/Decimal.html
