### PR TITLE
Simplify module syntax

### DIFF
--- a/hphp/hack/src/decl/decl_pos_utils.ml
+++ b/hphp/hack/src/decl/decl_pos_utils.ml
@@ -253,6 +253,4 @@ end
 (*****************************************************************************)
 (* Returns a signature with all the positions replaced with Pos.none *)
 (*****************************************************************************)
-module NormalizeSig = struct
-  include TraversePos(struct let pos _ = Pos.none end)
-end
+module NormalizeSig = TraversePos(struct let pos _ = Pos.none end)


### PR DESCRIPTION
The `struct include ... end` isn't needed here.