### PR TITLE
Add `_OS/mkostemps` primitive

### DIFF
--- a/hphp/hack/hhi/hsl/ext_hsl_os_private.hhi
+++ b/hphp/hack/hhi/hsl/ext_hsl_os_private.hhi
@@ -168,6 +168,11 @@ const int F_SETOWN = 0;
 
 const int FD_CLOEXEC = 0;
 
+const int LOCK_SH = 0;
+const int LOCK_EX = 0;
+const int LOCK_NB = 0;
+const int LOCK_UN = 0;
+
 type uint32_t = int;
 type sa_family_t = int;
 type in_port_t = int;
@@ -228,3 +233,4 @@ function listen(FileDescriptor $socket, int $backlog): void;
 function accept(FileDescriptor $socket): (FileDescriptor, sockaddr);
 function fcntl(FileDescriptor $fd, int $cmd, mixed $arg = null): mixed;
 function lseek(FileDescriptor $fd, int $offset, int $whence): int;
+function flock(FileDescriptor $fd, int $operation): void;

--- a/hphp/hack/hhi/hsl/ext_hsl_os_private.hhi
+++ b/hphp/hack/hhi/hsl/ext_hsl_os_private.hhi
@@ -127,9 +127,19 @@ const int SEEK_DATA = 0;
 
 final class ErrnoException extends \Exception {}
 
-function poll_async(FileDescriptor $fd, int $events, int $timeout_ns): Awaitable<int>;
+function poll_async(
+  FileDescriptor $fd,
+  int $events,
+  int $timeout_ns
+): Awaitable<int>;
 
 function open(string $path, int $flags, int $mode = 0): FileDescriptor;
+
+function mkostemps(
+  string $template,
+  int $suffixlen,
+  int $flags
+): (FileDescriptor, string);
 
 function read(
   FileDescriptor $fd,

--- a/hphp/runtime/ext/hsl/ext_hsl_os.php
+++ b/hphp/runtime/ext/hsl/ext_hsl_os.php
@@ -151,4 +151,7 @@ function fcntl(FileDescriptor $fd, int $cmd, mixed $arg = null): mixed;
 <<__Native>>
 function lseek(FileDescriptor $fd, int $offset, int $whence): int;
 
+<<__Native>>
+function flock(FileDescriptor $fd, int $operation): void;
+
 } // namespace _OS

--- a/hphp/runtime/ext/hsl/ext_hsl_os.php
+++ b/hphp/runtime/ext/hsl/ext_hsl_os.php
@@ -38,6 +38,9 @@ final class ErrnoException extends \Exception {}
 function open(string $path, int $flags, int $mode = 0): FileDescriptor;
 
 <<__Native>>
+function mkostemps(string $template, int $suffixlen, int $flags): varray<mixed> /* (FileDescriptor, string) */;
+
+<<__Native>>
 function read(
   FileDescriptor $fd,
   int $max_to_read,

--- a/hphp/test/slow/ext_hsl/flock.php
+++ b/hphp/test/slow/ext_hsl/flock.php
@@ -1,0 +1,25 @@
+<?hh
+use namespace HH\Lib\_Private\_OS;
+
+<<__EntryPoint>>
+function main(): void {
+  $path = sys_get_temp_dir().'/hsl-os-flock-'.bin2hex(random_bytes(16));
+  try {
+    $fda = _OS\open($path, _OS\O_CREAT | _OS\O_RDWR | _OS\O_EXCL, 0644);
+    print("Acquiring first lock\n");
+    _OS\flock($fda, _OS\LOCK_EX);
+    $fdb = _OS\open($path, _OS\O_RDWR, 0644);
+    print("Acquiring second lock\n");
+    try {
+      _OS\flock($fdb, _OS\LOCK_EX | _OS\LOCK_NB);
+    } catch (_OS\ErrnoException $e) {
+      printf(
+        "Caught errno %d - EAGAIN? %s\n",
+        $e->getCode(),
+        $e->getCode() === _OS\EAGAIN ? 'yes' : 'no'
+      );
+    }
+  } finally {
+    unlink($path);
+  }
+}

--- a/hphp/test/slow/ext_hsl/flock.php.expectf
+++ b/hphp/test/slow/ext_hsl/flock.php.expectf
@@ -1,0 +1,3 @@
+Acquiring first lock
+Acquiring second lock
+Caught errno %d - EAGAIN? yes

--- a/hphp/test/slow/ext_hsl/mkostemps.php
+++ b/hphp/test/slow/ext_hsl/mkostemps.php
@@ -1,0 +1,66 @@
+<?hh
+use namespace HH\Lib\_Private\_OS;
+
+// This file:
+// - tests that `mkostemps` works as expected
+// - tests that `mkostemps` can be used to implement related functions,
+//   such as `mkstemp`
+// - only uses six X's in patterns; other numbers of X's are not portable.
+
+<<__EntryPoint>>
+function main(): void {
+  $prefix = sys_get_temp_dir().'/hsl-mkostemps-test';
+  $pattern = $prefix.'XXXXXX';
+
+  // Emulate mkstemp
+  list($fd, $path) = _OS\mkostemps($pattern, 0, 0);
+  _OS\write($fd, "foo");
+  _OS\lseek($fd, -1, _OS\SEEK_CUR);
+  _OS\write($fd, "bar");
+  var_dump(vec[
+    'mkstemp',
+    $fd,
+    $path,
+    substr($path, 0, strlen($prefix)) === $prefix,
+    strlen($path) === strlen($pattern),
+    $path !== $pattern,
+    file_get_contents($path), // string(5) "fobar" due to lseek
+  ]);
+  unlink($path);
+
+  // Emulate mkstemps
+  list($fd, $path) = _OS\mkostemps($pattern.'.txt', 4, 0);
+  var_dump(vec[
+    'mkstemps',
+    $fd,
+    $path,
+    substr($path, 0, strlen($prefix)) === $prefix,
+    strlen($path) === strlen($pattern.'.txt'),
+    $path !== $pattern.'.txt',
+  ]);
+  unlink($path);
+
+  // Emulate mkostemp
+  list($fd, $path ) = _OS\mkostemps($pattern, 0, _OS\O_APPEND);
+  _OS\write($fd, "foo");
+  _OS\lseek($fd, -1, _OS\SEEK_CUR);
+  _OS\write($fd, "bar");
+  var_dump(vec['mkostemp', file_get_contents($path)]); // foobar, O_APPEND re-seeks to EOF
+  unlink($path);
+
+  // Test *all* the features
+  list($fd, $path ) = _OS\mkostemps($pattern.'.txt', 4, _OS\O_APPEND);
+  _OS\write($fd, "foo");
+  _OS\lseek($fd, -1, _OS\SEEK_CUR);
+  _OS\write($fd, "bar");
+  var_dump(vec[
+    'mkostemps',
+    $fd,
+    $path,
+    substr($path, 0, strlen($prefix)) === $prefix,
+    strlen($path) === strlen($pattern.'.txt'),
+    $path !== $pattern,
+    file_get_contents($path),
+  ]);
+  unlink($path);
+}

--- a/hphp/test/slow/ext_hsl/mkostemps.php.expectf
+++ b/hphp/test/slow/ext_hsl/mkostemps.php.expectf
@@ -1,0 +1,39 @@
+vec(7) {
+  string(7) "mkstemp"
+  object(HH\Lib\OS\FileDescriptor) (%d) {
+    ["fd"]=>
+    int(%d)
+  }
+  string(%d) "%s/hsl-mkostemps-test%s"
+  bool(true)
+  bool(true)
+  bool(true)
+  string(5) "fobar"
+}
+vec(6) {
+  string(8) "mkstemps"
+  object(HH\Lib\OS\FileDescriptor) (%d) {
+    ["fd"]=>
+    int(%d)
+  }
+  string(%s) "%s/hsl-mkostemps-test%s.txt"
+  bool(true)
+  bool(true)
+  bool(true)
+}
+vec(2) {
+  string(8) "mkostemp"
+  string(6) "foobar"
+}
+vec(7) {
+  string(9) "mkostemps"
+  object(HH\Lib\OS\FileDescriptor) (%d) {
+    ["fd"]=>
+    int(%d)
+  }
+  string(%d) "%s/hsl-mkostemps-test%s.txt"
+  bool(true)
+  bool(true)
+  bool(true)
+  string(6) "foobar"
+}


### PR DESCRIPTION
Summary:
Not actually a POSIX function, however:
- can be used to implement the related POSIX mkstemp function, and other related
  functions (covered in unit test)
- it is available on both platforms we support (Linux, MacOS)
- while we may support Windows in the future, the related POSIX function
  (mkstemp) is not available there either

In this diff, I'm
- adding the function
- adding specialization for std::tuple to CLI server extensibility
- while I'm here, standardize on `class` instead of `typename` in the
cli-server-ext-detail.h file.
- while I'm here, removing all the assertx(fd >= 0), instead putting that in the HSLFileDescriptor constructor, and throwing an exception instead of asserting so that the CLI client can't intentionally crash the CLI server by returning a bad fd

Reviewed By: paulbiss

Differential Revision: D20771508

