### PR TITLE
Build boost from release tarball instead of submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,6 @@
 [submodule "__FORKS__"]
 	path = third-party/forks
 	url = https://github.com/hhvm/hhvm-third-party.git
-[submodule "boost"]
-	path = third-party/boost/boost
-	url = https://github.com/boostorg/boost
 [submodule "brotli"]
 	path = third-party/brotli/src
 	url = https://github.com/google/brotli

--- a/third-party/CMakeLists.txt
+++ b/third-party/CMakeLists.txt
@@ -149,49 +149,7 @@ endif()
 
 ##### boost #####
 
-# boost checks
-find_package(Boost 1.62.0 COMPONENTS context fiber filesystem iostreams program_options regex system thread)
-if ("${Boost_VERSION}" EQUAL "107000")
-  # https://github.com/boostorg/variant/issues/69
-  message(WARNING "System boost is blacklisted version")
-
-  set(Boost_FOUND false)
-endif()
-
-add_library(boost INTERFACE)
-add_custom_target(boostMaybeBuild)
-if(NOT Boost_FOUND)
-  # The boost library can't have a dependency on boostBuild because of:
-  # https://public.kitware.com/Bug/view.php?id=15414
-  # Instead we add the dependency to the target being linked with hphp_link
-  add_dependencies(boostMaybeBuild boostBuild)
-  message(STATUS "Using third-party bundled boost")
-  add_subdirectory(boost)
-  # These are the archive names prefixed with lib so that cmake does not
-  # find these to be system archive instead of these third party ones.
-  set(Boost_LIBRARIES
-      "libboost_fiber"
-      "libboost_context"
-      "libboost_filesystem"
-      "libboost_iostreams"
-      "libboost_program_options"
-      "libboost_regex"
-      "libboost_system"
-      "libboost_thread"
-      CACHE STRING "" FORCE
-  )
-  foreach(lib ${Boost_LIBRARIES})
-    add_library(${lib} STATIC IMPORTED)
-    set_property(TARGET ${lib} PROPERTY IMPORTED_LOCATION
-                 "${CMAKE_CURRENT_SOURCE_DIR}/boost/build/lib/${lib}.a")
-  endforeach()
-  set(Boost_INCLUDE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/boost/build/include" CACHE STRING "" FORCE)
-  set(Boost_LIBRARY_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/boost/build/lib" CACHE STRING "" FORCE)
-  TP_INSTALL_HEADERS(boost boost/build/include/boost boost)
-  list(APPEND EXTRA_INCLUDE_PATHS "${TP_DIR}/boost/build/include")
-endif()
-target_include_directories(boost BEFORE INTERFACE ${Boost_INCLUDE_DIRS})
-target_link_libraries(boost INTERFACE ${Boost_LIBRARIES})
+add_subdirectory(boost)
 
 ##### libsodium #####
 

--- a/third-party/boost/CMakeLists.txt
+++ b/third-party/boost/CMakeLists.txt
@@ -1,12 +1,36 @@
-cmake_minimum_required(VERSION 2.8.0)                                           
-include(ExternalProject)                                                        
-message(STATUS "Boost CMAKE_CURRENT_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}")
-ExternalProject_Add(                                                            
-  boostBuild
-  SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/boost/                                 
-  CONFIGURE_COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/boost/bootstrap.sh --without-libraries=python --prefix=${CMAKE_CURRENT_SOURCE_DIR}/build
-  BUILD_COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/boost/b2 link=static variant=release threading=multi runtime-link=static cxxflags=-std=gnu++14 --prefix=${CMAKE_CURRENT_SOURCE_DIR}/build install
-  PREFIX ${CMAKE_CURRENT_SOURCE_DIR}/build                                                                  
-  BUILD_IN_SOURCE true                                                          
-  INSTALL_COMMAND ""                                                            
-)                                                                               
+# boost checks
+option(FORCE_BUNDLED_BOOST "Always build boost, instead of using system version" OFF)
+set(
+  BOOST_COMPONENTS
+  context
+  fiber
+  filesystem
+  headers
+  iostreams
+  program_options
+  regex
+  system
+  thread
+)
+if(FORCE_BUNDLED_BOOST)
+  set(Boost_FOUND false)
+else()
+  find_package(Boost 1.62.0 COMPONENTS ${BOOST_COMPONENTS})
+  if("${Boost_VERSION}" EQUAL "107000")
+    # https://github.com/boostorg/variant/issues/69
+    message(WARNING "System boost is blacklisted version")
+
+    set(Boost_FOUND false)
+  endif()
+endif()
+
+add_library(boost INTERFACE)
+
+if(Boost_FOUND)
+  message(STATUS "Using system boost")
+  target_include_directories(boost BEFORE INTERFACE ${Boost_INCLUDE_DIRS})
+  target_link_libraries(boost INTERFACE ${Boost_LIBRARIES})
+else ()
+  message(STATUS "Using third-party bundled boost")
+  include(bundled_boost.cmake)
+endif()

--- a/third-party/boost/b3a59d265929a213f02a451bb6-macos-coalesce-template.patch
+++ b/third-party/boost/b3a59d265929a213f02a451bb6-macos-coalesce-template.patch
@@ -1,0 +1,31 @@
+From b3a59d265929a213f02a451bb63cea75d668a4d9 Mon Sep 17 00:00:00 2001
+From: Bo Anderson <mail@boanderson.me>
+Date: Thu, 2 Apr 2020 01:31:47 +0100
+Subject: [PATCH] Fix compiler version check on macOS (#560)
+
+Fixes #440.
+---
+ src/tools/darwin.jam | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/src/tools/darwin.jam b/src/tools/darwin.jam
+index 8d477410b043207e35c5ecd543aa5680ae66f39d..97e7ecb851303a1f9a759c7801d42922a420a4fa 100644
+--- a/src/tools/darwin.jam
++++ b/src/tools/darwin.jam
+@@ -137,13 +137,14 @@ rule init ( version ? : command * : options * : requirement * )
+     # - Set the toolset generic common options.
+     common.handle-options darwin : $(condition) : $(command) : $(options) ;
+     
++    real-version = [ regex.split $(real-version) \\. ] ;
+     # - GCC 4.0 and higher in Darwin does not have -fcoalesce-templates.
+-    if $(real-version) < "4.0.0"
++    if [ version.version-less $(real-version) : 4 0 ]
+     {
+         flags darwin.compile.c++ OPTIONS $(condition) : -fcoalesce-templates ;
+     }
+     # - GCC 4.2 and higher in Darwin does not have -Wno-long-double.
+-    if $(real-version) < "4.2.0"
++    if [ version.version-less $(real-version) : 4 2 ]
+     {
+         flags darwin.compile OPTIONS $(condition) : -Wno-long-double ;
+     }

--- a/third-party/boost/bundled_boost.cmake
+++ b/third-party/boost/bundled_boost.cmake
@@ -32,6 +32,10 @@ foreach(COMPONENT IN LISTS BOOST_COMPONENTS)
   list(APPEND B2_ARGS "--with-${COMPONENT}")
 endforeach()
 
+if (APPLE)
+  set(BOOST_CXX_FLAGS "-isysroot${CMAKE_OSX_SYSROOT}")
+endif()
+
 ExternalProject_Add(                                                            
   bundled_boost
   ${BOOST_DOWNLOAD_ARGS}
@@ -39,6 +43,8 @@ ExternalProject_Add(
     cd tools/build && patch -p1 < "${CMAKE_CURRENT_SOURCE_DIR}/b3a59d265929a213f02a451bb6-macos-coalesce-template.patch"
   CONFIGURE_COMMAND
     CXX=${CMAKE_CXX_COMPILER}
+    CXXFLAGS=${BOOST_CXX_FLAGS}
+    NO_CXX11_CHECK=true # we have c++17 (at least), and the check ignores CXXFLAGS, including `-isysroot` on macos
     <SOURCE_DIR>/bootstrap.sh
     ${COMMON_ARGS}
     "--with-libraries=${BOOST_COMPONENTS_CSV}"

--- a/third-party/boost/bundled_boost.cmake
+++ b/third-party/boost/bundled_boost.cmake
@@ -9,7 +9,6 @@ SET_HHVM_THIRD_PARTY_SOURCE_ARGS(
   SOURCE_HASH
   "SHA256=4eb3b8d442b426dc35346235c8733b5ae35ba431690e38c6a8263dce9fcbb402"
 )
-list(JOIN BOOST_COMPONENTS "," BOOST_COMPONENTS_CSV)
 set(
   COMMON_ARGS
   --prefix=<INSTALL_DIR>
@@ -25,6 +24,8 @@ set(
   runtime-link=static
   cxxflags=-std=gnu++14
 )
+
+string(REPLACE ";" "," BOOST_COMPONENTS_CSV "${BOOST_COMPONENTS}")
 # We pass --with-libraires to boostrap.sh, but that does not consistently
 # affect b2
 foreach(COMPONENT IN LISTS BOOST_COMPONENTS)


### PR DESCRIPTION
While I'm here, also:
- only build the parts of it we need
- separate build from install
- do an out-of-source build
- move the system boost logic to third-party/boost too
- as it's a big/complex one, split out the `bundled_boost` stuff to a
  separate `.cmake` file for readability
- add an option to force using the bundled boost for testing

The deleted comments about boostMaybeBuild are due to old issues with
`target_link_libraries(foo INTERFACE bar)`; we're now using this in
several places, so we can kill the indirection.
