### PR TITLE
Fix unwinder (and rust panics) on MacOS

### DIFF
--- a/hphp/hack/src/dune
+++ b/hphp/hack/src/dune
@@ -32,6 +32,7 @@
   (modules
     hh_server)
   (ocamlc_flags (:standard -custom))
+  (link_flags (:standard (:include dune_config/ld-opts.sexp)))
   (libraries
     ai
     client
@@ -55,6 +56,7 @@
   (modules
     hh_client)
   (ocamlc_flags (:standard -custom))
+  (link_flags (:standard (:include dune_config/ld-opts.sexp)))
   (libraries
     ai
     client
@@ -92,6 +94,7 @@
     pocket_universes
     typing)
   (ocamlc_flags (:standard -custom))
+  (link_flags (:standard (:include dune_config/ld-opts.sexp)))
   (flags (:standard -unsafe-string)))
 
 (executable
@@ -99,6 +102,7 @@
   (modules
     hh_parse)
   (ocamlc_flags (:standard -custom))
+  (link_flags (:standard (:include dune_config/ld-opts.sexp)))
   (libraries
     debug
     default_injector_config
@@ -113,6 +117,7 @@
   (modules
     hackfmt)
   (ocamlc_flags (:standard -custom))
+  (link_flags (:standard (:include dune_config/ld-opts.sexp)))
   (libraries
     default_injector_config
     hackfmt
@@ -125,6 +130,7 @@
   (modules
     hh_single_parse)
   (ocamlc_flags (:standard -custom))
+  (link_flags (:standard (:include dune_config/ld-opts.sexp)))
   (libraries
     debug
     default_injector_config
@@ -138,6 +144,7 @@
   (modules
     generate_full_fidelity)
   (ocamlc_flags (:standard -custom))
+  (link_flags (:standard (:include dune_config/ld-opts.sexp)))
   (libraries
     procs_procs_lwt
     core_kernel

--- a/hphp/hack/src/dune_config/discover.ml
+++ b/hphp/hack/src/dune_config/discover.ml
@@ -4,18 +4,18 @@ https://jbuilder.readthedocs.io/en/latest/configurator.html *)
 module C = Configurator.V1
 
 let () =
-  C.main ~name:"hphpdir" (fun (_c : C.t) ->
-      let split s =
-        if s = "" then
-          []
-        else
-          String.split_on_char ' ' s
-      in
-      let rpath =
-        match Sys.getenv "FB_LD_OPTS" with
-        | t ->
-          let flags = split t in
-          List.fold_left (fun acc x -> "-ccopt" :: x :: acc) [] flags
-        | exception Not_found -> []
-      in
-      C.Flags.write_sexp "ld-opts.sexp" rpath)
+  C.main ~name:"hphpdir" (fun (c : C.t) ->
+  let split = (fun s -> if s = "" then [] else String.split_on_char ' ' s) in
+  let flags = match Sys.getenv "FB_LD_OPTS" with
+    | t -> let flags = split t in
+      List.fold_left (fun acc x -> "-ccopt" :: x :: acc ) [] flags
+    | exception Not_found -> [] in
+  let flags = match C.ocaml_config_var_exn c "system" with
+    (* ocaml builds with `-no_compact_unwind`, which breaks libunwind on
+     * MacOS; we need libunwind to work for rust std::panic::catch_unwind.
+     *
+     * This fix is included in ocaml 4.08
+     * (https://github.com/ocaml/ocaml/pull/8673) - but we're still on 4.07 *)
+    | "macosx" -> flags @ [ "-ccopt"; "-Wl,-keep_dwarf_unwind" ]
+    | _ -> flags in
+  C.Flags.write_sexp "ld-opts.sexp" flags)


### PR DESCRIPTION
OCaml links executables with `-no_compact_unwind`; on recent MacOS,
this breaks the unwinder. Add `-keep_dwarf_unwind`, which is is the same
fix applies in 4.08 (we're still on 4.07)

1. add the flag if on macos
2. rename `rpath` to `flags` as it's really whatever we want from the
   env var
3. use the flags for all hack executables (but not discover)

Test plan:

config.json
-----------

```
{
  "hhvm.hack.lang.hack_compiler_use_rust_parser": {
    "global_value": "1"
  }
}
```

before
------

```
$ build/hphp/hack/bin/hh_single_compile -c config.json hphp/test/quick/parser_massive_concat_exp.php
fatal runtime error: failed to initiate panic, error 5
Abort trap: 6
```

after
-----

```
$ build/hphp/hack/bin/hh_single_compile -c config.json hphp/test/quick/parser_massive_concat_exp.php
[hrust] warning: parser exceeded stack of 819 KiB on: hphp/test/quick/parser_massive_concat_exp.php
[hrust] warning: parser exceeded stack of 5324 KiB on: hphp/test/quick/parser_massive_concat_exp.php
[hrust] warning: parser exceeded stack of 10649 KiB on: hphp/test/quick/parser_massive_concat_exp.php
[hrust] warning: parser exceeded stack of 21299 KiB on: hphp/test/quick/parser_massive_concat_exp.php
[hrust] warning: parser exceeded stack of 42598 KiB on: hphp/test/quick/parser_massive_concat_exp.php
 # hphp/test/quick/parser_massive_concat_exp.php starts here

.filepath "hphp/test/quick/parser_massive_concat_exp.php";

.hh_file 1;

.main {
  String "Expression recursion limit reached"
  Fatal Parse
}

 # hphp/test/quick/parser_massive_concat_exp.php ends here
```