### PR TITLE
[AArch64] Correctly handle smashables which have been optimized.

### DIFF
--- a/hphp/runtime/vm/jit/tc-bind.cpp
+++ b/hphp/runtime/vm/jit/tc-bind.cpp
@@ -74,18 +74,15 @@ TCA bindJmp(TCA toSmash, SrcKey destSk, TransFlags /*trflags*/, bool& smashed) {
     not_reached();
   }();
 
+  // Return if already smashed.  Note that smashableXxTarget returns nullptr
+  // when the target was smashed if the XX was able to be optimized in place
+  // (so that it doesn't look like a smashable XX anymore).
   if (isJcc) {
     auto const target = smashableJccTarget(toSmash);
-    // Return if already smashed.  Note that smashableJccTarget returns nullptr
-    // when the target was smashed if the JCC was able to be optimized in place
-    // (so that it doesn't look like a smashable JCC anymore).
-    if (target == nullptr || target == tDest) return tDest;
+    if (!target || target == tDest) return tDest;
     sr->chainFrom(IncomingBranch::jccFrom(toSmash));
   } else {
     auto const target = smashableJmpTarget(toSmash);
-    assertx(target);
-
-    // Return if already smashed.
     if (!target || target == tDest) return tDest;
     sr->chainFrom(IncomingBranch::jmpFrom(toSmash));
   }
@@ -117,7 +114,11 @@ TCA bindAddr(TCA toSmash, SrcKey destSk, TransFlags /*trflags*/,
 }
 
 void bindCall(TCA toSmash, TCA start, Func* callee, int nArgs, bool immutable) {
-  if (!start || smashableCallTarget(toSmash) == start) return;
+  // Return if already smashed.  Note that smashableCallTarget returns nullptr
+  // when the target was smashed if the call was able to be optimized in place
+  // (so that it doesn't look like a smashable call anymore).
+  if (!start || !smashableCallTarget(toSmash) ||
+      smashableCallTarget(toSmash) == start) return;
 
   // For functions to be PGO'ed, if their current prologues are still
   // profiling ones (living in code.prof()), then save toSmash as a
@@ -144,7 +145,8 @@ void bindCall(TCA toSmash, TCA start, Func* callee, int nArgs, bool immutable) {
     if (start && !immutable) start = funcGuardFromPrologue(start, callee);
 
     // Do these checks again with the lock.
-    if (!start || smashableCallTarget(toSmash) == start) return;
+    if (!start || !smashableCallTarget(toSmash) ||
+	smashableCallTarget(toSmash) == start) return;
 
     if (code().prof().contains(start)) {
       if (immutable) {


### PR DESCRIPTION
Previously, there was special handling in bindJmp() (tc-bind.cpp) if
the veneer for a smashable jcc was already smashed and optimized from
a LDR, BR sequence to a simple B. This optimization is done in
optimizeSmashedJcc() (smashable-instr-arm.cpp). The special handling
involves recognizing that a smashed and optimized jcc no longer has
a smashable target as returned by smashableJccTarget(), and instead
a null ptr is returned.
    
This handling of a null ptr for the smashableXxTarget() was extended
to smashable jmps and calls. While these two smashables don't have
explicit optimizeSmashedXx() phases, they can be optimized while
smashing directly. Smashable jmps, jccs, and calls can all be
optimized during smashing and the result is that the veneer is
bypassed completely, which makes the respective smashableXXTarget()
calls all return a null ptr as in the scenario above for optimizing
a jcc after smashing. Only debug builds catch this case due to an
assert.
