### PR TITLE
prevent early xenon SIGPROF from terminating process

### DIFF
--- a/hphp/runtime/ext/xenon/ext_xenon.cpp
+++ b/hphp/runtime/ext/xenon/ext_xenon.cpp
@@ -205,6 +205,7 @@ void Xenon::start(uint64_t msec) {
     timer_create(CLOCK_REALTIME, &sev, &m_timerid);
 
     sync_signal(SIGPROF, onXenonTimer);
+    signal(SIGPROF, SIG_IGN);
 
     itimerspec ts={};
     ts.it_value.tv_sec = fSec;


### PR DESCRIPTION
Summary: When Xenon is enabled with a timer, the first timer event is set to
occur at a random interval up to the configured interval. If the timer signals
before block_sync_signals_and_start_handler_thread is invoked, the unhandled
SIGPROF terminates the process. Fixed by purposely ignoring SIGPROF until the
correct handler is installed. (Credit to @enjmusic for the fix.)