### PR TITLE
Adds -E option to tc-print, allowing for new perf events to be used.

### DIFF
--- a/hphp/tools/tc-print/offline-code.cpp
+++ b/hphp/tools/tc-print/offline-code.cpp
@@ -236,9 +236,8 @@ size_t OfflineCode::printBCMapping(BCMappingInfo bcMappingInfo,
   return currBC;
 }
 
-void OfflineCode::printEventStats(TCA address,
-				  uint32_t instrLen,
-				  const PerfEventsMap<TCA>& perfEvents) {
+void OfflineCode::printEventStats(TCA address, uint32_t instrLen,
+                                  const PerfEventsMap<TCA>& perfEvents) {
   for (size_t i = getFirstEventType(); i < getNumEventTypes(); i++) {
     PerfEventType event = static_cast<PerfEventType>(i);
     uint64_t eventCount = perfEvents.getEventCount(address,
@@ -247,8 +246,8 @@ void OfflineCode::printEventStats(TCA address,
     std::string eventStr;
     if (eventCount) {
       eventStr = folly::format("{:>3}:{:>4}",
-			       eventTypeToSmallCaption(event),
-			       eventCount).str();
+                               eventTypeToSmallCaption(event),
+                               eventCount).str();
     }
     std::cout << folly::format("{:<10} ", eventStr);
   }

--- a/hphp/tools/tc-print/offline-code.cpp
+++ b/hphp/tools/tc-print/offline-code.cpp
@@ -237,34 +237,18 @@ size_t OfflineCode::printBCMapping(BCMappingInfo bcMappingInfo,
 }
 
 void OfflineCode::printEventStats(TCA address,
-                                     uint32_t instrLen,
-                                     const PerfEventsMap<TCA>& perfEvents) {
-  static const PerfEventType AnnotatedEvents[] = {
-    EVENT_CYCLES,
-    EVENT_BRANCH_MISSES,
-    EVENT_ICACHE_MISSES,
-    EVENT_DCACHE_MISSES,
-    EVENT_LLC_MISSES,
-    EVENT_ITLB_MISSES,
-    EVENT_DTLB_MISSES,
-  };
-
-  const size_t NumAnnotatedEvents =
-    sizeof(AnnotatedEvents) / sizeof(AnnotatedEvents[0]);
-
-  static const char* SmallCaptions[] = {"cy", "bm", "ic", "dc", "lc", "it",
-                                        "dt"};
-
-  assert(sizeof(SmallCaptions)/sizeof(SmallCaptions[0]) == NumAnnotatedEvents);
-
-  for (size_t i = 0; i < NumAnnotatedEvents; i++) {
+				  uint32_t instrLen,
+				  const PerfEventsMap<TCA>& perfEvents) {
+  for (size_t i = getFirstEventType(); i < getNumEventTypes(); i++) {
+    PerfEventType event = static_cast<PerfEventType>(i);
     uint64_t eventCount = perfEvents.getEventCount(address,
                                                    address + instrLen - 1,
-                                                   AnnotatedEvents[i]);
+                                                   event);
     std::string eventStr;
     if (eventCount) {
       eventStr = folly::format("{:>3}:{:>4}",
-                               SmallCaptions[i], eventCount).str();
+			       eventTypeToSmallCaption(event),
+			       eventCount).str();
     }
     std::cout << folly::format("{:<10} ", eventStr);
   }

--- a/hphp/tools/tc-print/perf-events.cpp
+++ b/hphp/tools/tc-print/perf-events.cpp
@@ -63,7 +63,7 @@ void addEventType(std::string  eventId) {
 
   char caption[] = "xx";
   sprintf(caption, "u%c",
-	  static_cast<char>(numEventTypes - getFirstEventType()) + 'A');
+          static_cast<char>(numEventTypes - getFirstEventType()) + 'A');
   smallCaptions.push_back(std::string(caption));
 
   numEventTypes++;
@@ -73,9 +73,8 @@ PerfEventType perfScriptOutputToEventType(std::string eventId) {
   auto it = idToType.find(eventId);
   if (it == idToType.end()) {
     return EVENT_NULL;
-  } else {
-    return it->second;
   }
+  return it->second;
 }
 
 PerfEventType commandLineArgumentToEventType(const char* argument) {

--- a/hphp/tools/tc-print/perf-events.cpp
+++ b/hphp/tools/tc-print/perf-events.cpp
@@ -16,6 +16,7 @@
 #include "hphp/tools/tc-print/perf-events.h"
 
 #include <unordered_map>
+#include <vector>
 
 #include "hphp/tools/tc-print/tc-print.h"
 
@@ -23,80 +24,76 @@ namespace HPHP { namespace jit {
 
 using std::string;
 
-// PerfEvent
-
-PerfEventType perfScriptOutputToEventType(const char* eventId) {
-
-  // Events are duplicated so we can use the non-generic perf events.
-  std::pair<const char*, PerfEventType> idToType[] = {
-    std::make_pair("cycles",                    EVENT_CYCLES),
-    std::make_pair("cpu-clock",                 EVENT_CYCLES),
-
-    std::make_pair("branch-misses",             EVENT_BRANCH_MISSES),
-    std::make_pair("0x5300c5",                  EVENT_BRANCH_MISSES),
-
-    // fake event grouping all icache misses
-    std::make_pair("L1-icache-misses",          EVENT_ICACHE_MISSES),
-    // real icache miss events
-    std::make_pair("L1-icache-load-misses",     EVENT_ICACHE_MISSES),
-    std::make_pair("L1-icache-prefetch-misses", EVENT_ICACHE_MISSES),
-
-    // fake event grouping all dcache misses
-    std::make_pair("L1-dcache-misses",          EVENT_DCACHE_MISSES),
-    // real dcache miss events
-    std::make_pair("L1-dcache-load-misses",     EVENT_DCACHE_MISSES),
-    std::make_pair("L1-dcache-store-misses",    EVENT_DCACHE_MISSES),
-    std::make_pair("L1-dcache-prefetch-misses", EVENT_DCACHE_MISSES),
-
-    std::make_pair("cache-misses",              EVENT_LLC_MISSES),
-    std::make_pair("LLC-store-misses",          EVENT_LLC_STORE_MISSES),
-
-    // fake event grouping all iTLB misses
-    std::make_pair("iTLB-misses",               EVENT_ITLB_MISSES),
-    // real iTLB miss events
-    std::make_pair("iTLB-load-misses",          EVENT_ITLB_MISSES),
-
-    // fake event grouping all dTLB misses
-    std::make_pair("dTLB-misses",               EVENT_DTLB_MISSES),
-    // real dTLB miss events
-    std::make_pair("dTLB-load-misses",          EVENT_DTLB_MISSES),
-    std::make_pair("dTLB-store-misses",         EVENT_DTLB_MISSES),
-    std::make_pair("dTLB-prefetch-misses",      EVENT_DTLB_MISSES),
-  };
-
-  size_t numEle = sizeof idToType / sizeof (*idToType);
-  for (size_t i = 0; i < numEle; i++) {
-    if (!strcmp(idToType[i].first, eventId)) return idToType[i].second;
-  }
-
-  return NUM_EVENT_TYPES;
-}
-
-const char* validArguments[] = {
-  "cycles",
-  "branch-misses",
-  "L1-icache-misses",
-  "L1-dcache-misses",
-  "cache-misses",
-  "LLC-store-misses",
-  "iTLB-misses",
-  "dTLB-misses",
+// Predefined PerfEvent mappings.
+std::unordered_map<std::string, PerfEventType> idToType = {
+  {"cycles", EVENT_CYCLES},
+  {"branch-misses", EVENT_BRANCH_MISSES},
+  {"L1-icache-misses", EVENT_ICACHE_MISSES},
+  {"L1-dcache-misses", EVENT_DCACHE_MISSES},
+  {"cache-misses", EVENT_LLC_MISSES},
+  {"LLC-store-misses", EVENT_LLC_STORE_MISSES},
+  {"iTLB-misses", EVENT_ITLB_MISSES},
+  {"dTLB-misses", EVENT_DTLB_MISSES}
 };
 
-PerfEventType commandLineArgumentToEventType(const char* argument) {
-  constexpr size_t numEle = sizeof validArguments / sizeof (*validArguments);
-  static_assert(numEle == NUM_EVENT_TYPES, "need to update validArguments[]");
+std::vector<std::string> smallCaptions = {
+  "cy", "bm", "ic", "dc", "lc", "sm", "it", "dt"
+};
 
-  for (size_t i = 0; i < numEle; i++) {
-    if (!strcmp(validArguments[i], argument)) return (PerfEventType)i;
+bool usePredefinedTypes = true;
+size_t numEventTypes = NUM_PREDEFINED_EVENT_TYPES;
+
+size_t getFirstEventType() {
+  return usePredefinedTypes ? 0 : NUM_PREDEFINED_EVENT_TYPES;
+}
+
+size_t getNumEventTypes() {
+  return usePredefinedTypes ? NUM_PREDEFINED_EVENT_TYPES : numEventTypes;
+}
+
+void addEventType(std::string  eventId) {
+  usePredefinedTypes = false;
+
+  auto it = idToType.find(eventId);
+  if (it == idToType.end()) {
+    idToType.insert({eventId, static_cast<PerfEventType>(numEventTypes)});
+  } else {
+    it->second = static_cast<PerfEventType>(numEventTypes);
   }
 
-  return NUM_EVENT_TYPES;
+  char caption[] = "xx";
+  sprintf(caption, "u%c",
+	  static_cast<char>(numEventTypes - getFirstEventType()) + 'A');
+  smallCaptions.push_back(std::string(caption));
+
+  numEventTypes++;
+}
+
+PerfEventType perfScriptOutputToEventType(std::string eventId) {
+  auto it = idToType.find(eventId);
+  if (it == idToType.end()) {
+    return EVENT_NULL;
+  } else {
+    return it->second;
+  }
+}
+
+PerfEventType commandLineArgumentToEventType(const char* argument) {
+  return perfScriptOutputToEventType(std::string(argument));
 }
 
 const char* eventTypeToCommandLineArgument(PerfEventType eventType) {
-  always_assert(eventType != NUM_EVENT_TYPES);
-  return validArguments[eventType];
+  for (auto it = idToType.begin(); it != idToType.end(); ++it) {
+    if (it->second == eventType) {
+      return it->first.c_str();
+    }
+  }
+  always_assert(false);
+  return "Error: Event Type not supported.";
+}
+
+const char* eventTypeToSmallCaption(PerfEventType eventType) {
+  return smallCaptions[eventType].c_str();
 }
 
 // StackTraceTree

--- a/hphp/tools/tc-print/tc-print.cpp
+++ b/hphp/tools/tc-print/tc-print.cpp
@@ -181,7 +181,7 @@ void printValidEventTypes() {
 void parseOptions(int argc, char *argv[]) {
   int c;
   opterr = 0;
-  char* sortByArg = NULL;
+  char* sortByArg = nullptr;
   while ((c = getopt (argc, argv, "hc:Dd:f:g:ip:st:u:S:T:o:e:E:bB:v:k:a:A:n:x"))
          != -1) {
     switch (c) {
@@ -267,7 +267,7 @@ void parseOptions(int argc, char *argv[]) {
           char* p = strtok(optarg, ",");
           while (p) {
             addEventType(std::string(p));
-            p = strtok(NULL, ",");
+            p = strtok(nullptr, ",");
           }
         }
         break;
@@ -360,18 +360,15 @@ void loadPerfEvents() {
   char   eventCaption[MAX_SYM_LEN];
   char   line[2*MAX_SYM_LEN];
   TCA    addr;
-  uint32_t tcSamples[getNumEventTypes()];
-  uint32_t hhvmSamples[getNumEventTypes()];
+  vector<uint32_t> tcSamples(getNumEventTypes(), 0);
+  vector<uint32_t> hhvmSamples(getNumEventTypes(), 0);
   size_t numEntries = 0;
   PerfEventType eventType = EVENT_NULL;
-  // samplesPerKind[event][kind]
-  uint32_t samplesPerKind[getNumEventTypes()][NumTransKinds];
-  uint32_t samplesPerTCRegion[getNumEventTypes()][TCRCount];
-
-  memset(tcSamples  , 0, sizeof(tcSamples));
-  memset(hhvmSamples, 0, sizeof(hhvmSamples));
-  memset(samplesPerKind, 0, sizeof(samplesPerKind));
-  memset(samplesPerTCRegion, 0, sizeof(samplesPerTCRegion));
+  // samplesPerKind[event][kind], samplesPerTCRegion[event][TCRegion]
+  vector< vector<uint32_t> > samplesPerKind(getNumEventTypes(),
+                                            vector<uint32_t>(NumTransKinds, 0));
+  vector< vector<uint32_t> > samplesPerTCRegion(getNumEventTypes(),
+                                                vector<uint32_t>(TCRCount, 0));
 
   while (fgets(line, 2*MAX_SYM_LEN, profFile) != nullptr) {
     always_assert(sscanf(line, "%s %s %lu", program, eventCaption, &numEntries)


### PR DESCRIPTION
The existing set of supported perf events are now designated the
predefined event types. Using the -E option replaces them with a new
set.