### PR TITLE
Fix issue where static locals in closures are dropped to BoxedInitCell.

### DIFF
--- a/hphp/runtime/vm/jit/frame-state.cpp
+++ b/hphp/runtime/vm/jit/frame-state.cpp
@@ -774,7 +774,8 @@ void FrameStateMgr::update(const IRInstruction* inst) {
     }
 
     assertx(!extra.smashesAllLocals || extra.nChangedLocals == 0);
-    if (extra.smashesAllLocals || inst->marker().func()->isPseudoMain()) {
+    if (extra.smashesAllLocals || inst->marker().func()->isPseudoMain() ||
+	inst->marker().func()->isClosureBody()) {
       clearLocals();
     } else {
       auto it = extra.changedLocals;


### PR DESCRIPTION
FrameStateMgr drops references of TBoxedCell to TBoxedInitCell for locals.
Unfortunately, static locals in closures are managed the same way (see
"Static locals" commend in rds-util.h). The result is that
dropLocalsRefsInnerTypes() will incorrectly drop the type, which
triggers an assert for type mismatch in check_invariants() because
the type has been initialized with the initial execution of the
closure.

This issue was found when running hhvm as a server in a method similar
to the OSS performance suite and then using siege with a single URL
running the unit test: quick/static_closure_gen.php.
