### PR TITLE
stop repeating input in hphpd when using editline

### DIFF
--- a/hphp/runtime/debugger/debugger_client.cpp
+++ b/hphp/runtime/debugger/debugger_client.cpp
@@ -1231,10 +1231,6 @@ void DebuggerClient::console() {
         // treat ^D as quit
         print("quit");
         line = "quit";
-      } else {
-#ifdef USE_EDITLINE
-        print("%s", line); // Stay consistent with the readline library
-#endif
       }
     } else if (!NoPrompt && RuntimeOption::EnableDebuggerPrompt) {
       print("%s%s", getPrompt().c_str(), line);
@@ -1400,9 +1396,6 @@ char DebuggerClient::ask(const char *fmt, ...) {
   fflush(stdout);
   auto input = readline("");
   if (input == nullptr) return ' ';
-#ifdef USE_EDITLINE
-  print("%s", input); // Stay consistent with the readline library
-#endif
   if (strlen(input) > 0) return tolower(input[0]);
   return ' ';
 }


### PR DESCRIPTION
Summary:
On every supported platform, we get:

```
hphpd> =vec[123]
=vec[123]
Vec
(
    [0] => 123
)
```

note the extra `=vec[123]` line.

Given this is clearly intentional, I'm guessing this was needed for older versions of libedit/libeditline.

We use editline in open source builds due to readline's license.

Differential Revision: D27623901

