### PR TITLE
Change the type of format `%d` from `mixed` to `num`.

### DIFF
--- a/hphp/hack/hhi/printf.hhi
+++ b/hphp/hack/hhi/printf.hhi
@@ -20,7 +20,7 @@ namespace {
  * causes the corresponding method in T to be looked up. For example,
  * '%d' will "call" the method
  *
- *   function format_d(?int $s) : string;
+ *   function format_d(num $s) : string;
  *
  * and consume an 'int' from the argument list.
  *
@@ -40,10 +40,8 @@ namespace {
  */
 
 interface PlainSprintf {
-  // It's common to pass floats; would be nice to type this as
-  // 'number' once that type becomes available in userland.
  <<__Rx>>
-  public function format_d(mixed $s) : string;
+  public function format_d(num $s) : string;
  <<__Rx>>
   public function format_s(mixed $s) : string;
  <<__Rx>>

--- a/hphp/hack/hhi/printf.hhi
+++ b/hphp/hack/hhi/printf.hhi
@@ -22,7 +22,7 @@ namespace {
  *
  *   function format_d(num $s) : string;
  *
- * and consume an 'int' from the argument list.
+ * and consume a 'num' from the argument list.
  *
  * Hex escapes are used for non-alphabetic characters. The '%%'
  * pseudo-specifier consumes nothing and appears as


### PR DESCRIPTION
This is a remake of #8571, but without the merge commit.

---

I did `invariant($some_condition, 'Id must be greater than zero %d', $array_key);`
Scratching my head why this was allowed and figuring out that `%d` takes `mixed` in `PlainSprintf`, but `int` in `HH\Lib\Str\SprintfFormat`.

The docblock specifies `?int`

> function format_d(?int $s) : string;

But then again, another comment also specifies that it would be nice if this was `number` (`num`) instead.

> // It's common to pass floats; would be nice to type this as
> // 'number' once that type becomes available in userland.

It might be nice to make both formatters agree and end this confusion about what formatting interface what function is using. Either make `Str\format` weaker to take `num` too.
Or use `num` in `PlainSprintf` as an intermediate step to migrate to `int` later.

---

This will most definitely introduce typecheck failures in a codebase as big as Facebook's. I think using `%d` to format a numeric string or something nullable would be the most common. It is up to you if you want that loosely typed behavior to be retained.

If this is rejected for causing too many test failures, maybe we could make `invariant` and friends take `HH\Lib\Str\SprintfFormat` instead, since these functions are not replaceable in userland, because of their special meaning to the typechecker.