### PR TITLE
HTE lint-ignore message cleanup at fbcode

### DIFF
--- a/hphp/compiler/package.cpp
+++ b/hphp/compiler/package.cpp
@@ -510,7 +510,7 @@ bool Package::parseImpl(const std::string* fileName) {
 
   auto report = [&] (int lines) {
     struct stat fst;
-    // @lint-ignore HOWTOEVEN1
+    // @lint-ignore CLANGTIDY
     stat(fullPath.c_str(), &fst);
 
     Lock lock(m_mutex);


### PR DESCRIPTION
Summary: The diff removes HOWTOEVEN from all lint-ignore messages at fbcode

Reviewed By: dkgi

Differential Revision: D26278830

