### PR TITLE
fix reified_generics/shape-resolution-1.php test

### DIFF
--- a/hphp/test/slow/reified_generics/shape-resolution-1.php
+++ b/hphp/test/slow/reified_generics/shape-resolution-1.php
@@ -8,5 +8,5 @@ class C {
 function main() {
   var_dump(HH\ReifiedGenerics\get_type_structure<shape("foo"=> string)>());
   var_dump(HH\ReifiedGenerics\get_type_structure<shape(?"foo"=> string)>());
-  var_dump(HH\ReifiedGenerics\get_type_structure<shape("C::foo"=> string)>());
+  var_dump(HH\ReifiedGenerics\get_type_structure<shape(C::foo=> string)>());
 }

--- a/hphp/test/slow/reified_generics/shape-resolution-1.php.expect
+++ b/hphp/test/slow/reified_generics/shape-resolution-1.php.expect
@@ -29,7 +29,7 @@ array(2) {
   int(14)
   ["fields"]=>
   array(1) {
-    ["C::foo"]=>
+    ["A"]=>
     array(1) {
       ["kind"]=>
       int(4)


### PR DESCRIPTION
It should test the resolution of the class constant `C::foo`, not the literal string "C::foo".

I needed some small change for an end-to-end test of my new "open-source OnDemand" flow, this worked nicely :)