### PR TITLE
Add return types to html encoding functions

### DIFF
--- a/hphp/hack/hhi/stdlib/builtins_string.hhi
+++ b/hphp/hack/hhi/stdlib/builtins_string.hhi
@@ -110,13 +110,13 @@ function str_repeat(string $input, int $multiplier);
 <<__PHPStdLib>>
 function wordwrap(string $str, int $width = 75, string $wordbreak = "\n", bool $cut = false);
 <<__PHPStdLib>>
-function html_entity_decode(string $str, int $quote_style = ENT_COMPAT, string $charset = "ISO-8859-1");
+function html_entity_decode(string $str, int $quote_style = ENT_COMPAT, string $charset = "ISO-8859-1"): string;
 <<__PHPStdLib>>
-function htmlentities(string $str, int $quote_style = ENT_COMPAT, string $charset = "ISO-8859-1", bool $double_encode = true);
+function htmlentities(string $str, int $quote_style = ENT_COMPAT, string $charset = "ISO-8859-1", bool $double_encode = true): string;
 <<__PHPStdLib>>
-function htmlspecialchars_decode(string $str, int $quote_style = ENT_COMPAT);
+function htmlspecialchars_decode(string $str, int $quote_style = ENT_COMPAT): string;
 <<__PHPStdLib>>
-function htmlspecialchars(string $str, int $quote_style = ENT_COMPAT, string $charset = "ISO-8859-1", bool $double_encode = true);
+function htmlspecialchars(string $str, int $quote_style = ENT_COMPAT, string $charset = "ISO-8859-1", bool $double_encode = true): string;
 <<__PHPStdLib, __Rx>>
 function quoted_printable_encode(string $str);
 <<__PHPStdLib, __Rx>>


### PR DESCRIPTION
These functions have signatures like `String HHVM_FUNCTION(function_name_here, ...`.
So they always return strings.

https://github.com/facebook/hhvm/blob/master/hphp/runtime/ext/string/ext_string.cpp#L1698
https://github.com/facebook/hhvm/blob/master/hphp/runtime/ext/string/ext_string.cpp#L1708
https://github.com/facebook/hhvm/blob/master/hphp/runtime/ext/string/ext_string.cpp#L1720
https://github.com/facebook/hhvm/blob/master/hphp/runtime/ext/string/ext_string.cpp#L1727

If it wasn't for the TAny in the HHI I would have never gone to the PHP docs and read the following for htmlspecialchars:
`If the input string contains an invalid code unit sequence within the given encoding an empty string will be returned, unless either the ENT_IGNORE or ENT_SUBSTITUTE flags are set. `
I assumed false on failure since that is the PHP-way.