### PR TITLE
update fmt, stop submoduling it

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -25,9 +25,6 @@
 [submodule "fizz"]
 	path = third-party/fizz/src
 	url = https://github.com/facebookincubator/fizz
-[submodule "fmt"]
-	path = third-party/fmt/fmt
-	url = https://github.com/fmtlib/fmt
 [submodule "folly"]
 	path = third-party/folly/src
 	url = https://github.com/facebook/folly.git

--- a/third-party/fmt/CMakeLists.txt
+++ b/third-party/fmt/CMakeLists.txt
@@ -1,11 +1,23 @@
+include(ExternalProject)
+
+set(FMT_PREFIX "${CMAKE_CURRENT_BINARY_DIR}/fmt-prefix")
+ExternalProject_add(
+  fmtBuild
+  URL "https://github.com/fmtlib/fmt/releases/download/6.1.2/fmt-6.1.2.zip"
+  URL_HASH SHA512=d21085a2010786ff18c47acb033d9e4d51a3d58f9707cd9adf0f44642c1e4d80fd8cddafe58d95bb4f3e4a84ac5799caafead4a9feb12cc549b03d4d389fcc93
+  PREFIX "${FMT_PREFIX}"
+  CMAKE_ARGS
+    -DCMAKE_INSTALL_PREFIX=${FMT_PREFIX}
+    -DCMAKE_INSTALL_INCLUDEDIR=include
+    -DCMAKE_INSTALL_LIBDIR=lib
+)
 cmake_minimum_required(VERSION 2.8.0)
 
 set(FMT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/fmt/")
 
-# Main fmt library files
-auto_sources(files "*.cc" "RECURSE" "${FMT_DIR}/src")
-auto_sources(hfiles "*.h" "RECURSE" "${FMT_DIR}/include")
-include_directories("${FMT_DIR}/include")
-
-add_library(fmt STATIC ${files} ${hfiles})
-auto_source_group(fmt "${FMT_DIR}" ${files} ${hfiles})
+add_library(fmt INTERFACE)
+add_dependencies(fmt fmtbuild)
+target_include_directories(fmt INTERFACE "${FMT_PREFIX}/include")
+target_link_libraries(fmt INTERFACE
+  "${FMT_PREFIX}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}fmt${CMAKE_STATIC_LIBRARY_SUFFIX}"
+)

--- a/third-party/folly/CMakeLists.txt
+++ b/third-party/folly/CMakeLists.txt
@@ -157,6 +157,8 @@ int main() {
 # This is so clients of folly can #include <folly/blah>
 target_include_directories(folly PUBLIC ${FOLLY_ROOT})
 
+target_link_libraries(folly fmt)
+
 add_dependencies(folly boostMaybeBuild)
 target_link_libraries(folly boost)
 
@@ -181,8 +183,6 @@ endif()
 if (JEMALLOC_ENABLED)
   target_link_libraries(folly PUBLIC jemalloc)
 endif()
-
-include_directories("${TP_DIR}/fmt/fmt/include")
 
 # For some reason we aren't making a folly-config.h and this is in there.
 # Please fix properly!


### PR DESCRIPTION
This is one way to fix some MacOS build failures, but appears
unnecessary when combined with other changes - but it's a good change,
so let's do it anyway.