### PR TITLE
Fix typo in hphpd help info

### DIFF
--- a/hphp/doc/debugger.refs
+++ b/hphp/doc/debugger.refs
@@ -51,7 +51,7 @@ For examples,
 
     ------------------------ Special Breakpoints ------------------------
 
-There are special breakpoints what can only be set by names:
+There are special breakpoints that can only be set by names:
 
       start
       end
@@ -548,4 +548,3 @@ The space between & and command is not needed. '&s' works as well.
 Executes the shell command on connected machine.
 
 The space between ! and command is not needed. '!ls' works as well.
-

--- a/hphp/runtime/debugger/cmd/cmd_break.cpp
+++ b/hphp/runtime/debugger/cmd/cmd_break.cpp
@@ -172,7 +172,7 @@ void CmdBreak::help(DebuggerClient& client) {
 
   client.helpTitle("Special Breakpoints");
   client.helpSection(
-    "There are special breakpoints what can only be set by names:\n"
+    "There are special breakpoints that can only be set by names:\n"
     "\n"
     "\tstart\n"
     "\tend\n"


### PR DESCRIPTION
Summary: Fix typo in help message for break command in hphpd

Reviewed By: markw65

Differential Revision: D13213483
