### PR TITLE
Make it possible for extensions to register new CLI client callbacks

### DIFF
--- a/hphp/hack/hhi/hsl/ext_hsl_os.hhi
+++ b/hphp/hack/hhi/hsl/ext_hsl_os.hhi
@@ -1,0 +1,27 @@
+<?hh
+/**
+ * Copyright (c) 2018, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the "hack" directory of this source tree.
+ *
+ */
+
+namespace HH\Lib\OS;
+
+newtype FileDescriptor = mixed;
+
+const int O_RDONLY = 0;
+const int O_WRONLY = 0;
+const int O_RDWR= 0;
+const int O_NONBLOCK = 0;
+const int O_APPEND = 0;
+const int O_CREAT/*E < you dropped this*/ = 0;
+const int O_TRUNC = 0;
+const int O_EXCL = 0;
+const int O_SHLOCK = 0;
+const int O_EXLOCK = 0;
+const int O_NOFOLLOW = 0;
+const int O_SYMLINK = 0;
+const int O_CLOEXEC = 0;

--- a/hphp/runtime/ext/hsl/config.cmake
+++ b/hphp/runtime/ext/hsl/config.cmake
@@ -5,6 +5,13 @@ HHVM_DEFINE_EXTENSION("hsl_io"
     ext_hsl_io.php
 )
 
+HHVM_DEFINE_EXTENSION("hsl_os"
+  SOURCES
+    ext_hsl_os.cpp
+  SYSTEMLIB
+    ext_hsl_os.php
+)
+
 HHVM_DEFINE_EXTENSION("hsl_random"
   SOURCES
     ext_hsl_random.cpp

--- a/hphp/runtime/ext/hsl/ext_hsl_os.cpp
+++ b/hphp/runtime/ext/hsl/ext_hsl_os.cpp
@@ -1,0 +1,177 @@
+/*
+   +----------------------------------------------------------------------+
+   | HipHop for PHP                                                       |
+   +----------------------------------------------------------------------+
+   | Copyright (c) 2010-present Facebook, Inc. (http://www.facebook.com)  |
+   +----------------------------------------------------------------------+
+   | This source file is subject to version 3.01 of the PHP license,      |
+   | that is bundled with this package in the file LICENSE, and is        |
+   | available through the world-wide-web at the following url:           |
+   | http://www.php.net/license/3_01.txt                                  |
+   | If you did not receive a copy of the PHP license and are unable to   |
+   | obtain it through the world-wide-web, please send a note to          |
+   | license@php.net so we can mail you a copy immediately.               |
+   +----------------------------------------------------------------------+
+*/
+
+#include "hphp/runtime/base/array-init.h"
+#include "hphp/runtime/base/builtin-functions.h"
+#include "hphp/runtime/ext/extension.h"
+#include "hphp/runtime/vm/native.h"
+#include "hphp/runtime/vm/native-data.h"
+#include "hphp/system/systemlib.h"
+
+#include <fcntl.h>
+#include <stdio.h>
+
+// TODO: Add _Private\ErrnoException(int), throw that instead
+#define THROW_AS_ERRNO(code) throw_errno_exception(code)
+#define THROW_ERRNO_IF_MINUS_ONE(var) if (var == -1) { THROW_AS_ERRNO(errno); }
+
+namespace HPHP {
+namespace {
+
+const StaticString s_HSLFileDescriptor("HSLFileDescriptor");
+const StaticString s_fd("fd");
+const StaticString s_valid("valid");
+const StaticString s_source("source");
+const StaticString s_ErrnoException("HH\\Lib\\_Private\\OS\\ErrnoException");
+
+IMPLEMENT_REQUEST_LOCAL(std::set<int>, s_fds_to_close);
+
+[[noreturn]]
+void throw_errno_exception(int number) {
+  Array params;
+  params.append(folly::sformat("Errno {}: {}", number, ::strerror(number)));
+  params.append(number);
+  throw_object(s_ErrnoException, params);
+}
+
+struct HSLFileDescriptor {
+  static Object newInstance(int fd, const String& source) {
+    if (s_class == nullptr) {
+      s_class = Unit::lookupClass(s_classname.get());
+    }
+    assertx(s_class);
+    Object obj { s_class };
+
+    auto* data = Native::data<HSLFileDescriptor>(obj);
+    data->m_fd = fd;
+    data->m_valid = true;
+    data->m_source = source;
+
+    s_fds_to_close->insert(fd);
+    return obj;
+  }
+
+  int fd() const {
+    if (!m_valid) {
+      THROW_AS_ERRNO(EBADF);
+    }
+    return m_fd;
+  }
+
+  void close() {
+    if (!m_valid) {
+      THROW_AS_ERRNO(EBADF);
+    }
+    int result = ::close(m_fd);
+    THROW_ERRNO_IF_MINUS_ONE(result);
+    s_fds_to_close->erase(m_fd);
+    m_valid = false;
+  }
+
+  Array __debugInfo() const {
+    Array ret = Array::CreateDArray();
+    ret.set(s_fd, m_fd);
+    ret.set(s_valid, m_valid);
+    ret.set(s_source, m_source);
+    return ret;
+  }
+
+  private:
+    static Class* s_class;
+    static StaticString s_classname;
+    int m_fd;
+    bool m_valid;
+    String m_source;
+};
+
+Class* HSLFileDescriptor::s_class = nullptr;
+StaticString HSLFileDescriptor::s_classname("HH\\Lib\\OS\\FileDescriptor");
+
+Array HHVM_METHOD(HSLFileDescriptor, __debugInfo) {
+  return Native::data<HSLFileDescriptor>(this_)->__debugInfo();
+}
+
+Object HHVM_FUNCTION(HSL_os_open, const String& path, int64_t flags, const Variant& mode) {
+int fd;
+  if (flags & O_CREAT) {
+    // TODO: throw ??? if mode is not an int
+    fd = ::open(path.c_str(), flags, mode.asInt64Val());
+  } else {
+    fd = ::open(path.c_str(), flags);
+  }
+  THROW_ERRNO_IF_MINUS_ONE(fd);
+  return HSLFileDescriptor::newInstance(fd, folly::sformat("open('{}', {})", path.c_str(), flags));
+}
+
+int64_t HHVM_FUNCTION(HSL_os_write, const Object& obj, const String& data) {
+  auto fd = Native::data<HSLFileDescriptor>(obj)->fd();
+  ssize_t written = ::write(fd, data.data(), data.length());
+  THROW_ERRNO_IF_MINUS_ONE(written);
+  return written;
+}
+
+void HHVM_FUNCTION(HSL_os_close, const Object& obj) {
+   Native::data<HSLFileDescriptor>(obj)->close();
+}
+
+struct OSExtension final : Extension {
+
+  OSExtension() : Extension("hsl_os", "0.1") {}
+
+  void moduleInit() override {
+    Native::registerNativeDataInfo<HSLFileDescriptor>(s_HSLFileDescriptor.get());
+
+    // Remember to update the HHI :)
+    // open() flags ----------
+    // The preprocessor doesn't like "\" immediately before a ##
+#define O_(name) HHVM_RC_INT(HH\\Lib\\OS\\O_##name, O_##name)
+    O_(RDONLY);
+    O_(WRONLY);
+    O_(RDWR);
+    O_(NONBLOCK);
+    O_(APPEND);
+    O_(CREAT);
+    O_(TRUNC);
+    O_(EXCL);
+    O_(SHLOCK);
+    O_(EXLOCK);
+    O_(NOFOLLOW);
+    O_(SYMLINK);
+    O_(CLOEXEC);
+#undef O_
+    // MacOS: O_EVTONLY
+    // Linux: ... lots ...
+
+    HHVM_FALIAS(HH\\Lib\\_Private\\OS\\open, HSL_os_open);
+    HHVM_FALIAS(HH\\Lib\\_Private\\OS\\write, HSL_os_write);
+    HHVM_FALIAS(HH\\Lib\\_Private\\OS\\close, HSL_os_close);
+
+    HHVM_NAMED_ME(HH\\Lib\\OS\\FileDescriptor, __debugInfo, HHVM_MN(HSLFileDescriptor, __debugInfo));
+
+    loadSystemlib();
+  }
+
+  void requestShutdown() override {
+    int result = 0;
+    for (int fd : *s_fds_to_close) {
+      ::close(fd);
+    }
+    s_fds_to_close->clear();
+  }
+} s_os_extension;
+
+} // anonymous namespace
+} // namespace HPHP

--- a/hphp/runtime/ext/hsl/ext_hsl_os.php
+++ b/hphp/runtime/ext/hsl/ext_hsl_os.php
@@ -1,0 +1,56 @@
+<?hh // strict
+
+/*
+   +----------------------------------------------------------------------+
+   | HipHop for PHP                                                       |
+   +----------------------------------------------------------------------+
+   | Copyright (c) 2010-present Facebook, Inc. (http://www.facebook.com)  |
+   +----------------------------------------------------------------------+
+   | This source file is subject to version 3.01 of the PHP license,      |
+   | that is bundled with this package in the file LICENSE, and is        |
+   | available through the world-wide-web at the following url:           |
+   | http://www.php.net/license/3_01.txt                                  |
+   | If you did not receive a copy of the PHP license and are unable to   |
+   | obtain it through the world-wide-web, please send a note to          |
+   | license@php.net so we can mail you a copy immediately.               |
+   +----------------------------------------------------------------------+
+ */
+namespace HH\Lib\OS {
+
+<<__NativeData("HSLFileDescriptor")>>
+final class FileDescriptor {
+  private function __construct() {}
+
+  <<__Native>>
+  public function __debugInfo(): darray;
+}
+
+}
+
+namespace HH\Lib\_Private\OS {
+
+
+use type HH\Lib\OS\FileDescriptor;
+
+final class ErrnoException extends \Exception {}
+
+<<__Native>>
+function open(string $path, int $flags, ?int $mode = null): FileDescriptor;
+
+/*
+<<__Native>>
+function pipe(): (FileDescriptor, FileDescriptor);
+ */
+
+<<__Native>>
+function write(FileDescriptor $fd, string $data): int;
+
+/*
+<<__Native>>
+function pwrite(FileDescriptor $fd, string $data, int $offset);
+ */
+
+<<__Native>>
+function close(FileDescriptor $fd): void;
+
+}

--- a/hphp/runtime/server/cli-server-ext.h
+++ b/hphp/runtime/server/cli-server-ext.h
@@ -1,0 +1,78 @@
+/*
+   +----------------------------------------------------------------------+
+   | HipHop for PHP                                                       |
+   +----------------------------------------------------------------------+
+   | Copyright (c) 2010-present Facebook, Inc. (http://www.facebook.com)  |
+   +----------------------------------------------------------------------+
+   | This source file is subject to version 3.01 of the PHP license,      |
+   | that is bundled with this package in the file LICENSE, and is        |
+   | available through the world-wide-web at the following url:           |
+   | http://www.php.net/license/3_01.txt                                  |
+   | If you did not receive a copy of the PHP license and are unable to   |
+   | obtain it through the world-wide-web, please send a note to          |
+   | license@php.net so we can mail you a copy immediately.               |
+   +----------------------------------------------------------------------+
+*/
+
+#ifndef incl_HPHP_CLI_SERVER_IO_H_
+#define incl_HPHP_CLI_SERVER_IO_H_
+
+#include "hphp/util/afdt-util.h"
+#include "hphp/util/trace.h"
+
+#include <afdt.h>
+#include <functional>
+
+namespace HPHP {
+
+int cli_get_cli_sock();
+
+template<class... Args>
+void cli_write(int afdt_fd, Args&&... args) {
+  FTRACE(4, "cli_write({}, nargs={})\n", afdt_fd, sizeof...(args) + 1);
+  try {
+    afdt::sendx(afdt_fd, std::forward<Args>(args)...);
+  } catch (const std::runtime_error& ex) {
+    throw Exception("Failed in afdt::sendRaw: %s [%s]",
+                    ex.what(), folly::errnoStr(errno).c_str());
+  }
+}
+
+template<class... Args>
+void cli_read(int afdt_fd, Args&&... args) {
+  FTRACE(4, "cli_read({}, nargs={})\n", afdt_fd, sizeof...(args) + 1);
+  try {
+    afdt::recvx(afdt_fd, std::forward<Args>(args)...);
+  } catch (const std::runtime_error& ex) {
+    throw Exception("Failed in afdt::recvRaw: %s [%s]",
+                    ex.what(), folly::errnoStr(errno).c_str());
+  }
+}
+
+int cli_read_fd(int afdt_fd);
+void cli_write_fd(int afdt_fd, int fd);
+
+void cli_register_handler(const char* name, std::function<void(int)> impl);
+template<class... Args> void cli_invoke_handler(const char* name, Args&&... args) {
+  int afdt_fd = cli_get_cli_sock();
+  cli_write(afdt_fd, "ext", name, std::forward<Args>(args)...);
+  bool handler_defined;
+  cli_read(afdt_fd, handler_defined);
+  if (!handler_defined) {
+    throw Exception("Undefined CLI extension handler: %s", name);
+  }
+}
+
+}
+
+#define CLI_INVOKE_HANDLER(x, ...) \
+  static_assert(&x##_cli_client); \
+  cli_invoke_handler(#x, __VA_ARGS__);
+
+#define CLI_CLIENT_HANDLER(x, ...) \
+x##_cli_client(__VA_ARGS__)
+
+#define CLI_REGISTER_HANDLER(name) \
+  cli_register_handler(#name, name##_cli_client);
+
+#endif

--- a/hphp/test/slow/ext_hsl/ext_os_primitives.php
+++ b/hphp/test/slow/ext_hsl/ext_os_primitives.php
@@ -1,0 +1,38 @@
+<?hh // strict
+
+use namespace HH\Lib\OS;
+use namespace HH\Lib\_Private\OS as _OS;
+<<__EntryPoint>>
+function main(): void {
+  $filename = sys_get_temp_dir()."/".\bin2hex(\random_bytes(8));
+  $fd = _OS\open($filename, OS\O_CREAT | OS\O_WRONLY, 0644);
+  var_dump($fd);
+  _OS\write($fd, "Hello, world\n");
+  _OS\close($fd);
+  var_dump(\file_get_contents($filename));
+  var_dump($fd);
+  printf("Expecting exception EBADF\n");
+  try {
+    _OS\write($fd, "Foo bar\n");
+  } catch (\Throwable $e) {
+    printf(
+      "> Caught exception %s with code (%d): %s\n",
+      get_class($e),
+      $e->getCode(),
+      $e->getMessage(),
+    );
+  }
+  printf("Expecting exception EEXIST\n");
+  try {
+    $fd = _OS\open($filename, OS\O_CREAT | OS\O_EXCL | OS\O_WRONLY, 0644);
+  } catch (\Throwable $e) {
+    printf(
+      "> Caught exception %s with code (%d): %s\n",
+      get_class($e),
+      $e->getCode(),
+      $e->getMessage(),
+    );
+  }
+
+  unlink($filename);
+}

--- a/hphp/test/slow/ext_hsl/ext_os_primitives.php.expectf
+++ b/hphp/test/slow/ext_hsl/ext_os_primitives.php.expectf
@@ -1,0 +1,22 @@
+object(HH\Lib\OS\FileDescriptor) (3) {
+  ["fd"]=>
+  int(%d)
+  ["valid"]=>
+  bool(true)
+  ["source"]=>
+  string(%d) "open('%s', %d)"
+}
+string(13) "Hello, world
+"
+object(HH\Lib\OS\FileDescriptor) (3) {
+  ["fd"]=>
+  int(%d)
+  ["valid"]=>
+  bool(false)
+  ["source"]=>
+  string(%d) "open('%s', %d)"
+}
+Expecting exception EBADF
+> Caught exception HH\Lib\_Private\OS\ErrnoException with code (%d): %s
+Expecting exception EEXIST
+> Caught exception HH\Lib\_Private\OS\ErrnoException with code (%d): %s

--- a/hphp/util/hphp-config.h.in
+++ b/hphp/util/hphp-config.h.in
@@ -91,7 +91,7 @@ ${HHVM_COMPILES_DEFINE_STRING}
 #endif
 
 #ifdef USE_CMAKE
-# if ${HHVM_EXTENSION_COUNT} != 92
+# if ${HHVM_EXTENSION_COUNT} != 93
 #  error You need to update the config file for the new builtin extension, and add the define to the FB section
 # endif
 ${HHVM_EXTENSIONS_ENABLED_DEFINE_STRING}
@@ -125,6 +125,7 @@ ${HHVM_EXTENSIONS_ENABLED_DEFINE_STRING}
 # define ENABLE_EXTENSION_HH_CLIENT 1
 # define ENABLE_EXTENSION_HOTPROFILER 1
 # define ENABLE_EXTENSION_HSL_IO 1
+# define ENABLE_EXTENSION_HSL_OS 1
 # define ENABLE_EXTENSION_HSL_RANDOM 1
 # define ENABLE_EXTENSION_HSL_REGEX 1
 # define ENABLE_EXTENSION_HSL_TIME 1


### PR DESCRIPTION
** review second commit only **

Test Plan:

Start hhvm CLI server as root, then run this as me...

```hack
<<__EntryPoint>>
function main(): void {
  var_dump(getmypid());
  $fda=\HH\Lib\_Private\OS\open('/tmp/mytestfile', HH\Lib\OS\O_CREAT, 0644);
  $fdb=\HH\Lib\_Private\OS\open('/var/root/mytestfile', HH\Lib\OS\O_CREAT, 0644);
}
```

- check the dumped PID is the server PID to make sure we're actually
using the CLI server
- check that /tmp/mytestfile is owned by me, not root
- check that a permission denied exception was thrown for the attempt to
write to root's home dir (/var/root on mac)
