### PR TITLE
Remove PHP7 from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,7 @@
 [Dev group](https://www.facebook.com/groups/hhvm.dev/) |
 [Twitter](https://twitter.com/HipHopVM)
 
-HHVM is an open-source virtual machine designed for executing programs written in [Hack](http://hacklang.org). HHVM uses a just-in-time (JIT) compilation approach to achieve superior performance while maintaining the development flexibility that PHP provides.
-
-HHVM is intended for [Hack](http://hacklang.org) projects, and also supports a large subset of PHP 7 that is required by common tools and libraries. We no longer recommend using HHVM for purely PHP projects.
+HHVM is an open-source virtual machine designed for executing programs written in [Hack](http://hacklang.org). HHVM uses a just-in-time (JIT) compilation approach to achieve superior performance while maintaining amazing development flexibility.
 
 HHVM should be used together with a webserver like the built in, easy to deploy [Proxygen](https://docs.hhvm.com/hhvm/basic-usage/proxygen), or a [FastCGI](https://docs.hhvm.com/hhvm/advanced-usage/fastCGI)-based webserver on top of nginx or Apache.
 
@@ -24,7 +22,7 @@ You can install a [prebuilt package](https://docs.hhvm.com/hhvm/installation/int
 You can run standalone programs just by passing them to hhvm: `hhvm example.hack`.
 
 If you want to host a website:
-* Install your favorite webserver. [Proxygen](https://docs.hhvm.com/hhvm/basic-usage/proxygen) is built in to HHVM, fast and easy to deploy.
+* Install your favorite webserver. [Proxygen](https://docs.hhvm.com/hhvm/basic-usage/proxygen) is built into HHVM, fast and easy to deploy.
 * Install our [package](https://docs.hhvm.com/hhvm/installation/introduction#prebuilt-packages)
 * Start your webserver
 * Run `sudo /etc/init.d/hhvm start`


### PR DESCRIPTION
We are unable to execute PHP7 code, since HHVM 3.30 is longer supported.