### PR TITLE
RFC: Add Str\foo_l UTF8-capable and locale-aware functions.

### DIFF
--- a/hphp/hsl/src/str/divide_l.php
+++ b/hphp/hsl/src/str/divide_l.php
@@ -1,0 +1,50 @@
+<?hh
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the hphp/hsl/ subdirectory of this source tree.
+ *
+ */
+
+namespace HH\Lib\Str;
+
+use namespace HH\Lib\{Locale, _Private\_Str};
+
+/**
+ * Returns a vec containing the string split into chunks with the given number
+ * of characters.
+ *
+ * $chunk_size is in characters,
+ *
+ * To split the string on a delimiter, see `Str\split_l()`.
+ */
+function chunk_l(
+  Locale\Locale $locale,
+  string $string,
+  int $chunk_size = 1,
+)[]: vec<string> {
+  /* HH_FIXME[4390] missing [] */
+  return _Str\chunk_l($string, $chunk_size, $locale);
+}
+
+/**
+ * Returns a vec containing the string split on the given delimiter. The vec
+ * will not contain the delimiter itself.
+ *
+ * If the limit is provided, the vec will only contain that many elements, where
+ * the last element is the remainder of the string.
+ *
+ * To split the string into equally-sized chunks, see `Str\chunk_l()`.
+ * To use a pattern as delimiter, see `Regex\split()`.
+ */
+function split_l(
+  Locale\Locale $locale,
+  string $string,
+  string $delimiter,
+  ?int $limit = null,
+)[]: vec<string> {
+  /* HH_FIXME[4390] missing [] */
+  return _Str\split_l($string, $delimiter, $limit, $locale);
+}

--- a/hphp/hsl/src/str/format_l.php
+++ b/hphp/hsl/src/str/format_l.php
@@ -1,0 +1,27 @@
+<?hh
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the hphp/hsl/ subdirectory of this source tree.
+ *
+ */
+
+namespace HH\Lib\Str;
+
+use namespace HH\Lib\Locale;
+use namespace HH\Lib\_Private\_Str;
+
+/**
+ * Given a valid format string (defined by `SprintfFormatString`), return a
+ * formatted string using `$format_args`
+ */
+function format_l(
+  Locale\Locale $locale,
+  SprintfFormatString $format_string,
+  mixed ...$format_args
+)[]: string {
+  /* HH_FIXME[4390] missing [] */
+  return _Str\vsprintf_l($locale, $format_string as string, $format_args);
+}

--- a/hphp/hsl/src/str/introspect.php
+++ b/hphp/hsl/src/str/introspect.php
@@ -139,6 +139,8 @@ function is_empty(
 
 /**
  * Returns the length of the given string, i.e. the number of bytes.
+ *
+ * @see `Str\length_l()` for the length in characters.
  */
 function length(
   string $string,

--- a/hphp/hsl/src/str/introspect_l.php
+++ b/hphp/hsl/src/str/introspect_l.php
@@ -1,0 +1,296 @@
+<?hh
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the hphp/hsl/ subdirectory of this source tree.
+ *
+ */
+
+namespace HH\Lib\Str;
+
+use namespace HH\Lib\{Locale, _Private, _Private\_Str};
+
+/**
+ * Returns < 0 if `$string1` is less than `$string2`, > 0 if `$string1` is
+ * greater than `$string2`, and 0 if they are equal.
+ *
+ * For a case-insensitive comparison, see `Str\compare_ci_l()`.
+ *
+ * Locale-specific collation rules will be followed, and strings will be
+ * normalized in encodings that support multiple representations of the same
+ * characters, such as UTF8.
+ */
+function compare_l(
+  Locale\Locale $locale,
+  string $string1,
+  string $string2,
+)[]: int {
+  /* HH_FIXME[4390] missing [] */
+  return _Str\strcoll_l($string1, $string2, $locale);
+}
+
+/**
+ * Returns < 0 if `$string1` is less than `$string2`, > 0 if `$string1` is
+ * greater than `$string2`, and 0 if they are equal (case-insensitive).
+ *
+ * For a case-sensitive comparison, see `Str\compare_l()`.
+ *
+ * Locale-specific collation and case-sensitivity rules will be used. For
+ * example, case-insensitive comparisons between `i`, `I`, `ı`, and `İ` vary
+ * by locale.
+ */
+function compare_ci_l(
+  Locale\Locale $locale,
+  string $string1,
+  string $string2,
+)[]: int {
+  /* HH_FIXME[4390] missing [] */
+  return _Str\strcasecmp_l($string1, $string2, $locale);
+}
+
+/**
+ * Returns whether the "haystack" string contains the "needle" string.
+ *
+ * An optional offset determines where in the haystack the search begins. If the
+ * offset is negative, the search will begin that many characters from the end
+ * of the string. If the offset is out-of-bounds, a ViolationException will be
+ * thrown.
+ *
+ * Strings will be normalized for comparison in encodings that support multiple
+ * representations, such as UTF-8.
+ *
+ * - To get the position of the needle, see `Str\search_l()`.
+ * - To search for the needle case-insensitively, see `Str\contains_ci_l()`.
+ */
+function contains_l(
+  Locale\Locale $locale,
+  string $haystack,
+  string $needle,
+  int $offset = 0,
+)[]: bool {
+  if ($needle === '') {
+    if ($offset === 0) {
+      return true;
+    }
+    $length = length_l($locale, $haystack);
+    if ($offset > $length || $offset < -$length) {
+      throw new \InvalidArgumentException(
+        format('Offset %d out of bounds for length %d', $offset, $length)
+      );
+    }
+    return true;
+  }
+  return search_l($locale, $haystack, $needle, $offset) !== null;
+}
+
+/**
+ * Returns whether the "haystack" string contains the "needle" string
+ * (case-insensitive).
+ *
+ * An optional offset determines where in the haystack the search begins. If the
+ * offset is negative, the search will begin that many characters from the end
+ * of the string. If the offset is out-of-bounds, a ViolationException will be
+ * thrown.
+ *
+ * Locale-specific rules for case-insensitive comparisons will be used, and
+ * strings will be normalized before comparing if the locale specifies an
+ * encoding that supports multiple representations of the same characters, such
+ * as UTF-8.
+ *
+ * - To search for the needle case-sensitively, see `Str\contains_l()`.
+ * - To get the position of the needle case-insensitively, see `Str\search_ci_l()`.
+ */
+function contains_ci_l(
+  Locale\Locale $locale,
+  string $haystack,
+  string $needle,
+  int $offset = 0,
+)[]: bool {
+  if ($needle === '') {
+    if ($offset === 0) {
+      return true;
+    }
+    $length = length_l($locale, $haystack);
+    if ($offset > $length || $offset < -$length) {
+      throw new \InvalidArgumentException(
+        format('Offset %d out of bounds for length %d', $offset, $length)
+      );
+    }
+    return true;
+  }
+  return search_ci_l($locale, $haystack, $needle, $offset) !== null;
+}
+
+/**
+ * Returns whether the string ends with the given suffix.
+ *
+ * Locale-specific rules for case-insensitive comparisons will be used, and
+ * strings will be normalized before comparing if the locale specifies an
+ * encoding that supports multiple representations of the same characters, such
+ * as UTF-8.
+ *
+ * For a case-insensitive check, see `Str\ends_with_ci_l()`.
+ */
+function ends_with_l(
+  Locale\Locale $locale,
+  string $string,
+  string $suffix,
+)[]: bool {
+  /* HH_FIXME[4390] missing [] */
+  return _Str\ends_with_l($string, $suffix, $locale);
+}
+
+/**
+ * Returns whether the string ends with the given suffix (case-insensitive).
+ *
+ * Locale-specific rules for case-insensitive comparisons will be used, and
+ * strings will be normalized before comparing if the locale specifies an
+ * encoding that supports multiple representations of the same characters, such
+ * as UTF-8.
+ *
+ * For a case-sensitive check, see `Str\ends_with_l()`.
+ */
+function ends_with_ci_l(
+  Locale\Locale $locale,
+  string $string,
+  string $suffix,
+)[]: bool {
+  /* HH_FIXME[4390] missing [] */
+  return _Str\ends_with_ci_l($string, $suffix, $locale);
+}
+
+/**
+ * Returns the length of the given string in characters.
+ *
+ * @see `Str\length()` (or pass `Locale\c()`) for the length in bytes.
+ */
+function length_l(
+  Locale\Locale $locale,
+  string $string,
+)[]: int {
+  /* HH_FIXME[4390] missing [] */
+  return _Str\strlen_l($string, $locale);
+}
+
+/**
+ * Returns the first position of the "needle" string in the "haystack" string,
+ * or null if it isn't found.
+ *
+ * An optional offset determines where in the haystack the search begins. If the
+ * offset is negative, the search will begin that many characters from the end
+ * of the string. If the offset is out-of-bounds, a ViolationException will be
+ * thrown.
+ *
+ * - To simply check if the haystack contains the needle, see `Str\contains_l()`.
+ * - To get the case-insensitive position, see `Str\search_ci_l()`.
+ * - To get the last position of the needle, see `Str\search_last_l()`.
+ */
+function search_l(
+  Locale\Locale $locale,
+  string $haystack,
+  string $needle,
+  int $offset = 0,
+)[]: ?int {
+  /* HH_FIXME[4390] missing [] */
+  $position = _Str\strpos_l($haystack, $needle, $offset, $locale);
+  if ($position < 0) {
+    return null;
+  }
+  return $position;
+}
+
+/**
+ * Returns the first position of the "needle" string in the "haystack" string,
+ * or null if it isn't found (case-insensitive).
+ *
+ * Locale-specific rules for case-insensitive comparisons will be used.
+ *
+ * An optional offset determines where in the haystack the search begins. If the
+ * offset is negative, the search will begin that many characters from the end
+ * of the string. If the offset is out-of-bounds, a ViolationException will be
+ * thrown.
+ *
+ * - To simply check if the haystack contains the needle, see `Str\contains()`.
+ * - To get the case-sensitive position, see `Str\search()`.
+ * - To get the last position of the needle, see `Str\search_last()`.
+ */
+function search_ci_l(
+  Locale\Locale $locale,
+  string $haystack,
+  string $needle,
+  int $offset = 0,
+)[]: ?int {
+  /* HH_FIXME[4390] missing [] */
+  $position = _Str\stripos_l($haystack, $needle, $offset, $locale);
+  if ($position < 0) {
+    return null;
+  }
+  return $position;
+}
+
+/**
+ * Returns the last position of the "needle" string in the "haystack" string,
+ * or null if it isn't found.
+ *
+ * An optional offset determines where in the haystack (from the beginning) the
+ * search begins. If the offset is negative, the search will begin that many
+ * characters from the end of the string and go backwards. If the offset is
+ * out-of-bounds, a ViolationException will be thrown.
+ *
+ * - To simply check if the haystack contains the needle, see `Str\contains()`.
+ * - To get the first position of the needle, see `Str\search()`.
+ *
+ * Previously known in PHP as `strrpos`.
+ */
+function search_last_l(
+  Locale\Locale $locale,
+  string $haystack,
+  string $needle,
+  int $offset = 0,
+)[]: ?int {
+  $haystack_length = length_l($locale, $haystack);
+  /* HH_FIXME[4390] missing [] */
+  $position = _Str\strrpos_l($haystack, $needle, $offset, $locale);
+  if ($position < 0) {
+    return null;
+  }
+  return $position;
+}
+
+/**
+ * Returns whether the string starts with the given prefix.
+ *
+ * Strings will be normalized for comparison in encodings that support multiple
+ * representations, such as UTF-8.
+ *
+ * For a case-insensitive check, see `Str\starts_with_ci_l()`.
+ * For a byte-wise check, see `Str\starts_with()`
+ */
+function starts_with_l(
+  Locale\Locale $locale,
+  string $string,
+  string $prefix,
+)[]: bool {
+  /* HH_FIXME[4390] missing [] */
+  return _Str\starts_with_l($string, $prefix, $locale);
+}
+
+/**
+ * Returns whether the string starts with the given prefix (case-insensitive).
+ *
+ * Locale-specific collation rules will be followed, and strings will be
+ * normalized in encodings that support multiple representations of the same
+ * characters, such as UTF8.
+ *
+ * For a case-sensitive check, see `Str\starts_with()`.
+ */
+function starts_with_ci_l(
+  Locale\Locale $locale,
+  string $string,
+  string $prefix,
+)[]: bool {
+  /* HH_FIXME[4390] missing [] */
+  return _Str\starts_with_ci_l($string, $prefix, $locale);
+}

--- a/hphp/hsl/src/str/select_l.php
+++ b/hphp/hsl/src/str/select_l.php
@@ -1,0 +1,121 @@
+<?hh
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the hphp/hsl/ subdirectory of this source tree.
+ *
+ */
+
+namespace HH\Lib\Str;
+
+use namespace HH\Lib\{Locale, _Private, _Private\_Str};
+
+/**
+ * Returns a substring of length `$length` of the given string starting at the
+ * `$offset`.
+ *
+ * `$offset` and `$length` are specified as a number of characters.
+ *
+ * If no length is given, the slice will contain the rest of the
+ * string. If the length is zero, the empty string will be returned. If the
+ * offset is out-of-bounds, an InvalidArgumentException will be thrown.
+ *
+ * See `slice()` for a byte-based operation.
+ */
+function slice_l(
+  Locale\Locale $locale,
+  string $string,
+  int $offset,
+  ?int $length = null,
+)[]: string {
+  /* HH_FIXME[4390] missing [] */
+  return _Str\slice_l($string, $offset, $length ?? \PHP_INT_MAX, $locale);
+}
+
+/**
+ * Returns the string with the given prefix removed, or the string itself if
+ * it doesn't start with the prefix.
+ *
+ * Strings will be normalized for comparison in encodings that support multiple
+ * representations, such as UTF-8.
+ */
+function strip_prefix_l(
+  Locale\Locale $locale,
+  string $string,
+  string $prefix,
+)[]: string {
+  /* HH_FIXME[4390] missing [] */
+  return _Str\strip_prefix_l($string, $prefix, $locale);
+}
+
+/**
+ * Returns the string with the given suffix removed, or the string itself if
+ * it doesn't end with the suffix.
+ *
+ * Strings will be normalized for comparison in encodings that support multiple
+ * representations, such as UTF-8.
+ */
+function strip_suffix_l(
+  Locale\Locale $locale,
+  string $string,
+  string $suffix,
+)[]: string {
+  /* HH_FIXME[4390] missing [] */
+  return _Str\strip_suffix_l($string, $suffix, $locale);
+}
+
+/**
+ * Returns the given string with whitespace stripped from the beginning and end.
+ *
+ * If the optional character mask isn't provided, the characters removed are
+ * defined by the locale/encoding.
+ *
+ * - To only strip from the left, see `Str\trim_left_l()`.
+ * - To only strip from the right, see `Str\trim_right_l()`.
+ */
+function trim_l(
+  Locale\Locale $locale,
+  string $string,
+  ?string $char_mask = null,
+)[]: string {
+  /* HH_FIXME[4390] missing [] */
+  return _Str\trim_l($string, $char_mask, $locale);
+}
+
+/**
+ * Returns the given string with whitespace stripped from the left.
+ * See `Str\trim_l()` for more details.
+ *
+ * - To strip from both ends, see `Str\trim_l()`.
+ * - To only strip from the right, see `Str\trim_right_l()`.
+ * - To strip a specific prefix (instead of all characters matching a mask),
+ *   see `Str\strip_prefix_l()`.
+ */
+function trim_left_l(
+  Locale\Locale $locale,
+  string $string,
+  ?string $char_mask = null,
+)[]: string {
+  /* HH_FIXME[4390] missing [] */
+  return _Str\trim_left_l($string, $char_mask, $locale);
+}
+
+/**
+ * Returns the given string with whitespace stripped from the right.
+ * See `Str\trim_l` for more details.
+ *
+ * - To strip from both ends, see `Str\trim_l()`.
+ * - To only strip from the left, see `Str\trim_left_l()`.
+ * - To strip a specific suffix (instead of all characters matching a mask),
+ *   see `Str\strip_suffix_l()`.
+ */
+function trim_right_l(
+  Locale\Locale $locale,
+  string $string,
+  ?string $char_mask = null,
+)[]: string {
+  /* HH_FIXME[4390] missing [] */
+  return _Str\trim_right_l($string, $char_mask, $locale);
+}

--- a/hphp/hsl/src/str/transform.php
+++ b/hphp/hsl/src/str/transform.php
@@ -76,14 +76,15 @@ function lowercase(
 }
 
 /**
- * Returns the string padded to the total length by appending the `$pad_string`
- * to the left.
+ * Returns the string padded to the total length (in bytes) by appending the
+ * `$pad_string` to the left.
  *
  * If the length of the input string plus the pad string exceeds the total
  * length, the pad string will be truncated. If the total length is less than or
  * equal to the length of the input string, no padding will occur.
  *
  * To pad the string on the right, see `Str\pad_right()`.
+ * To pad the string to a fixed number of characters, see `Str\pad_left_l()`.
  */
 function pad_left(
   string $string,
@@ -96,14 +97,15 @@ function pad_left(
 }
 
 /**
- * Returns the string padded to the total length by appending the `$pad_string`
- * to the right.
+ * Returns the string padded to the total length (in bytes) by appending the
+ * `$pad_string` to the right.
  *
  * If the length of the input string plus the pad string exceeds the total
  * length, the pad string will be truncated. If the total length is less than or
  * equal to the length of the input string, no padding will occur.
  *
  * To pad the string on the left, see `Str\pad_left()`.
+ * To pad the string to a fixed number of characters, see `Str\pad_right_l()`.
  */
 function pad_right(
   string $string,
@@ -307,6 +309,10 @@ function replace_every_nonrecursive_ci(
   return $output;
 }
 
+/** Reverse a string by bytes.
+ *
+ * @see `Str\reverse_l()` to reverse by characters instead.
+ */
 function reverse(string $string)[]: string {
   for ($lo = 0, $hi = namespace\length($string) - 1; $lo < $hi; $lo++, $hi--) {
     $temp = $string[$lo];

--- a/hphp/hsl/src/str/transform_l.php
+++ b/hphp/hsl/src/str/transform_l.php
@@ -1,0 +1,314 @@
+<?hh
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the hphp/hsl/ subdirectory of this source tree.
+ *
+ */
+
+namespace HH\Lib\Str;
+
+use namespace HH\Lib\{_Private, C, Keyset, Locale, Vec, _Private\_Str};
+
+/**
+ * Returns the string with the first character capitalized.
+ *
+ * If the first character is already capitalized or isn't alphabetic, the string
+ * will be unchanged.
+ *
+ * Locale-specific capitalization rules will be respected, e.g. `i` -> `I` vs
+ * `i` -> `İ`.
+ *
+ * - To capitalize all characters, see `Str\uppercase_l()`.
+ * - To capitalize all words, see `Str\capitalize_words_l()`.
+ */
+function capitalize_l(
+  Locale\Locale $locale,
+  string $string,
+)[]: string {
+  if ($string === '') {
+    return '';
+  }
+  return uppercase_l($locale, slice_l($locale, $string, 0, 1)).slice_l($locale, $string, 1);
+}
+
+/**
+ * Returns the string with all words capitalized.
+ *
+ * Locale-specific capitalization rules will be respected, e.g. `i` -> `I` vs
+ * `i` -> `İ`.
+ *
+ * Delimiters are defined by the locale.
+ *
+ * - To capitalize all characters, see `Str\uppercase_l()`.
+ * - To capitalize only the first character, see `Str\capitalize_l()`.
+ */
+function capitalize_words_l(
+  Locale\Locale $locale,
+  string $string,
+)[]: string {
+  /* HH_FIXME[4390] missing [] */
+  return _Str\titlecase_l($string, $locale);
+}
+
+/**
+ * Returns the string with all alphabetic characters converted to lowercase.
+ *
+ * Locale-specific capitalization rules will be respected, e.g. `I` -> `i` vs
+ * `I` -> `ı`
+ */
+function lowercase_l(
+  Locale\Locale $locale,
+  string $string,
+)[]: string {
+  /* HH_FIXME[4390] missing [] */
+  return _Str\lowercase_l($string, $locale);
+}
+
+/**
+ * Returns the string padded to the total length (in characters) by appending
+ * the `$pad_string` to the left.
+ *
+ * If the length of the input string plus the pad string exceeds the total
+ * length, the pad string will be truncated. If the total length is less than or
+ * equal to the length of the input string, no padding will occur.
+ *
+ * To pad the string on the right, see `Str\pad_right_l()`.
+ * To pad the string to a fixed number of bytes, see `Str\pad_left()`.
+ */
+function pad_left_l(
+  Locale\Locale $locale,
+  string $string,
+  int $total_length,
+  string $pad_string = ' ',
+)[]: string {
+  /* HH_FIXME[4390] missing [] */
+  return _Str\pad_left_l($string, $total_length, $pad_string, $locale);
+}
+
+/**
+ * Returns the string padded to the total length (in characters) by appending
+ * the `$pad_string` to the right.
+ *
+ * If the length of the input string plus the pad string exceeds the total
+ * length, the pad string will be truncated. If the total length is less than or
+ * equal to the length of the input string, no padding will occur.
+ *
+ * To pad the string on the left, see `Str\pad_left()`.
+ * To pad the string to a fixed number of bytes, see `Str\pad_right()`
+ */
+function pad_right_l(
+  Locale\Locale $locale,
+  string $string,
+  int $total_length,
+  string $pad_string = ' ',
+)[]: string {
+  /* HH_FIXME[4390] missing [] */
+  return _Str\pad_right_l($string, $total_length, $pad_string, $locale);
+}
+
+/**
+ * Returns the "haystack" string with all occurrences of `$needle` replaced by
+ * `$replacement`.
+ *
+ * Strings will be normalized for comparison in encodings that support multiple
+ * representations, such as UTF-8.
+ *
+ * - For a case-insensitive search/replace, see `Str\replace_ci_l()`.
+ * - For multiple case-sensitive searches/replacements, see `Str\replace_every_l()`.
+ * - For multiple case-insensitive searches/replacements, see `Str\replace_every_ci_l()`.
+ */
+function replace_l(
+  Locale\Locale $locale,
+  string $haystack,
+  string $needle,
+  string $replacement,
+)[]: string {
+  /* HH_FIXME[4390] missing [] */
+  return _Str\replace_l($haystack, $needle, $replacement, $locale);
+}
+
+/**
+ * Returns the "haystack" string with all occurrences of `$needle` replaced by
+ * `$replacement` (case-insensitive).
+ *
+ * Locale-specific rules for case-insensitive comparisons will be used, and
+ * strings will be normalized before comparing if the locale specifies an
+ * encoding that supports multiple representations of the same characters, such
+ * as UTF-8.
+ *
+ * - For a case-sensitive search/replace, see `Str\replace_l()`.
+ * - For multiple case-sensitive searches/replacements, see `Str\replace_every_l()`.
+ * - For multiple case-insensitive searches/replacements, see `Str\replace_every_ci_l()`.
+ */
+// not pure: str_ireplace uses global locale for capitalization
+function replace_ci_l(
+  Locale\Locale $locale,
+  string $haystack,
+  string $needle,
+  string $replacement,
+)[rx]: string {
+  /* HH_FIXME[4390] missing [] */
+  return _Str\replace_ci_l($haystack, $needle, $replacement, $locale);
+}
+
+/**
+ * Returns the "haystack" string with all occurrences of the keys of
+ * `$replacements` replaced by the corresponding values.
+ *
+ * Strings will be normalized for comparison in encodings that support multiple
+ * representations, such as UTF-8.
+ *
+ * Replacements are applied in the order they are specified in `$replacements`,
+ * and the new values are searched again for subsequent matches. For example,
+ * `dict['a' => 'b', 'b' => 'c']` is equivalent to `dict['a' => 'c']`, but
+ * `dict['b' => 'c', 'a' => 'b']` is not, despite having the same elements.
+ *
+ * If there are multiple overlapping matches, the match occuring earlier in
+ * `$replacements` (not in `$haystack`) takes precedence.
+ *
+ * - For a single case-sensitive search/replace, see `Str\replace_l()`.
+ * - For a single case-insensitive search/replace, see `Str\replace_ci_l()`.
+ * - For multiple case-insensitive searches/replacements, see `Str\replace_every_ci_l()`.
+ * - For not having new values searched again, see `Str\replace_every_nonrecursive_l()`.
+ */
+function replace_every_l(
+  Locale\Locale $locale,
+  string $haystack,
+  KeyedContainer<string, string> $replacements,
+)[]: string {
+  /* HH_FIXME[4390] missing [] */
+  return _Str\replace_every_l($haystack, dict($replacements), $locale);
+}
+
+/**
+ * Returns the "haystack" string with all occurrences of the keys of
+ * `$replacements` replaced by the corresponding values (case-insensitive).
+ *
+ * Locale-specific rules for case-insensitive comparisons will be used, and
+ * strings will be normalized before comparing if the locale specifies an
+ * encoding that supports multiple representations of the same characters, such
+ * as UTF-8.
+ *
+ * Replacements are applied in the order they are specified in `$replacements`,
+ * and the new values are searched again for subsequent matches. For example,
+ * `dict['a' => 'b', 'b' => 'c']` is equivalent to `dict['a' => 'c']`, but
+ * `dict['b' => 'c', 'a' => 'b']` is not, despite having the same elements.
+ *
+ * If there are multiple overlapping matches, the match occuring earlier in
+ * `$replacements` (not in `$haystack`) takes precedence.
+ *
+ * - For a single case-sensitive search/replace, see `Str\replace_l()`.
+ * - For a single case-insensitive search/replace, see `Str\replace_ci_l()`.
+ * - For multiple case-sensitive searches/replacements, see `Str\replace_every_l()`.
+ * - For not having new values searched again, see `Str\replace_every_nonrecursive_ci_l()`.
+ */
+function replace_every_ci_l(
+  Locale\Locale $locale,
+  string $haystack,
+  KeyedContainer<string, string> $replacements,
+)[rx]: string {
+  /* HH_FIXME[4390] missing [] */
+  return _Str\replace_every_ci_l($haystack, dict($replacements), $locale);
+}
+
+/**
+ * Returns the "haystack" string with all occurrences of the keys of
+ * `$replacements` replaced by the corresponding values. Once a substring has
+ * been replaced, its new value will not be searched again.
+ *
+ * Strings will be normalized for comparison in encodings that support multiple
+ * representations, such as UTF-8.
+ *
+ * If there are multiple overlapping matches, the match occuring earlier in
+ * `$haystack` takes precedence. If a replacer is a prefix of another (like
+ * "car" and "carpet"), the longer one (carpet) takes precedence. The ordering
+ * of `$replacements` therefore doesn't matter.
+ *
+ * - For having new values searched again, see `Str\replace_every_l()`.
+ */
+function replace_every_nonrecursive_l(
+  Locale\Locale $locale,
+  string $haystack,
+  KeyedContainer<string, string> $replacements,
+)[rx]: string {
+  /* HH_FIXME[4390] missing [] */
+  return _Str\replace_every_nonrecursive_l($haystack, dict($replacements), $locale);
+}
+
+/**
+ * Returns the "haystack" string with all occurrences of the keys of
+ * `$replacements` replaced by the corresponding values (case-insensitive).
+ * Once a substring has been replaced, its new value will not be searched
+ * again.
+ *
+ * Locale-specific rules for case-insensitive comparisons will be used, and
+ * strings will be normalized before comparing if the locale specifies an
+ * encoding that supports multiple representations of the same characters, such
+ * as UTF-8.
+ *
+ * If there are multiple overlapping matches, the match occuring earlier in
+ * `$haystack` takes precedence. If a replacer is a case-insensitive prefix of
+ * another (like "Car" and "CARPET"), the longer one (carpet) takes precedence.
+ * The ordering of `$replacements` therefore doesn't matter.
+ *
+ * When two replacers are passed that are identical except for case,
+ * an InvalidArgumentException is thrown.
+ *
+ * Time complexity: O(a + length * b), where a is the sum of all key lengths and
+ * b is the sum of distinct key lengths (length is the length of `$haystack`)
+ *
+ * - For having new values searched again, see `Str\replace_every_ci_l()`.
+ */
+function replace_every_nonrecursive_ci_l(
+  Locale\Locale $locale,
+  string $haystack,
+  KeyedContainer<string, string> $replacements,
+)[rx]: string {
+  /* HH_FIXME[4390] missing [] */
+  return _Str\replace_every_nonrecursive_ci_l($haystack, dict($replacements), $locale);
+}
+
+/** Reverse a string by characters.
+ *
+ * @see `Str\reverse()` to reverse by bytes instead.
+ */
+function reverse_l(Locale\Locale $locale, string $string)[]: string {
+  /* HH_FIXME[4390] missing [] */
+  return _Str\reverse_l($string, $locale);
+}
+
+/**
+ * Return the string with a slice specified by the offset/length replaced by the
+ * given replacement string.
+ *
+ * If the length is omitted or exceeds the upper bound of the string, the
+ * remainder of the string will be replaced. If the length is zero, the
+ * replacement will be inserted at the offset.
+ */
+function splice_l(
+  Locale\Locale $locale,
+  string $string,
+  string $replacement,
+  int $offset,
+  ?int $length = null,
+)[]: string {
+  /* HH_FIXME[4390] missing [] */
+  return _Str\splice_l($string, $replacement, $offset, $length, $locale);
+}
+
+/**
+ * Returns the string with all alphabetic characters converted to uppercase.
+ *
+ * Locale-specific capitalization rules will be respected, e.g. `i` -> `I` vs
+ * `i` -> `İ`.
+ */
+function uppercase_l(
+  Locale\Locale $locale,
+  string $string,
+)[]: string {
+  /* HH_FIXME[4390] missing [] */
+  return _Str\uppercase_l($string, $locale);
+}


### PR DESCRIPTION
Summary:
We have a single object that represents encoding + locale, similar to the `en_US.UTF-8` strings being used with `setlocale()`.

For now, we only support single-byte and UTF-8, as we require that all pairs are potentially valid thread/process locales - UTF-16 isn't because C locales can't have null bytes except as terminators. We could (and probably should) support UTF-16 in the future, but we would have to make Locale\set_native() throw an exception when a UTF-16 is passed.

As for design:
- if `Str\foo()` exists, so does `Str\foo_l()`, and `Str\foo_l()` will always take a `Locale\Locale` object as the first parameter.
- in most cases, the rest of the parameters match; in some cases, the locale defines previously optional parameters, so I've removed the parameter in the `_l` version

`_Private\_Str`: not a supported API. That said, it follows the BSD libc conventions; most glibc _l functions also exist in BSD libc, and BSD libc has many more.

I went with that convention for `_Str` mostly to unblock implementation. I've not used it for the public API as:
- the parameter convention is 'the last non-variadic non-format-string parameter'; this isn't super clear and feels inconsistent, but makes sense for C. Given that past work shows edge cases like `vsprintf_l(char* str, locale_t loc, const char* format, va_list ap)`, we can avoid them with a more consistent design now.
- unintuitive naming: the case-sensitive version of `strcasecmp()` is `strcoll()`, not `strcmp()`; `strcasecmp()`  and `strcoll()` are locale-sensitive, `strcmp()` isn't.
- having `foo` and `foo_l` with similar args may raise awareness of the need for locale-sensitivity

Manual test/example:

```hack
use namespace HH\Lib\{Locale, Str};
<<__EntryPoint>>
function main(): void {
  $en_us_utf8 = Locale\create('en_US.UTF8');
  $fr_fr = Locale\create('fr_FR');
  var_dump(Str\format_l($en_us_utf8, '%f', 1.23)); // 1.230000
  var_dump(Str\format_l($fr_fr, '%f', 1.23));      // 1,230000
  var_dump(Str\length_l($en_us_utf8, '😀'));       // 1
  var_dump(Str\length_l($fr_fr, '😀'));            // 4
}
```

Differential Revision: D30458827

