### PR TITLE
Add TypeStructureKind::OF_ANY_ARRAY

### DIFF
--- a/hphp/hack/hhi/typestructure.hhi
+++ b/hphp/hack/hhi/typestructure.hhi
@@ -42,6 +42,7 @@ enum TypeStructureKind : int {
   OF_DARRAY = 0;
   OF_VARRAY = 0;
   OF_VARRAY_OR_DARRAY = 0;
+  OF_ANY_ARRAY = 0;
   OF_NULL = 0;
   OF_NOTHING = 0;
   OF_DYNAMIC = 0;

--- a/hphp/runtime/ext/reflection/ext_reflection-classes.php
+++ b/hphp/runtime/ext/reflection/ext_reflection-classes.php
@@ -1322,6 +1322,7 @@ namespace HH {
     OF_DARRAY = 24;
     OF_VARRAY = 25;
     OF_VARRAY_OR_DARRAY = 26;
+    OF_ANY_ARRAY = 27;
     OF_NULL = 28;
     OF_NOTHING = 29;
     OF_DYNAMIC = 30;


### PR DESCRIPTION
## TEST
```HACK
<<__EntryPoint>>
function main(): void {
  \var_dump(\HH\ReifiedGenerics\get_type_structure<AnyArray<int, int>>());
}
```
```
// expect
darray(2) {
  ["kind"]=>
  int(27)
  ["generic_types"]=>
  varray(2) {
    darray(1) {
      ["kind"]=>
      int(1)
    }
    darray(1) {
      ["kind"]=>
      int(1)
    }
  }
}
```

## Reason
When passing `AnyArray<_, _>` to `Facebook\TypeSpec\of<_>()`, the following error is thrown:
```
Facebook\TypeAssert\UnsupportedTypeException' with message 'Not able to handle type '27'
```
Adding a case to the switch with the value of `27` requires a `HH_FIXME[4020]`.
This is not in the allow_list of any oss project that I know of so far.
Adding this switch without the fixme is desired, since requiring each `.hhconfig` to be updated is a hassle.