### PR TITLE
Modernize libsodium and lz4 building

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -22,9 +22,6 @@
 [submodule "libafdt"]
 	path = third-party/libafdt/src
 	url = https://github.com/facebook/libafdt
-[submodule "libsodium"]
-	path = third-party/libsodium/libsodium
-	url = https://github.com/jedisct1/libsodium.git
 [submodule "mcrouter"]
 	path = third-party/mcrouter/src
 	url = https://github.com/facebook/mcrouter

--- a/CMake/HPHPFindLibs.cmake
+++ b/CMake/HPHPFindLibs.cmake
@@ -360,7 +360,6 @@ macro(hphp_link target)
 
   add_dependencies(${target} boostMaybeBuild)
   target_link_libraries(${target} boost)
-  add_dependencies(${target} libsodiumMaybeBuild)
   target_link_libraries(${target} libsodium)
 
   target_link_libraries(${target} ${PCRE_LIBRARY})

--- a/third-party/CMakeLists.txt
+++ b/third-party/CMakeLists.txt
@@ -149,21 +149,7 @@ add_subdirectory(boost)
 
 ##### libsodium #####
 
-add_library(libsodium INTERFACE)
-add_custom_target(libsodiumMaybeBuild)
-find_package(LibSodium 1.0.9)
-if (LIBSODIUM_INCLUDE_DIRS AND LIBSODIUM_LIBRARIES)
-  message(STATUS "Using system libsodium ${LIBSODIUM_VERSION}")
-else()
-  message(STATUS "Using third-party bundled libsodium")
-  add_dependencies(libsodiumMaybeBuild libsodiumBuild)
-  add_subdirectory(libsodium EXCLUDE_FROM_ALL)
-endif()
-target_include_directories(libsodium INTERFACE ${LIBSODIUM_INCLUDE_DIRS})
-target_link_libraries(libsodium INTERFACE ${LIBSODIUM_LIBRARIES})
-add_definitions("-DHAVE_LIBSODIUM")
-list(APPEND EXTRA_INCLUDE_PATHS "${LIBSODIUM_INCLUDE_DIRS}")
-list(APPEND THIRD_PARTY_DEFINITIONS "-DHAVE_LIBSODIUM")
+add_subdirectory(libsodium)
 
 ##### rustc #####
 

--- a/third-party/fizz/CMakeLists.txt
+++ b/third-party/fizz/CMakeLists.txt
@@ -19,7 +19,4 @@ auto_source_group(fizz "${FIZZ_DIR}" ${files} ${hfiles})
 find_package(OpenSSL REQUIRED)
 include_directories(${OPENSSL_INCLUDE_DIR} ${FIZZ_DIR})
 
-add_dependencies(fizz libsodiumMaybeBuild)
-target_include_directories(fizz PUBLIC "${LIBSODIUM_INCLUDE_DIRS}")
-
 target_link_libraries(fizz folly boost brotli zstd libsodium ${OPENSSL_LIBRARIES})

--- a/third-party/folly/CMakeLists.txt
+++ b/third-party/folly/CMakeLists.txt
@@ -158,8 +158,6 @@ target_link_libraries(folly fmt)
 add_dependencies(folly boostMaybeBuild)
 target_link_libraries(folly boost)
 
-add_dependencies(folly libsodiumMaybeBuild)
-target_include_directories(folly PUBLIC "${LIBSODIUM_INCLUDE_DIRS}")
 target_link_libraries(folly libsodium)
 
 find_package(Glog REQUIRED)

--- a/third-party/libsodium/CMakeLists.txt
+++ b/third-party/libsodium/CMakeLists.txt
@@ -1,18 +1,49 @@
-cmake_minimum_required(VERSION 2.8.0)
-include(ExternalProject)
-set(LIBSODIUM_DIR "${CMAKE_CURRENT_SOURCE_DIR}/libsodium")
-ExternalProject_Add(
-  libsodiumBuild
-  SOURCE_DIR "${LIBSODIUM_DIR}"
-  CONFIGURE_COMMAND
-  ./configure "--prefix=${CMAKE_CURRENT_BINARY_DIR}/install"
-    --disable-debug
-    --disable-dependency-tracking
-    --disable-shared
-    --enable-static
-  PREFIX "${CMAKE_CURRENT_BINARY_DIR}/install"
-  BUILD_IN_SOURCE true
-)
-set(LIBSODIUM_INCLUDEDIR "${CMAKE_CURRENT_BINARY_DIR}/install/include" PARENT_SCOPE)
-set(LIBSODIUM_INCLUDE_DIRS "${CMAKE_CURRENT_BINARY_DIR}/install/include" PARENT_SCOPE)
-set(LIBSODIUM_LIBRARIES "${CMAKE_CURRENT_BINARY_DIR}/install/lib/${CMAKE_STATIC_LIBRARY_PREFIX}sodium${CMAKE_STATIC_LIBRARY_SUFFIX}" PARENT_SCOPE)
+add_library(libsodium INTERFACE)
+target_compile_definitions(libsodium INTERFACE -DHAVE_LIBSODIUM=1)
+option(FORCE_BUNDLED_LIBSODIUM "Always build libsodium, instead of using the system version" OFF)
+
+if (NOT FORCE_BUNDLED_LIBSODIUM)
+  find_package(LibSodium 1.0.9)
+endif ()
+
+# Explicitly check FORCE_BUNDLED_LIBSODIUM again in case the other vars are cached
+# from a previous run
+if (LIBSODIUM_INCLUDE_DIRS AND LIBSODIUM_LIBRARIES AND NOT FORCE_BUNDLED_LIBSODIUM)
+  message(STATUS "Using system libsodium ${LIBSODIUM_VERSION}")
+  target_include_directories(libsodium INTERFACE ${LIBSODIUM_INCLUDE_DIRS})
+  target_link_libraries(libsodium INTERFACE ${LIBSODIUM_LIBRARIES})
+else ()
+  message(STATUS "Using third-party bundled libsodium")
+
+  include(ExternalProject)
+  include(HPHPFunctions)
+
+  SET_HHVM_THIRD_PARTY_SOURCE_ARGS(
+    LIBSODIUM_DOWNLOAD_ARGS
+    SOURCE_URL
+    "https://github.com/jedisct1/libsodium/releases/download/1.0.18-RELEASE/libsodium-1.0.18.tar.gz"
+    SOURCE_HASH
+    "SHA512=17e8638e46d8f6f7d024fe5559eccf2b8baf23e143fadd472a7d29d228b186d86686a5e6920385fe2020729119a5f12f989c3a782afbd05a8db4819bb18666ef"
+  )
+
+  ExternalProject_Add(
+    bundled_libsodium
+    ${LIBSODIUM_DOWNLOAD_ARGS}
+    CONFIGURE_COMMAND
+    <SOURCE_DIR>/configure
+      "--prefix=<INSTALL_DIR>"
+      "--libdir=<INSTALL_DIR>/lib"
+      "--includedir=<INSTALL_DIR>/include"
+      --disable-debug
+      --disable-dependency-tracking
+      --disable-shared
+      --enable-static
+  )
+  ExternalProject_Get_Property(bundled_libsodium INSTALL_DIR)
+  target_include_directories(libsodium INTERFACE "${INSTALL_DIR}/include")
+  target_link_libraries(
+    libsodium
+    INTERFACE
+    "${INSTALL_DIR}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}sodium${CMAKE_STATIC_LIBRARY_SUFFIX}"
+  )
+endif ()

--- a/third-party/lz4/CMakeLists.txt
+++ b/third-party/lz4/CMakeLists.txt
@@ -1,29 +1,41 @@
 add_library(lz4 INTERFACE)
 
-find_package(LZ4)  # also checks minimum required version
+option(FORCE_BUNDLED_LZ4 "Always build lz4, instead of using the system version" ON)
 
-if (LZ4_FOUND)
+if (NOT FORCE_BUNDLED_LZ4)
+  find_package(LZ4)  # also checks minimum required version
+endif ()
+
+if (LZ4_FOUND AND NOT FORCE_BUNDLED_LZ4)
   target_include_directories(lz4 INTERFACE ${LZ4_INCLUDE_DIR})
   target_link_libraries(lz4 INTERFACE ${LZ4_LIBRARY})
-
-else (LZ4_FOUND)
+else ()
   cmake_minimum_required(VERSION 2.8.0)
   include(ExternalProject)
+  include(HPHPFunctions)
 
+  SET_HHVM_THIRD_PARTY_SOURCE_ARGS(
+    LZ4_DOWNLOAD_ARGS
+    SOURCE_URL "https://github.com/lz4/lz4/archive/v1.9.2.tar.gz"
+    SOURCE_HASH "SHA256=658ba6191fa44c92280d4aa2c271b0f4fbc0e34d249578dd05e50e76d0e5efcc"
+  )
+  set(MAKE_ARGS MOREFLAGS=-fPIC)
   ExternalProject_Add(
-    lz4Build
-    URL "https://github.com/lz4/lz4/archive/v1.9.2.tar.gz"
-    URL_HASH SHA256=658ba6191fa44c92280d4aa2c271b0f4fbc0e34d249578dd05e50e76d0e5efcc
+    bundled_lz4
+    ${LZ4_DOWNLOAD_ARGS}
     BUILD_IN_SOURCE true
     CONFIGURE_COMMAND ""
-    BUILD_COMMAND ""
-    INSTALL_COMMAND make MOREFLAGS=-fPIC PREFIX=<INSTALL_DIR> install
+    BUILD_COMMAND \$\(MAKE\) ${MAKE_ARGS}
+    INSTALL_COMMAND \$\(MAKE\) ${MAKE_ARGS} PREFIX=<INSTALL_DIR> install
   )
 
-  ExternalProject_Get_Property(lz4Build INSTALL_DIR)
+  ExternalProject_Get_Property(bundled_lz4 INSTALL_DIR)
 
-  add_dependencies(lz4 lz4Build)
+  add_dependencies(lz4 bundled_lz4)
   target_include_directories(lz4 INTERFACE "${INSTALL_DIR}/include")
-  target_link_libraries(lz4 INTERFACE "${INSTALL_DIR}/lib/liblz4.a")
-
-endif (LZ4_FOUND)
+  target_link_libraries(
+    lz4
+    INTERFACE
+    "${INSTALL_DIR}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}lz4${CMAKE_STATIC_LIBRARY_SUFFIX}"
+  )
+endif ()

--- a/third-party/proxygen/CMakeLists.txt
+++ b/third-party/proxygen/CMakeLists.txt
@@ -83,9 +83,6 @@ endif()
 add_library(hphp_proxygen STATIC ${CXX_SOURCES})
 target_include_directories(hphp_proxygen PUBLIC ${PROXYGEN_GENERATED_ROOT})
 
-add_dependencies(hphp_proxygen libsodiumMaybeBuild)
-target_include_directories(hphp_proxygen PUBLIC "${LIBSODIUM_INCLUDE_DIRS}")
-
 target_link_libraries(hphp_proxygen wangle zstd boost
   fizz libsodium
   ${LIBGLOG_LIBRARY} ${LIBPTHREAD_LIBRARIES})


### PR DESCRIPTION
Summary:
- fewer submodules; only download these when building hhvm, not just hack
- the DOWNLOAD_ARGS macro lets us cache the downloads internally ('manifold')
- simplify the targets; the whole maybeBuild thing is due to a limitation in versions of cmake that we no longer support
- use new 'bundled_' convention for the target names

Reviewed By: jjergus

Differential Revision: D22962168

