### PR TITLE
Allow resetting stat_cache from Hack

### DIFF
--- a/hphp/runtime/base/stat-cache.cpp
+++ b/hphp/runtime/base/stat-cache.cpp
@@ -420,7 +420,7 @@ StatCache::NodePtr StatCache::Node::getChild(const std::string& childName,
 // StatCache.
 
 StatCache::StatCache()
-  : m_lock(false /*reentrant*/, RankStatCache), m_ifd(-1), m_shouldClear(false),
+  : m_lock(false /*reentrant*/, RankStatCache), m_ifd(-1),
     m_lastRefresh(time(nullptr)) {
 }
 
@@ -648,13 +648,6 @@ void StatCache::removeLPath(const std::string& path, Node* node) {
 void StatCache::refresh() {
 #ifdef __linux__
   SimpleLock lock(m_lock);
-
-  // Check if we should reset the cache
-  // as part of this refresh
-  if (m_shouldClear) {
-    m_shouldClear = false;
-    reset();
-  }
 
   if (m_ifd == -1) {
     return;
@@ -949,7 +942,7 @@ void StatCache::clearCache() {
   if (!RuntimeOption::ServerStatCache) return;
 
   SimpleLock lock(s_sc.m_lock);
-  s_sc.m_shouldClear = true;
+  s_sc.reset();
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/hphp/runtime/base/stat-cache.h
+++ b/hphp/runtime/base/stat-cache.h
@@ -129,7 +129,6 @@ struct StatCache {
 
   SimpleMutex m_lock;       // Protects the following fields.
   int m_ifd;
-  bool m_shouldClear;      // True if we should clear the cache on the next request
 #ifdef __linux__
   static const size_t kReadBufSize = 10 * (sizeof(struct inotify_event)
                                            + NAME_MAX + 1);

--- a/hphp/runtime/base/stat-cache.h
+++ b/hphp/runtime/base/stat-cache.h
@@ -78,6 +78,7 @@ struct StatCache {
     int m_wd;                // Watch descriptor; -1 if a file.
 
     bool m_valid;            // True if m_stat/m_lstat are currently valid.
+
     struct stat m_stat;      // Cached stat() result.
     struct stat m_lstat;     // Cached lstat() result.
     std::string m_link;      // Cached readlink() result.
@@ -100,6 +101,7 @@ struct StatCache {
   static int lstat(const std::string& path, struct stat* buf);
   static std::string readlink(const std::string& path);
   static std::string realpath(const char* path);
+  static void clearCache();
 
  private:
   bool init();
@@ -127,6 +129,7 @@ struct StatCache {
 
   SimpleMutex m_lock;       // Protects the following fields.
   int m_ifd;
+  bool m_shouldClear;      // True if we should clear the cache on the next request
 #ifdef __linux__
   static const size_t kReadBufSize = 10 * (sizeof(struct inotify_event)
                                            + NAME_MAX + 1);

--- a/hphp/runtime/ext/std/ext_std_file.cpp
+++ b/hphp/runtime/ext/std/ext_std_file.cpp
@@ -1268,7 +1268,7 @@ Variant HHVM_FUNCTION(lstat,
 
 void HHVM_FUNCTION(clearstatcache, bool /*clear_realpath_cache*/ /* = false */,
                    const Variant& /*filename*/ /* = uninit_variant */) {
-  // we are not having a cache for file stats, so do nothing here
+  StatCache::clearCache();
 }
 
 Variant HHVM_FUNCTION(readlink_internal,

--- a/hphp/runtime/ext/std/ext_std_file.cpp
+++ b/hphp/runtime/ext/std/ext_std_file.cpp
@@ -1268,7 +1268,7 @@ Variant HHVM_FUNCTION(lstat,
 
 void HHVM_FUNCTION(clearstatcache, bool /*clear_realpath_cache*/ /* = false */,
                    const Variant& /*filename*/ /* = uninit_variant */) {
-  StatCache::clearCache();
+  // we are not having a cache for file stats, so do nothing here
 }
 
 Variant HHVM_FUNCTION(readlink_internal,

--- a/hphp/runtime/server/admin-request-handler.cpp
+++ b/hphp/runtime/server/admin-request-handler.cpp
@@ -29,6 +29,7 @@
 #include "hphp/runtime/base/rds.h"
 #include "hphp/runtime/base/request-tracing.h"
 #include "hphp/runtime/base/runtime-option.h"
+#include "hphp/runtime/base/stat-cache.h"
 #include "hphp/runtime/base/timestamp.h"
 #include "hphp/runtime/base/unit-cache.h"
 
@@ -294,6 +295,8 @@ void AdminRequestHandler::handleRequest(Transport *transport) {
         "/memory.xml:      show memory status in XML\n"
         "/memory.json:     show memory status in JSON\n"
         "/memory.html:     show memory status in HTML\n"
+
+	"/statcache-clear: clear the stat cache entries\n"
 
         "/stats-on:        main switch: enable server stats\n"
         "/stats-off:       main switch: disable server stats\n"
@@ -678,6 +681,11 @@ void AdminRequestHandler::handleRequest(Transport *transport) {
     }
     if (cmd == "proxy") {
       handleProxyRequest(cmd, transport);
+      break;
+    }
+
+    if (cmd == "statcache-clear") {
+      StatCache::clearCache();
       break;
     }
 


### PR DESCRIPTION
We'd like to enable the stat_cache, but are worried about any drift of the in-memory view of the stat_cache with what's on disk.

Background on our deploy:
• We rsync files onto the we serving hosts into A or B directory, and flip the serving root back and forth.
• We drain each host on deploy, and then run a quick warm up script
• We do not restart hhvm between deploys
• We do no currently run with the stat_cache

What we'd like:
• We'd like to enable the stat_cache in prod and clear the cache on each deploy without restarting hhvm (operationally, this is complicated, although we do aim to do that this year before switching to repo auth)
• On each deploy, we'll run a script before putting traffic on the server, which would call clearstatcache()

We're looking for feedback on this approach, or any hints of alternate ways to solve this. To be clear, we've not seen any problems with the StatCache, we're just nervous at the risk that it gets out of sync on deploy.

Additionally, we're not quite sure when it's safe to reset the stat_cache, so we defer that until the requestInit function, partially because of the comment that the work in StatCache::requestInit() that must be done before ExecutionContext::requestInit. https://github.com/facebook/hhvm/blob/HHVM-3.30/hphp/runtime/base/program-functions.cpp#L2617

Thanks!