### PR TITLE
Widen SplFileObject::fgetcsv()'s return type to mixed

### DIFF
--- a/hphp/hack/hhi/stdlib/builtins_spl.hhi
+++ b/hphp/hack/hhi/stdlib/builtins_spl.hhi
@@ -121,12 +121,12 @@ class SplFileObject extends SplFileInfo
   public function eof(): bool;
   public function fflush(): bool;
   public function fgetc(): string;
+  /** @return varray|false*/
   public function fgetcsv(
     string $delimiter = ",",
     string $enclosure = "\"",
     string $escape = "\\",
-    /* HH_IGNORE_ERROR[2071] */
-  ): varray;
+  ): mixed;
   public function fgets();
   public function fgetss(?string $allowable_tags = null): string;
   public function flock(int $operation, inout mixed $wouldblock): bool;


### PR DESCRIPTION
The Hack code that implements this method has a literal `return false;`
See https://github.com/facebook/hhvm/blob/a20c7945409cb0b10cf901abb029a2ca6035897c/hphp/system/php/spl/file_handling/SplFileObject.php#L172-L174

This also has the side-effect of removing a HH_FIXME for a genericless varray.
A vscode search for `>\s*?fgetcsv` found three callsites.

An assignment to an untyped member variable.
https://github.com/facebook/hhvm/blob/a20c7945409cb0b10cf901abb029a2ca6035897c/hphp/system/php/spl/file_handling/SplFileObject.php#L567-L571

Used as an immediate to var_dump().
https://github.com/facebook/hhvm/blob/a20c7945409cb0b10cf901abb029a2ca6035897c/hphp/test/zend/good/ext/spl/tests/SplFileObject_fgetcsv_escape_error.php#L7

Used as an immediate to var_dump().
https://github.com/facebook/hhvm/blob/a20c7945409cb0b10cf901abb029a2ca6035897c/hphp/test/zend/good/ext/spl/tests/SplFileObject_fgetcsv_delimiter_error.php#L12

refs https://github.com/facebook/hhvm/issues/5823 PHP returns `NULL` when reading the line after the last line, while we return `false`. The documentation on PHP.net says that we should return false.
_Returns an indexed array containing the fields read, or FALSE on error._

We could also match PHP's behavior here and return NULL (deviating from the docs).
However, with the low test coverage we have, I don't dare changing this over to `return null;`.