### PR TITLE
Implement signed-source in hh_codegen.rs

### DIFF
--- a/hphp/hack/src/hh_codegen/Cargo.toml
+++ b/hphp/hack/src/hh_codegen/Cargo.toml
@@ -15,6 +15,7 @@ features = ["full", "extra-traits", "visit-mut", "visit"]
 [dependencies]
 proc-macro2 = "^1.0.4"
 quote ="^1.0.2"
+rust-crypto = "^0.2"
 synstructure = "^0.12.0"
 itertools = "^0.7"
 clap = "^2.33.0"

--- a/hphp/hack/src/oxidized/regen.sh
+++ b/hphp/hack/src/oxidized/regen.sh
@@ -13,8 +13,6 @@ REGEN_COMMAND="$(realpath --relative-to=. "${BASH_SOURCE[0]}")"
 # rustfmt is committed at fbsource/tools/third-party/rustfmt/rustfmt
 RUSTFMT_PATH="$(realpath ../tools/third-party/rustfmt/rustfmt)"
 
-SIGNER_PATH="$(realpath ../tools/signedsource)"
-
 buck run hphp/hack/src/hh_oxidize --                                          \
   --out-dir hphp/hack/src/oxidized/gen                                        \
   --regen-command "$REGEN_COMMAND"                                            \
@@ -39,7 +37,6 @@ buck run hphp/hack/src/hh_oxidize --                                          \
   hphp/hack/src/parser/scoured_comments.ml                                    \
 
 buck run //hphp/hack/src/hh_codegen:hh_codegen --                             \
-  --signer "$SIGNER_PATH"                                                     \
   --regen-cmd "$REGEN_COMMAND"                                                \
   --rustfmt "$RUSTFMT_PATH"                                                   \
   enum_constr                                                                 \
@@ -48,7 +45,6 @@ buck run //hphp/hack/src/hh_codegen:hh_codegen --                             \
   --output "hphp/hack/src/oxidized/impl_gen/"                                 \
 
 buck run //hphp/hack/src/hh_codegen:hh_codegen --                             \
-  --signer "$SIGNER_PATH"                                                     \
   --regen-cmd "$REGEN_COMMAND"                                                \
   --rustfmt "$RUSTFMT_PATH"                                                   \
   visitor                                                                     \


### PR DESCRIPTION
Summary:
- we already do this for ocaml
- this is needed for external contributors to change the AST

Differential Revision: D18362104

