### PR TITLE
Support libxml 2.9.8

### DIFF
--- a/hphp/runtime/ext/domdocument/ext_domdocument.cpp
+++ b/hphp/runtime/ext/domdocument/ext_domdocument.cpp
@@ -1460,7 +1460,13 @@ struct notationIterator {
   xmlNotation *notation;
 };
 
-static void itemHashScanner(void* payload, void* data, xmlChar* /*name*/) {
+#if LIBXML_VERSION >= 20908
+#define XMLCHAR_CONST const
+#else
+#define XMLCHAR_CONST
+#endif
+static void itemHashScanner(void* payload, void* data, XMLCHAR_CONST xmlChar* /*name*/) {
+#undef XMLCHAR_CONST
   nodeIterator *priv = (nodeIterator *)data;
   if (priv->cur < priv->index) {
     priv->cur++;


### PR DESCRIPTION
BC break in definition of xmlHashScanner from 2.9.7

fixes #8200

Test Plan:

Local build failed on MacOS with latest Homebrew. Made this patch. Build
succeeded. Check older versions with *castle.