### PR TITLE
Erase files before updating them

### DIFF
--- a/hphp/runtime/ext/facts/symbol-map-defs.h
+++ b/hphp/runtime/ext/facts/symbol-map-defs.h
@@ -695,6 +695,7 @@ void SymbolMap<S>::update(
 
   // Write information about base and derived types
   for (auto i = 0; i < alteredPaths.size(); i++) {
+    wlock->removePath(db, txn, Path<S>{alteredPaths[i]});
     wlock->updatePath(Path<S>{alteredPaths[i]}, alteredPathFacts[i]);
   }
 


### PR DESCRIPTION
Summary:
We've been seeing a number of situations where old types wouldn't get evicted from a subtypes query, or from a types-with-attribute query.

scotthovestadt finally managed to reproduce this problem. To do so, you need to move a type from one file to another, at the same time, without deleting either file.

It's pretty tricky to do in prod (and it's impressive he was able to figure this out!), but fortunately it's actually pretty easy to add this repro as a unit test.

The unit test starts passing if we erase files before updating them. This is something we already do in SQLFacts. I wasn't sure if we needed to do this for native Facts, so... I left it off because I didn't have proof we needed it{emoji:1f613}

Now we have proof, so let's erase files before we update them.

Differential Revision: D27496919

