### PR TITLE
Allow for the use of disallow_array_literal outside of fb

### DIFF
--- a/hphp/hack/hhi/stdlib/builtins_image.hhi
+++ b/hphp/hack/hhi/stdlib/builtins_image.hhi
@@ -40,11 +40,11 @@ function image_type_to_mime_type(int $imagetype);
 <<__PHPStdLib>>
 function image2wbmp(resource $image, string $filename = "", int $threshold = -1);
 <<__PHPStdLib>>
-function imageaffine(resource $image, $affine = array(), $clip = array());
+function imageaffine(resource $image, $affine = varray[], $clip = darray[]);
 <<__PHPStdLib>>
 function imageaffinematrixconcat($m1, $m2);
 <<__PHPStdLib>>
-function imageaffinematrixget(int $type, $options = array());
+function imageaffinematrixget(int $type, $options = darray[]);
 <<__PHPStdLib>>
 function imagealphablending(resource $image, bool $blendmode);
 <<__PHPStdLib>>

--- a/hphp/hack/hhi/stdlib/builtins_mysql.hhi
+++ b/hphp/hack/hhi/stdlib/builtins_mysql.hhi
@@ -22,15 +22,15 @@ const int MYSQL_CLIENT_SSL = 2048;
 // Since no further damage is possible, I added the $conn_attrs parameter
 // instead of creating new functions - jkedgar@fb.com
 <<__PHPStdLib>>
-function mysql_connect(string $server = "", string $username = "", string $password = "", bool $new_link = false, int $client_flags = 0, int $connect_timeout_ms = -1, int $query_timeout_ms = -1, darray<string, string> $conn_attrs = []);
+function mysql_connect(string $server = "", string $username = "", string $password = "", bool $new_link = false, int $client_flags = 0, int $connect_timeout_ms = -1, int $query_timeout_ms = -1, darray<string, string> $conn_attrs = darray[]);
 <<__PHPStdLib>>
-function mysql_pconnect(string $server = "", string $username = "", string $password = "", int $client_flags = 0, int $connect_timeout_ms = -1, int $query_timeout_ms = -1, darray<string, string> $conn_attrs = []);
+function mysql_pconnect(string $server = "", string $username = "", string $password = "", int $client_flags = 0, int $connect_timeout_ms = -1, int $query_timeout_ms = -1, darray<string, string> $conn_attrs = darray[]);
 <<__PHPStdLib>>
-function mysql_connect_with_db(string $server = "", string $username = "", string $password = "", string $database = "", bool $new_link = false, int $client_flags = 0, int $connect_timeout_ms = -1, int $query_timeout_ms = -1, darray<string, string> $conn_attrs = []);
+function mysql_connect_with_db(string $server = "", string $username = "", string $password = "", string $database = "", bool $new_link = false, int $client_flags = 0, int $connect_timeout_ms = -1, int $query_timeout_ms = -1, darray<string, string> $conn_attrs = darray[]);
 <<__PHPStdLib>>
-function mysql_connect_with_ssl(string $server = "", string $username = "", string $password = "", string $database = "", int $client_flags = 0, int $connect_timeout_ms = -1, int $query_timeout_ms = -1, ?MySSLContextProvider $ssl_context = null, darray<string, string> $conn_attrs = []);
+function mysql_connect_with_ssl(string $server = "", string $username = "", string $password = "", string $database = "", int $client_flags = 0, int $connect_timeout_ms = -1, int $query_timeout_ms = -1, ?MySSLContextProvider $ssl_context = null, darray<string, string> $conn_attrs = darray[]);
 <<__PHPStdLib>>
-function mysql_pconnect_with_db(string $server = "", string $username = "", string $password = "", string $database = "", int $client_flags = 0, int $connect_timeout_ms = -1, int $query_timeout_ms = -1, darray<string, string> $conn_attrs = []);
+function mysql_pconnect_with_db(string $server = "", string $username = "", string $password = "", string $database = "", int $client_flags = 0, int $connect_timeout_ms = -1, int $query_timeout_ms = -1, darray<string, string> $conn_attrs = darray[]);
 <<__PHPStdLib>>
 function mysql_set_charset(string $charset, $link_identifier = null);
 <<__PHPStdLib>>

--- a/hphp/hack/hhi/stdlib/builtins_redis.hhi
+++ b/hphp/hack/hhi/stdlib/builtins_redis.hhi
@@ -153,8 +153,8 @@ class Redis {
   public function zRem($key, $member1, $member2 = null, $memberN = null) {}
   public function zDelete($key, $member1, $member2 = null, $memberN = null) {}
   public function zRevRange($key, $start, $end, $withscore = null) {}
-  public function zRangeByScore($key, $start, $end, array $options = array()) {}
-  public function zRevRangeByScore($key, $start, $end, array $options = array()) {}
+  public function zRangeByScore($key, $start, $end, array $options = darray[]) {}
+  public function zRevRangeByScore($key, $start, $end, array $options = darray[]) {}
   public function zCount($key, $start, $end) {}
   public function zRemRangeByScore($key, $start, $end) {}
   public function zDeleteRangeByScore($key, $start, $end) {}
@@ -166,8 +166,8 @@ class Redis {
   public function zRank($key, $member) {}
   public function zRevRank($key, $member) {}
   public function zIncrBy($key, $value, $member) {}
-  public function zUnion($Output, $ZSetKeys, array $Weights = array(), $aggregateFunction = 'SUM') {}
-  public function zInter($Output, $ZSetKeys, array $Weights = array(), $aggregateFunction = 'SUM') {}
+  public function zUnion($Output, $ZSetKeys, array $Weights = varray[], $aggregateFunction = 'SUM') {}
+  public function zInter($Output, $ZSetKeys, array $Weights = varray[], $aggregateFunction = 'SUM') {}
   public function hSet($key, $hashKey, $value) {}
   public function hSetNx($key, $hashKey, $value) {}
   public function hGet($key, $hashKey) {}
@@ -182,9 +182,9 @@ class Redis {
   public function hMset($key, $hashKeys) {}
   public function hMGet($key, $hashKeys) {}
   public function config($operation, $key, $value) {}
-  public function evaluate($script, $args = array(), $numKeys = 0) {}
-  public function evalSha($scriptSha, $args = array(), $numKeys = 0) {}
-  public function evaluateSha($scriptSha, $args = array(), $numKeys = 0) {}
+  public function evaluate($script, $args = varray[], $numKeys = 0) {}
+  public function evalSha($scriptSha, $args = varray[], $numKeys = 0) {}
+  public function evaluateSha($scriptSha, $args = varray[], $numKeys = 0) {}
   public function script($command, $script) {}
   public function getLastError() {}
   public function clearLastError() {}
@@ -203,7 +203,7 @@ class RedisException extends RuntimeException {
 <<__PHPStdLib>>
 class RedisArray {
   public function __call($function_name, $arguments) {}
-  public function __construct($name = '', array $hosts = array(), array $opts = array()) {}
+  public function __construct($name = '', array $hosts = varray[], array $opts = darray[]) {}
   public function _distributor() {}
   public function _function() {}
   public function _hosts() {}


### PR DESCRIPTION
I applied the typechecker setting `disallow_array_literal` and made my code use `darray[...]` and `varray[...]` instead of `[...]` and `array(...)`. HHVM's built-in hhi's don't typecheck with this setting turned on. The PR attempts to mitigate that.

As far as I understand the default values in hhi's are not used at runtime. I did check for PHP examples of each function, to make sure that the `d/v`array type was possible. I did not try to rule out if a function could also take the other type.