### PR TITLE
Update hphp.7.tab.cpp

### DIFF
--- a/hphp/parser/hphp.7.tab.cpp
+++ b/hphp/parser/hphp.7.tab.cpp
@@ -658,11 +658,12 @@ static void xhp_children_stmt(Parser *_p, Token &out, Token &children) {
   {
     _p->onStatementListStart(stmts0);
   }
+   
   Token stmts1;
   {
-    // return children;
+    // return children
     Token arr;
-    if (children.num() == 2) {
+    if (std::equal(children.num(), 2)) {
       arr = children;
     } else if (children.num() >= 0) {
       scalar_num(_p, arr, children.num());


### PR DESCRIPTION
Use `std::equal` due to other uses of `std::` in file & functional instantiation