### PR TITLE
predicate test to avoid issues on aarch64

### DIFF
--- a/hphp/runtime/vm/jit/vasm-simplify.cpp
+++ b/hphp/runtime/vm/jit/vasm-simplify.cpp
@@ -667,7 +667,8 @@ bool simplify(Env& env, const addq& vadd, Vlabel b, size_t i) {
 //
 // first, try to simplify lea (%r1), %r2 into copy %r1,%r2
 bool simplify(Env& env, const lea& vlea, Vlabel b, size_t i) {
-  if (vlea.s.disp == 0 && !vlea.s.index.isValid()) {
+  if (vlea.s.disp == 0 && !vlea.s.index.isValid() &&
+    arch() != Arch::ARM) {
     env.unit.blocks[b].code[i] = copy{ vlea.s.base, vlea.d };
     return true;
   }


### PR DESCRIPTION
This commit https://github.com/facebook/hhvm/commit/c02ec574cdae149eed5d1795b2349428ecac37c2
broke the regression suite on aarch64 hosts.  The first transformation removes a form expected by
the service requests code.  An internal assert correctly detected this condition.

/data2/swalk/play.120518a/hhvm/hphp/runtime/vm/jit/service-requests.cpp:280: HPHP::jit::FPInvOffset HPHP::jit::svcreq::extract_spoff(HPHP::jit::TCA): assertion `false && "Expected an instruction that offsets SP"' failed.
Core dumped: Aborted

A full MOP was run.  The results reflected the new baseline as documented in issue #8396.

This fixes issue #8397 