### PR TITLE
Extend third-party URL macros to support platform-specific downloads

### DIFF
--- a/CMake/HPHPFunctions.cmake
+++ b/CMake/HPHPFunctions.cmake
@@ -513,10 +513,60 @@ set(
   "Path to a text file to put a list of sources that should be in the cache"
 )
 
-macro(SET_HHVM_THIRD_PARTY_SOURCE_ARGS VAR_NAME URL)
-  set(${VAR_NAME} URL)
+# Usage:
+#  SET_HHVM_THIRD_PARTY_SOURCE_ARGS(
+#    MY_VAR_NAME
+#    SOURCE_URL https://example.com/
+#    SOURCE_HASH SHA256=deadbeef
+#  )
+#  ... or ...
+#  SET_HHVM_THIRD_PARTY_SOURCE_ARGS(
+#    MY_VAR_NAME
+#    Linux_URL https://example.com/linux.tar.bz2
+#    Linux_HASH SHA256=deadbeef
+#    Darwin_URL https://example.com/macos.tar.bz2
+#    Darwin_HASH SHA256=deadbeef
+#  )
+#
+macro(SET_HHVM_THIRD_PARTY_SOURCE_ARGS VAR_NAME)
+  cmake_parse_arguments(
+    # Prefix (FOO becomes _arg_FOO - trailing _ implied)
+    _arg
+    # No-arg parameter (none):
+    ""
+    # Single-argument parameters
+    "SOURCE_URL;SOURCE_HASH;Linux_URL;Linux_HASH;Darwin_URL;Darwin_HASH"
+    # Multi-argument parameters (none)
+    ""
+    ${ARGN}
+  )
+
+  # Try source, but fall back to platform-specific
+  if (NOT "${_arg_SOURCE_URL}" STREQUAL "")
+    set(_URL "${_arg_SOURCE_URL}")
+    set("${VAR_NAME}" URL_HASH "${_arg_SOURCE_HASH}")
+    if (NOT "${HHVM_THIRD_PARTY_SOURCE_URL_LIST_OUTPUT}" STREQUAL "")
+      FILE(
+        APPEND
+        "${HHVM_THIRD_PARTY_SOURCE_URL_LIST_OUTPUT}"
+        "${_arg_SOURCE_URL}\n"
+      )
+    endif()
+  else()
+    set(_URL "${_arg_${CMAKE_HOST_SYSTEM_NAME}_URL}")
+    set("${VAR_NAME}" URL_HASH "${_arg_${CMAKE_HOST_SYSTEM_NAME}_HASH}")
+    if (NOT "${HHVM_THIRD_PARTY_SOURCE_URL_LIST_OUTPUT}" STREQUAL "")
+      FILE(
+        APPEND
+        "${HHVM_THIRD_PARTY_SOURCE_URL_LIST_OUTPUT}"
+        "${_arg_Linux_URL}\n"
+        "${_arg_Darwin_URL}\n"
+      )
+    endif()
+  endif()
+
   if ("${HHVM_THIRD_PARTY_SOURCE_CACHE_PREFIX}" STREQUAL "")
-    list(APPEND ${VAR_NAME} "${URL}")
+    list(APPEND ${VAR_NAME} URL "${_URL}")
     if (${HHVM_THIRD_PARTY_SOURCE_ONLY_USE_CACHE})
       message(
         FATAL_ERROR
@@ -524,15 +574,16 @@ macro(SET_HHVM_THIRD_PARTY_SOURCE_ARGS VAR_NAME URL)
       )
     endif()
   else()
-    get_filename_component("${VAR_NAME}_NAME" "${URL}" NAME)
-    list(APPEND ${VAR_NAME} "${HHVM_THIRD_PARTY_SOURCE_CACHE_PREFIX}${${VAR_NAME}_NAME}${HHVM_THIRD_PARTY_SOURCE_CACHE_SUFFIX}")
+    get_filename_component("_URL_NAME" "${_URL}" NAME)
+    list(APPEND "${VAR_NAME}" DOWNLOAD_NAME "${URL_NAME}")
+
+    list(
+      APPEND "${VAR_NAME}"
+      URL
+      "${HHVM_THIRD_PARTY_SOURCE_CACHE_PREFIX}${_URL_NAME}${HHVM_THIRD_PARTY_SOURCE_CACHE_SUFFIX}"
+    )
     if (NOT ${HHVM_THIRD_PARTY_SOURCE_ONLY_USE_CACHE})
-      list(APPEND "${VAR_NAME}" "${URL}")
+      list(APPEND "${VAR_NAME}" "${_URL}")
     endif()
   endif()
-  if (NOT "${HHVM_THIRD_PARTY_SOURCE_URL_LIST_OUTPUT}" STREQUAL "")
-    FILE(APPEND "${HHVM_THIRD_PARTY_SOURCE_URL_LIST_OUTPUT}" "${URL}\n")
-  endif()
-  # If a suffix is provided, we need to specify the downloaded file name
-  list(APPEND "${VAR_NAME}" DOWNLOAD_NAME "${${VAR_NAME}_NAME}")
 endmacro()

--- a/third-party/fmt/CMakeLists.txt
+++ b/third-party/fmt/CMakeLists.txt
@@ -3,14 +3,16 @@ include(HPHPFunctions)
 
 SET_HHVM_THIRD_PARTY_SOURCE_ARGS(
   FMT_SOURCE_ARGS
+  SOURCE_URL
   "https://github.com/fmtlib/fmt/releases/download/6.1.2/fmt-6.1.2.zip"
+  SOURCE_HASH
+  "SHA512=d21085a2010786ff18c47acb033d9e4d51a3d58f9707cd9adf0f44642c1e4d80fd8cddafe58d95bb4f3e4a84ac5799caafead4a9feb12cc549b03d4d389fcc93"
 )
 
 set(FMT_PREFIX "${CMAKE_CURRENT_BINARY_DIR}/fmt-prefix")
 ExternalProject_add(
   fmtBuild
   ${FMT_SOURCE_ARGS}
-  URL_HASH SHA512=d21085a2010786ff18c47acb033d9e4d51a3d58f9707cd9adf0f44642c1e4d80fd8cddafe58d95bb4f3e4a84ac5799caafead4a9feb12cc549b03d4d389fcc93
   PREFIX "${FMT_PREFIX}"
   CMAKE_ARGS
     -DCMAKE_INSTALL_PREFIX=${FMT_PREFIX}

--- a/third-party/rustc/CMakeLists.txt
+++ b/third-party/rustc/CMakeLists.txt
@@ -8,23 +8,26 @@
 #
 # This also avoids the need to depend on gpg in the installation.
 
-if (CMAKE_HOST_SYSTEM_NAME STREQUAL "Linux")
-  set(RUST_URL "https://static.rust-lang.org/dist/rust-1.39.0-x86_64-unknown-linux-gnu.tar.gz")
-  set(RUST_SHA256 "b10a73e5ba90034fe51f0f02cb78f297ed3880deb7d3738aa09dc5a4d9704a25")
-elseif (CMAKE_HOST_SYSTEM_NAME STREQUAL "Darwin")
-  set(RUST_URL "https://static.rust-lang.org/dist/rust-1.39.0-x86_64-apple-darwin.tar.gz")
-  set(RUST_SHA256 "3736d49c5e9592844e1a5d5452883aeaf8f1e25d671c1bc8f01e81c1766603b5")
-else()
-  message(FATAL_ERROR "HHVM does not support this operating system")
-endif()
+include(HPHPFunctions)
+
+SET_HHVM_THIRD_PARTY_SOURCE_ARGS(
+  RUST_DOWNLOAD_ARGS
+  Linux_URL
+  "https://static.rust-lang.org/dist/rust-1.39.0-x86_64-unknown-linux-gnu.tar.gz"
+  Darwin_URL
+  "https://static.rust-lang.org/dist/rust-1.39.0-x86_64-apple-darwin.tar.gz"
+  Linux_HASH
+  "SHA256=b10a73e5ba90034fe51f0f02cb78f297ed3880deb7d3738aa09dc5a4d9704a25"
+  Darwin_HASH
+  "SHA256=3736d49c5e9592844e1a5d5452883aeaf8f1e25d671c1bc8f01e81c1766603b5"
+)
 
 set(RUST_PREFIX "${CMAKE_CURRENT_BINARY_DIR}/rust-prefix")
 
 include(ExternalProject)
 ExternalProject_Add(
   rustInstall
-  URL "${RUST_URL}"
-  URL_HASH "SHA256=${RUST_SHA256}"
+  ${RUST_DOWNLOAD_ARGS}
   PREFIX "${RUST_PREFIX}"
   CONFIGURE_COMMAND ""
   BUILD_COMMAND ""


### PR DESCRIPTION
Use for rustc.

Test plan:
- building third-party/fmt and third-party/rustc
- told cmake to generate URLs list - saw source and all platforms:

```
https://static.rust-lang.org/dist/rust-1.39.0-x86_64-unknown-linux-gnu.tar.gz
https://static.rust-lang.org/dist/rust-1.39.0-x86_64-apple-darwin.tar.gz
https://github.com/fmtlib/fmt/releases/download/6.1.2/fmt-6.1.2.zip
```