### PR TITLE
use SIGPROF for Xenon

### DIFF
--- a/hphp/runtime/base/program-functions.cpp
+++ b/hphp/runtime/base/program-functions.cpp
@@ -2209,8 +2209,6 @@ static void on_timeout(int sig, siginfo_t* info, void* /*context*/) {
     auto data = (RequestTimer*)info->si_value.sival_ptr;
     if (data) {
       data->onTimeout();
-    } else {
-      Xenon::getInstance().onTimer();
     }
   }
 }

--- a/hphp/runtime/ext/xenon/ext_xenon.cpp
+++ b/hphp/runtime/ext/xenon/ext_xenon.cpp
@@ -27,6 +27,7 @@
 #include "hphp/runtime/vm/vm-regs.h"
 
 #include "hphp/util/struct-log.h"
+#include "hphp/util/sync-signal.h"
 #include "hphp/util/thread-local.h"
 
 #include <signal.h>
@@ -145,7 +146,7 @@ Array parsePhpStack(const Array& bt) {
 // If in always on mode, the Xenon Surprise flags have to be on for each thread
 // and are never cleared.
 // For timer mode, when start is invoked, it adds a new timer to the existing
-// handler for SIGVTALRM.
+// handler for SIGPROF.
 
 Xenon& Xenon::getInstance() noexcept {
   static Xenon instance;
@@ -165,6 +166,13 @@ void Xenon::incrementMissedSampleCount(ssize_t val) {
 int64_t Xenon::getAndClearMissedSampleCount() {
     return std::atomic_exchange<int64_t>(&m_missedSampleCount, 0);
 }
+
+static void onXenonTimer(int signo) {
+  if (signo == SIGPROF) {
+    Xenon::getInstance().onTimer();
+  }
+}
+
 // XenonForceAlwaysOn is active - it doesn't need a timer, it is always on.
 // Xenon needs to be started once per process.
 // The number of milliseconds has to be greater than zero.
@@ -193,9 +201,10 @@ void Xenon::start(uint64_t msec) {
 
     sigevent sev={};
     sev.sigev_notify = SIGEV_SIGNAL;
-    sev.sigev_signo = SIGVTALRM;
-    sev.sigev_value.sival_ptr = nullptr; // null for Xenon signals
+    sev.sigev_signo = SIGPROF;
     timer_create(CLOCK_REALTIME, &sev, &m_timerid);
+
+    sync_signal(SIGPROF, onXenonTimer);
 
     itimerspec ts={};
     ts.it_value.tv_sec = fSec;
@@ -366,7 +375,7 @@ bool HHVM_FUNCTION(xenon_get_is_profiled_request, void) {
 }
 
 struct xenonExtension final : Extension {
-  xenonExtension() : Extension("xenon", "1.0") { }
+  xenonExtension() : Extension("xenon", "2.0") { }
 
   void moduleInit() override {
     HHVM_FALIAS(HH\\xenon_get_data, xenon_get_data);

--- a/hphp/runtime/ext/xenon/ext_xenon.h
+++ b/hphp/runtime/ext/xenon/ext_xenon.h
@@ -29,12 +29,11 @@
   stack at that time (ie it flashes the code).
 
   How does it work?
-  There are two ways for Xenon to work: 1) always on, 2) via timer.
-  For the timer mode:  Xenon appends a timer to the already existing SIGVTALRM
-  handler.  When that timer fires it sets a semaphore so that others may
-  know.  We'd like to be able to record the status of every stack for every
-  thread at this point, but during a timer handler is not a reasonable place
-  to do this.
+  There are two ways for Xenon to work: 1) always on, 2) via timer. For the
+  timer mode: Xenon starts a timer that raises SIGPROF periodically. When that
+  timer fires it sets a semaphore so that others may know. We'd like to be able
+  to record the status of every stack for every thread at this point, but during
+  a timer handler is not a reasonable place to do this.
   Instead, Xenon has a pthread waiting for the semaphore.  When the semaphore
   is set in the handler, it wakes, sets the Xenon Surprise flag for every
   thread - this is the flash.


### PR DESCRIPTION
Summary: Currently SIGVTALRM is used by both Xenon and request timer.  This tris to use SIGPROF for Xenon, and handle it in the dedicated signal handling thread.

Differential Revision: D15696983

