### PR TITLE
Add getAttributesNamespaced() to ReflectionThing

### DIFF
--- a/hphp/hack/hhi/reflection.hhi
+++ b/hphp/hack/hhi/reflection.hhi
@@ -17,7 +17,7 @@ class Reflection  {
   <<__Rx>>
   public static function getModifierNames($modifiers);
   public static function export(Reflector $reflector, $return = false);
-}
+}Reflection
 
 class ReflectionClass implements Reflector {
 
@@ -396,6 +396,8 @@ class ReflectionProperty implements Reflector {
   <<__Rx, __MaybeMutable>>
   public function getTypeText();
   public function getAttributes(): darray<string, varray<mixed>>;
+  <<__Rx, __MaybeMutable>>
+  final public function getAttributesNamespaced(): dict<arraykey, varray<mixed>>;
   public function getAttribute(string $name): ?varray<mixed>;
 }
 

--- a/hphp/hack/hhi/reflection.hhi
+++ b/hphp/hack/hhi/reflection.hhi
@@ -17,7 +17,7 @@ class Reflection  {
   <<__Rx>>
   public static function getModifierNames($modifiers);
   public static function export(Reflector $reflector, $return = false);
-}Reflection
+}
 
 class ReflectionClass implements Reflector {
 

--- a/hphp/hack/hhi/reflection.hhi
+++ b/hphp/hack/hhi/reflection.hhi
@@ -72,6 +72,8 @@ class ReflectionClass implements Reflector {
   <<__Rx, __MaybeMutable>>
   final public function getAttributes(): darray<string, varray<mixed>>;
   <<__Rx, __MaybeMutable>>
+  public function getAttributesNamespaced(): darray<string, array<mixed>>;
+  <<__Rx, __MaybeMutable>>
   final public function getAttribute(string $name): ?varray<mixed>;
   <<__Rx, __MaybeMutable>>
   final public function getAttributeClass<T as HH\ClassLikeAttribute>(classname<T> $c): ?T;
@@ -205,6 +207,8 @@ abstract class ReflectionFunctionAbstract implements Reflector {
   public function getReturnTypeText();
   <<__Rx, __MaybeMutable>>
   final public function getAttributes(): darray<string, varray<mixed>>;
+  <<__Rx, __MaybeMutable>>
+  final public function getAttributesNamespaced(): darray<arraykey, varray<mixed>>;
   <<__Rx, __MaybeMutable>>
   final public function getAttribute(string $name): ?varray<mixed>;
   <<__Rx, __MaybeMutable>>
@@ -464,6 +468,8 @@ class ReflectionTypeAlias implements Reflector {
   <<__Rx, __MaybeMutable>>
   final public function getAttributes(): darray<string, varray<mixed>>;
   <<__Rx, __MaybeMutable>>
+  final public function getAttributesNamespaced(): darray<arraykey, varray<mixed>>;
+  <<__Rx, __MaybeMutable>>
   final public function getAttribute(string $name): ?varray<mixed>;
   <<__Rx, __MaybeMutable>>
   final public function getAttributeClass<T as HH\TypeAliasAttribute>(classname<T> $c): ?T;
@@ -494,6 +500,8 @@ class ReflectionFile implements Reflector {
   final public function getAttributes(): darray<string, varray<mixed>>;
   <<__Rx, __MaybeMutable>>
   final public function getAttribute(string $name): ?varray<mixed>;
+  <<__Rx, __MaybeMutable>>
+  final public function getAttributesNamespaced(): darray<arraykey, varray<mixed>>;
   <<__Rx, __MaybeMutable>>
   final public function getAttributeClass<T as HH\FileAttribute>(classname<T> $c): ?T;
 }


### PR DESCRIPTION
Where Thing is File, Function, TypeAlias, and Class.

I didn't know this function existed and I have been emulating it for some time using tens of `getAttributeClass()` calls.

The signatures came from [here](https://github.com/facebook/hhvm/blob/7f4b187f5e39de84ea4c559175d3a96d03461cb8/hphp/runtime/ext/reflection/ext_reflection_hni.php#L2524).

If there is no reason to hide this, I would really love to have this. :sweat_smile: It would save me from programming backwards.