### PR TITLE
Fix BufferedReader::readByteAsync after default buffer size

### DIFF
--- a/hphp/hsl/src/io/BufferedReader.php
+++ b/hphp/hsl/src/io/BufferedReader.php
@@ -268,7 +268,6 @@ final class BufferedReader implements IO\ReadHandle {
     $ret = $this->buffer[0];
     if ($ret === $this->buffer) {
       $this->buffer = '';
-      $this->eof = true;
       return $ret;
     }
     $this->buffer = Str\slice($this->buffer, 1);


### PR DESCRIPTION
Fixes https://github.com/facebook/hhvm/issues/8859

- existing check is incorrect at chunk boundary
- unneeded as `BufferedReader::isEndOfFile()` checks if there is more data available if EOF flag is false and buffer is empty

Test plan:

new unit test
