### PR TITLE
Make visibility in HHI for AsyncMysqlClient::__construct private

### DIFF
--- a/hphp/hack/hhi/stdlib/builtins_async_mysql.hhi
+++ b/hphp/hack/hhi/stdlib/builtins_async_mysql.hhi
@@ -52,7 +52,7 @@ const int ASYNC_OP_CONNECT = 0;
 const int ASYNC_OP_QUERY = 0;
 
 class AsyncMysqlClient {
-  public function __construct() { }
+  private function __construct() { }
   static public function setPoolsConnectionLimit(int $limit) { }
   static public function connect(
       string $host,


### PR DESCRIPTION
Fatal error: Uncaught Error: Call to private AsyncMysqlClient::__construct() from invalid context
Stack trace:
#0 (): main()
#1 {main}

fixes #6520