### PR TITLE
Remove editor-plugins directory

### DIFF
--- a/hphp/hack/editor-plugins/README.md
+++ b/hphp/hack/editor-plugins/README.md
@@ -1,1 +1,0 @@
-See https://github.com/facebook/hhvm/wiki/Hack-Editor-Plugins for plugin information


### PR DESCRIPTION
The reason for the removal of this directory is that it contains a readme file that redirects us to [Hack Editor Plugins](https://github.com/facebook/hhvm/wiki/Hack-Editor-Plugins), which in turn redirects us to [Getting Started: Tools](https://docs.hhvm.com/hack/getting-started/tools) on the main page.