### PR TITLE
never build boost

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,6 @@
 [submodule "__FORKS__"]
 	path = third-party/forks
 	url = https://github.com/hhvm/hhvm-third-party.git
-[submodule "boost"]
-	path = third-party/boost/boost
-	url = https://github.com/boostorg/boost
 [submodule "brotli"]
 	path = third-party/brotli/src
 	url = https://github.com/google/brotli

--- a/third-party/CMakeLists.txt
+++ b/third-party/CMakeLists.txt
@@ -142,9 +142,6 @@ if(NOT PCRE_LIBRARY)
   set(PCRE_BUILD_TESTS OFF CACHE BOOL "Build the tests")
 endif()
 
-# Add bundled libzip if the system one will not be used
-add_subdirectory(libzip)
-
 list(APPEND THIRD_PARTY_MODULES ocaml)
 
 # Add bundled XED library if XED is enabled and the specified XED library
@@ -153,52 +150,6 @@ if(ENABLE_XED AND NOT LibXed_FOUND)
   list(APPEND THIRD_PARTY_MODULES xed)
   list(APPEND EXTRA_INCLUDE_PATHS "${TP_DIR}/xed/xed/build/include/xed")
 endif()
-
-##### boost #####
-
-# boost checks
-find_package(Boost 1.62.0 COMPONENTS context fiber filesystem iostreams program_options regex system thread)
-if ("${Boost_VERSION}" EQUAL "107000")
-  # https://github.com/boostorg/variant/issues/69
-  message(WARNING "System boost is blacklisted version")
-
-  set(Boost_FOUND false)
-endif()
-
-add_library(boost INTERFACE)
-add_custom_target(boostMaybeBuild)
-if(NOT Boost_FOUND)
-  # The boost library can't have a dependency on boostBuild because of:
-  # https://public.kitware.com/Bug/view.php?id=15414
-  # Instead we add the dependency to the target being linked with hphp_link
-  add_dependencies(boostMaybeBuild boostBuild)
-  message(STATUS "Using third-party bundled boost")
-  add_subdirectory(boost)
-  # These are the archive names prefixed with lib so that cmake does not
-  # find these to be system archive instead of these third party ones.
-  set(Boost_LIBRARIES
-      "libboost_fiber"
-      "libboost_context"
-      "libboost_filesystem"
-      "libboost_iostreams"
-      "libboost_program_options"
-      "libboost_regex"
-      "libboost_system"
-      "libboost_thread"
-      CACHE STRING "" FORCE
-  )
-  foreach(lib ${Boost_LIBRARIES})
-    add_library(${lib} STATIC IMPORTED)
-    set_property(TARGET ${lib} PROPERTY IMPORTED_LOCATION
-                 "${CMAKE_CURRENT_SOURCE_DIR}/boost/build/lib/${lib}.a")
-  endforeach()
-  set(Boost_INCLUDE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/boost/build/include" CACHE STRING "" FORCE)
-  set(Boost_LIBRARY_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/boost/build/lib" CACHE STRING "" FORCE)
-  TP_INSTALL_HEADERS(boost boost/build/include/boost boost)
-  list(APPEND EXTRA_INCLUDE_PATHS "${TP_DIR}/boost/build/include")
-endif()
-target_include_directories(boost BEFORE INTERFACE ${Boost_INCLUDE_DIRS})
-target_link_libraries(boost INTERFACE ${Boost_LIBRARIES})
 
 ##### libsodium #####
 
@@ -218,9 +169,12 @@ add_definitions("-DHAVE_LIBSODIUM")
 list(APPEND EXTRA_INCLUDE_PATHS "${LIBSODIUM_INCLUDE_DIRS}")
 list(APPEND THIRD_PARTY_DEFINITIONS "-DHAVE_LIBSODIUM")
 
-##### rustc #####
+##### new-style things #####
 
-add_subdirectory("rustc")
+add_subdirectory(boost)
+add_subdirectory(rustc)
+add_subdirectory(libzip)
+
 
 ##### --- footer --- #####
 

--- a/third-party/boost/CMakeLists.txt
+++ b/third-party/boost/CMakeLists.txt
@@ -1,12 +1,21 @@
-cmake_minimum_required(VERSION 2.8.0)                                           
-include(ExternalProject)                                                        
-message(STATUS "Boost CMAKE_CURRENT_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}")
-ExternalProject_Add(                                                            
-  boostBuild
-  SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/boost/                                 
-  CONFIGURE_COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/boost/bootstrap.sh --without-libraries=python --prefix=${CMAKE_CURRENT_SOURCE_DIR}/build
-  BUILD_COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/boost/b2 link=static variant=release threading=multi runtime-link=static cxxflags=-std=gnu++14 --prefix=${CMAKE_CURRENT_SOURCE_DIR}/build install
-  PREFIX ${CMAKE_CURRENT_SOURCE_DIR}/build                                                                  
-  BUILD_IN_SOURCE true                                                          
-  INSTALL_COMMAND ""                                                            
-)                                                                               
+add_library(boost INTERFACE)
+
+# Every supported platform now includes a new enough boost.
+# Keeping this in third-party though as it doesn't seem unlikely that that
+# will change in the future, and to provide a consistent way to reference
+# dependencies
+find_package(
+  Boost 1.62.0
+  REQUIRED
+  COMPONENTS
+  context
+  fiber
+  filesystem
+  iostreams
+  program_options
+  regex
+  system
+  thread
+)
+target_include_directories(boost INTERFACE ${Boost_INCLUDE_DIRS})
+target_link_libraries(boost INTERFACE ${Boost_LIBRARIES})


### PR DESCRIPTION
All supported platforms have a new enough boost.

Also, remove submodule. If we need to build again in the future, use
`ExternalProject_add`, like other recent modifications.