### PR TITLE
mailparse: abort message parsing when max mime parts is exceeded

### DIFF
--- a/hphp/runtime/ext/mailparse/mime.cpp
+++ b/hphp/runtime/ext/mailparse/mime.cpp
@@ -621,7 +621,14 @@ bool MimePart::parse(const char *buf, int bufsize) {
     if (len < bufsize && buf[len] == '\n') {
       ++len;
       m_parsedata.workbuf += String(buf, len, CopyString);
-      ProcessLine(req::ptr<MimePart>(this), m_parsedata.workbuf);
+      if (!ProcessLine(req::ptr<MimePart>(this), m_parsedata.workbuf)) {
+        // ProcessLine() only returns FAILURE in case the count of children
+        // have exceeded MAXPARTS at the very beginning, without doing any work.
+        // Short-circuit since the exceeded state won't change on subsequent
+        // calls.
+        return false;
+      }
+
       m_parsedata.workbuf.clear();
     } else {
       m_parsedata.workbuf += String(buf, len, CopyString);

--- a/hphp/test/slow/ext_mailparse/ext_mailparse.php
+++ b/hphp/test/slow/ext_mailparse/ext_mailparse.php
@@ -310,3 +310,41 @@ VS($output,
    "UUE\n".
    "this is a test\n");
 }
+
+//////////////////////////////////////////////////////////////////////
+
+$text =
+  "To: fred@bloggs.com\n".
+  "Content-Type: multipart/mixed;\n".
+  "\tboundary=\"----=_NextPart_\"\n".
+  "\n".
+  "This is a multi-part message in MIME format.\n".
+  "\n".
+  "------=_NextPart_\n".
+  "Content-Type: tex/plain;\n".
+  "\tcharset=\"us-ascii\"\n".
+  "Content-Transfer-Encoding: 7bit\n".
+  "\n".
+  "this is a regular mime attachment.\n".
+  "\n";
+
+# MAXPARTS is 300, but the error does not occur until the 302nd
+# MIME part is parsed.
+for ($i = 0; $i < 301; $i++) {
+  $text .=
+    "------=_NextPart_\n".
+    "Content-Type: application/octet-stream;\n".
+    "\tname=\"README{$i}\"\n".
+    "Content-Transfer-Encoding: 7bit\n".
+    "Content-Disposition: attachment;;\n".
+    "\tfilename=\"README{$i}\"\n".
+    "\n".
+    "Part{$i}\n".
+    "\n";
+}
+
+$text .= "------=_NextPart_--\n";
+
+$mime = mailparse_msg_create();
+$result = mailparse_msg_parse($mime, $text);
+VS($result, false);

--- a/hphp/test/slow/ext_mailparse/ext_mailparse.php.expectf
+++ b/hphp/test/slow/ext_mailparse/ext_mailparse.php.expectf
@@ -1,3 +1,5 @@
+Warning: MIME message too complex in %s/ext_mailparse.php on line %d
+bool(true)
 bool(true)
 Message: mime
 


### PR DESCRIPTION
Aborts mail message parsing when the maximum number of MIME parts
has been reached, rather than continuing to process message lines.

Fixes #8532