### PR TITLE
build_and_run.sh needs the hack root in the path

### DIFF
--- a/hphp/hack/scripts/build_and_run.sh
+++ b/hphp/hack/scripts/build_and_run.sh
@@ -21,7 +21,7 @@ ARGS=(${ARGS[@]:2})
 
 function dune_build() {
   # OCaml
-  if [ -e "${HACK_SUBDIR}/${TARGET}.ml" ]; then
+  if [ -e "${HACK_ROOT}/${HACK_SUBDIR}/${TARGET}.ml" ]; then
     (
       cd "${HACK_ROOT}"
       "${DUNE}" build "${HACK_SUBDIR}/${TARGET}.exe"


### PR DESCRIPTION
It seems like the .ml file (hh_oxidize.ml in my case) is never found so that path isn't run. This fixes it for me, but perhaps there's another solution