### PR TITLE
Fix jemalloc compatibility with latest XCode and MacOS SDK

### DIFF
--- a/third-party/jemalloc/CMakeLists.txt
+++ b/third-party/jemalloc/CMakeLists.txt
@@ -6,6 +6,8 @@ ExternalProject_add(
   URL "https://github.com/jemalloc/jemalloc/releases/download/5.2.1/jemalloc-5.2.1.tar.bz2"
   URL_HASH SHA512=0bbb77564d767cef0c6fe1b97b705d368ddb360d55596945aea8c3ba5889fbce10479d85ad492c91d987caacdbbdccc706aa3688e321460069f00c05814fae02
   PREFIX "${JEMALLOC_PREFIX}"
+  PATCH_COMMAND
+    patch -p1 < "${CMAKE_CURRENT_SOURCE_DIR}/mac-sys-nothrow.patch"
   CONFIGURE_COMMAND
     "${JEMALLOC_PREFIX}/src/jemallocBuild/configure" "--prefix=${JEMALLOC_PREFIX}"
       --disable-shared

--- a/third-party/jemalloc/mac-sys-nothrow.patch
+++ b/third-party/jemalloc/mac-sys-nothrow.patch
@@ -1,0 +1,74 @@
+From 871d0a1354011e034e2c3563bc4ba76b447c8c1b Mon Sep 17 00:00:00 2001
+From: David Goldblatt <davidgoldblatt@fb.com>
+Date: Thu, 26 Mar 2020 11:40:49 -0700
+Subject: [PATCH] Mac: don't declare system functions as nothrow.
+
+This contradicts the system headers, which can lead to breakages.
+---
+ include/jemalloc/jemalloc_macros.h.in |  6 ++++++
+ include/jemalloc/jemalloc_protos.h.in | 19 ++++++++++---------
+ 2 files changed, 16 insertions(+), 9 deletions(-)
+
+diff --git a/include/jemalloc/jemalloc_macros.h.in b/include/jemalloc/jemalloc_macros.h.in
+index b4469d8e9..1ceb7b170 100644
+--- a/include/jemalloc/jemalloc_macros.h.in
++++ b/include/jemalloc/jemalloc_macros.h.in
+@@ -134,3 +134,9 @@
+ #  define JEMALLOC_RESTRICT_RETURN
+ #  define JEMALLOC_ALLOCATOR
+ #endif
++
++#if defined(__APPLE__) && !defined(JEMALLOC_NO_RENAME)
++#  define JEMALLOC_SYS_NOTHROW
++#else
++#  define JEMALLOC_SYS_NOTHROW JEMALLOC_NOTHROW
++#endif
+diff --git a/include/jemalloc/jemalloc_protos.h.in b/include/jemalloc/jemalloc_protos.h.in
+index a78414b19..d75b2224c 100644
+--- a/include/jemalloc/jemalloc_protos.h.in
++++ b/include/jemalloc/jemalloc_protos.h.in
+@@ -8,21 +8,22 @@ extern JEMALLOC_EXPORT void		(*@je_@malloc_message)(void *cbopaque,
+     const char *s);
+ 
+ JEMALLOC_EXPORT JEMALLOC_ALLOCATOR JEMALLOC_RESTRICT_RETURN
+-    void JEMALLOC_NOTHROW	*@je_@malloc(size_t size)
++    void JEMALLOC_SYS_NOTHROW	*@je_@malloc(size_t size)
+     JEMALLOC_CXX_THROW JEMALLOC_ATTR(malloc) JEMALLOC_ALLOC_SIZE(1);
+ JEMALLOC_EXPORT JEMALLOC_ALLOCATOR JEMALLOC_RESTRICT_RETURN
+-    void JEMALLOC_NOTHROW	*@je_@calloc(size_t num, size_t size)
++    void JEMALLOC_SYS_NOTHROW	*@je_@calloc(size_t num, size_t size)
+     JEMALLOC_CXX_THROW JEMALLOC_ATTR(malloc) JEMALLOC_ALLOC_SIZE2(1, 2);
+-JEMALLOC_EXPORT int JEMALLOC_NOTHROW	@je_@posix_memalign(void **memptr,
+-    size_t alignment, size_t size) JEMALLOC_CXX_THROW JEMALLOC_ATTR(nonnull(1));
++JEMALLOC_EXPORT int JEMALLOC_SYS_NOTHROW @je_@posix_memalign(
++    void **memptr, size_t alignment, size_t size) JEMALLOC_CXX_THROW
++    JEMALLOC_ATTR(nonnull(1));
+ JEMALLOC_EXPORT JEMALLOC_ALLOCATOR JEMALLOC_RESTRICT_RETURN
+-    void JEMALLOC_NOTHROW	*@je_@aligned_alloc(size_t alignment,
++    void JEMALLOC_SYS_NOTHROW	*@je_@aligned_alloc(size_t alignment,
+     size_t size) JEMALLOC_CXX_THROW JEMALLOC_ATTR(malloc)
+     JEMALLOC_ALLOC_SIZE(2);
+ JEMALLOC_EXPORT JEMALLOC_ALLOCATOR JEMALLOC_RESTRICT_RETURN
+-    void JEMALLOC_NOTHROW	*@je_@realloc(void *ptr, size_t size)
++    void JEMALLOC_SYS_NOTHROW	*@je_@realloc(void *ptr, size_t size)
+     JEMALLOC_CXX_THROW JEMALLOC_ALLOC_SIZE(2);
+-JEMALLOC_EXPORT void JEMALLOC_NOTHROW	@je_@free(void *ptr)
++JEMALLOC_EXPORT void JEMALLOC_SYS_NOTHROW	@je_@free(void *ptr)
+     JEMALLOC_CXX_THROW;
+ 
+ JEMALLOC_EXPORT JEMALLOC_ALLOCATOR JEMALLOC_RESTRICT_RETURN
+@@ -55,12 +56,12 @@ JEMALLOC_EXPORT size_t JEMALLOC_NOTHROW	@je_@malloc_usable_size(
+ 
+ #ifdef JEMALLOC_OVERRIDE_MEMALIGN
+ JEMALLOC_EXPORT JEMALLOC_ALLOCATOR JEMALLOC_RESTRICT_RETURN
+-    void JEMALLOC_NOTHROW	*@je_@memalign(size_t alignment, size_t size)
++    void JEMALLOC_SYS_NOTHROW	*@je_@memalign(size_t alignment, size_t size)
+     JEMALLOC_CXX_THROW JEMALLOC_ATTR(malloc);
+ #endif
+ 
+ #ifdef JEMALLOC_OVERRIDE_VALLOC
+ JEMALLOC_EXPORT JEMALLOC_ALLOCATOR JEMALLOC_RESTRICT_RETURN
+-    void JEMALLOC_NOTHROW	*@je_@valloc(size_t size) JEMALLOC_CXX_THROW
++    void JEMALLOC_SYS_NOTHROW	*@je_@valloc(size_t size) JEMALLOC_CXX_THROW
+     JEMALLOC_ATTR(malloc);
+ #endif


### PR DESCRIPTION
jemalloc defineds malloc (and various other functions) as `nothrow`,
which is incompatible with the system definition.

This is https://github.com/jemalloc/jemalloc/pull/1799