### PR TITLE
Reorder trace output when handling REQ_POST_INTERP_RET.

### DIFF
--- a/hphp/runtime/vm/jit/service-request-handlers.cpp
+++ b/hphp/runtime/vm/jit/service-request-handlers.cpp
@@ -358,11 +358,11 @@ TCA handleServiceRequest(ReqInfo& info) noexcept {
         }
       }
       assertx(caller == vmfp());
-      sk = liveSK();
-      start = getTranslation(TransArgs{sk});
       TRACE(3, "REQ_POST_INTERP_RET: from %s to %s\n",
             ar->m_func->fullName()->data(),
             caller->m_func->fullName()->data());
+      sk = liveSK();
+      start = getTranslation(TransArgs{sk});
       break;
     }
 


### PR DESCRIPTION
Reorder trace output when handling REQ_POST_INTERP_RET.

Moved the trace output before the call to getTranslation() in a way
similar to other service request handling code. getTransation()
can cause a new translation which can mutate the original activation
record via calls to ActRec::trashThis() and Stack::[n]discard().
