### PR TITLE
[HHI] add missing closure methods interface

### DIFF
--- a/hphp/hack/hhi/stdlib/builtins_closure.hhi
+++ b/hphp/hack/hhi/stdlib/builtins_closure.hhi
@@ -10,6 +10,10 @@
 
 class Closure {
   public function __construct() { }
+
+  public static function bind(Closure $closure, $object, mixed $scope = 'static'): Closure;
+
+  public function bindTo($object, mixed $scope = 'static'): Closure;
 }
 class DummyClosure {
   public function __construct() { }


### PR DESCRIPTION
HHVM supports `Closure::bind` and `Closure::bindTo`.

this fixes an issue with the type checker.