### PR TITLE
fix for `_OS\poll_async` blocked forever after close

### DIFF
--- a/hphp/runtime/base/file-await.cpp
+++ b/hphp/runtime/base/file-await.cpp
@@ -12,11 +12,13 @@ namespace HPHP {
 /////////////////////////////////////////////////////////////////////////////
 
 void FileTimeoutHandler::timeoutExpired() noexcept {
-  m_fileAwait.setFinished(FileAwait::TIMEOUT);
+  m_fileAwait.m_eventHandler.unregisterHandler();
+  m_fileAwait.setFinished(FileAwait::TIMEOUT, true);
 }
 
 void FileEventHandler::handlerReady(uint16_t events) noexcept {
-  m_fileAwait.setFinished(events ? FileAwait::READY : FileAwait::CLOSED);
+  m_fileAwait.m_timeoutHandler.cancelTimeout();
+  m_fileAwait.setFinished(events ? FileAwait::READY : FileAwait::CLOSED, true);
 }
 
 /////////////////////////////////////////////////////////////////////////////
@@ -25,36 +27,32 @@ FileAwait::FileAwait(
   int fd,
   uint16_t events,
   std::chrono::nanoseconds timeout
-) {
+) : m_fd(fd),
+    m_eventHandler(getSingleton<AsioEventBase>().get(), fd, *this),
+    m_timeoutHandler(getSingleton<AsioEventBase>().get(), *this) {
+
   assertx(timeout.count() >= 0);
   assertx(fd >= 0);
   assertx(events & FileEventHandler::READ_WRITE);
 
-  auto asio_event_base = getSingleton<AsioEventBase>();
-  m_file = std::make_unique<FileEventHandler>(asio_event_base.get(), fd, *this);
-  m_file->registerHandler(events);
-
-  if (timeout != std::chrono::nanoseconds::zero()) {
-    m_timeout = std::make_unique<FileTimeoutHandler>(asio_event_base.get(),
-                                                     *this);
-    asio_event_base->runInEventBaseThreadAndWait([this,timeout] {
-      // Folly internally converts everything to milliseconds, so might as well do the same
-      m_timeout->scheduleTimeout(folly::chrono::ceil<std::chrono::milliseconds>(timeout));
-    });
-  }
+  getSingleton<AsioEventBase>()->runInEventBaseThread([this, events, timeout] {
+    m_eventHandler.registerHandler(events);
+    if (timeout != std::chrono::nanoseconds::zero()) {
+      // Folly internally converts everything to milliseconds, so might as well
+      // do the same
+      m_timeoutHandler.scheduleTimeout(
+        folly::chrono::ceil<std::chrono::milliseconds>(timeout));
+    }
+    FileAwait::fdToFileAwaits()[m_fd].insert(this);
+  });
 }
 
 FileAwait::~FileAwait() {
-  if (m_file) {
-    m_file->unregisterHandler();
-    m_file.reset();
-  }
-  if (m_timeout) {
-    getSingleton<AsioEventBase>()
-      ->runInEventBaseThreadAndWait([to{std::move(m_timeout)}] {
-        to->cancelTimeout();
-      });
-  }
+  assertx(!m_eventHandler.isHandlerRegistered());
+  assertx(!m_timeoutHandler.isScheduled());
+  assertx(
+    !FileAwait::fdToFileAwaits().count(m_fd) ||
+    !FileAwait::fdToFileAwaits()[m_fd].count(this));
 }
 
 void FileAwait::unserialize(TypedValue& c) {
@@ -62,15 +60,41 @@ void FileAwait::unserialize(TypedValue& c) {
   c.m_data.num = m_result;
 }
 
-void FileAwait::setFinished(int64_t status) {
-  if (m_finished.exchange(true)) {
-    return;
+void FileAwait::closeAllForFD(int fd) {
+  getSingleton<AsioEventBase>()->runInEventBaseThreadAndWait([fd] {
+    for (FileAwait* fa : FileAwait::fdToFileAwaits()[fd]) {
+      fa->m_eventHandler.unregisterHandler();
+      fa->m_timeoutHandler.cancelTimeout();
+      // don't remove_from_map because we're iterating over it, and we do it
+      // more efficiently below
+      fa->setFinished(FileAwait::CLOSED, false);
+    }
+    FileAwait::fdToFileAwaits().erase(fd);
+  });
+}
+
+// must be called from the EventBase thread, as it's not thread-safe
+void FileAwait::setFinished(int64_t status, bool remove_from_map) {
+  assertx(!m_eventHandler.isHandlerRegistered());
+  assertx(!m_timeoutHandler.isScheduled());
+
+  if (remove_from_map) {
+    FileAwait::fdToFileAwaits()[m_fd].erase(this);
+    if (FileAwait::fdToFileAwaits()[m_fd].empty()) {
+      FileAwait::fdToFileAwaits().erase(m_fd);
+    }
   }
 
   if (status > m_result) {
     m_result = status;
   }
   markAsFinished();
+}
+
+std::unordered_map<int, std::unordered_set<FileAwait*>>&
+    FileAwait::fdToFileAwaits() {
+  static std::unordered_map<int, std::unordered_set<FileAwait*>> ret;
+  return ret;
 }
 
 /////////////////////////////////////////////////////////////////////////////
@@ -117,13 +141,7 @@ Object File::await(uint16_t events, double timeout) {
     events,
     std::chrono::milliseconds(static_cast<int64_t>(timeout * 1000.0))
   );
-  try {
-    return Object{ev->getWaitHandle()};
-  } catch (...) {
-    assertx(false);
-    ev->abandon();
-    throw;
-  }
+  return Object{ev->getWaitHandle()};
 }
 
 /////////////////////////////////////////////////////////////////////////////

--- a/hphp/runtime/ext/hsl/ext_hsl_os.cpp
+++ b/hphp/runtime/ext/hsl/ext_hsl_os.cpp
@@ -392,6 +392,7 @@ struct HSLFileDescriptor {
   void close() {
     switch (m_type) {
       case Type::FD:
+        FileAwait::closeAllForFD(m_fd);
         throw_errno_if_minus_one(::close(fd()));
         s_fds_to_close->erase(m_fd);
         m_fd = -1;


### PR DESCRIPTION
This is my attempt at a fix for #8716 implemented fully inside HHVM -- hsl-experimental tests now pass even after deleting `CancelablePoller` ([hsl-experimental diff here](https://gist.github.com/jjergus/bcbeb535e1945d82c1a72e503374afba)).

@fredemmott I'm adding you as a reviewer first so you can check that

- this looks like the approach we want (compared to CancelablePoller or other possible solutions)
- I'm not doing anything obviously wrong (e.g. memory management -- I couldn't find any good documentation about how to properly manage memory in HHVM code. As far as I can tell C++'s smart pointers are generally not used and Object is the closest equivalent I could find (it seems roughly equivalent to shared_ptr?), but I'm not sure if Object was meant to be used like that...)

I'll import it to Phabricator and add more reviewers after that.