### PR TITLE
aarch64 - sxtb/lsl peephole

### DIFF
--- a/hphp/runtime/vm/jit/vasm-arm.cpp
+++ b/hphp/runtime/vm/jit/vasm-arm.cpp
@@ -406,6 +406,7 @@ struct Vgen {
   void emit(const fcvtzs& i) { a->Fcvtzs(X(i.d), D(i.s)); }
   void emit(const mrs& i) { a->Mrs(X(i.r), vixl::SystemRegister(i.s.l())); }
   void emit(const msr& i) { a->Msr(vixl::SystemRegister(i.s.l()), X(i.r)); }
+  void emit(const sbfmqi& i) { a->sbfm(X(i.d), X(i.s), i.mr.w(), i.ms.w()); }
   void emit(const ubfmli& i) { a->ubfm(W(i.d), W(i.s), i.mr.w(), i.ms.w()); }
 
   void emit_nop() { a->Nop(); }

--- a/hphp/runtime/vm/jit/vasm-dead.cpp
+++ b/hphp/runtime/vm/jit/vasm-dead.cpp
@@ -179,6 +179,7 @@ bool effectful(Vinstr& inst) {
     case Vinstr::testwim:
     case Vinstr::ucomisd:
     case Vinstr::unpcklpd:
+    case Vinstr::sbfmqi:
     case Vinstr::ubfmli:
     case Vinstr::xorb:
     case Vinstr::xorbi:

--- a/hphp/runtime/vm/jit/vasm-instr.cpp
+++ b/hphp/runtime/vm/jit/vasm-instr.cpp
@@ -306,6 +306,7 @@ Width width(Vinstr::Opcode op) {
     case Vinstr::loadtql:
     case Vinstr::storel:
     case Vinstr::storeli:
+    case Vinstr::sbfmqi:
     case Vinstr::ubfmli:
       return Width::Long;
 

--- a/hphp/runtime/vm/jit/vasm-instr.h
+++ b/hphp/runtime/vm/jit/vasm-instr.h
@@ -327,6 +327,7 @@ struct Vunit;
   O(fcvtzs, Inone, U(s), D(d))\
   O(mrs, I(s), Un, D(r))\
   O(msr, I(s), U(r), Dn)\
+  O(sbfmqi, I(mr) I(ms), U(s), D(d))\
   O(ubfmli, I(mr) I(ms), U(s), D(d))\
   /* ppc64 instructions */\
   O(fcmpo, Inone, U(s0) U(s1), D(sf))\
@@ -1202,6 +1203,7 @@ struct csincq { ConditionCode cc; VregSF sf; Vreg64 f, t, d; };
 struct fcvtzs { VregDbl s; Vreg64 d;};
 struct mrs { Immed s; Vreg64 r; };
 struct msr { Vreg64 r; Immed s; };
+struct sbfmqi { Immed mr, ms; Vreg64 s, d; };
 struct ubfmli { Immed mr, ms; Vreg32 s, d; };
 
 /*


### PR DESCRIPTION

This adds a peephole which captures a common pattern seen in Mediawiki traces.

Before
=====
```
0xcb00a04  93401c21     sxtb x1, w1
0xcb00a08  d37ef421     lsl x1, x1, #2
```
After
====
```
0xcb00a04  937e1c21     sbfiz  x1, x1, #2,  #8
```

The standard regression tests were run with 6 option sets.  No new issues were seen.
The mediawiki oss-performance test was run without incident.
