### PR TITLE
Ensure that the has_xhp_keyword field is set correctly

### DIFF
--- a/hphp/hack/src/parser/lowerer.rs
+++ b/hphp/hack/src/parser/lowerer.rs
@@ -4629,7 +4629,10 @@ where
                     Some(TK::XHPClassName) => true,
                     _ => false,
                 };
-                let has_xhp_keyword = kinds.has(modifier::XHP);
+                let has_xhp_keyword = match Self::token_kind(&c.classish_xhp) {
+                    Some(TK::XHP) => true,
+                    _ => false,
+                };
                 let name = Self::pos_name(&c.classish_name, env)?;
                 *env.cls_reified_generics() = HashSet::new();
                 let tparams = ast::ClassTparams {

--- a/hphp/hack/test/tast/dune
+++ b/hphp/hack/test/tast/dune
@@ -23,7 +23,10 @@
           (glob_files %{project_root}/test/tast/global_inference/typeparams/*.exp)
           (glob_files %{project_root}/test/tast/global_inference/return/HH_FLAGS)
           (glob_files %{project_root}/test/tast/global_inference/return/*.php)
-          (glob_files %{project_root}/test/tast/global_inference/return/*.exp))
+          (glob_files %{project_root}/test/tast/global_inference/return/*.exp)
+          (glob_files %{project_root}/test/tast/xhp_modifier/HH_FLAGS)
+          (glob_files %{project_root}/test/tast/xhp_modifier/*.php)
+          (glob_files %{project_root}/test/tast/xhp_modifier/*.exp))
     (action (run %{project_root}/test/verify.py %{project_root}/test/tast
     --program %{exe:../../src/hh_single_type_check.exe}
     --flags --new-inference-lambda)))

--- a/hphp/hack/test/tast/xhp_modifier/HH_FLAGS
+++ b/hphp/hack/test/tast/xhp_modifier/HH_FLAGS
@@ -1,0 +1,1 @@
+--enable-xhp-class-modifier --tast

--- a/hphp/hack/test/tast/xhp_modifier/xhp.php
+++ b/hphp/hack/test/tast/xhp_modifier/xhp.php
@@ -1,0 +1,3 @@
+<?hh // strict
+
+xhp class foo implements XHPChild {}

--- a/hphp/hack/test/tast/xhp_modifier/xhp.php.exp
+++ b/hphp/hack/test/tast/xhp_modifier/xhp.php.exp
@@ -1,0 +1,20 @@
+[(Class
+    { c_span = [3:1-37]; c_annotation = (); c_mode = Mstrict;
+      c_final = false; c_is_xhp = true; c_has_xhp_keyword = true;
+      c_kind = Cnormal; c_name = ([3:11-14], "\\foo");
+      c_tparams = { c_tparam_list = []; c_tparam_constraints = {} };
+      c_extends = []; c_uses = []; c_use_as_alias = [];
+      c_insteadof_alias = []; c_method_redeclarations = [];
+      c_xhp_attr_uses = []; c_xhp_category = None; c_reqs = [];
+      c_implements = [([3:26-34], (Happly (([3:26-34], "\\XHPChild"), [])))];
+      c_where_constraints = []; c_consts = []; c_typeconsts = [];
+      c_vars = []; c_methods = []; c_attributes = []; c_xhp_children = [];
+      c_xhp_attrs = [];
+      c_namespace =
+      { Namespace_env.ns_ns_uses = <opaque>; ns_class_uses = <opaque>;
+        ns_record_def_uses = <opaque>; ns_fun_uses = <opaque>;
+        ns_const_uses = <opaque>; ns_name = None; ns_auto_ns_map = [];
+        ns_is_codegen = false };
+      c_user_attributes = []; c_file_attributes = []; c_enum = None;
+      c_pu_enums = []; c_doc_comment = None })
+  ]


### PR DESCRIPTION
This is a bugfix on top of #8638. In that PR we changed the XHP keyword from a class `kinds` to be a separate optional keyword before `class`. However the lowerer.rs line below remained the same, fixing to read the xhp keyword instead of attempting to find it in kinds.