### PR TITLE
Add `hh_parse --generate-hhi`

### DIFF
--- a/hphp/hack/src/dune
+++ b/hphp/hack/src/dune
@@ -96,7 +96,8 @@
   (name hh_parse)
   (modes exe byte_complete)
   (modules
-    hh_parse)
+    hh_parse
+    generate_hhi)
   (link_flags (:standard (:include dune_config/ld-opts.sexp)))
   (libraries
     default_injector_config

--- a/hphp/hack/src/generate_hhi.ml
+++ b/hphp/hack/src/generate_hhi.ml
@@ -1,0 +1,51 @@
+(*
+ * Copyright (c) 2016-present , Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the "hack" directory of this source tree.
+ *
+ *)
+
+(**
+ * Usage: hh_parse --generate-hhi [FILE]
+ *
+ * Generates a .hhi file from a .hack or .php file; intended for use in the
+ * build system for a typechecked systemlib.
+ *)
+
+open Hh_prelude
+module Syntax = Full_fidelity_editable_syntax
+module SourceText = Full_fidelity_source_text
+module Rewriter = Full_fidelity_rewriter.WithSyntax (Syntax)
+module Token = Full_fidelity_editable_token
+module TokenKind = Full_fidelity_token_kind
+
+let go editable =
+  let without_bodies =
+    Rewriter.rewrite_pre_and_stop
+    (fun inner ->
+      match Syntax.syntax inner with
+      | Syntax.MarkupSuffix _ -> (* remove `<?hh` line if present *)
+        Rewriter.Replace (Syntax.make_missing SourceText.empty 0)
+      | Syntax.FunctionDeclaration f -> (* remove function bodies *)
+        Rewriter.Replace (Syntax.make_function_declaration
+          f.function_attribute_spec
+          f.function_declaration_header
+          (* replace body *)
+          (Syntax.make_token (Token.create TokenKind.Semicolon ";" [] []))
+        )
+      | Syntax.MethodishDeclaration m -> (* remove method bodies *)
+        Rewriter.Replace (Syntax.make_methodish_declaration
+          m.methodish_attribute
+          m.methodish_function_decl_header
+          (* no body *)
+          (Syntax.make_missing SourceText.empty 0)
+          (* but always a semicolon, even if not abstract *)
+          (Syntax.make_token (Token.create TokenKind.Semicolon ";" [] []))
+        )
+      | _ -> Rewriter.Keep)
+    editable
+  in
+  let text = Syntax.text without_bodies in
+  "<?hh // decl\n// @"^"generated from implementation\n\n"^text

--- a/hphp/hack/src/hh_parse.ml
+++ b/hphp/hack/src/hh_parse.ml
@@ -45,6 +45,7 @@ module FullFidelityParseArgs = struct
     program_text: bool;
     pretty_print: bool;
     pretty_print_json: bool;
+    generate_hhi: bool;
     schema: bool;
     show_file_name: bool;
     (* Configuring the parser *)
@@ -89,6 +90,7 @@ module FullFidelityParseArgs = struct
       program_text
       pretty_print
       pretty_print_json
+      generate_hhi
       schema
       codegen
       php5_compat_mode
@@ -129,6 +131,7 @@ module FullFidelityParseArgs = struct
       program_text;
       pretty_print;
       pretty_print_json;
+      generate_hhi;
       schema;
       codegen;
       php5_compat_mode;
@@ -182,6 +185,8 @@ module FullFidelityParseArgs = struct
     let set_pretty_print () = pretty_print := true in
     let pretty_print_json = ref false in
     let set_pretty_print_json () = pretty_print_json := true in
+    let generate_hhi = ref false in
+    let set_generate_hhi () = generate_hhi := true in
     let schema = ref false in
     let set_schema () = schema := true in
     let codegen = ref false in
@@ -248,6 +253,9 @@ No errors are filtered out."
         ( "--program-text",
           Arg.Unit set_program_text,
           "Displays the text of the given file." );
+        ( "--generate-hhi",
+          Arg.Unit set_generate_hhi,
+          "Generate and display a .hhi file for the given input file.");
         ( "--pretty-print",
           Arg.Unit set_pretty_print,
           "Displays the text of the given file after pretty-printing." );
@@ -396,6 +404,7 @@ No errors are filtered out."
       !program_text
       !pretty_print
       !pretty_print_json
+      !generate_hhi
       !schema
       !codegen
       !php5_compat_mode
@@ -556,6 +565,10 @@ let handle_existing_file args filename =
   ( if args.pretty_print then
     let pretty = Libhackfmt.format_tree syntax_tree in
     Printf.printf "%s\n" pretty );
+  ( if args.generate_hhi then
+    let hhi = Generate_hhi.go editable in
+    Printf.printf "%s\n" hhi
+  );
 
   ( if print_errors then
     let level =

--- a/hphp/hack/test/hhi/generate/dune
+++ b/hphp/hack/test/hhi/generate/dune
@@ -1,0 +1,18 @@
+(alias
+    (name generate_hhis_test)
+    (deps %{exe:../../../src/hh_parse.exe}
+          %{project_root}/test/verify.py
+          %{project_root}/test/review.sh
+          (glob_files %{project_root}/test/hhi/generate/*.php)
+          (glob_files %{project_root}/test/hhi/generate/*.hack)
+          (glob_files %{project_root}/test/hhi/generate/*.hhi.exp))
+    (action (run %{project_root}/test/verify.py %{project_root}/test/hhi/generate
+    --out-extension .hhi.out
+    --expect-extension .hhi.exp
+    --program %{exe:../../../src/hh_parse.exe}
+    --flags
+    --generate-hhi)))
+
+(alias
+  (name runtest)
+  (deps (alias generate_hhis_test)))

--- a/hphp/hack/test/hhi/generate/no_function_bodies.php
+++ b/hphp/hack/test/hhi/generate/no_function_bodies.php
@@ -1,0 +1,20 @@
+<?hh // strict
+
+namespace GeneratedHHITest;
+
+/** Top level function doc block */
+function top_level_function(): void {
+  foo();
+}
+
+class Foo {
+  /** public method doc block */
+  public function publicMethod(): void {
+    bar();
+  }
+
+  /** public static method doc block */
+  public static function publicStaticMethod(): void {
+    bar();
+  }
+}

--- a/hphp/hack/test/hhi/generate/no_function_bodies.php.hhi.exp
+++ b/hphp/hack/test/hhi/generate/no_function_bodies.php.hhi.exp
@@ -1,0 +1,14 @@
+<?hh // decl
+// @generated from implementation
+
+
+namespace GeneratedHHITest;
+
+/** Top level function doc block */
+function top_level_function(): void ;
+class Foo {
+  /** public method doc block */
+  public function publicMethod(): void ;
+  /** public static method doc block */
+  public static function publicStaticMethod(): void ;}
+


### PR DESCRIPTION
Summary:

Starting to work on having HSL truly built-in; we want to keep it typechecked, but we don't want
the typechecker to always typecheck the implementation. If we generate HHIs, we can remove
the HH_FIXMEs around the PHP builtin calls, as we will no longer need the body to typecheck when using
the deregister_phpstdlib option.

ocamlformat and buck support todo before commit

Test plan:

```
dune runtest test/hhi/generate
```
