### PR TITLE
Require jemalloc 5, build and statically link if system version too old

### DIFF
--- a/CMake/HPHPFindLibs.cmake
+++ b/CMake/HPHPFindLibs.cmake
@@ -203,34 +203,11 @@ if (USE_GOOGLE_HEAP_PROFILER AND GOOGLE_PROFILER_LIB)
   endif()
 endif()
 
-if (USE_JEMALLOC AND NOT GOOGLE_TCMALLOC_ENABLED)
-  FIND_LIBRARY(JEMALLOC_LIB NAMES jemalloc)
-  FIND_PATH(JEMALLOC_INCLUDE_DIR NAMES jemalloc/jemalloc.h)
-
-  if (JEMALLOC_INCLUDE_DIR AND JEMALLOC_LIB)
-    include_directories(${JEMALLOC_INCLUDE_DIR})
-
-    set (CMAKE_REQUIRED_INCLUDES ${JEMALLOC_INCLUDE_DIR})
-    INCLUDE(CheckCXXSourceCompiles)
-    CHECK_CXX_SOURCE_COMPILES("
-#include <jemalloc/jemalloc.h>
-
-#define JEMALLOC_VERSION_NUMERIC ((JEMALLOC_VERSION_MAJOR << 24) | (JEMALLOC_VERSION_MINOR << 16) | (JEMALLOC_VERSION_BUGFIX << 8) | JEMALLOC_VERSION_NDEV)
-
-#if JEMALLOC_VERSION_NUMERIC < 0x03050100
-# error jemalloc version >= 3.5.1 required
-#endif
-
-int main(void) { return 0; }" JEMALLOC_VERSION_MINIMUM)
-    set (CMAKE_REQUIRED_INCLUDES)
-
-    if (JEMALLOC_VERSION_MINIMUM)
-      message(STATUS "Found jemalloc: ${JEMALLOC_LIB}")
-      set(JEMALLOC_ENABLED 1)
-    else()
-      message(STATUS "Found jemalloc, but it was too old")
-    endif()
-  endif()
+if(USE_JEMALLOC AND NOT GOOGLE_TCMALLOC_ENABLED)
+  add_definitions(-DUSE_JEMALLOC=1)
+  set(JEMALLOC_ENABLED 1)
+else()
+  add_definitions(-DNO_JEMALLOC=1)
 endif()
 
 if (USE_TCMALLOC AND NOT JEMALLOC_ENABLED AND NOT GOOGLE_TCMALLOC_ENABLED)
@@ -243,11 +220,6 @@ if (USE_TCMALLOC AND NOT JEMALLOC_ENABLED AND NOT GOOGLE_TCMALLOC_ENABLED)
   endif()
 endif()
 
-if (JEMALLOC_ENABLED)
-  add_definitions(-DUSE_JEMALLOC=1)
-else()
-  add_definitions(-DNO_JEMALLOC=1)
-endif()
 if (GOOGLE_TCMALLOC_ENABLED)
   add_definitions(-DGOOGLE_TCMALLOC=1)
 else()
@@ -425,12 +397,13 @@ macro(hphp_link target)
     target_link_libraries(${target} ${LIBDL_LIBRARIES})
   endif ()
 
+  if (JEMALLOC_ENABLED)
+    target_link_libraries(${target} jemalloc)
+    add_dependencies(${target} jemalloc)
+  endif ()
+
   if (GOOGLE_HEAP_PROFILER_ENABLED OR GOOGLE_CPU_PROFILER_ENABLED)
     target_link_libraries(${target} ${GOOGLE_PROFILER_LIB})
-  endif()
-
-  if (JEMALLOC_ENABLED)
-    target_link_libraries(${target} ${JEMALLOC_LIB})
   endif()
 
   if (GOOGLE_HEAP_PROFILER_ENABLED)

--- a/CMake/HPHPSetup.cmake
+++ b/CMake/HPHPSetup.cmake
@@ -64,12 +64,6 @@ include(HPHPCompiler)
 include(HPHPFunctions)
 include(HPHPFindLibs)
 
-# Ubuntu 15.10 and 14.04 have been failing to include a dependency on jemalloc
-# as a these linked flags force the dependency to be recorded
-if (JEMALLOC_ENABLED AND LINUX)
-  LIST(APPEND HHVM_LINK_LIBRARIES -Wl,--no-as-needed ${JEMALLOC_LIB} -Wl,--as-needed)
-endif()
-
 if (HHVM_VERSION_OVERRIDE)
   parse_version("HHVM_VERSION_" ${HHVM_VERSION_OVERRIDE})
   add_definitions("-DHHVM_VERSION_OVERRIDE")

--- a/CMake/Options.cmake
+++ b/CMake/Options.cmake
@@ -11,6 +11,8 @@ option(ENABLE_SSE4_2 "Enable SSE4.2 supported code." OFF)
 option(EXECUTION_PROFILER "Enable the execution profiler" OFF)
 
 option(USE_JEMALLOC "Use jemalloc" ON)
+option(FORCE_TP_JEMALLOC "Always build and statically link jemalloc instead of using system version" OFF)
+
 option(ENABLE_HHPROF "Enable HHProf" OFF)
 
 option(CLANG_FORCE_LIBSTDCXX "Force libstdc++ when building against Clang/LLVM" OFF)

--- a/third-party/CMakeLists.txt
+++ b/third-party/CMakeLists.txt
@@ -14,10 +14,28 @@
 #   +----------------------------------------------------------------------+
 #
 
+##### --- header --- #####
 set(EXTRA_INCLUDE_PATHS)
 set(THIRD_PARTY_MODULES)
 set(THIRD_PARTY_HEADERS)
 
+function(TP_INSTALL_HEADERS TARGET SRCDIR DEST)
+  file(GLOB_RECURSE files "${SRCDIR}/*.h")
+  install(
+    CODE "INCLUDE(\"${HPHP_HOME}/CMake/HPHPFunctions.cmake\")
+      HHVM_INSTALL_HEADERS(${TARGET}
+        \"${CMAKE_CURRENT_BINARY_DIR}/${SRCDIR}\"
+      \"\${CMAKE_INSTALL_PREFIX}/include/hphp/third-party/${DEST}\"
+      ${files})"
+    COMPONENT dev)
+endfunction()
+
+
+##### easy stuff #####
+
+if(JEMALLOC_ENABLED)
+  list(APPEND THIRD_PARTY_MODULES jemalloc)
+endif()
 
 list(APPEND THIRD_PARTY_MODULES forks/libmbfl)
 list(APPEND EXTRA_INCLUDE_PATHS
@@ -138,34 +156,14 @@ if(ENABLE_XED AND NOT LibXed_FOUND)
   list(APPEND EXTRA_INCLUDE_PATHS "${TP_DIR}/xed/xed/build/include/xed")
 endif()
 
-function(TP_INSTALL_HEADERS TARGET SRCDIR DEST)
-  file(GLOB_RECURSE files "${SRCDIR}/*.h")
-  install(
-    CODE "INCLUDE(\"${HPHP_HOME}/CMake/HPHPFunctions.cmake\")
-      HHVM_INSTALL_HEADERS(${TARGET}
-      \"${CMAKE_CURRENT_SOURCE_DIR}/${SRCDIR}\"
-      \"\${CMAKE_INSTALL_PREFIX}/include/hphp/third-party/${DEST}\"
-      ${files})"
-    COMPONENT dev)
-endfunction()
-
-foreach(MODULE ${THIRD_PARTY_MODULES})
-  add_subdirectory(${MODULE})
-  # Install headers here, rather than in the individual submodules, so that we
-  # can easily control the destination. Put them in include/hphp/third-party.
-  if(MODULE STREQUAL folly)
-    TP_INSTALL_HEADERS(folly folly/src/folly folly)
-  else()
-    TP_INSTALL_HEADERS(${MODULE} ${MODULE} ${MODULE})
-  endif()
-endforeach()
-
 if(NOT PCRE_LIBRARY)
   target_include_directories(pcre PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/forks/pcre")
   target_compile_definitions(pcre PUBLIC "PCRE_STATIC=1")
 endif()
 
-# boost checks                                                                        
+##### boost #####
+
+# boost checks     
 find_package(Boost 1.62.0 COMPONENTS context fiber filesystem iostreams program_options regex system thread)
 if ("${Boost_VERSION}" EQUAL "107000")
   # https://github.com/boostorg/variant/issues/69
@@ -173,7 +171,7 @@ if ("${Boost_VERSION}" EQUAL "107000")
 
   set(Boost_FOUND false)
 endif()
-                                                                                      
+
 add_library(boost INTERFACE)
 add_custom_target(boostMaybeBuild)
 if(NOT Boost_FOUND)
@@ -182,10 +180,10 @@ if(NOT Boost_FOUND)
   # Instead we add the dependency to the target being linked with hphp_link
   add_dependencies(boostMaybeBuild boostBuild)
   message(STATUS "Using third-party bundled boost")
-  add_subdirectory(boost)                                                             
+  add_subdirectory(boost)
   # These are the archive names prefixed with lib so that cmake does not
   # find these to be system archive instead of these third party ones.
-  set(Boost_LIBRARIES 
+  set(Boost_LIBRARIES
       "libboost_fiber"
       "libboost_context"
       "libboost_filesystem"
@@ -205,9 +203,11 @@ if(NOT Boost_FOUND)
   set(Boost_LIBRARY_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/boost/build/lib" CACHE STRING "" FORCE)
   TP_INSTALL_HEADERS(boost boost/build/include/boost boost)
   list(APPEND EXTRA_INCLUDE_PATHS "${TP_DIR}/boost/build/include")
-endif()                                                                               
+endif()
 target_include_directories(boost BEFORE INTERFACE ${Boost_INCLUDE_DIRS})
 target_link_libraries(boost INTERFACE ${Boost_LIBRARIES})
+
+##### libsodium #####
 
 add_library(libsodium INTERFACE)
 add_custom_target(libsodiumMaybeBuild)
@@ -225,6 +225,20 @@ add_definitions("-DHAVE_LIBSODIUM")
 list(APPEND EXTRA_INCLUDE_PATHS "${LIBSODIUM_INCLUDE_DIRS}")
 list(APPEND THIRD_PARTY_DEFINITIONS "-DHAVE_LIBSODIUM")
 
-set(THIRD_PARTY_INCLUDE_PATHS ${EXTRA_INCLUDE_PATHS} CACHE INTERNAL "" FORCE)
+##### rustc #####
 
 add_subdirectory("rustc")
+
+##### --- footer --- #####
+
+foreach(MODULE ${THIRD_PARTY_MODULES})
+  add_subdirectory(${MODULE})
+  # Install headers here, rather than in the individual submodules, so that we
+  # can easily control the destination. Put them in include/hphp/third-party.
+  if(MODULE STREQUAL folly)
+    TP_INSTALL_HEADERS(folly folly/src/folly folly)
+  else()
+    TP_INSTALL_HEADERS(${MODULE} ${MODULE} ${MODULE})
+  endif()
+endforeach()
+set(THIRD_PARTY_INCLUDE_PATHS ${EXTRA_INCLUDE_PATHS} CACHE INTERNAL "" FORCE)

--- a/third-party/folly/CMakeLists.txt
+++ b/third-party/folly/CMakeLists.txt
@@ -167,7 +167,7 @@ else()
 endif()
 
 if (JEMALLOC_ENABLED)
-  target_link_libraries(folly ${JEMALLOC_LIB})
+  target_link_libraries(folly PUBLIC jemalloc)
 endif()
 
 # For some reason we aren't making a folly-config.h and this is in there.

--- a/third-party/jemalloc/CMakeLists.txt
+++ b/third-party/jemalloc/CMakeLists.txt
@@ -1,0 +1,50 @@
+include(ExternalProject)
+
+set(JEMALLOC_PREFIX "${CMAKE_CURRENT_BINARY_DIR}/jemallocBuild-prefix")
+ExternalProject_add(
+  jemallocBuild
+  URL "https://github.com/jemalloc/jemalloc/releases/download/5.2.1/jemalloc-5.2.1.tar.bz2"
+  URL_HASH SHA512=0bbb77564d767cef0c6fe1b97b705d368ddb360d55596945aea8c3ba5889fbce10479d85ad492c91d987caacdbbdccc706aa3688e321460069f00c05814fae02
+  PREFIX "${JEMALLOC_PREFIX}"
+  CONFIGURE_COMMAND
+    "${JEMALLOC_PREFIX}/src/jemallocBuild/configure" "--prefix=${JEMALLOC_PREFIX}"
+      --disable-shared
+      --enable-static
+      --with-jemalloc-prefix=
+  EXCLUDE_FROM_ALL
+)
+
+
+add_library(jemalloc INTERFACE)
+
+if (NOT FORCE_TP_JEMALLOC)
+  find_library(JEMALLOC_LIB NAMES jemalloc)
+  find_path(JEMALLOC_INCLUDE_DIR NAMES jemalloc/jemalloc.h)
+  set(CMAKE_REQUIRED_INCLUDES "${JEMALLOC_INCLUDE_DIR}")
+  include(CheckCXXSourceCompiles)
+  check_cxx_source_compiles("
+#include <jemalloc/jemalloc.h>
+
+#if JEMALLOC_VERSION_MAJOR < 5
+# error jemalloc version >= 5.0 required
+#endif
+
+  int main(void) { return 0; }" JEMALLOC_VERSION_MINIMUM)
+  set(CMAKE_REQUIRED_INCLUDES)
+endif()
+if (JEMALLOC_VERSION_MINIMUM)
+  message(STATUS "Found jemalloc: ${JEMALLOC_LIB}")
+  target_link_libraries(jemalloc INTERFACE "${JEMALLOC_LIB}")
+  target_include_directories(jemalloc INTERFACE "${JEMALLOC_INCLUDE_DIR}")
+else()
+  message(STATUS "Using third-party bundled jemalloc")
+
+  set(JEMALLOC_INCLUDE_DIR "${JEMALLOC_PREFIX}/include")
+  set(JEMALLOC_LIB "${JEMALLOC_PREFIX}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}jemalloc_pic${CMAKE_STATIC_LIBRARY_SUFFIX}")
+  add_dependencies(jemalloc jemallocBuild)
+  target_link_libraries(jemalloc INTERFACE "${JEMALLOC_LIB}")
+  if(UNIX AND NOT APPLE)
+    target_link_libraries(jemalloc INTERFACE dl pthread)
+  endif()
+  target_include_directories(jemalloc INTERFACE "${JEMALLOC_PREFIX}/include")
+endif()


### PR DESCRIPTION
HHVM uses 2mb-aligned 2mb slabs; on jemalloc < 5, these get a 4mb.

Older versions of HHVM detect the 4mb allocation and use it, but do not use it
correctly.