### PR TITLE
Enable SSE4.2 by default in open source builds

### DIFF
--- a/CMake/Options.cmake
+++ b/CMake/Options.cmake
@@ -6,7 +6,7 @@ option(STATIC_CXX_LIB "Statically link libstd++ and libgcc." OFF)
 option(ENABLE_AVX2 "Enable the use of AVX2 instructions" OFF)
 option(ENABLE_AARCH64_CRC "Enable the use of CRC instructions" OFF)
 option(ENABLE_FASTCGI "Enable the FastCGI interface." ON)
-option(ENABLE_SSE4_2 "Enable SSE4.2 supported code." OFF)
+option(ENABLE_SSE4_2 "Enable SSE4.2 supported code." ON)
 
 option(EXECUTION_PROFILER "Enable the execution profiler" OFF)
 


### PR DESCRIPTION
Summary:
It looks like we depend on SSE 4.2 implicitly already, might as well do it explicitly to enable performance
improvements. Changing the baseline cpu build for our MacOS builds led to a 20x improvement in some real-world cases.

I plan to remove the option if there isn't negative feedback about it.

Reviewed By: ricklavoie

Differential Revision: D30074423

