### PR TITLE
Update cmake, simplify CXX version handling

### DIFF
--- a/CMake/FindLibDwarf.cmake
+++ b/CMake/FindLibDwarf.cmake
@@ -72,12 +72,6 @@ if (LIBDWARF_LIBRARIES AND LIBDWARF_INCLUDE_DIRS)
       # Check to see if we can use a const name.
       unset(DW_CONST CACHE)
 
-      if (NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-        # -std=c++11 is already set in HPHPCompiler.cmake, don't
-        # add -std=c++0x on top of that or clang will give errors
-        set(CMAKE_REQUIRED_FLAGS "-std=c++0x")
-      endif()
-
       CHECK_CXX_SOURCE_COMPILES("
       #include <libdwarf.h>
       #include <cstddef>

--- a/CMake/HPHPCompiler.cmake
+++ b/CMake/HPHPCompiler.cmake
@@ -67,7 +67,6 @@ if (${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang" OR ${CMAKE_CXX_COMPILER_ID} STREQU
   # General options to pass to the C++ compiler
   set(GENERAL_CXX_OPTIONS)
   list(APPEND GENERAL_CXX_OPTIONS
-    "std=gnu++1z"
     "fno-omit-frame-pointer"
     "fno-operator-names"
     "Wall"
@@ -159,20 +158,6 @@ if (${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang" OR ${CMAKE_CXX_COMPILER_ID} STREQU
       "-param=inline-unit-growth=200"
       "-param=large-unit-insns=10000"
     )
-
-    # Fix problem with GCC 4.9, https://kb.isc.org/article/AA-01167
-    if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 4.9 OR
-       CMAKE_CXX_COMPILER_VERSION VERSION_EQUAL 4.9)
-      list(APPEND GENERAL_OPTIONS "fno-delete-null-pointer-checks")
-    else()
-       message(FATAL_ERROR "${PROJECT_NAME} requires g++ 4.9 or greater.")
-    endif()
-
-    # Warn about a GCC 4.9 bug leading to an incorrect refcounting issue
-    # https://github.com/facebook/hhvm/issues/8011
-    if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5.0)
-       message(WARNING "HHVM is known to trigger optimization bugs in GCC 4.9. Upgrading to GCC 5 is recommended. See https://github.com/facebook/hhvm/issues/8011 for more details.")
-    endif()
 
     if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 8.3 OR
        CMAKE_CXX_COMPILER_VERSION VERSION_EQUAL 8.3)
@@ -312,7 +297,7 @@ if (${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang" OR ${CMAKE_CXX_COMPILER_ID} STREQU
 # using Intel C++
 elseif (${CMAKE_CXX_COMPILER_ID} STREQUAL "Intel")
   set(CMAKE_C_FLAGS   "${CMAKE_C_FLAGS} -no-ipo -fp-model precise -wd584 -wd1418 -wd1918 -wd383 -wd869 -wd981 -wd424 -wd1419 -wd444 -wd271 -wd2259 -wd1572 -wd1599 -wd82 -wd177 -wd593 -w")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -no-ipo -fp-model precise -wd584 -wd1418 -wd1918 -wd383 -wd869 -wd981 -wd424 -wd1419 -wd444 -wd271 -wd2259 -wd1572 -wd1599 -wd82 -wd177 -wd593 -fno-omit-frame-pointer -Wall -Woverloaded-virtual -Wno-deprecated -w1 -Wno-strict-aliasing -Wno-write-strings -Wno-invalid-offsetof -fno-operator-names")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -no-ipo -fp-model precise -wd584 -wd1418 -wd1918 -wd383 -wd869 -wd981 -wd424 -wd1419 -wd444 -wd271 -wd2259 -wd1572 -wd1599 -wd82 -wd177 -wd593 -fno-omit-frame-pointer -Wall -Woverloaded-virtual -Wno-deprecated -w1 -Wno-strict-aliasing -Wno-write-strings -Wno-invalid-offsetof -fno-operator-names")
 # using Visual Studio C++
 elseif (${CMAKE_CXX_COMPILER_ID} STREQUAL "MSVC")
   message(WARNING "MSVC support is VERY experimental. It will likely not compile, and is intended for the utterly insane.")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,9 @@
-CMAKE_MINIMUM_REQUIRED(VERSION 2.8.7 FATAL_ERROR)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.1.3 FATAL_ERROR)
+# OLD: report Apple Clang as "Clang" in CMAKE_COMPILER_ID
+# NEW: report Apple Clang as "AppleClang"
+#
+# TWe have a bunch of checks for "Clang" that need updating
+cmake_policy(SET CMP0025 OLD)
 
 # This needs to be done before any languages are enabled or
 # projects are created.
@@ -8,7 +13,7 @@ INCLUDE("${CMAKE_CURRENT_SOURCE_DIR}/CMake/VisualStudioToolset.cmake")
 SET(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/CMake" ${CMAKE_MODULE_PATH})
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
-PROJECT(hhvm C CXX ASM)
+PROJECT(hhvm LANGUAGES C CXX ASM)
 
 include(HHVMProject)
 
@@ -104,6 +109,10 @@ include(MSVCDefaults)
 include(Options)
 include(HPHPCompiler)
 include(HPHPFindLibs)
+
+set(CMAKE_CXX_STANDARD 17) # Enable C++17 mode if supported...
+set(CMAKE_CXX_STANDARD_REQUIRED ON) # ... and fail hard if not
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 ADD_SUBDIRECTORY(third-party EXCLUDE_FROM_ALL)
 ADD_SUBDIRECTORY(hphp)

--- a/third-party/folly/CMakeLists.txt
+++ b/third-party/folly/CMakeLists.txt
@@ -157,27 +157,27 @@ int main() {
 # This is so clients of folly can #include <folly/blah>
 target_include_directories(folly PUBLIC ${FOLLY_ROOT})
 
-target_link_libraries(folly fmt)
+target_link_libraries(folly PUBLIC fmt)
 
 add_dependencies(folly boostMaybeBuild)
-target_link_libraries(folly boost)
+target_link_libraries(folly PUBLIC boost)
 
 add_dependencies(folly libsodiumMaybeBuild)
 target_include_directories(folly PUBLIC "${LIBSODIUM_INCLUDE_DIRS}")
-target_link_libraries(folly libsodium)
+target_link_libraries(folly PUBLIC libsodium)
 
 find_package(Glog REQUIRED)
 target_include_directories(folly PUBLIC ${LIBGLOG_INCLUDE_DIR})
-target_link_libraries(folly ${LIBGLOG_LIBRARY})
+target_link_libraries(folly PUBLIC ${LIBGLOG_LIBRARY})
 
 find_package(PThread REQUIRED)
 target_include_directories(folly PUBLIC ${LIBPTHREAD_INCLUDE_DIRS})
-target_link_libraries(folly ${LIBPTHREAD_LIBRARIES})
+target_link_libraries(folly PRIVATE ${LIBPTHREAD_LIBRARIES})
 
 if (DOUBLE_CONVERSION_FOUND)
-  target_link_libraries(folly ${DOUBLE_CONVERSION_LIBRARY})
+  target_link_libraries(folly PUBLIC ${DOUBLE_CONVERSION_LIBRARY})
 else()
-  target_link_libraries(folly double-conversion)
+  target_link_libraries(folly PUBLIC double-conversion)
 endif()
 
 if (JEMALLOC_ENABLED)


### PR DESCRIPTION
- We currently manually set the C++ version flags for each compiler, let
  CMake do this instead
- That requires updating the minimum CMake version
- that makes the syntax for target_link_libraries slightly stricter; update folly build
- it also makes Apple Clang start being considered it's own thing ('AppleClang' instead of just 'Clang');
  opt out of the behavior for now, as we do `if (clang)` a bunch.

Seen a few diffs recently where people can't use some specific part of C++17 - hopefully this fixes it,
as well as making future updates simpler.

I set the cmake minimum version to the minimum version that has CMAKE_CXX_STANDARD in it, which is older
than anything we support, but given that updating that changes cmake's behavior, trying to keep it as small
as possible for this diff.