### PR TITLE
(raw)url(en|de)code and base64encode return string

### DIFF
--- a/hphp/hack/hhi/stdlib/builtins_url.hhi
+++ b/hphp/hack/hhi/stdlib/builtins_url.hhi
@@ -23,7 +23,7 @@ const int PHP_QUERY_RFC3986 = 2;
 <<__PHPStdLib, __Rx>>
 function base64_decode(string $data, bool $strict = false);
 <<__PHPStdLib, __Rx>>
-function base64_encode(string $data);
+function base64_encode(string $data): string;
 <<__PHPStdLib>>
 function get_headers(string $url, int $format = 0);
 <<__PHPStdLib>>
@@ -33,10 +33,10 @@ function http_build_query($formdata, $numeric_prefix = null, string $arg_separat
 <<__PHPStdLib>>
 function parse_url(string $url, int $component = -1);
 <<__PHPStdLib, __Rx>>
-function rawurldecode(string $str);
+function rawurldecode(string $str): string;
 <<__PHPStdLib, __Rx>>
-function rawurlencode(string $str);
+function rawurlencode(string $str): string;
 <<__PHPStdLib, __Rx>>
-function urldecode(string $str);
+function urldecode(string $str): string;
 <<__PHPStdLib, __Rx>>
-function urlencode(string $str);
+function urlencode(string $str): string;

--- a/hphp/runtime/ext/url/ext_url.cpp
+++ b/hphp/runtime/ext/url/ext_url.cpp
@@ -53,12 +53,8 @@ Variant HHVM_FUNCTION(base64_decode, const String& data,
   return decoded;
 }
 
-Variant HHVM_FUNCTION(base64_encode, const String& data) {
-  String encoded = StringUtil::Base64Encode(data);
-  if (encoded.isNull()) {
-    return false;
-  }
-  return encoded;
+String HHVM_FUNCTION(base64_encode, const String& data) {
+  return StringUtil::Base64Encode(data);
 }
 
 Variant HHVM_FUNCTION(get_headers, const String& url, int format /* = 0 */) {

--- a/hphp/runtime/ext/url/ext_url.h
+++ b/hphp/runtime/ext/url/ext_url.h
@@ -36,7 +36,7 @@ extern const int64_t k_PHP_QUERY_RFC3986;
 
 Variant HHVM_FUNCTION(base64_decode, const String& data,
                                      bool strict /* = false */);
-Variant HHVM_FUNCTION(base64_encode, const String& data);
+String HHVM_FUNCTION(base64_encode, const String& data);
 
 Variant HHVM_FUNCTION(get_headers, const String& url, int format /* = 0 */);
 Array HHVM_FUNCTION(get_meta_tags, const String& filename,

--- a/hphp/runtime/ext/url/ext_url.php
+++ b/hphp/runtime/ext/url/ext_url.php
@@ -18,10 +18,10 @@ function base64_decode(string $data, bool $strict = false): mixed;
  *
  * @param string $data - The data to encode.
  *
- * @return string - The encoded data, as a string or FALSE on failure.
+ * @return string - The encoded data, as a string or FALSE on failure (when does this happen?).
  */
 <<__Native, __IsFoldable, __Rx>>
-function base64_encode(string $data): mixed;
+function base64_encode(string $data): string;
 
 /**
  * Fetches all the headers sent by the server in response to a HTTP request

--- a/hphp/runtime/ext/url/ext_url.php
+++ b/hphp/runtime/ext/url/ext_url.php
@@ -18,7 +18,7 @@ function base64_decode(string $data, bool $strict = false): mixed;
  *
  * @param string $data - The data to encode.
  *
- * @return string - The encoded data, as a string or FALSE on failure (when does this happen?).
+ * @return string - The encoded data, as a string.
  */
 <<__Native, __IsFoldable, __Rx>>
 function base64_encode(string $data): string;


### PR DESCRIPTION
As far as I am aware, these functions never return a non-string. The PHP manual does not mention a false on failure. It doesn't make sense for these functions to fail either

[base64_encode](https://www.php.net/manual/en/function.base64-encode.php)
[rawurldecode](https://www.php.net/manual/en/function.rawurldecode.php)
[rawurlencode](https://www.php.net/manual/en/function.rawurlencode.php)
[urldecode](https://www.php.net/manual/en/function.urldecode.php)
[urlencode](https://www.php.net/manual/en/function.urlencode.php)