### PR TITLE
Add cmake macro for downloading third-party sources, and caching them.

### DIFF
--- a/CMake/HPHPFunctions.cmake
+++ b/CMake/HPHPFunctions.cmake
@@ -483,3 +483,46 @@ function(object_library_ld_link_libraries target)
     endif()
   endif()
 endfunction()
+
+set(
+  HHVM_THIRD_PARTY_SOURCE_CACHE_PREFIX
+  ""
+  CACHE
+  STRING
+  "URL prefix containing cache of third-party dependencies"
+)
+set(
+  HHVM_THIRD_PARTY_SOURCE_ONLY_USE_CACHE
+  OFF
+  CACHE
+  BOOL
+  "Do not download sources that are not in cache; may cause build to fail."
+)
+set(
+  HHVM_THIRD_PARTY_SOURCE_URL_LIST_OUTPUT
+  ""
+  CACHE
+  STRING
+  "Path to a text file to put a list of sources that should be in the cache"
+)
+
+macro(SET_HHVM_THIRD_PARTY_SOURCE_URLS VAR_NAME URL)
+  if ("${HHVM_THIRD_PARTY_SOURCE_CACHE_PREFIX}" STREQUAL "")
+    set("${VAR_NAME}" "${URL}")
+    if (${HHVM_THIRD_PARTY_SOURCE_ONLY_USE_CACHE})
+      message(
+        FATAL_ERROR
+        "HHVM_THIRD_PARTY_ONLY_USE_CACHE is set, but cache is not configured"
+      )
+    endif()
+  else()
+    get_filename_component("${VAR_NAME}_NAME" "${URL}" NAME)
+    set("${VAR_NAME}" "${HHVM_THIRD_PARTY_SOURCE_CACHE_PREFIX}${${VAR_NAME}_NAME}")
+    if (NOT ${HHVM_THIRD_PARTY_SOURCE_ONLY_USE_CACHE})
+      list(APPEND "${VAR_NAME}" "${URL}")
+    endif()
+  endif()
+  if (NOT "${HHVM_THIRD_PARTY_SOURCE_URL_LIST_OUTPUT}" STREQUAL "")
+    FILE(APPEND "${HHVM_THIRD_PARTY_SOURCE_URL_LIST_OUTPUT}" "${URL}\n")
+  endif()
+endmacro()

--- a/third-party/fmt/CMakeLists.txt
+++ b/third-party/fmt/CMakeLists.txt
@@ -1,9 +1,15 @@
 include(ExternalProject)
+include(HPHPFunctions)
+
+SET_HHVM_THIRD_PARTY_SOURCE_URLS(
+  FMT_SOURCE_URLS
+  "https://github.com/fmtlib/fmt/releases/download/6.1.2/fmt-6.1.2.zip"
+)
 
 set(FMT_PREFIX "${CMAKE_CURRENT_BINARY_DIR}/fmt-prefix")
 ExternalProject_add(
   fmtBuild
-  URL "https://github.com/fmtlib/fmt/releases/download/6.1.2/fmt-6.1.2.zip"
+  URL ${FMT_SOURCE_URLS}
   URL_HASH SHA512=d21085a2010786ff18c47acb033d9e4d51a3d58f9707cd9adf0f44642c1e4d80fd8cddafe58d95bb4f3e4a84ac5799caafead4a9feb12cc549b03d4d389fcc93
   PREFIX "${FMT_PREFIX}"
   CMAKE_ARGS


### PR DESCRIPTION
Just doing one project for now to keep this diff small.

Can run in three modes:
- always download from origin (default)
- try cache, fall back to origin
- only use cache, never try origin

Also added an option to generate a text file containing a list of all
the origin URLs; this could be useful for populating a cache.