### PR TITLE
Fix crash in tc-print when using '-e list' option.

### DIFF
--- a/hphp/tools/tc-print/tc-print.cpp
+++ b/hphp/tools/tc-print/tc-print.cpp
@@ -803,10 +803,13 @@ int main(int argc, char *argv[]) {
 
   pcre_init();
 
-  parseOptions(argc, argv);
-
+  // Initially use stdout logger while parsing arguments. Optionally switch
+  // to DBLogger below if the printToDb argument was passed.
   StdLogger stdoutlogger{};
   g_logger = &stdoutlogger;
+
+  parseOptions(argc, argv);
+
   #ifdef FACEBOOK
   folly::Optional<DBLogger> dblogger = folly::none;
   if (printToDB) {
@@ -815,6 +818,7 @@ int main(int argc, char *argv[]) {
     g_logger->printGeneric("Printing to database");
   }
   #endif
+
   g_transData = new OfflineTransData(dumpDir);
   transCode = new OfflineCode(dumpDir,
                                  g_transData->getHotBase(),


### PR DESCRIPTION
Crash was due the the use of the g_logger before it was initialized.
The '-B list' option was broken in the same way.