### PR TITLE
Fix Xenon Interrupting Syscalls in Run Mode

### DIFF
--- a/hphp/runtime/base/program-functions.cpp
+++ b/hphp/runtime/base/program-functions.cpp
@@ -2228,8 +2228,6 @@ static void on_timeout(int sig, siginfo_t* info, void* /*context*/) {
     auto data = (RequestTimer*)info->si_value.sival_ptr;
     if (data) {
       data->onTimeout();
-    } else {
-      Xenon::getInstance().onTimer();
     }
   }
 }

--- a/hphp/runtime/ext/xenon/ext_xenon.cpp
+++ b/hphp/runtime/ext/xenon/ext_xenon.cpp
@@ -57,6 +57,11 @@ void *s_waitThread(void *arg) {
   return nullptr;
 }
 
+// Invoked every time the Xenon timer fires
+void s_xenonTimerFunc(union sigval sv) {
+  Xenon::getInstance().onTimer();
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 
 // Data that is kept per request and is only valid per request.
@@ -192,9 +197,9 @@ void Xenon::start(uint64_t msec) {
           fSec, fNsec);
 
     sigevent sev={};
-    sev.sigev_notify = SIGEV_SIGNAL;
-    sev.sigev_signo = SIGVTALRM;
-    sev.sigev_value.sival_ptr = nullptr; // null for Xenon signals
+    sev.sigev_notify = SIGEV_THREAD;
+    sev.sigev_notify_function = s_xenonTimerFunc;
+    sev.sigev_notify_attributes = nullptr;
     timer_create(CLOCK_REALTIME, &sev, &m_timerid);
 
     itimerspec ts={};

--- a/hphp/runtime/ext/xenon/ext_xenon.h
+++ b/hphp/runtime/ext/xenon/ext_xenon.h
@@ -30,8 +30,8 @@
 
   How does it work?
   There are two ways for Xenon to work: 1) always on, 2) via timer.
-  For the timer mode:  Xenon appends a timer to the already existing SIGVTALRM
-  handler.  When that timer fires it sets a semaphore so that others may
+  For the timer mode:  Xenon creates a timer, which calls a small timer
+  handler in a pthread. This handler sets a semaphore so that others may
   know.  We'd like to be able to record the status of every stack for every
   thread at this point, but during a timer handler is not a reasonable place
   to do this.


### PR DESCRIPTION
## Description

This PR alters the behavior of Xenon sampling to fix #4744, a long-standing issue with Xenon's behavior where any Hack code running in the main thread of execution would have its syscalls interrupted if they were outstanding when Xenon's sampling timer fired.

This issue was caused because the alarm mechanism chosen was to send a `SIGVTALRM` to the process, which (without specifying `sigev_notify_thread_id`) would interrupt syscalls in the main thread of HHVM, the context in which CLI scripts are invoked. I opted to change this alarm mechanism to use a `SIGEV_THREAD` notification which calls a simple timer function wrapping the current Xenon singleton's `onTimer` method. This completely removes signals from the functionality of Xenon.

### Considered Alternatives

I considered keeping the `SIGVTALRM` version of Xenon and adding a thread ID to the `sigev_notify_thread_id` struct member of the `sigevent` created in `Xenon::start`. However, this would require a new dummy thread waiting on a semaphore with no other threads posting to it, or significant changes to `s_waitThread`, both of which felt less clean than this solution. Also, the man page for `timer_create` states that:
> This flag is intended only for use by threading libraries

I also considered refactoring certain segments of `execute_program_impl` to be invoked in a child `pthread`, but this would have been a fairly blunt refactor for the sake of this fix and also wouldn't have mitigated other possible interactions between Xenon and HHVM's main thread, just the Hack execution part.

## Testing

To test this fix, I created the following script, which performs sleeps in XBox tasks and in the main thread (to wait for the XBox tasks to complete). Before this change, the main thread sleeps were cut short by Xenon's sampling. This test, albeit only demonstrating `sleep`, applies to all syscalls. Below are the test files I used and their outputs before/after this patch.

### Test Files

`test.php`
```Hack
<?hh // strict

<<__EntryPoint>>
function main(): void {
	echo "Spawning 10 children...\n";

	$tasks = dict[];
	for ($i = 0; $i < 10; $i++) {
		$tasks[$i] = xbox_task_start((string)($i + 5));
	}

        // Wait for all children to exit
	$loop = true;
	while ($loop) {
		$loop = false;
		foreach ($tasks as $key => $task) {
			if ($task === null) continue;
			if (!xbox_task_status($task)) {
				$loop = true;
			} else {
				$ret = '';
				$result = xbox_task_result($task, 0, inout $ret);
				echo $ret;
				$tasks[$key] = null;
			}
		}

		$before_sleep = microtime(true);
		sleep(2);
		$diff = round(microtime(true) - $before_sleep, 2);
		echo "Sleeping in main thread while loop - slept $diff seconds, should have slept 2 seconds.\n";
	}

	echo "All children exited!\n";
	$samples_gathered = count(xenon_get_data());
	echo "Main thread gathered $samples_gathered samples.\n";
}

function child_func(string $seconds): string {
	$before_sleep = microtime(true);
	sleep((int)$seconds);
	$diff = round(microtime(true) - $before_sleep, 2);
	$samples_gathered = count(xenon_get_data());
	return "Desired sleep: $seconds seconds. Actual sleep: $diff seconds. Gathered $samples_gathered samples.\n";
}
```

`test.ini`
```raw
hhvm.xbox.process_message_func="child_func"
hhvm.xbox.server_info.thread_count=25
hhvm.xbox.server_info.request_init_document="test.php"
hhvm.xenon.period=0.997
```

### Testing Command
```Bash
hhvm --config test.ini test.php
```

### Before
Sleeps in main thread are cut short while sleeps in child XBox task `pthread`s are not.

```raw
Sleeping in main thread while loop - slept 0.16 seconds, should have slept 2 seconds.
Sleeping in main thread while loop - slept 0.99 seconds, should have slept 2 seconds.
Sleeping in main thread while loop - slept 1 seconds, should have slept 2 seconds.
Sleeping in main thread while loop - slept 1 seconds, should have slept 2 seconds.
Sleeping in main thread while loop - slept 1 seconds, should have slept 2 seconds.
Sleeping in main thread while loop - slept 1 seconds, should have slept 2 seconds.
Desired sleep: 5 seconds. Actual sleep: 5 seconds. Gathered 1 samples.
Sleeping in main thread while loop - slept 0.99 seconds, should have slept 2 seconds.
Desired sleep: 6 seconds. Actual sleep: 6 seconds. Gathered 1 samples.
Sleeping in main thread while loop - slept 1 seconds, should have slept 2 seconds.
Desired sleep: 7 seconds. Actual sleep: 7 seconds. Gathered 1 samples.
Sleeping in main thread while loop - slept 1 seconds, should have slept 2 seconds.
Desired sleep: 8 seconds. Actual sleep: 8 seconds. Gathered 1 samples.
Sleeping in main thread while loop - slept 1 seconds, should have slept 2 seconds.
Desired sleep: 9 seconds. Actual sleep: 9 seconds. Gathered 1 samples.
Sleeping in main thread while loop - slept 1 seconds, should have slept 2 seconds.
Desired sleep: 10 seconds. Actual sleep: 10 seconds. Gathered 1 samples.
Sleeping in main thread while loop - slept 1 seconds, should have slept 2 seconds.
Desired sleep: 11 seconds. Actual sleep: 11 seconds. Gathered 1 samples.
Sleeping in main thread while loop - slept 1 seconds, should have slept 2 seconds.
Desired sleep: 12 seconds. Actual sleep: 12 seconds. Gathered 1 samples.
Sleeping in main thread while loop - slept 1 seconds, should have slept 2 seconds.
Desired sleep: 13 seconds. Actual sleep: 13 seconds. Gathered 1 samples.
Sleeping in main thread while loop - slept 1 seconds, should have slept 2 seconds.
Desired sleep: 14 seconds. Actual sleep: 14 seconds. Gathered 1 samples.
Sleeping in main thread while loop - slept 1 seconds, should have slept 2 seconds.
All children exited!
Main thread gathered 16 samples.
```

### After
All sleeps continue for the intended duration. Xenon still successfully gathers samples as indicated by the "Gathered X samples" printouts.

```raw
Spawning 10 children...
Sleeping in main thread while loop - slept 2 seconds, should have slept 2 seconds.
Sleeping in main thread while loop - slept 2 seconds, should have slept 2 seconds.
Sleeping in main thread while loop - slept 2 seconds, should have slept 2 seconds.
Desired sleep: 5 seconds. Actual sleep: 5 seconds. Gathered 1 samples.
Desired sleep: 6 seconds. Actual sleep: 6 seconds. Gathered 1 samples.
Sleeping in main thread while loop - slept 2 seconds, should have slept 2 seconds.
Desired sleep: 7 seconds. Actual sleep: 7.02 seconds. Gathered 1 samples.
Desired sleep: 8 seconds. Actual sleep: 8 seconds. Gathered 1 samples.
Sleeping in main thread while loop - slept 2 seconds, should have slept 2 seconds.
Desired sleep: 9 seconds. Actual sleep: 9 seconds. Gathered 1 samples.
Desired sleep: 10 seconds. Actual sleep: 10 seconds. Gathered 1 samples.
Sleeping in main thread while loop - slept 2 seconds, should have slept 2 seconds.
Desired sleep: 11 seconds. Actual sleep: 11 seconds. Gathered 1 samples.
Desired sleep: 12 seconds. Actual sleep: 12 seconds. Gathered 1 samples.
Sleeping in main thread while loop - slept 2 seconds, should have slept 2 seconds.
Desired sleep: 13 seconds. Actual sleep: 13 seconds. Gathered 1 samples.
Desired sleep: 14 seconds. Actual sleep: 14 seconds. Gathered 1 samples.
Sleeping in main thread while loop - slept 2 seconds, should have slept 2 seconds.
All children exited!
Main thread gathered 8 samples.
```