### PR TITLE
Use dev_env.sh to set up the real build environment

### DIFF
--- a/hphp/hack/CMakeLists.txt
+++ b/hphp/hack/CMakeLists.txt
@@ -91,28 +91,10 @@ function(invoke_dune name target)
   add_custom_target(
       ${name}
       COMMAND
-        export "RUSTC=${RUSTC_EXECUTABLE}" &&
-        export "CARGO_HOME=${CMAKE_CURRENT_BINARY_DIR}/cargo_home" &&
-        export "HACK_NO_CARGO_VENDOR=true" &&
-        export OPAMROOT=${OPAMROOT} &&
-        export PYTHONPATH="${HPHP_HOME}" && # needed for verify.py for `hack_dune_test`
-        export HACK_SOURCE_ROOT="${CMAKE_CURRENT_SOURCE_DIR}" &&
-        export HACK_BUILD_ROOT="${HACK_BUILD_ROOT}" &&
-        PATH="${RUSTC_BIN_DIR}:${CARGO_BIN_DIR}:${TP_BUILD_DIR}/ocaml/build/bin:$(PATH)"
+        source "${CMAKE_CURRENT_BINARY_DIR}/dev_env.sh" &&
         opam config exec --
         $(MAKE) --makefile=Makefile.dune ${target}
-        DUNE_BUILD_DIR="${DUNE_BUILD_DIR}"
-        CMAKE_BINARY_DIR="${CMAKE_BINARY_DIR}"
-        CMAKE_SOURCE_DIR="${CMAKE_SOURCE_DIR}"
-        CMAKE_INSTALL_FULL_SYSCONFDIR="${CMAKE_INSTALL_FULL_SYSCONFDIR}"
-        CMAKE_INSTALL_FULL_BINDIR="${CMAKE_INSTALL_FULL_BINDIR}"
-        EXTRA_INCLUDE_PATHS="${extra_include_paths}"
-        EXTRA_LINK_OPTS="${extra_link_opts}"
-        EXTRA_LIB_PATHS="${extra_lib_paths}"
-        EXTRA_NATIVE_LIBRARIES="${extra_native_libraries}"
         BYTECODE="${EMIT_OCAML_BYTECODE}"
-        OCAML="${OCAML_EXECUTABLE}"
-        OCAMLC="${OCAMLC_EXECUTABLE}"
       WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
     )
 

--- a/hphp/hack/Makefile.dune
+++ b/hphp/hack/Makefile.dune
@@ -1,13 +1,6 @@
-EXTRA_INCLUDE_PATHS=
-EXTRA_LIB_PATHS=
-EXTRA_LINK_OPTS=
-EXTRA_NATIVE_LIBRARIES=
 BYTECODE=
-DUNE_BUILD_DIR=
-CMAKE_BINARY_DIR=
 
 ROOT=$(shell pwd)
-HACK_BIN_DIR="$(CMAKE_BINARY_DIR)/hphp/hack/bin"
 
 ################################################################################
 #                                    Rules                                     #

--- a/hphp/hack/dev_env.sh.in
+++ b/hphp/hack/dev_env.sh.in
@@ -5,19 +5,32 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the "hack" directory of this source tree.
 
-# This file is processed by cmake; the produced file is intended for
-# direct usage by people working on Hack itself from CMake builds:
+# This file is processed by cmake; the produced file is intended for both
+# internal usage by the build system, and for direct usage by people working on
+# Hack itself from CMake builds:
 #
 #  source $BUILD_DIR/hphp/hack/dev_env.sh
 
+export CMAKE_SOURCE_DIR="@CMAKE_SOURCE_DIR@"
+export CMAKE_INSTALL_FULL_SYSCONFDIR="@CMAKE_INSTALL_FULL_SYSCONFDIR@"
+export CMAKE_INSTALL_FULL_BINDIR="@CMAKE_INSTALL_FULL_BINDIR@"
+
 export HACK_NO_CARGO_VENDOR=true
 export OPAMROOT="@OPAMROOT@"
-export PYTHONPATH="@HPHP_HOME@"
+export PYTHONPATH="@HPHP_HOME@" # needed for verify.py for `hack_dune_test`
 export CARGO_HOME="@CMAKE_CURRENT_BINARY_DIR@/cargo_home"
 export RUSTC="@RUSTC_BIN_DIR@/rustc"
 export DUNE_BUILD_DIR="@DUNE_BUILD_DIR@"
 export HACK_SOURCE_ROOT="@CMAKE_CURRENT_SOURCE_DIR@"
 export HACK_BUILD_ROOT="@HACK_BUILD_ROOT@"
+export HACK_BIN_DIR="@CMAKE_BINARY_DIR@/hphp/hack/bin"
 export PATH="@RUSTC_BIN_DIR@:@CARGO_BIN_DIR@:@TP_BUILD_DIR@/ocaml/build/bin:$PATH"
+export OCAML="@OCAML_EXECUTABLE@"
+export OCAMLC="@OCAMLC_EXECUTABLE@"
+
+export HACK_EXTRA_INCLUDE_PATHS="@extra_include_paths@"
+export HACK_EXTRA_LINK_OPTS="@extra_link_opts@"
+export HACK_EXTRA_LIB_PATHS="@extra_lib_paths@"
+export HACK_EXTRA_NATIVE_LIBRARIES="@extra_native_libraries@"
 
 eval $(opam env)

--- a/hphp/hack/src/heap/config/discover.ml
+++ b/hphp/hack/src/heap/config/discover.ml
@@ -4,15 +4,15 @@ https://jbuilder.readthedocs.io/en/latest/configurator.html *)
 module C = Configurator.V1
 
 (* cmake should have prepared some information for us in the env:
-  EXTRA_INCLUDE_PATHS
-  EXTRA_LIB_PATHS
-  EXTRA_NATIVE_LIBRARIES
-  EXTRA_LINK_OPTS
+  HACK_EXTRA_INCLUDE_PATHS
+  HACK_EXTRA_LIB_PATHS
+  HACK_EXTRA_NATIVE_LIBRARIES
+  HACK_EXTRA_LINK_OPTS
 *)
 let query_env s =
   match Sys.getenv s with
   | "" -> []
-  | s -> String.split_on_char ' ' s
+  | s -> String.split_on_char ';' s
   | exception Not_found -> []
 
 let abs =
@@ -27,13 +27,13 @@ let abs =
 
 let process_env () =
   let includes =
-    query_env "EXTRA_INCLUDE_PATHS" |> List.map (fun s -> "-I" ^ abs s)
+    query_env "HACK_EXTRA_INCLUDE_PATHS" |> List.map (fun s -> "-I" ^ abs s)
   in
-  let dirs = query_env "EXTRA_LIB_PATHS" |> List.map (fun s -> "-L" ^ abs s) in
+  let dirs = query_env "HACK_EXTRA_LIB_PATHS" |> List.map (fun s -> "-L" ^ abs s) in
   let names =
-    query_env "EXTRA_NATIVE_LIBRARIES" |> List.map (fun s -> "-l" ^ s)
+    query_env "HACK_EXTRA_NATIVE_LIBRARIES" |> List.map (fun s -> "-l" ^ s)
   in
-  let opaque_opts = query_env "EXTRA_LINK_OPTS" in
+  let opaque_opts = query_env "HACK_EXTRA_LINK_OPTS" in
   (includes, dirs @ names @ opaque_opts)
 
 let () =

--- a/hphp/hack/src/heap/config/dune
+++ b/hphp/hack/src/heap/config/dune
@@ -7,8 +7,8 @@
 (rule
   (targets c_flags.sexp c_library_flags.sexp)
   (deps
-    (env_var EXTRA_INCLUDE_PATHS)
-    (env_var EXTRA_LIB_PATHS)
-    (env_var EXTRA_NATIVE_LIBRARIES)
-    (env_var EXTRA_LINK_OPTS))
+    (env_var HACK_EXTRA_INCLUDE_PATHS)
+    (env_var HACK_EXTRA_LIB_PATHS)
+    (env_var HACK_EXTRA_NATIVE_LIBRARIES)
+    (env_var HACK_EXTRA_LINK_OPTS))
   (action (run ./discover.exe)))


### PR DESCRIPTION
This means that I can now `source $BUILD/hphp/hack/dev_env.sh` then
directly run `dune`

Test plan:

`make hack_test` and:

```
fredemmott@fredemmott-mm1 parsing % pwd
/Users/fredemmott/code/hhvm/hphp/hack/test/pocket_universes/parsing
fredemmott@fredemmott-mm1 parsing % dune runtest
Entering directory '/Users/fredemmott/code/hhvm/hphp/hack'
      verify alias test/pocket_universes/parsing/pocket_universes_parsing_good (exit 1)
(cd /Users/fredemmott/code/hhvm/build/hphp/hack/default/test/pocket_universes/parsing && ../../verify.py ../../../test/pocket_universes/parsing --program ../../../src/hh_parse.exe --in-extension .good.php --flags --full-fidelity-errors --full-fidelity-errors-all --full-fidelity-s-expression)
The number of tests that failed: 3/3

To review the failures, use the following command:
OUT_EXT=.out EXP_EXT=.exp SOURCE_ROOT=/Users/fredemmott/code/hhvm/hphp/hack OUTPUT_ROOT=/Users/fredemmott/code/hhvm/build/hphp/hack/default NO_COPY=false ./hphp/hack/test/review.sh hphp/hack/test/pocket_universes/parsing/simple.good.php hphp/hack/test/pocket_universes/parsing/final.good.php hphp/hack/test/pocket_universes/parsing/empty.good.php
```
