### PR TITLE
use ExternalProject for lz4

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -34,9 +34,6 @@
 [submodule "libsodium"]
 	path = third-party/libsodium/libsodium
 	url = https://github.com/jedisct1/libsodium.git
-[submodule "lz4"]
-	path = third-party/lz4/src
-	url = https://github.com/Cyan4973/lz4
 [submodule "mcrouter"]
 	path = third-party/mcrouter/src
 	url = https://github.com/facebook/mcrouter

--- a/CMake/HPHPFindLibs.cmake
+++ b/CMake/HPHPFindLibs.cmake
@@ -126,12 +126,6 @@ if (DOUBLE_CONVERSION_INCLUDE_DIR)
   include_directories(${DOUBLE_CONVERSION_INCLUDE_DIR})
 endif ()
 
-# liblz4
-find_package(LZ4)
-if (LZ4_FOUND)
-  include_directories(${LZ4_INCLUDE_DIR})
-endif()
-
 # fastlz
 find_package(FastLZ)
 if (FASTLZ_INCLUDE_DIR)
@@ -464,14 +458,7 @@ macro(hphp_link target)
     target_link_libraries(${target} double-conversion)
   endif()
 
-  if (LZ4_FOUND)
-    target_link_libraries(${target} ${LZ4_LIBRARY})
-  else()
-    target_link_libraries(${target} lz4)
-  endif()
-  # The syntax used for these warnings is unparsable by Apple's Clang
-  add_definitions("-DLZ4_DISABLE_DEPRECATE_WARNINGS=1")
-
+  target_link_libraries(${target} lz4)
   target_link_libraries(${target} libzip)
 
   if (PCRE_LIBRARY)

--- a/hphp/hack/CMakeLists.txt
+++ b/hphp/hack/CMakeLists.txt
@@ -66,13 +66,14 @@ if(LZ4_FOUND)
   list(APPEND extra_lib_paths ${pth})
   list(APPEND extra_native_libraries "lz4")
 else()
-  list(APPEND extra_include_paths "${TP_DIR}/lz4/src/lib")
+  get_target_property(LZ4_INCLUDE_DIRS lz4 INTERFACE_INCLUDE_DIRECTORIES)
+  list(APPEND extra_include_paths ${LZ4_INCLUDE_DIRS})
   # If LZ4_FOUND is false either we didn't find lz4 or we found it but it's the
   # wrong version.  We can't just add the new path and a native_lib because we
   # can't control the order (and -l won't accept the raw path to the lib).  By
   # doing it this way we specify the path explicitly.
-  get_target_property(LZ4_DIR lz4 BINARY_DIR)
-  list(APPEND extra_link_opts "${LZ4_DIR}/${CMAKE_STATIC_LIBRARY_PREFIX}lz4${CMAKE_STATIC_LIBRARY_SUFFIX}")
+  get_target_property(LZ4_LIBS lz4 INTERFACE_LINK_LIBRARIES)
+  list(APPEND extra_link_opts ${LZ4_LIBS})
 endif()
 
 if(PC_SQLITE3_FOUND)

--- a/third-party/CMakeLists.txt
+++ b/third-party/CMakeLists.txt
@@ -120,10 +120,7 @@ if(NOT LIBSQLITE3_LIBRARY)
 endif()
 
 # Add bundled lz4 if the system one will not be used
-if(NOT LZ4_FOUND)
-  list(APPEND THIRD_PARTY_MODULES lz4)
-  list(APPEND EXTRA_INCLUDE_PATHS "${TP_DIR}/lz4/src/lib")
-endif()
+add_subdirectory(lz4)
 
 # Add bundled double-conversion if the system one will not be used
 if(NOT DOUBLE_CONVERSION_FOUND)

--- a/third-party/lz4/CMakeLists.txt
+++ b/third-party/lz4/CMakeLists.txt
@@ -10,21 +10,20 @@ else (LZ4_FOUND)
   cmake_minimum_required(VERSION 2.8.0)
   include(ExternalProject)
 
-  set(LZ4_PREFIX "${CMAKE_CURRENT_BINARY_DIR}/lz4-install")
-
   ExternalProject_Add(
     lz4Build
     URL "https://github.com/lz4/lz4/archive/v1.9.2.tar.gz"
     URL_HASH SHA256=658ba6191fa44c92280d4aa2c271b0f4fbc0e34d249578dd05e50e76d0e5efcc
-    PREFIX ${LZ4_PREFIX}
     BUILD_IN_SOURCE true
     CONFIGURE_COMMAND ""
     BUILD_COMMAND ""
-    INSTALL_COMMAND make MOREFLAGS=-fPIC PREFIX=${LZ4_PREFIX} install
+    INSTALL_COMMAND make MOREFLAGS=-fPIC PREFIX=<INSTALL_DIR> install
   )
 
+  ExternalProject_Get_Property(lz4Build INSTALL_DIR)
+
   add_dependencies(lz4 lz4Build)
-  target_include_directories(lz4 INTERFACE "${LZ4_PREFIX}/include")
-  target_link_libraries(lz4 INTERFACE "${LZ4_PREFIX}/lib/liblz4.a")
+  target_include_directories(lz4 INTERFACE "${INSTALL_DIR}/include")
+  target_link_libraries(lz4 INTERFACE "${INSTALL_DIR}/lib/liblz4.a")
 
 endif (LZ4_FOUND)

--- a/third-party/lz4/CMakeLists.txt
+++ b/third-party/lz4/CMakeLists.txt
@@ -1,2 +1,30 @@
-add_definitions(-fPIC)
-add_library(lz4 STATIC src/lib/lz4.c src/lib/lz4.h src/lib/lz4hc.c src/lib/lz4hc.h)
+add_library(lz4 INTERFACE)
+
+find_package(LZ4)  # also checks minimum required version
+
+if (LZ4_FOUND)
+  target_include_directories(lz4 INTERFACE ${LZ4_INCLUDE_DIR})
+  target_link_libraries(lz4 INTERFACE ${LZ4_LIBRARY})
+
+else (LZ4_FOUND)
+  cmake_minimum_required(VERSION 2.8.0)
+  include(ExternalProject)
+
+  set(LZ4_PREFIX "${CMAKE_CURRENT_BINARY_DIR}/lz4-install")
+
+  ExternalProject_Add(
+    lz4Build
+    URL "https://github.com/lz4/lz4/archive/v1.9.2.tar.gz"
+    URL_HASH SHA256=658ba6191fa44c92280d4aa2c271b0f4fbc0e34d249578dd05e50e76d0e5efcc
+    PREFIX ${LZ4_PREFIX}
+    BUILD_IN_SOURCE true
+    CONFIGURE_COMMAND ""
+    BUILD_COMMAND ""
+    INSTALL_COMMAND make MOREFLAGS=-fPIC PREFIX=${LZ4_PREFIX} install
+  )
+
+  add_dependencies(lz4 lz4Build)
+  target_include_directories(lz4 INTERFACE "${LZ4_PREFIX}/include")
+  target_link_libraries(lz4 INTERFACE "${LZ4_PREFIX}/lib/liblz4.a")
+
+endif (LZ4_FOUND)


### PR DESCRIPTION
- remove submodule, use ExternalProject to download the lz4 sources
- lz4 doesn't use cmake, so override the INSTALL_COMMAND
- other than that this is the same as what we did for libzip a while ago

I was planning to do this after https://github.com/facebook/hhvm/pull/8723 but I keep having issues because the dependency between the new fb-mysql and lz4 is not properly handled there -- so doing this first.