### PR TITLE
Update fragile test case

### DIFF
--- a/hphp/test/zend/good/ext/intl/tests/timezone_getDisplayName_variant3-49+.php.expectf
+++ b/hphp/test/zend/good/ext/intl/tests/timezone_getDisplayName_variant3-49+.php.expectf
@@ -1,4 +1,4 @@
 string(30) "Western European Standard Time"
 string(30) "Western European Standard Time"
-string(32) "Hora Padrão da Europa Ocidental"
+string(32) "Hora %cadrão da Europa Ocidental"
 ==DONE==


### PR DESCRIPTION
This test has been failing for more than two years.  There is a 1-char case difference
in the timezone string which is not significant.  Apparently, distros are allowed to make
minor edits to timezone information.

This was seen failing on Ubuntu 16.04.

Before
=====
hphp/test/run hphp/test/zend/good/ext/intl/tests/timezone_getDisplayName_variant3-49+.php
Running 1 tests in 1 threads (0 in serial)

FAILED: hphp/test/zend/good/ext/intl/tests/timezone_getDisplayName_variant3-49+.php
003+ string(32) "Hora padrão da Europa Ocidental"
003- string\(32\) "Hora Padrão da Europa Ocidental"

After
====
hphp/test/run hphp/test/zend/good/ext/intl/tests/timezone_getDisplayName_variant3-49+.php
Running 1 tests in 1 threads (0 in serial)

All tests passed.

This change was previously submitted to php-src as
https://github.com/php/php-src/pull/2511
