### PR TITLE
Fix order of destruction issues

### DIFF
--- a/hphp/runtime/base/program-functions.cpp
+++ b/hphp/runtime/base/program-functions.cpp
@@ -2852,6 +2852,7 @@ void hphp_process_exit() noexcept {
   LOG_AND_IGNORE(folly::SingletonVault::singleton()->destroyInstances())
   LOG_AND_IGNORE(embedded_data_cleanup())
   LOG_AND_IGNORE(Debug::destroyDebugInfo())
+  LOG_AND_IGNORE(clearUnitCacheForExit())
 #undef LOG_AND_IGNORE
 }
 

--- a/hphp/runtime/base/unit-cache.cpp
+++ b/hphp/runtime/base/unit-cache.cpp
@@ -893,6 +893,12 @@ void preloadRepo() {
   }
 }
 
+void clearUnitCacheForExit() {
+  s_nonRepoUnitCache.clear();
+  s_repoUnitCache.clear();
+  s_perUserUnitCaches.clear();
+}
+
 //////////////////////////////////////////////////////////////////////
 
 }

--- a/hphp/runtime/base/unit-cache.cpp
+++ b/hphp/runtime/base/unit-cache.cpp
@@ -40,7 +40,6 @@
 #include "hphp/util/mutex.h"
 #include "hphp/util/process.h"
 #include "hphp/util/rank.h"
-#include "hphp/util/smalllocks.h"
 #include "hphp/util/struct-log.h"
 #include "hphp/util/timer.h"
 
@@ -92,15 +91,31 @@ private:
 };
 
 struct CachedUnit {
-  CachedUnit() = default;
-  explicit CachedUnit(Unit* unit, size_t rdsBitId)
-    : unit(unit)
-    , rdsBitId(rdsBitId)
-  {}
-
-  Unit* unit{nullptr};  // null if there is no Unit for this path
-  size_t rdsBitId{-1u}; // id of the RDS bit for whether the Unit is included
+  Unit* unit{};
+  size_t rdsBitId{-1uL};
 };
+
+struct CachedUnitInternal {
+  CachedUnitInternal() = default;
+  CachedUnitInternal(const CachedUnitInternal& src) :
+      unit{src.unit.copy()},
+      rdsBitId{src.rdsBitId} {}
+  CachedUnitInternal& operator=(const CachedUnitInternal&) = delete;
+
+  static Unit* const Uninit;
+
+  CachedUnit cachedUnit() const {
+    return CachedUnit { *unit.get().get(), rdsBitId };
+  }
+
+  // nullptr if there is no Unit for this path, Uninit if the CachedUnit
+  // hasn't been initialized yet.
+  mutable LockFreePtrWrapper<Unit*> unit{Uninit};
+  // id of the RDS bit for whether the Unit is included
+  mutable size_t rdsBitId{-1u};
+};
+
+Unit* const CachedUnitInternal::Uninit = reinterpret_cast<Unit*>(-8);
 
 //////////////////////////////////////////////////////////////////////
 // RepoAuthoritative mode unit caching
@@ -112,33 +127,9 @@ struct CachedUnit {
  * Because of this it pays to keep it separate from the other cases so
  * they don't need to be littered with RepoAuthoritative checks.
  */
-
-struct CachedUnitRepoAuth {
-  CachedUnitRepoAuth() = default;
-
-  CachedUnitRepoAuth(const CachedUnitRepoAuth& src)
-    : unit(src.unit)
-    , rdsBitId(src.rdsBitId.load(std::memory_order_relaxed))
-  {}
-
-  operator CachedUnit() const {
-    auto const u = unit;
-    auto const bits = rdsBitId.load(std::memory_order_relaxed);
-    return CachedUnit { u, bits };
-  }
-
-  mutable AtomicLowPtr<
-    Unit,
-    std::memory_order_acquire,
-    std::memory_order_release
-  > unit{reinterpret_cast<Unit*>(0x1)};
-  mutable SmallLock lock{};
-  mutable std::atomic<size_t> rdsBitId{-1u};
-};
-
 using RepoUnitCache = RankedCHM<
   const StringData*,     // must be static
-  CachedUnitRepoAuth,
+  CachedUnitInternal,
   StringDataHashCompare,
   RankUnitCache
 >;
@@ -152,46 +143,42 @@ CachedUnit lookupUnitRepoAuth(const StringData* path,
   s_repoUnitCache.insert(acc, path);
   auto const& cu = acc->second;
 
-  // Check for initialization before we grab the futex; the entry is
-  // write-once.
-  if (!(reinterpret_cast<uintptr_t>(cu.unit.get()) & 0x1)) return cu;
+  if (cu.unit.copy() != CachedUnitInternal::Uninit) return cu.cachedUnit();
 
-  std::unique_lock<SmallLock> lock(cu.lock);
-
-  if (!(reinterpret_cast<uintptr_t>(cu.unit.get()) & 0x1)) return cu;
+  cu.unit.lock_for_update();
+  if (cu.unit.copy() != CachedUnitInternal::Uninit) {
+    // Someone else updated the unit while we were waiting on the lock
+    cu.unit.unlock();
+    return cu.cachedUnit();
+  }
 
   try {
     /*
-     * Insert path.  Find the Md5 for this path, and then the unit for
-     * this Md5.  If either aren't found we return the
-     * default-constructed cache entry.
-     *
-     * NB: we're holding the CHM lock on this bucket while we're doing
-     * this.
+     * We got the lock, so we're responsible for updating the entry.
      */
     MD5 md5;
     if (Repo::get().findFile(path->data(),
                              RuntimeOption::SourceRoot,
                              md5) == RepoStatus::error) {
-      cu.unit = nullptr;
-      return cu;
+      cu.unit.update_and_unlock(nullptr);
+      return cu.cachedUnit();
     }
 
-    auto const unit = Repo::get().loadUnit(
+    auto unit = Repo::get().loadUnit(
         path->data(),
         md5,
         nativeFuncs)
       .release();
     if (unit) {
-      cu.rdsBitId.store(rds::allocBit(), std::memory_order_relaxed);
-      cu.unit = unit;
+      cu.rdsBitId = rds::allocBit();
     }
+    cu.unit.update_and_unlock(std::move(unit));
   } catch (...) {
-    lock.unlock();
+    cu.unit.unlock();
     s_repoUnitCache.erase(acc);
     throw;
   }
-  return cu;
+  return cu.cachedUnit();
 }
 
 //////////////////////////////////////////////////////////////////////
@@ -761,8 +748,10 @@ std::vector<Unit*> loadedUnitsRepoAuth() {
   std::vector<Unit*> units;
   units.reserve(s_repoUnitCache.size());
   for (auto const& elm : s_repoUnitCache) {
-    if (elm.second.unit) {
-      units.push_back(elm.second.unit);
+    if (auto const unit = elm.second.unit.copy()) {
+      if (unit != CachedUnitInternal::Uninit) {
+        units.push_back(unit);
+      }
     }
   }
   return units;

--- a/hphp/runtime/base/unit-cache.h
+++ b/hphp/runtime/base/unit-cache.h
@@ -106,6 +106,14 @@ String resolveVmInclude(StringData* path,
 
 void preloadRepo();
 
+/*
+ * Needed to avoid order of destruction issues. Destroying the unit
+ * caches destroys the units, which destroys the classes, which tries
+ * to grab global mutexes, which can fail if the mutexes have already
+ * been destroyed.
+ */
+void clearUnitCacheForExit();
+
 //////////////////////////////////////////////////////////////////////
 
 }

--- a/hphp/util/lock-free-ptr-wrapper.h
+++ b/hphp/util/lock-free-ptr-wrapper.h
@@ -56,6 +56,7 @@ struct LockFreePtrWrapper {
   LockFreePtrWrapper(const LockFreePtrWrapper<T>&) = delete;
   LockFreePtrWrapper<T>& operator=(const LockFreePtrWrapper<T>&) = delete;
   LockFreePtrWrapper() : val{} { assertx(!(raw() & ~kPtrMask)); };
+  LockFreePtrWrapper(const T& v) : val{v} { assertx(!(raw() & ~kPtrMask)); };
   ~LockFreePtrWrapper() {
     assertx(!(raw() & ~kPtrMask));
     val.~T();
@@ -92,8 +93,23 @@ struct LockFreePtrWrapper {
     return x.val;
   }
 
+  /*
+   * Get an exclusive lock on the wrapped value. Other threads can
+   * still read its current value via get() or copy(). After calling
+   * this, you must unlock it either with update_and_unlock (if you
+   * want to change the value), or unlock (if you don't).
+   */
   void lock_for_update();
+  /*
+   * Unlock it.
+   */
   void unlock();
+  /*
+   * Update the wrapped value, and return the old value. The old value
+   * will typically need to be destroyed via a treadmill-like
+   * mechanism, because other threads may have read the old value just
+   * prior to the update (and still be using it).
+   */
   T update_and_unlock(T&& v);
 private:
   uintptr_t unlock_helper(uintptr_t rep);


### PR DESCRIPTION
Summary:
When the unit caches are destroyed, the element's destructors could
try to access other globals which might already have been destroyed.

Explicitly destroy the caches in hphp_process_init to avoid issues.

Reviewed By: ricklavoie

Differential Revision: D10263499
