### PR TITLE
avoid specific length tests

### DIFF
--- a/hphp/test/slow/ext_zlib/chunked.php.expectf
+++ b/hphp/test/slow/ext_zlib/chunked.php.expectf
@@ -1,15 +1,15 @@
 -----
 Testing inflator
-Chunk 0: produced 979; eof: false
-Chunk 1: produced 1098; eof: false
-Chunk 2: produced 1111; eof: false
-Chunk 3: produced 1118; eof: false
-Chunk 4: produced 1106; eof: false
-Chunk 5: produced 1099; eof: false
-Chunk 6: produced 1093; eof: false
-Chunk 7: produced 1098; eof: false
-Chunk 8: produced 1071; eof: false
-Chunk 9: produced 204; eof: true
+Chunk 0: produced %d; eof: false
+Chunk 1: produced %d; eof: false
+Chunk 2: produced %d; eof: false
+Chunk 3: produced %d; eof: false
+Chunk 4: produced %d; eof: false
+Chunk 5: produced %d; eof: false
+Chunk 6: produced %d; eof: false
+Chunk 7: produced %d; eof: false
+Chunk 8: produced %d; eof: false
+Chunk 9: produced %d; eof: true
 -----
 Input size: 9977
 Output size: 9977
@@ -17,16 +17,16 @@ In MD5: 73f8802b7f98c4c0410287916f847fc7
 Out MD5: 73f8802b7f98c4c0410287916f847fc7
 -----
 Testing gunzipper
-Chunk 0: produced 959; eof: false
-Chunk 1: produced 1099; eof: false
-Chunk 2: produced 1110; eof: false
-Chunk 3: produced 1117; eof: false
-Chunk 4: produced 1106; eof: false
-Chunk 5: produced 1102; eof: false
-Chunk 6: produced 1088; eof: false
-Chunk 7: produced 1101; eof: false
-Chunk 8: produced 1068; eof: false
-Chunk 9: produced 227; eof: true
+Chunk 0: produced %d; eof: false
+Chunk 1: produced %d; eof: false
+Chunk 2: produced %d; eof: false
+Chunk 3: produced %d; eof: false
+Chunk 4: produced %d; eof: false
+Chunk 5: produced %d; eof: false
+Chunk 6: produced %d; eof: false
+Chunk 7: produced %d; eof: false
+Chunk 8: produced %d; eof: false
+Chunk 9: produced %d; eof: true
 -----
 Input size: 9977
 Output size: 9977


### PR DESCRIPTION

Test case introduced within the last day is failing all option sets tested.
Per conversation on the slack channel - HackLang - build-and-dev, the
length fields are fudged a little.
