### PR TITLE
Make it possible to start hh_server with sqlite symbol index enabled

### DIFF
--- a/hphp/hack/src/search/sqliteSearchService.ml
+++ b/hphp/hack/src/search/sqliteSearchService.ml
@@ -98,7 +98,7 @@ let find_or_build_sqlite_file
           custom_repo_name = None;
           include_builtins = true;
           set_paths_for_worker = false;
-          hhi_root_folder = None;
+          hhi_root_folder = Some (Hhi.get_hhi_root ());
           silent;
         }
       in

--- a/hphp/hack/src/stubs/state_loader_futures.ml
+++ b/hphp/hack/src/stubs/state_loader_futures.ml
@@ -6,6 +6,6 @@
  *
  *)
 
-let load ~repo:_ ~saved_state_type:_ = failwith "Not implemented"
+let load ~repo:_ ~saved_state_type:_ = Future.of_value (Error "Not implemented")
 
 let wait_for_finish _ = failwith "Not implemented"


### PR DESCRIPTION
- don't `failwith` when we can return an error
- the fallback set include_builtins to true with no HHI dir. This is
  invalid.

Test plan:

```
~/code/hhvm/build/hphp/hack/bin/hh_server --config symbolindex_search_provider=SqliteIndex .
```

no exception.