### PR TITLE
Allow resetting stat_cache from Hack

### DIFF
--- a/hphp/runtime/base/stat-cache.cpp
+++ b/hphp/runtime/base/stat-cache.cpp
@@ -420,7 +420,7 @@ StatCache::NodePtr StatCache::Node::getChild(const std::string& childName,
 // StatCache.
 
 StatCache::StatCache()
-  : m_lock(false /*reentrant*/, RankStatCache), m_ifd(-1), m_should_clear(false),
+  : m_lock(false /*reentrant*/, RankStatCache), m_ifd(-1), m_shouldClear(false),
     m_lastRefresh(time(nullptr)) {
 }
 
@@ -651,8 +651,8 @@ void StatCache::refresh() {
 
   // Check if we should reset the cache
   // as part of this refresh
-  if (m_should_clear) {
-    m_should_clear = false;
+  if (m_shouldClear) {
+    m_shouldClear = false;
     reset();
   }
 
@@ -682,12 +682,6 @@ void StatCache::refresh() {
     }
   }
 #endif
-}
-
-void StatCache::markShouldClearImpl() {
-  SimpleLock lock(m_lock);
-
-  m_should_clear = true;
 }
 
 time_t StatCache::lastRefresh() {
@@ -951,9 +945,11 @@ std::string StatCache::realpath(const char* path) {
   return s_sc.realpathImpl(path);
 }
 
-void StatCache::clear_cache() {
+void StatCache::clearCache() {
   if (!RuntimeOption::ServerStatCache) return;
-  s_sc.markShouldClearImpl();
+
+  SimpleLock lock(s_sc.m_lock);
+  s_sc.m_shouldClear = true;
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/hphp/runtime/base/stat-cache.h
+++ b/hphp/runtime/base/stat-cache.h
@@ -78,6 +78,7 @@ struct StatCache {
     int m_wd;                // Watch descriptor; -1 if a file.
 
     bool m_valid;            // True if m_stat/m_lstat are currently valid.
+
     struct stat m_stat;      // Cached stat() result.
     struct stat m_lstat;     // Cached lstat() result.
     std::string m_link;      // Cached readlink() result.
@@ -100,6 +101,7 @@ struct StatCache {
   static int lstat(const std::string& path, struct stat* buf);
   static std::string readlink(const std::string& path);
   static std::string realpath(const char* path);
+  static void clear_cache();
 
  private:
   bool init();
@@ -119,6 +121,7 @@ struct StatCache {
   int lstatImpl(const std::string& path, struct stat* buf);
   std::string readlinkImpl(const std::string& path);
   std::string realpathImpl(const char* path);
+  void markShouldClearImpl();
 
   static StatCache s_sc;
 
@@ -127,6 +130,7 @@ struct StatCache {
 
   SimpleMutex m_lock;       // Protects the following fields.
   int m_ifd;
+  bool m_should_clear;      // True if we should clear the cache on the next request
 #ifdef __linux__
   static const size_t kReadBufSize = 10 * (sizeof(struct inotify_event)
                                            + NAME_MAX + 1);

--- a/hphp/runtime/base/stat-cache.h
+++ b/hphp/runtime/base/stat-cache.h
@@ -101,7 +101,7 @@ struct StatCache {
   static int lstat(const std::string& path, struct stat* buf);
   static std::string readlink(const std::string& path);
   static std::string realpath(const char* path);
-  static void clear_cache();
+  static void clearCache();
 
  private:
   bool init();
@@ -121,7 +121,6 @@ struct StatCache {
   int lstatImpl(const std::string& path, struct stat* buf);
   std::string readlinkImpl(const std::string& path);
   std::string realpathImpl(const char* path);
-  void markShouldClearImpl();
 
   static StatCache s_sc;
 
@@ -130,7 +129,7 @@ struct StatCache {
 
   SimpleMutex m_lock;       // Protects the following fields.
   int m_ifd;
-  bool m_should_clear;      // True if we should clear the cache on the next request
+  bool m_shouldClear;      // True if we should clear the cache on the next request
 #ifdef __linux__
   static const size_t kReadBufSize = 10 * (sizeof(struct inotify_event)
                                            + NAME_MAX + 1);

--- a/hphp/runtime/ext/std/ext_std_file.cpp
+++ b/hphp/runtime/ext/std/ext_std_file.cpp
@@ -1271,7 +1271,7 @@ Variant HHVM_FUNCTION(lstat,
 
 void HHVM_FUNCTION(clearstatcache, bool /*clear_realpath_cache*/ /* = false */,
                    const Variant& /*filename*/ /* = uninit_variant */) {
-  // we are not having a cache for file stats, so do nothing here
+  StatCache::clear_cache();
 }
 
 Variant HHVM_FUNCTION(readlink_internal,

--- a/hphp/runtime/ext/std/ext_std_file.cpp
+++ b/hphp/runtime/ext/std/ext_std_file.cpp
@@ -1271,7 +1271,7 @@ Variant HHVM_FUNCTION(lstat,
 
 void HHVM_FUNCTION(clearstatcache, bool /*clear_realpath_cache*/ /* = false */,
                    const Variant& /*filename*/ /* = uninit_variant */) {
-  StatCache::clear_cache();
+  StatCache::clearCache();
 }
 
 Variant HHVM_FUNCTION(readlink_internal,


### PR DESCRIPTION
We'd like to enable the stat_cache, but are worried about any drift of the in-memory view of the stat_cache with what's on disk.

Background on our deploy:
• We rsync files onto the we serving hosts into A or B directory, and flip the serving root back and forth.
• We drain each host on deploy, and then run a quick warm up script
• We do not restart hhvm between deploys
• We do no currently run with the stat_cache

What we'd like:
• We'd like to enable the stat_cache in prod and clear the cache on each deploy without restarting hhvm (operationally, this is complicated, although we do aim to do that this year before switching to repo auth)
• On each deploy, we'll run a script before putting traffic on the server, which would call clearstatcache()

We're looking for feedback on this approach, or any hints of alternate ways to solve this. To be clear, we've not seen any problems with the StatCache, we're just nervous at the risk that it gets out of sync on deploy.

Additionally, we're not quite sure when it's safe to reset the stat_cache, so we defer that until the requestInit function, partially because of the comment that the work in StatCache::requestInit() that must be done before ExecutionContext::requestInit. https://github.com/facebook/hhvm/blob/HHVM-3.30/hphp/runtime/base/program-functions.cpp#L2617

Thanks!