### PR TITLE
Add vscode directories to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@
 hphp.log
 /build
 /_build
+hphp/hack/_build/
+hphp/hack/cargo_home/
 /deps
 
 /hphp/test/test
@@ -67,6 +69,9 @@ TAGS
 *.vimrc
 .syntastic_cpp_config
 *~
+
+# vscode
+.vscode
 
 # CMake
 CMakeCache.txt


### PR DESCRIPTION
Adds the .vscode related directory to git ignore.
Additionally I have a cargo_home and _build show up. I think this is from the regen.sh script. Either way it'd be nice to avoid mistakenly adding it to git.