### PR TITLE
setlocale get

### DIFF
--- a/hphp/runtime/base/thread-safe-setlocale.cpp
+++ b/hphp/runtime/base/thread-safe-setlocale.cpp
@@ -21,6 +21,8 @@
 #include "hphp/runtime/base/execution-context.h"
 #include "hphp/util/rds-local.h"
 
+#include <dlfcn.h>
+
 /*
  * This class reimplements the setlocale() and localeconv() functions
  * in a thread-safe manner and provides stronger symbols for them than
@@ -51,39 +53,101 @@ namespace HPHP {
 RDS_LOCAL(ThreadSafeLocaleHandler, g_thread_safe_locale_handler);
 RDS_LOCAL(struct lconv, g_thread_safe_localeconv_data);
 
+namespace {
+
 static const locale_t s_null_locale = (locale_t) 0;
 
-ThreadSafeLocaleHandler::ThreadSafeLocaleHandler() {
-#define FILL_IN_CATEGORY_LOCALE_MAP(category) \
-  {category, category ## _MASK, #category, ""}
-  m_category_locale_map = {
-      FILL_IN_CATEGORY_LOCALE_MAP(LC_CTYPE),
-      FILL_IN_CATEGORY_LOCALE_MAP(LC_NUMERIC),
-      FILL_IN_CATEGORY_LOCALE_MAP(LC_TIME),
-      FILL_IN_CATEGORY_LOCALE_MAP(LC_COLLATE),
-      FILL_IN_CATEGORY_LOCALE_MAP(LC_MONETARY),
-      #ifndef _MSC_VER
-      FILL_IN_CATEGORY_LOCALE_MAP(LC_MESSAGES),
-      #endif
-      FILL_IN_CATEGORY_LOCALE_MAP(LC_ALL),
-      #if !defined(__APPLE__) && !defined(_MSC_VER)
-      FILL_IN_CATEGORY_LOCALE_MAP(LC_PAPER),
-      FILL_IN_CATEGORY_LOCALE_MAP(LC_NAME),
-      FILL_IN_CATEGORY_LOCALE_MAP(LC_ADDRESS),
-      FILL_IN_CATEGORY_LOCALE_MAP(LC_TELEPHONE),
-      FILL_IN_CATEGORY_LOCALE_MAP(LC_MEASUREMENT),
-      FILL_IN_CATEGORY_LOCALE_MAP(LC_IDENTIFICATION),
-      #endif
-  };
-#undef FILL_IN_CATEGORY_LOCALE_MAP
+} // namespace
 
-#ifdef _MSC_VER
-  _configthreadlocale(_ENABLE_PER_THREAD_LOCALE);
-  ::setlocale(LC_ALL, "C");
+#if defined(_MSC_VER)
+#define FILL_IN_CATEGORY_LOCALE_MAP() \
+      CATEGORY_LOCALE_MAP_ENTRY(LC_CTYPE), \
+      CATEGORY_LOCALE_MAP_ENTRY(LC_NUMERIC), \
+      CATEGORY_LOCALE_MAP_ENTRY(LC_TIME), \
+      CATEGORY_LOCALE_MAP_ENTRY(LC_COLLATE), \
+      CATEGORY_LOCALE_MAP_ENTRY(LC_MONETARY), \
+      CATEGORY_LOCALE_MAP_ENTRY(LC_ALL)
+#elif defined(__APPLE__)
+#define FILL_IN_CATEGORY_LOCALE_MAP() \
+      CATEGORY_LOCALE_MAP_ENTRY(LC_CTYPE), \
+      CATEGORY_LOCALE_MAP_ENTRY(LC_NUMERIC), \
+      CATEGORY_LOCALE_MAP_ENTRY(LC_TIME), \
+      CATEGORY_LOCALE_MAP_ENTRY(LC_COLLATE), \
+      CATEGORY_LOCALE_MAP_ENTRY(LC_MONETARY), \
+      CATEGORY_LOCALE_MAP_ENTRY(LC_MESSAGES), \
+      CATEGORY_LOCALE_MAP_ENTRY(LC_ALL)
+#elif defined(__GLIBC__)
+#define FILL_IN_CATEGORY_LOCALE_MAP()  \
+      CATEGORY_LOCALE_MAP_ENTRY(LC_CTYPE), \
+      CATEGORY_LOCALE_MAP_ENTRY(LC_NUMERIC), \
+      CATEGORY_LOCALE_MAP_ENTRY(LC_TIME), \
+      CATEGORY_LOCALE_MAP_ENTRY(LC_COLLATE), \
+      CATEGORY_LOCALE_MAP_ENTRY(LC_MONETARY), \
+      CATEGORY_LOCALE_MAP_ENTRY(LC_MESSAGES), \
+      CATEGORY_LOCALE_MAP_ENTRY(LC_ALL), \
+      CATEGORY_LOCALE_MAP_ENTRY(LC_PAPER), \
+      CATEGORY_LOCALE_MAP_ENTRY(LC_NAME), \
+      CATEGORY_LOCALE_MAP_ENTRY(LC_ADDRESS), \
+      CATEGORY_LOCALE_MAP_ENTRY(LC_TELEPHONE), \
+      CATEGORY_LOCALE_MAP_ENTRY(LC_MEASUREMENT), \
+      CATEGORY_LOCALE_MAP_ENTRY(LC_IDENTIFICATION)
 #else
-  m_locale = s_null_locale;
+#error "Unsupported platform"
 #endif
 
+ThreadSafeLocaleHandler::LocaleInfo ThreadSafeLocaleHandler::getCLocale() {
+  static std::optional<ThreadSafeLocaleHandler::LocaleInfo> li;
+  if (li) {
+    return *li;
+  }
+  auto locale = newlocale(LC_ALL, "C", (locale_t) 0);
+
+  std::vector<CategoryAndLocaleMap> category_map = {
+#define CATEGORY_LOCALE_MAP_ENTRY(category) \
+  {category, category ## _MASK, #category, "C"}
+    FILL_IN_CATEGORY_LOCALE_MAP()
+#undef CATEGORY_LOCALE_MAP_ENTRY
+  };
+
+  li = std::make_tuple(locale, category_map);
+  return *li;
+}
+
+ThreadSafeLocaleHandler::LocaleInfo ThreadSafeLocaleHandler::getEnvLocale() {
+  static std::optional<ThreadSafeLocaleHandler::LocaleInfo> li;
+  if (li) {
+    return *li;
+  }
+  auto locale = newlocale(LC_ALL, "", (locale_t) 0);
+  // Per POSIX, a processes' default locale is "C" until `setlocale()` is
+  // called; to use env from environment, `setlocale(LC_ALL, "")` should
+  // be called.
+  //
+  // Can't actually check that nothing in HHVM has set the locale yet, but
+  // this is pretty close.
+  //
+  // Asserting as we restore it later. The alternative would be to store
+  // the original locale for each category, but if we're setting process
+  // locale somewhere else, this should be re-reviewed anyway
+  auto real_setlocale = reinterpret_cast<decltype(&setlocale)>(dlsym(RTLD_NEXT, "setlocale"));
+  assertx(!strcmp((*real_setlocale)(LC_ALL, nullptr), "C"));
+  // ... but to find out what the env locale actually is, we need to use it
+  (*real_setlocale)(LC_ALL, "");
+  SCOPE_EXIT { (*real_setlocale)(LC_ALL, "C"); };
+
+  std::vector<CategoryAndLocaleMap> map = {
+#define CATEGORY_LOCALE_MAP_ENTRY(category) \
+  {category, category ## _MASK, #category, strdup((*real_setlocale)(category, nullptr))}
+    FILL_IN_CATEGORY_LOCALE_MAP()
+#undef CATEGORY_LOCALE_MAP_ENTRY
+  };
+
+  li = std::make_tuple(locale, map);
+  return *li;
+}
+
+ThreadSafeLocaleHandler::ThreadSafeLocaleHandler() {
+  m_locale = s_null_locale;
   reset();
 }
 
@@ -92,16 +156,12 @@ ThreadSafeLocaleHandler::~ThreadSafeLocaleHandler() {
 }
 
 void ThreadSafeLocaleHandler::reset() {
-#ifdef _MSC_VER
-  ::setlocale(LC_ALL, "C");
-#else
   if (m_locale != s_null_locale) {
     freelocale(m_locale);
-    m_locale = s_null_locale;
   }
-
-  uselocale(LC_GLOBAL_LOCALE);
-#endif
+  std::tie(m_locale, m_category_locale_map) = getCLocale();
+  m_locale = duplocale(m_locale);
+  uselocale(m_locale);
 }
 
 const char* ThreadSafeLocaleHandler::actuallySetLocale(
@@ -185,19 +245,29 @@ const char* ThreadSafeLocaleHandler::actuallySetLocale(
          */
         for (auto &i : m_category_locale_map) {
           if (i.category_str == key) {
-            i.locale_str = value ? value : "";
+            i.locale_str = value ? value : "C";
             break;
           }
         }
       }
 
       free(locale_cstr_copy);
+    } else if (locale_cstr[0] == 0) {
+      auto [_, env_map] = getEnvLocale();
+      m_category_locale_map = env_map;
+      // LC_CTYPE is arbitrary: as we've set LC_ALL, any works
+      locale_cstr = env_map[LC_CTYPE].locale_str.c_str();
     } else {
       /* Copy the locale into all categories */
       for (auto &i : m_category_locale_map) {
         i.locale_str = locale_cstr;
       }
     }
+  } else if (locale_cstr[0] == 0) {
+    auto [_, env_map] = getEnvLocale();
+    auto& locale_str = env_map[category].locale_str;
+    m_category_locale_map[category].locale_str = locale_str;
+    locale_cstr = locale_str.c_str();
   } else {
     m_category_locale_map[category].locale_str = locale_cstr;
   }

--- a/hphp/runtime/base/thread-safe-setlocale.h
+++ b/hphp/runtime/base/thread-safe-setlocale.h
@@ -47,6 +47,10 @@ private:
 #ifndef _MSC_VER
   locale_t m_locale;
 #endif
+
+  typedef std::tuple<locale_t, std::vector<CategoryAndLocaleMap>> LocaleInfo;
+  static LocaleInfo getCLocale();
+  static LocaleInfo getEnvLocale();
 };
 
 extern RDS_LOCAL(ThreadSafeLocaleHandler, g_thread_safe_locale_handler);


### PR DESCRIPTION
- Guarantee query results in post operation callback
- correctly emit shapes with unknown fields only
- Add bespoke support for APC
- Bump BespokeStructDictMaxNumKeys
- porting hh_naming_table_builder to rust
- Log fanout on --config log_categories=fanout_information for lazy incremental fanouts
- Log fanout on --config log_categories=fanout_information on saved-state init
- Add --dump-dep-hashes mode to dump the dep-hash-to-symbol map for a file
- Add fanout test for saved-state scenario
- Fanout tests for incremental change without old decls
- Fanout tests for incremental change with old decls
- Add fanout test related to changing the position of other types in the file
- Add fanout test for changes to functions
- Add fanout test for changes to typedefs
- Add fanout test for changes to global constants
- Remove deadcode related to disable_conservative_redecl
- Remove unused FunName dep type
- Add fanout test for changes to class members (excluding signatures)
- Add fanout test for changes to class member signatures
- Add fanout test for changes to "big diff" class properties
- Add hover tooltip option to hh_single_type_check
- do not emit `__construct` twice when it is the target method
- Add flag to treat require extends and implements as ancestors in the class check
- Update flag name
- Bespoke support for static props
- Add runtime definition for `HH\ParseTree`
- add watchman to third-party, build ext_facts and ext_watchman by default (#8820)
- Add flag to enable abstract context constants
- Add readonly to select collection interfaces
- Relax <<_SDT>> static method interfaces when checking <<__SDT>> method bodies
- add queue metrics like we have for pagelets
- Fix setlocale() with magic locale strings
