### PR TITLE
add Locale\

### DIFF
--- a/hphp/hack/hhi/hsl/ext_hsl_locale.hhi
+++ b/hphp/hack/hhi/hsl/ext_hsl_locale.hhi
@@ -27,6 +27,12 @@ function set_request_locale(Locale $loc): void;
 function newlocale_mask(int $mask, string $locale, Locale $base): Locale;
 /** Take a single category, e.g. `LC_TYPE` */
 function newlocale_category(int $category, string $locale, Locale $base): Locale;
+/** Create a new locale object using the specified locale for all categories.
+ *
+ * This function will throw if a 'magic' locale is passed, e.g.
+ * `"0"` (fetch current locale) or `""` (environment locale).
+ */
+function newlocale_all(string $locale)[]: Locale;
 
 // --- platform-specific constants ---
 // more are defined for every platform, but the HHI is only including ones that

--- a/hphp/hsl/minitest.sh
+++ b/hphp/hsl/minitest.sh
@@ -24,5 +24,4 @@ exec "${HHVM_BIN}" \
   -vEval.HSLSystemlibEnabled=false \
   -vAutoload.Enabled=true \
   "-vAutoload.DB.Path=${AUTOLOAD_DB_DIR}/autoload.db" \
-  "-vAutoload.DBPath=${AUTOLOAD_DB_DIR}/autoload.db" \
   minitest/main.hack "$@"

--- a/hphp/hsl/src/locale/Category.php
+++ b/hphp/hsl/src/locale/Category.php
@@ -1,0 +1,23 @@
+<?hh
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace HH\Lib\Locale;
+
+use namespace HH\Lib\_Private\_Locale;
+
+enum Category: int {
+  LC_ALL = _Locale\LC_ALL;
+  LC_COLLATE = _Locale\LC_COLLATE;
+  LC_CTYPE = _Locale\LC_CTYPE;
+  LC_MONETARY = _Locale\LC_MONETARY;
+  LC_NUMERIC = _Locale\LC_NUMERIC;
+  LC_TIME = _Locale\LC_TIME;
+  LC_MESSAGES = _Locale\LC_MESSAGES;
+};

--- a/hphp/hsl/src/locale/Locale.php
+++ b/hphp/hsl/src/locale/Locale.php
@@ -1,0 +1,19 @@
+<?hh
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace HH\Lib\Locale;
+
+/** An object representing a locale and related settings.
+ *
+ * This also encapsulates the various `LC_*` settings, so, for example,
+ * `LC_CTYPE` can indicate UTF-8, and `LC_COLLATE` and `LC_NUMERIC` can
+ * be set to differing locations (e.g. `en_US` or and `fr_FR`).
+ */
+type Locale = \HH\Lib\_Private\_Locale\Locale;

--- a/hphp/hsl/src/locale/mutate.php
+++ b/hphp/hsl/src/locale/mutate.php
@@ -1,0 +1,55 @@
+<?hh
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace HH\Lib\Locale;
+
+use namespace HH\Lib\_Private\_Locale;
+
+/**
+ * Create a new `Locale` object.
+ *
+ * The input should be of the form `country[.encoding]`, for example:
+ * `"C"`, `en_US`, `en_US.UTF-8`.
+ *
+ * If present, the encoding currently **must** be 'UTF-8'.
+ *
+ * This will throw on 'magic' locales such as:
+ * - the empty string: use `from_environment()`
+ * - `'0'`: use `get()`
+ */
+function create(string $locale)[]: Locale {
+  return _Locale\newlocale_all($locale);
+}
+
+/**
+ * Create a new `Locale` object, based on an existing one.
+ *
+ * The input should be of the form `country[.encoding]`, for example:
+ * `"C"`, `en_US`, `en_US.UTF-8`.
+ *
+ * If present, the encoding currently **must** be 'UTF-8'.
+ *
+ * The empty string is not considered a valid locale in Hack; the libc behavior
+ * is equivalent to `get()`.
+ */
+function modified(Locale $orig, Category $cat, string $new): Locale {
+  if ($new === '') {
+    // '' is the magic 'fetch from environment'
+    throw new InvalidLocaleException(
+      "Empty string passed; use `Locale\\from_environment() instead."
+    );
+  }
+
+  return _Locale\newlocale_category(
+    (int) $cat,
+    $new,
+    $orig,
+  );
+}

--- a/hphp/hsl/src/locale/predefined.php
+++ b/hphp/hsl/src/locale/predefined.php
@@ -1,0 +1,58 @@
+<?hh
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace HH\Lib\Locale;
+
+use namespace HH\Lib\_Private\_Locale;
+
+/** Retrieve the constant "C" locale.
+ *
+ * This locale is also known as `"POSIX"` or `"en_US_POSIX"`. It is *not* the
+ * current libc locale.
+ *
+ * @see `get()`
+ */
+function c()[]: Locale {
+  return _Locale\get_c_locale();
+}
+
+/** Retrieve the locale being used by libc functions for the current thread.
+ *
+ * In general, we discourage this: it can be surprising that it changes the
+ * behavior of many libc functions, like `sprintf('%f'`), and error messages
+ * from native code may be translated.
+ *
+ * For web applications, that's likely unwanted - we recommend frameworks add
+ * the concept of a 'viewer locale', and explicitly pass it to the relevant
+ * string functions instead.
+ */
+function get(): Locale {
+  return _Locale\get_request_locale();
+}
+
+/** Set the libc locale for the current thread.
+ *
+ * This is highly discouraged; see the note for `get()` for details.
+ */
+function set(Locale $loc): void {
+  _Locale\set_request_locale($loc);
+}
+
+/** Retrieve the active locale from the native environment.
+ *
+ * This is usually set based on the `LC_*` environment variables.
+ *
+ * Web applications targetting diverse users should probably not use this,
+ * however it is useful when aiming to support diverse users in CLI
+ * programs.
+ */
+function from_environment(): Locale {
+  return _Locale\get_environment_locale();
+}

--- a/hphp/hsl/tests/locale/LocaleTest.php
+++ b/hphp/hsl/tests/locale/LocaleTest.php
@@ -1,0 +1,89 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the hphp/hsl/ subdirectory of this source tree.
+ *
+ */
+
+// Using `_Str` for now to test locales before they're exposed to `Str\`
+use namespace HH\Lib\{Locale, _Private\_Str};
+use function HH\__Private\MiniTest\expect;
+use type HH\__Private\MiniTest\HackTest;
+
+// Intentionally using \sprintf() instead of Str\format() throughout as we want
+// to test the request/thread locale, regardless of future changes to
+// Str\format(), which we expect to change to always use 'C'
+final class LocaleTest extends HackTest {
+  public function __construct() {
+    // Hopefully no-op...
+    \setlocale(\LC_ALL, "C");
+    // Prime the autoloader. HACKY HACK HACK. FIXME.
+    //
+    // As of 2021-08-17, the autoloader fails to find `ExpectObj` if the
+    // locale is `fr_FR`. Let's pre-load.
+    //
+    // To reproduce the failure:
+    // - change the `"C"` above to `"fr_FR"`
+    // - `cd fbcode/hphp/hsl; ./minitest.sh LocaleTest`
+    expect(123)->toEqual(123);
+  }
+
+  public function testCLocale(): void {
+    \setlocale(\LC_ALL, "fr_FR");
+    try {
+      // Make sure the `\setlocale()` worked
+      expect(\sprintf("%.02f", 1.23))->toEqual('1,23');
+
+      $l = Locale\c();
+      expect(_Str\strlen_l("💩", $l))->toEqual(4);
+      expect(_Str\vsprintf_l($l, "%.02f", vec[1.23]))->toEqual('1.23');
+    } finally {
+      \setlocale(\LC_ALL, "C");
+    }
+  }
+
+  public function testUTF8Locale(): void {
+    \setlocale(\LC_ALL, "en_US.UTF-8");
+    try {
+      // Make sure the `\setlocale()` worked
+      expect(\sprintf("%.02f", 1.23))->toEqual('1.23');
+
+      $l = Locale\create('fr_FR.UTF8');
+      expect(_Str\strlen_l("💩", $l))->toEqual(1);
+      expect(_Str\vsprintf_l($l, "%.02f", vec[1.23]))->toEqual('1,23');
+    } finally {
+      \setlocale(\LC_ALL, "C");
+    }
+  }
+
+  public function testGetSet(): void {
+    \setlocale(\LC_ALL, "fr_FR");
+    try {
+      expect(\setlocale(\LC_NUMERIC, '0'))->toEqual('fr_FR');
+      $l = Locale\get();
+      \setlocale(\LC_ALL, "C");
+      expect(\setlocale(\LC_NUMERIC, '0'))->toEqual('C');
+      expect(\sprintf('%.02f', 1.23))->toEqual('1.23');
+      expect(_Str\vsprintf_l($l, '%.02f', vec[1.23]))->toEqual('1,23');
+      Locale\set($l);
+      expect(\sprintf('%.02f', 1.23))->toEqual('1,23');
+      expect(\setlocale(\LC_NUMERIC, '0'))->toEqual('fr_FR');
+    } finally {
+      \setlocale(\LC_ALL, "C");
+    }
+  }
+
+  public function testModified(): void {
+    $c = Locale\c();
+    expect(_Str\strlen_l('💩', $c))->toEqual(4);
+    $c_utf8 = Locale\modified($c, Locale\Category::LC_CTYPE, 'en_US.UTF-8');
+    expect(_Str\strlen_l('💩', $c_utf8))->toEqual(1);
+    $fr_numeric = Locale\modified($c, Locale\Category::LC_NUMERIC, 'fr_FR.UTF-8');
+    // as we didn't change LC_CTYPE, count bytes
+    expect(_Str\strlen_l('💩', $fr_numeric))->toEqual(4);
+    expect(_Str\vsprintf_l($fr_numeric, '%.02f', vec['1.23']))->toEqual('1,23');
+  }
+}

--- a/hphp/runtime/ext/hsl/ext_hsl_locale.cpp
+++ b/hphp/runtime/ext/hsl/ext_hsl_locale.cpp
@@ -150,6 +150,31 @@ Object HHVM_FUNCTION(newlocale_category,
   return HSLLocale::newInstance(loc);
 }
 
+Object HHVM_FUNCTION(newlocale_all,
+                     const String& locale) {
+  // As this function is pure:
+  // - we need to ban all the magic behavior
+  // - implemented in C++ instead of Hack so that we can enforce purity in
+  //   Hack code in the future.
+  if (locale.isNull()) {
+    throw_object(
+      s_InvalidLocaleException,
+      make_vec_array("Locale must not be null")
+    );
+  }
+  if (locale.empty() || (locale.length() == 1 && locale[0] == '0')) {
+    throw_object(
+      s_InvalidLocaleException,
+      make_vec_array("Magic locales are not supported.")
+    );
+  }
+  return HHVM_FN(newlocale_mask)(
+    LC_ALL_MASK,
+    locale,
+    HHVM_FN(get_c_locale)()
+  );
+}
+
 struct LocaleExtension final : Extension {
 
   LocaleExtension() : Extension("hsl_locale", "0.1") {}
@@ -166,6 +191,7 @@ struct LocaleExtension final : Extension {
     HHVM_FALIAS(HH\\Lib\\_Private\\_Locale\\set_request_locale, set_request_locale);
     HHVM_FALIAS(HH\\Lib\\_Private\\_Locale\\newlocale_mask, newlocale_mask);
     HHVM_FALIAS(HH\\Lib\\_Private\\_Locale\\newlocale_category, newlocale_category);
+    HHVM_FALIAS(HH\\Lib\\_Private\\_Locale\\newlocale_all, newlocale_all);
 
 #define LC_(x) \
     HHVM_RC_INT(HH\\Lib\\_Private\\_Locale\\LC_##x, LC_##x); \

--- a/hphp/runtime/ext/hsl/ext_hsl_locale.php
+++ b/hphp/runtime/ext/hsl/ext_hsl_locale.php
@@ -40,10 +40,17 @@ function newlocale_mask(int $mask, string $locale, Locale $base): Locale;
 /** Take a single category, e.g. `LC_TYPE` */
 <<__Native>>
 function newlocale_category(int $category, string $locale, Locale $base): Locale;
+/** Create a new locale object using the specified locale for all categories.
+ *
+ * This function will throw if a 'magic' locale is passed, e.g.
+ * `"0"` (fetch current locale) or `""` (environment locale).
+ */
+<<__Native>>
+function newlocale_all(string $locale)[]: Locale;
 
 } // namespace _Locale
 
 namespace HH\Lib\Locale {
-  final class InvalidLocaleException extends \Exception {
+  final class InvalidLocaleException extends \InvalidArgumentException {
   }
 }

--- a/hphp/test/slow/ext_hsl/newlocale_all.php
+++ b/hphp/test/slow/ext_hsl/newlocale_all.php
@@ -1,0 +1,30 @@
+<?hh // strict
+
+use namespace HH\Lib\_Private\_Locale as L;
+use namespace HH\Lib\_Private\_Str;
+
+<<__EntryPoint>>
+function main(): void {
+  $en_gb = L\newlocale_all('en_GB.UTF-8');
+  $fr_fr = L\newlocale_all('fr_FR.UTF-8');
+  print _Str\vsprintf_l($en_gb, "%f\n", vec[1.23]);
+  print _Str\vsprintf_l($fr_fr, "%f\n", vec[1.23]);
+  print "Trying empty locale (env)\n";
+  try {
+    L\newlocale_all('');
+  } catch (InvalidArgumentException $e) {
+    \var_dump(\get_class($e), $e->getMessage());
+  }
+  print "Trying '0' locale (return)\n";
+  try {
+    L\newlocale_all('0');
+  } catch (InvalidArgumentException $e) {
+    \var_dump(\get_class($e), $e->getMessage());
+  }
+  print "Trying int 0 locale (type error)\n";
+  try {
+    L\newlocale_all(0);
+  } catch (Throwable $e) {
+    printf("%s\n", $e->getMessage());
+  }
+}

--- a/hphp/test/slow/ext_hsl/newlocale_all.php.expect
+++ b/hphp/test/slow/ext_hsl/newlocale_all.php.expect
@@ -1,0 +1,10 @@
+1.230000
+1,230000
+Trying empty locale (env)
+string(36) "HH\Lib\Locale\InvalidLocaleException"
+string(32) "Magic locales are not supported."
+Trying '0' locale (return)
+string(36) "HH\Lib\Locale\InvalidLocaleException"
+string(32) "Magic locales are not supported."
+Trying int 0 locale (type error)
+HH\Lib\_Private\_Locale\newlocale_all() expects parameter 1 to be string, integer given


### PR DESCRIPTION
Summary:
As part of string purity, we need to remove the implicit use of the thread locale.

To unblock that, we need to be able to explicitly retrieve and set it.

This diff is just about `Locale\`: the locale-aware string functions used here are
meant to be fairly close to libc, and are definitely not the desired API for `Str\`,
which will be a separate PR/diff.

This is meant to be enough `Locale\` for practical use of `Str\` and setting the request locale. It is not intended to be complete - in particular, it should probably be possible to inspect a locale without going via `\setlocale()` or depending on the debuginfo. Leaving that for later for use cases to develop.

Differential Revision: D29311121

