### PR TITLE
Add cmake-generated shell script to set up Hack developer environment

### DIFF
--- a/hphp/hack/.gitignore
+++ b/hphp/hack/.gitignore
@@ -21,3 +21,4 @@ hhi/**/INDEX
 facebook/opam
 facebook/opam2-mini-repository
 target/
+dev_env.sh

--- a/hphp/hack/CMakeLists.txt
+++ b/hphp/hack/CMakeLists.txt
@@ -145,6 +145,8 @@ endif()
 add_custom_target(hack ALL DEPENDS hack_dune)
 add_custom_target(hack_test DEPENDS hack_dune_test)
 
+configure_file(dev_env.sh.in dev_env.sh ESCAPE_QUOTES @ONLY)
+
 install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/bin/hh_client
   DESTINATION bin
   COMPONENT dev)

--- a/hphp/hack/dev_env.sh.in
+++ b/hphp/hack/dev_env.sh.in
@@ -1,0 +1,22 @@
+#!/bin/sh
+# Copyright (c) 2019, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the "hack" directory of this source tree.
+
+# This file is processed by cmake; the produced file is intended for
+# direct usage by people working on Hack itself from CMake builds:
+#
+#  source $BUILD_DIR/hphp/hack/dev_env.sh
+
+export HACK_NO_CARGO_VENDOR=true
+export OPAMROOT="@OPAMROOT@"
+export PYTHONPATH="@HPHP_HOME@"
+export CARGO_HOME="@CMAKE_CURRENT_BINARY_DIR@/cargo_home"
+export RUSTC="@RUSTC_BIN_DIR@/rustc"
+export HACK_SOURCE_ROOT="@CMAKE_CURRENT_SOURCE_DIR@"
+export HACK_BUILD_ROOT="@CMAKE_CURRENT_SOURCE_DIR@/_build/default"
+export PATH="@RUSTC_BIN_DIR@:@CARGO_BIN_DIR@:@TP_BUILD_DIR@/ocaml/build/bin:$PATH"
+
+eval $(opam env)


### PR DESCRIPTION
Sets rust and ocaml environment variables.

Test plan:

`cd code/hhvm; mkdir build; cd build; cmake .. $OPTIONS; make hack`,
then:

```
fredemmott@fredemmott-mm1 hack % cat ~/code/hhvm/build/hphp/hack/dev_env.sh

export HACK_NO_CARGO_VENDOR=true
export OPAMROOT="/Users/fredemmott/code/hhvm/build/hphp/hack/opam"
export PYTHONPATH="/Users/fredemmott/code/hhvm"
export CARGO_HOME="/Users/fredemmott/code/hhvm/build/hphp/hack/cargo_home"
export RUSTC="/Users/fredemmott/code/hhvm/build/third-party/rustc/rust-opt/bin/rustc"
export HACK_SOURCE_ROOT="/Users/fredemmott/code/hhvm/hphp/hack"
export HACK_BUILD_ROOT="/Users/fredemmott/code/hhvm/hphp/hack/_build/default"
export PATH="/Users/fredemmott/code/hhvm/build/third-party/rustc/rust-opt/bin:/Users/fredemmott/code/hhvm/build/third-party/rustc/rust-opt/bin:/Users/fredemmott/code/hhvm/build/third-party/ocaml/build/bin:$PATH"

eval $(opam env)
fredemmott@fredemmott-mm1 hack % source $_
fredemmott@fredemmott-mm1 hack % which opam
/Users/fredemmott/code/hhvm/build/third-party/ocaml/build/bin/opam
fredemmott@fredemmott-mm1 hack % which rustc
/Users/fredemmott/code/hhvm/build/third-party/rustc/rust-opt/bin/rustc
fredemmott@fredemmott-mm1 hack % which ocamlformat
/Users/fredemmott/code/hhvm/build/hphp/hack/opam/hack-switch/bin/ocamlformat
```