### PR TITLE
Add `hh_server --concatenate-all`

### DIFF
--- a/hphp/hack/src/server/serverArgs_sig.ml
+++ b/hphp/hack/src/server/serverArgs_sig.ml
@@ -38,6 +38,8 @@ module type S = sig
 
   val check_mode : options -> bool
 
+  val concatenate_prefix : options -> string option
+
   val config : options -> (string * string) list
 
   val custom_telemetry_data : options -> (string * string) list

--- a/hphp/hack/src/server/serverMain.ml
+++ b/hphp/hack/src/server/serverMain.ml
@@ -1504,8 +1504,17 @@ let run_once options config local_config =
         Some save_result
   in
   (* Finish up by generating the output and the exit code *)
-  Hh_logger.log "Running in check mode";
-  Program.run_once_and_exit genv env save_state_results
+  match ServerArgs.concatenate_prefix genv.options with
+    | Some prefix ->
+      let prefix = Relative_path.from_root ~suffix:prefix
+        |> Relative_path.to_absolute
+      in
+      let text = ServerConcatenateAll.go genv env [ prefix ] in
+      print_endline text;
+      Exit.exit Exit_status.No_error;
+    | _ ->
+      Hh_logger.log "Running in check mode";
+      Program.run_once_and_exit genv env save_state_results
 
 (*
  * The server monitor will pass client connections to this process


### PR DESCRIPTION
This is equivalent to `hh_client --concatenate-all`, but does not need a
running server (or cleaning up a server afterwards).

This would be more suitable for including in a build process.

Test plan:

```
$ cd $(mktemp -d)
$ git clone https://github.com/hhvm/hsl.git
$ cd hsl
$ CHECKOUT_DIR=$(pwd)
$ /Users/fredemmott/code/hhvm/build/hphp/hack/default/src/hh_server.exe \
  --concatenate-all=src/ . > hsl.hack
[2021-03-17 15:42:48.843] Running without daemon mode.
... snip ...
$ cd $(mktemp -d)
$ cp $CHECKOUT_DIR/{hsl.hack,.hhconfig} .
$ hh_client
No errors!
$
```

then manually checked that hsl.hack actually includes the expected
definitions.
