### PR TITLE
Make HHI types match runtime types

### DIFF
--- a/hphp/hack/hhi/stdlib/builtins_async_mysql.hhi
+++ b/hphp/hack/hhi/stdlib/builtins_async_mysql.hhi
@@ -198,10 +198,10 @@ class AsyncMysqlQueryResult extends AsyncMysqlResult {
   public function numRowsAffected(): int { }
   public function lastInsertId(): int { }
   public function numRows(): int { }
-  public function mapRows(): Vector<Map<string, string>>{ }
-  public function vectorRows() { }
+  public function mapRows(): Vector<Map<string, ?string>> { }
+  public function vectorRows() Vector<?string> { }
   public function mapRowsTyped(): Vector<Map<string, mixed>> { }
-  public function vectorRowsTyped() { }
+  public function vectorRowsTyped() Vector<mixed> { }
  /* Can't put a return type for rowBlocks as it will ask that the type is
   * iterable because of the usage and then we can't have the AsyncMysqlRowBlock
   * implement the Iterable interface because mocks will complain they don't

--- a/hphp/hack/hhi/stdlib/builtins_async_mysql.hhi
+++ b/hphp/hack/hhi/stdlib/builtins_async_mysql.hhi
@@ -199,9 +199,9 @@ class AsyncMysqlQueryResult extends AsyncMysqlResult {
   public function lastInsertId(): int { }
   public function numRows(): int { }
   public function mapRows(): Vector<Map<string, ?string>> { }
-  public function vectorRows() Vector<?string> { }
+  public function vectorRows(): Vector<?string> { }
   public function mapRowsTyped(): Vector<Map<string, mixed>> { }
-  public function vectorRowsTyped() Vector<mixed> { }
+  public function vectorRowsTyped(): Vector<mixed> { }
  /* Can't put a return type for rowBlocks as it will ask that the type is
   * iterable because of the usage and then we can't have the AsyncMysqlRowBlock
   * implement the Iterable interface because mocks will complain they don't


### PR DESCRIPTION
In the face-sql implementation from slack, we discussed how they were casting NULL to string. I presumed that the return value should have a nullable string, instead of a string. `mapRows(): Map<string, ?string>` instead of `Map<string, string>`. I checked my HHI, but it says that a string was used. I did not believe that, so I tried the runtime. At runtime you actually get a nullable string.