### PR TITLE
Update the hover text for `__Soft`

### DIFF
--- a/hphp/hack/src/server/serverHover.ml
+++ b/hphp/hack/src/server/serverHover.ml
@@ -299,10 +299,10 @@ let make_hover_attr_docs name =
     ]
   | "__Soft" ->
     [
-      "This parameter/property will not be type checked at runtime."
+      "A runtime type mismatch on this parameter/property will not throw a TypeError/Error."
       ^ " This is useful for migrating partial code where you're unsure about the type."
-      ^ "\n\nThe type checker will still use the type, so callers will get checked."
-      ^ " If the type is wrong at runtime, a warning will be logged.";
+      ^ "\n\nThe type checker will ignore this attribute, so your code will still get type checked."
+      ^ " If the type is wrong at runtime, a warning will be logged and code execution will continue.";
     ]
   | "__VMSwitchMode" ->
     [


### PR DESCRIPTION
The text _"will not be typechecked at runtime"_ suggests that HHVM is running hh_client (type checking) when running code. Not throwing a TypeError/Error more accurately describes the behavior of the runtime.

The text _"so callers will get checked"_ does not cover the case of a property, since they are assigned, not called.

Be double clear about continued execution after logging a warning.