### PR TITLE
revise callstubs defs for aarch64 target

### DIFF
--- a/hphp/runtime/vm/jit/reg-alloc.cpp
+++ b/hphp/runtime/vm/jit/reg-alloc.cpp
@@ -233,8 +233,10 @@ void getEffects(const Abi& abi, const Vinstr& i,
 
     case Vinstr::callstub:
       defs =
-        (abi.all() - (abi.calleeSaved | rvmfp()))
-        | jit::abi(CodeKind::CrossTrace).unreserved();
+        (abi.all() - (abi.calleeSaved | rvmfp()));
+      if (arch() != Arch::ARM) {
+        defs |= jit::abi(CodeKind::CrossTrace).unreserved();
+      }
       break;
 
     case Vinstr::callfaststub:

--- a/hphp/runtime/vm/jit/reg-alloc.cpp
+++ b/hphp/runtime/vm/jit/reg-alloc.cpp
@@ -233,10 +233,8 @@ void getEffects(const Abi& abi, const Vinstr& i,
 
     case Vinstr::callstub:
       defs =
-        (abi.all() - (abi.calleeSaved | rvmfp()));
-      if (arch() != Arch::ARM) {
-        defs |= jit::abi(CodeKind::CrossTrace).unreserved();
-      }
+        (abi.all() - (abi.calleeSaved | rvmfp()))
+        | jit::abi(CodeKind::CrossTrace).unreserved();
       break;
 
     case Vinstr::callfaststub:


### PR DESCRIPTION
This commit https://github.com/facebook/hhvm/commit/98c4f446b683756cf7f98aef8fa9ac97d791b4c1
changed the registers presented to the allocator for the callstub Vinstr.  The comment says
it did not change the register sets for aarch64.  This is not correct.  This change caused an
internal assert to fire when it was trying to create spill space on the stack.  This sounds like
the problem seen on other hosts.

The standard regression tests were run with 6 option sets.  This brings the results back to
the normal baseline for the lab machine I use.

This fixes issue https://github.com/facebook/hhvm/issues/8396
