### PR TITLE
Reuse Zstd DContext to avoid frequent memory allocations

### DIFF
--- a/hphp/hhvm/thread_locals.txt
+++ b/hphp/hhvm/thread_locals.txt
@@ -115,3 +115,6 @@ HPHP::(anonymous namespace)::cc_misses
 HPHP::(anonymous namespace)::s_predict
 HPHP::(anonymous namespace)::s_predictors
 HPHP::(anonymous namespace)::tl_cti_cache
+
+# MemcacheClient reuse DCtx when during call to Zstd
+facebook::memcache::CacheClientSerializer<HPHP::Variant>::zstduncompress(char const*, unsigned long)::pDctx


### PR DESCRIPTION
Summary: Avoid high volume of calls to malloc during memcache client decompression.

Differential Revision: D20802366

