### PR TITLE
Add JitPgoPseudomain command line option to allow retranslation.

### DIFF
--- a/hphp/runtime/base/runtime-option.h
+++ b/hphp/runtime/base/runtime-option.h
@@ -803,6 +803,7 @@ struct RuntimeOption {
                                                                         \
   F(bool, JitDisabledByHphpd,          false)                           \
   F(bool, JitPseudomain,               true)                            \
+  F(bool, JitPGOPseudomain,            false)                           \
   F(uint32_t, JitWarmupStatusBytes,    ((25 << 10) + 1))                \
   F(uint32_t, JitWarmupMaxCodeGenRate, 20000)                           \
   F(uint32_t, JitWarmupRateSeconds,    64)                              \

--- a/hphp/runtime/vm/jit/tc-internal.cpp
+++ b/hphp/runtime/vm/jit/tc-internal.cpp
@@ -71,7 +71,13 @@ bool shouldPGOFunc(const Func* func) {
   // JITing pseudo-mains requires extra checks that blow the IR.  PGO
   // can significantly increase the size of the regions, so disable it for
   // pseudo-mains (so regions will be just tracelets).
-  return !func->isPseudoMain();
+  //
+  // However, on many OSS workloads, this is not an issue. Furthermore, JITing
+  // pseudo-mains on these workloads increase performance due to the fact that
+  // the pseudo-mainsare now optimized and their call sites point to new
+  // optimized functions. Without, many of the pseudo-main's call sites
+  // point to the profile versions of those functions.
+  return !func->isPseudoMain() || RuntimeOption::EvalJitPGOPseudomain;
 }
 
 }


### PR DESCRIPTION
This new flag changes the behavior of shouldPGOFunc() additionally
allowing pseudomains to be PGO'd. This allows pseudomains to be
retranslated as a TransOptimize translation instead of the a simple
TransLive translation. This leads to more optimized pseudomains,
but more importantly, any call sites within the pseudomain that
originally pointed to a TransProfile translation will now point to
a TransOptimize translation.

Experiments using tcprint on the OSS Mediawiki target showed
a significant number of perf samples in aProf without the new
JitPgoPseudomain flag. Setting the existing JitPseudomain to false
led to profiles with no perf samples in aProf because the
pseudomains were always always interpretted and thus the call sites
were never "stale". The performance was mildly better, but
intpretting pseudomains was slow. Using the new JitPgoPseudomain
gave the strongest performance increase also with no perf samples
in aProf.