### PR TITLE
Fix opam2/arm64 build

### DIFF
--- a/hphp/hack/ocaml.patch
+++ b/hphp/hack/ocaml.patch
@@ -1,0 +1,32 @@
+diff --git asmcomp/arm64/emit.mlp asmcomp/arm64/emit.mlp
+index f75646e..075d408 100644
+--- a/asmcomp/arm64/emit.mlp
++++ b/asmcomp/arm64/emit.mlp
+@@ -439,8 +439,10 @@ module BR = Branch_relaxation.Make (struct
+     | Lop (Iload (size, addr)) | Lop (Istore (size, addr, _)) ->
+       let based = match addr with Iindexed _ -> 0 | Ibased _ -> 1 in
+       based + begin match size with Single -> 2 | _ -> 1 end
+-    | Lop (Ialloc _) when !fastcode_flag -> 4
+-    | Lop (Ispecific (Ifar_alloc _)) when !fastcode_flag -> 5
++    | Lop (Ialloc {words = num_words}) when !fastcode_flag ->
++      if num_words <= 0xFFF then 4 else 5
++    | Lop (Ispecific (Ifar_alloc {words = num_words})) when !fastcode_flag ->
++      if num_words <= 0xFFF then 5 else 6
+     | Lop (Ialloc { words = num_words; _ })
+     | Lop (Ispecific (Ifar_alloc { words = num_words; _ })) ->
+       begin match num_words with
+@@ -518,8 +520,13 @@ let assembly_code_for_allocation ?label_after_call_gc i ~n ~far =
+   if !fastcode_flag then begin
+     let lbl_redo = new_label() in
+     let lbl_call_gc = new_label() in
++    assert (n < 0x1_000_000);
++    let nl = n land 0xFFF and nh = n land 0xFFF_000 in
+     `{emit_label lbl_redo}:`;
+-    `	sub	{emit_reg reg_alloc_ptr}, {emit_reg reg_alloc_ptr}, #{emit_int n}\n`;
++    if nh <> 0 then
++      `	sub	{emit_reg reg_alloc_ptr}, {emit_reg reg_alloc_ptr}, #{emit_int nh}\n`;
++    if nl <> 0 then
++      `	sub	{emit_reg reg_alloc_ptr}, {emit_reg reg_alloc_ptr}, #{emit_int nl}\n`;
+     `	cmp	{emit_reg reg_alloc_ptr}, {emit_reg reg_alloc_limit}\n`;
+     `	add	{emit_reg i.res.(0)}, {emit_reg reg_alloc_ptr}, #8\n`;
+     if not far then begin

--- a/hphp/hack/opam_setup.sh
+++ b/hphp/hack/opam_setup.sh
@@ -37,6 +37,8 @@ opam_require_version_2 () {
 opam_switch_create_if_needed () {
     local name=$1
     local switch=$2
+    local source_dir="$OPAMROOT/custom-sources"
+    local ocaml_dir="$source_dir/$switch"
     local switch_exists=no
     for installed_switch in $(opam switch list --short); do
         if [ "$installed_switch" == "$name" ]; then
@@ -45,7 +47,16 @@ opam_switch_create_if_needed () {
         fi
     done
     if [ "$switch_exists" = "no" ]; then
-        opam switch create "$name" "$switch"
+        # Creates an empty switch so we can fetch ocaml source code
+        # and patch it for arm64 builds
+        opam switch create --empty "$name"
+        mkdir -p "$source_dir"
+        opam source "$switch" --dir "$ocaml_dir"
+        pushd "$ocaml_dir"
+        patch -p1 < "$ROOT/ocaml.patch"
+        popd
+        opam pin add ocaml-variants.4.05.0+arm64-patch "$ocaml_dir"
+        eval $(opam env)
     fi
 }
 
@@ -67,7 +78,7 @@ then
   tar xzf "$MINI_TARBALL" -C "$ROOT/_build"
   opam init --disable-sandboxing --reinit offline_clone "$MINI_REPO" --no-setup --bare
 else
-  opam init --disable-sandboxing --reinit --no-setup
+  opam init --disable-sandboxing --reinit --no-setup --bare
 fi
 
 opam_switch_create_if_needed "$HACK_OPAM_NAME" "$HACK_OPAM_SWITCH"


### PR DESCRIPTION
The current ocaml used to build hhvm is from opam2, which is lacking
the patches/ocaml.patch patch. This PR updates the opam switch creation
so that ocaml is patched before it is built.

The old ocaml is still present to have a simple PR. Next PR will remove
the old ocaml from third-party and the toplevel ocaml-patch