### PR TITLE
Remove support for non-code ('markup') sections, `<?hh` always optional

### DIFF
--- a/hphp/hack/src/parser/full_fidelity_ast.ml
+++ b/hphp/hack/src/parser/full_fidelity_ast.ml
@@ -2378,13 +2378,10 @@ and pMarkup node env =
     let filename = Pos.filename pos in
     let has_dot_hack_extension = String_utils.string_ends_with (Relative_path.suffix filename) ".hack" in
     if env.is_hh_file then
-      if (is_missing markup_prefix) && not has_dot_hack_extension &&
-      (width markup_text) > 0 && not (is_hashbang markup_text) then
-        raise_parsing_error env (`Node node) SyntaxError.error1001
-      else if has_dot_hack_extension && not (is_missing markup_prefix) then
+      if has_dot_hack_extension then
         raise_parsing_error env (`Node node) SyntaxError.error1060
-      else if (token_kind markup_prefix) = Some TK.QuestionGreaterThan then
-        raise_parsing_error env (`Node node) SyntaxError.error2067;
+      else if (is_missing markup_prefix) && (width markup_text) > 0 && not (is_hashbang markup_text) then
+        raise_parsing_error env (`Node node) SyntaxError.error1001;
     let expr =
       match syntax markup_expression with
       | Missing -> None

--- a/hphp/hack/src/parser/full_fidelity_lexer.mli
+++ b/hphp/hack/src/parser/full_fidelity_lexer.mli
@@ -40,8 +40,7 @@ module WithToken : functor (Token : Lexable_token_sig.LexableToken_S) -> sig
   val next_token : t -> t * Token.t
   val next_token_no_trailing : t -> t * Token.t
   val next_token_in_string : t -> string_literal_kind -> t * Token.t
-  val scan_markup: t ->
-    is_leading_section:bool ->
+  val scan_header: t ->
     (* lexer *)
     t *
     (* markup text *)

--- a/hphp/hack/src/parser/full_fidelity_lexer_sig.ml
+++ b/hphp/hack/src/parser/full_fidelity_lexer_sig.ml
@@ -23,8 +23,7 @@ module WithToken(Token : Lexable_token_sig.LexableToken_S) = struct
     val next_token_non_reserved_as_name : t -> t * Token.t
     val next_docstring_header : t -> t * Token.t * string
     val next_token_in_string : t -> string_literal_kind -> t * Token.t
-    val scan_markup: t ->
-      is_leading_section:bool ->
+    val scan_header: t ->
       (* lexer *)
       t *
       (* markup text *)

--- a/hphp/hack/src/parser/full_fidelity_parser_helpers.ml
+++ b/hphp/hack/src/parser/full_fidelity_parser_helpers.ml
@@ -131,9 +131,9 @@ module WithParser(Parser : Parser_S) = struct
   let peek_token_kind ?(lookahead=0) parser =
     Token.kind (peek_token ~lookahead parser)
 
-  let scan_markup parser ~is_leading_section =
+  let scan_header parser =
     let (lexer, markup, suffix) =
-      Lexer.scan_markup (lexer parser) ~is_leading_section
+      Lexer.scan_header (lexer parser)
     in
     with_lexer parser lexer, markup, suffix
 

--- a/hphp/hack/src/parser/full_fidelity_statement_parser.ml
+++ b/hphp/hack/src/parser/full_fidelity_statement_parser.ml
@@ -182,9 +182,6 @@ module WithExpressionAndDeclAndTypeParser
     | Name when peek_token_kind ~lookahead:1 parser = Colon ->
       parse_goto_label parser
     | Goto -> parse_goto_statement parser
-    | QuestionGreaterThan ->
-      let (p, s, _) = parse_markup_section parser ~is_leading_section:false in
-      (p, s)
     | Semicolon -> parse_expression_statement parser
     (* ERROR RECOVERY: when encountering a token that's invalid now but the
      * context says is expected later, make the whole statement missing
@@ -194,19 +191,15 @@ module WithExpressionAndDeclAndTypeParser
       Make.missing parser (pos parser)
     | _ -> parse_expression_statement parser
 
-  and parse_markup_section parser ~is_leading_section =
+  and parse_header parser =
     let parser, prefix =
       (* for markup section at the beginning of the file
          treat ?> as a part of markup text *)
       (* The closing ?> tag is not legal hack, but accept it here and give an
          error in a later pass *)
-      if not is_leading_section
-        && peek_token_kind parser = TokenKind.QuestionGreaterThan then
-        fetch_token parser
-      else
-        Make.missing parser (pos parser)
+      Make.missing parser (pos parser)
     in
-    let parser, markup, suffix_opt = scan_markup parser ~is_leading_section in
+    let parser, markup, suffix_opt = scan_header parser in
     let (parser, markup) = Make.token parser markup in
     let (parser, suffix, is_echo_tag, has_suffix) =
       match suffix_opt with

--- a/hphp/hack/src/parser/full_fidelity_statement_parser_type.ml
+++ b/hphp/hack/src/parser/full_fidelity_statement_parser_type.ml
@@ -31,8 +31,7 @@ module WithSyntax(Syntax : Syntax_sig.Syntax_S) = struct
         -> t * SC.r
       val parse_compound_statement : t -> t * SC.r
       val parse_statement : t -> t * SC.r
-      val parse_markup_section: t
-        -> is_leading_section:bool
+      val parse_header: t
         -> t * SC.r * bool
       val parse_possible_php_function: t
         -> toplevel:bool


### PR DESCRIPTION
First, to clarify the terms

```
This is leading markup
<?php
?>
this is markup, but not leading markup
```

This diff
- removes support for all kinds of markup except for a leading shebang line, in
  all languages
- removes differing leading markup behavior for HHVM mode vs other parser modes
- removes all parser-level differences between `.hack` and other files
- makes `?>` invalid
- makes `<?` optional in non-hack files: if omitted, they will be
  considered strict. `<?` remains banned in `.hack` files.

This diff is because making the parser act differently based on the
filename extension is incredibly brittle, especially when the LSP is
involved. This is also why `<?` is now optional for PHP files.

Reviewers: jjergus, kunalm, rmlynch

Test plan:

- existing unit tests (a bunch are going to break, I'll fix them on FB
infra)
- hh_client and unit tests for HHAST. This covers a bunch of weird caes

```
$ for file in *; do echo ">>>> $file <<<<"; cat $file; done
>>>> header.hack <<<<
<?hh // strict

function header_dot_hack(): void {
}
>>>> header.php <<<<
<?hh // strict

function header_dot_php(): void {}
>>>> no_header.php <<<<
function no_header_dot_php(): void {}
>>>> qmgt.php <<<<
<?php

echo 'foo';

?>
>>>> shebang.hack <<<<
function shebang_dot_hack(): void {}
>>>> shebang.php <<<<
<?hh // strict
>>>> shebang_header.hack <<<<
<?hh // strict
$ hh_client
header.hack:1:1,4: Leading markup and `<?hh` are not permitted in `.hack` files, which are always strict. (Parsing[1002])
shebang_header.hack:1:1,24: Leading markup and `<?hh` are not permitted in `.hack` files, which are always strict. (Parsing[1002])
$ hhvm qmgt.php

Fatal error: Uncaught Error: An expression is expected here. in /private/tmp/hhtest/qmgt.php:6
Stack trace:
```