### PR TITLE
Fix Race Condition Between Sync Signals and Forking

### DIFF
--- a/hphp/util/sync-signal.cpp
+++ b/hphp/util/sync-signal.cpp
@@ -127,6 +127,7 @@ void* handle_signals(void*) {
 
 // Clear state in child process after fork().
 void postfork_clear() {
+  reset_sync_signals();
   g_handler_thread_started.store(false, std::memory_order_release);
   g_handler_thread = pthread_t{};
 }
@@ -140,7 +141,7 @@ void block_sync_signals() {
   // If we ever fork(), avoid affecting child processes.
   static std::atomic_flag flag ATOMIC_FLAG_INIT;
   if (!flag.test_and_set()) {
-    pthread_atfork(reset_sync_signals, block_sync_signals, postfork_clear);
+    pthread_atfork(nullptr, nullptr, postfork_clear);
   }
 }
 


### PR DESCRIPTION
# Description

While trying to upgrade some web servers to HHVM 4.1.0 with the two recent Xenon fixes cherrypicked ([`c7622408c8b3a6f861ae9292433623163966cd21`](https://github.com/facebook/hhvm/commit/c7622408c8b3a6f861ae9292433623163966cd21), [`c65b853724bc83204452493bea814eb026dba858`](https://github.com/facebook/hhvm/commit/c65b853724bc83204452493bea814eb026dba858)), we discovered that our servers were still being killed by Xenon's `SIGPROF` timer. We narrowed this down to a race condition involving the [prefork and parent postfork](https://github.com/facebook/hhvm/blob/aa310fa33287c6268a033bb64d5e5c6a3031b948/hphp/util/sync-signal.cpp#L143) handlers registered in `block_sync_signals`.

When any thread in the root HHVM process decides to fork, there is a small window of time after the prefork handler, `reset_sync_signals`, where any registered sync signal that should be handled instead leaks through and can kill HHVM, which is what we experienced with Xenon. Our solution moves the child-inherited effect of `reset_sync_signals` to just be an explicit call in `postfork_clear`, and does away with any modification of signal handling for sync signals in the parent process. With this change, we did not observe `SIGPROF` killing HHVM despite seeing it extremely consistency within 10s of seconds previously.

The repro below worked in our augmented build of 4.1.0 and in the latest `hhvm/hhvm` docker image, which is running `4.18.1`.

# Testing

## Test Endpoint

`proc_open.php`:
```Hack
<?hh // strict

function dump_date(): void {
    $descriptorspec = array(
        0 => array("pipe", "r"),
        1 => array("pipe", "w"),
        2 => array("file", "/tmp/error-output1.txt", "a")
    );
    $pipes = array();
    $process = proc_open('date', $descriptorspec, &$pipes, '/tmp', array());
    if (is_resource($process)) {
        fclose($pipes[0]);
        echo stream_get_contents($pipes[1]);
        fclose($pipes[1]);
        $return_value = proc_close($process);
        if ($return_value != 0) {
            echo "bad exit ". $return_value . "\n";
        }
    } else {
        echo "nope1\n";
    }
}

<<__EntryPoint>>
function main(): void {
    dump_date();
}
```

## Server Config File

`server.ini`
```raw
hhvm.server.port=12111
hhvm.server.default_document="proc_open.php"
hhvm.xenon.period=0.010
```

## Server Command
`hhvm -m server --config server.ini &`

## Test Command
`while true; do curl http://localhost:12111/; done`

## Before
Within a fraction of a second, `SIGPROF` kills the server.

```raw
Thu Aug 15 19:53:20 PDT 2019
Thu Aug 15 19:53:20 PDT 2019
Thu Aug 15 19:53:20 PDT 2019
Thu Aug 15 19:53:20 PDT 2019
Thu Aug 15 19:53:20 PDT 2019
Thu Aug 15 19:53:20 PDT 2019
curl: (52) Empty reply from server
[1]+  Profiling timer expired hhvm -m server --config server.ini
curl: (7) Failed to connect to localhost port 12111: Connection refused
curl: (7) Failed to connect to localhost port 12111: Connection refused
curl: (7) Failed to connect to localhost port 12111: Connection refused
curl: (7) Failed to connect to localhost port 12111: Connection refused
...
```

## After
The while loop can run for several minutes without causing HHVM to crash due to `SIGPROF`.

```raw
Thu Aug 15 19:56:58 PDT 2019
Thu Aug 15 19:56:58 PDT 2019
Thu Aug 15 19:56:58 PDT 2019
Thu Aug 15 19:56:58 PDT 2019
Thu Aug 15 19:56:58 PDT 2019
Thu Aug 15 19:56:58 PDT 2019
Thu Aug 15 19:56:58 PDT 2019
Thu Aug 15 19:56:58 PDT 2019
Thu Aug 15 19:56:58 PDT 2019
... (abridged)
Thu Aug 15 20:09:45 PDT 2019
Thu Aug 15 20:09:45 PDT 2019
Thu Aug 15 20:09:45 PDT 2019
Thu Aug 15 20:09:46 PDT 2019
Thu Aug 15 20:09:46 PDT 2019
Thu Aug 15 20:09:46 PDT 2019
Thu Aug 15 20:09:46 PDT 2019
```