### PR TITLE
Remove TIMELIB_MODERN checks

### DIFF
--- a/hphp/runtime/base/datetime.cpp
+++ b/hphp/runtime/base/datetime.cpp
@@ -196,19 +196,11 @@ Array DateTime::ParseAsStrptime(const String& format, const String& date) {
   PHP_DATE_PARSE_DATE_SET_TIME_ELEMENT(s_minute,    i);
   PHP_DATE_PARSE_DATE_SET_TIME_ELEMENT(s_second,    s);
 
-#if TIMELIB_VERSION >= TIMELIB_MODERN
   if (parsed_time->us == TIMELIB_UNSET) {
     ret.set(s_fraction, false);
   } else {
     ret.set(s_fraction, (double) parsed_time->us / 1000000.0);
   }
-#else
-  if (parsed_time->f == -99999) {
-    ret.set(s_fraction, false);
-  } else {
-    ret.set(s_fraction, parsed_time->f);
-  }
-#endif
 
   setLastErrors(error);
   {
@@ -256,11 +248,7 @@ Array DateTime::ParseAsStrptime(const String& format, const String& date) {
       s_second, parsed_time->relative.s
     );
     if (
-#if defined(TIMELIB_VERSION)
         parsed_time->relative.have_weekday_relative
-#else
-        parsed_time->have_weekday_relative
-#endif
     ) {
       element.set(s_weekday, parsed_time->relative.weekday);
     }
@@ -384,13 +372,7 @@ int DateTime::offset() const {
     switch (m_time->zone_type) {
     case TIMELIB_ZONETYPE_ABBR:
     case TIMELIB_ZONETYPE_OFFSET:
-
-#if TIMELIB_VERSION >= TIMELIB_MODERN
       return m_time->z + m_time->dst * 3600;
-#else
-      return (m_time->z - (m_time->dst * 60)) * -60;
-#endif
-
     default:
       {
         bool error;
@@ -473,9 +455,7 @@ void DateTime::setTime(int hour, int minute, int second) {
   m_time->i = minute;
   m_time->s = second;
   update();
-#if TIMELIB_VERSION >= TIMELIB_MODERN
   timelib_update_from_sse(m_time.get());
-#endif
 }
 
 void DateTime::setTimezone(req::ptr<TimeZone> timezone) {
@@ -555,11 +535,9 @@ void DateTime::internalModify(timelib_time *t) {
       }
     }
   }
-#if TIMELIB_VERSION >= TIMELIB_MODERN
   if (t->us != TIMELIB_UNSET) {
     m_time->us = t->us;
   }
-#endif
   internalModifyRelative(&(t->relative), t->have_relative, 1);
 }
 
@@ -571,9 +549,7 @@ void DateTime::internalModifyRelative(timelib_rel_time *rel,
   m_time->relative.h = rel->h * bias;
   m_time->relative.i = rel->i * bias;
   m_time->relative.s = rel->s * bias;
-#if TIMELIB_VERSION >= TIMELIB_MODERN
   m_time->relative.us = rel->us * bias;
-#endif
   m_time->relative.weekday = rel->weekday;
   m_time->have_relative = have_relative;
   m_time->relative.special = rel->special;
@@ -593,15 +569,11 @@ void DateTime::add(const req::ptr<DateInterval>& interval) {
 
 void DateTime::sub(const req::ptr<DateInterval>& interval) {
   timelib_rel_time *rel = interval->get();
-#if TIMELIB_VERSION >= TIMELIB_MODERN
   timelib_time* new_time;
   new_time = timelib_sub(m_time.get(), rel);
   m_timestamp = 0;
   m_timestampSet = false;
   m_time = TimePtr(new_time, time_deleter());
-#else
-  internalModifyRelative(rel, true, rel->invert ?  1 : -1);
-#endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -735,13 +707,8 @@ String DateTime::rfcFormat(const String& format) const {
     case 'H': s.printf("%02d", (int)hour()); break;
     case 'i': s.printf("%02d", (int)minute()); break;
     case 's': s.printf("%02d", (int)second()); break;
-#if TIMELIB_VERSION >= TIMELIB_MODERN
     case 'u': s.printf("%06d", (int)m_time->us); break;
     case 'v': s.printf("%03d", (int)(m_time->us / 1000)); break;
-#else
-    case 'u': s.printf("%06d", (int)floor(fraction() * 1000000)); break;
-    case 'v': s.printf("%03d", (int)floor(fraction() * 1000)); break;
-#endif
     case 'I': s.append(!utc() && m_tz->dst(toTimeStamp(error)) ? 1 : 0);
       break;
     case 'P': rfc_colon = true; /* break intentionally missing */
@@ -762,11 +729,7 @@ String DateTime::rfcFormat(const String& format) const {
         if (m_time->zone_type != TIMELIB_ZONETYPE_OFFSET) {
           s.append(m_time->tz_abbr);
         } else {
-#if TIMELIB_VERSION >= TIMELIB_MODERN
           auto offset = m_time->z;
-#else
-          auto offset = m_time->z * -60;
-#endif
 
           char abbr[9] = {0};
           snprintf(abbr, 9, "GMT%c%02d%02d",
@@ -784,11 +747,7 @@ String DateTime::rfcFormat(const String& format) const {
         if (m_time->zone_type != TIMELIB_ZONETYPE_OFFSET) {
           s.append(m_tz->name());
         } else {
-#if TIMELIB_VERSION >= TIMELIB_MODERN
           auto offset = m_time->z;
-#else
-          auto offset = m_time->z * -60;
-#endif
           char abbr[7] = {0};
           snprintf(abbr, 7, "%c%02d:%02d",
             ((offset < 0) ? '-' : '+'),
@@ -992,11 +951,9 @@ bool DateTime::fromString(const String& input, req::ptr<TimeZone> tz,
   }
 
   int options = TIMELIB_NO_CLONE;
-#if TIMELIB_VERSION >= TIMELIB_MODERN
 	if (format != nullptr) {
     	options |= TIMELIB_OVERRIDE_TIME;
   }
-#endif
   timelib_fill_holes(t, m_time.get(), options);
   timelib_update_ts(t, m_tz->getTZInfo());
   timelib_update_from_sse(t);

--- a/hphp/runtime/base/datetime.h
+++ b/hphp/runtime/base/datetime.h
@@ -245,11 +245,7 @@ public:
   int minute() const { return m_time->i;}
   int second() const { return m_time->s;}
   double fraction() const {
-#if TIMELIB_VERSION >= TIMELIB_MODERN
       return m_time->us / 1000000.0;
-#else
-      return m_time->f;
-#endif
   }
   int zoneType() const { return m_time->zone_type;}
   int beat() const;    // Swatch Beat a.k.a. Internet Time

--- a/hphp/runtime/base/timezone.cpp
+++ b/hphp/runtime/base/timezone.cpp
@@ -31,11 +31,9 @@
 
 
 // The opaque "struct _ttinfo" moved into a private header file.
-#if TIMELIB_VERSION >= TIMELIB_MODERN
 extern "C" {
 #include <timelib_private.h>
 }
-#endif
 
 namespace HPHP {
 
@@ -124,32 +122,19 @@ const timelib_tzdb *TimeZone::GetDatabase() {
   return Database;
 }
 
-#if TIMELIB_VERSION >= TIMELIB_MODERN
 timelib_tzinfo* TimeZone::GetTimeZoneInfoRaw(const char* name,
                                              const timelib_tzdb* db,
                                              int* error_code)
-#else
-timelib_tzinfo* TimeZone::GetTimeZoneInfoRaw(char* name,
-                                             const timelib_tzdb* db)
-#endif
 {
   auto const it = s_tzCache->find(name);
   if (it != s_tzCache->end()) {
     return it->second;
   }
-#if TIMELIB_VERSION >= TIMELIB_MODERN
   auto tzi = timelib_parse_tzfile(name, db, error_code);
-#else
-  auto tzi = timelib_parse_tzfile(name, db);
-#endif
   if (!tzi) {
     char* tzid = timelib_timezone_id_from_abbr(name, -1, 0);
     if (tzid) {
-#if TIMELIB_VERSION >= TIMELIB_MODERN
       tzi = timelib_parse_tzfile(tzid, db, error_code);
-#else
-      tzi = timelib_parse_tzfile(tzid, db);
-#endif
     }
   }
 
@@ -280,21 +265,13 @@ TimeZone::TimeZone(const String& name) {
    * - `GMT+0` is usually (tzdb-dependent) a ZONETYPE_ID
    * - `CET` quirk below
    */
-#if TIMELIB_VERSION >= TIMELIB_MODERN
   const char* tzname = name.data();
-#else
-  char* tzname = (char*) name.data();
-#endif
   // Try an ID lookup first, so that `CET` is interpreted as an ID, not an
   // abbreviation. It's valid as either. PHP 5.5+ considers it an abbreviation,
   // HHVM currently intentionally considers it an ID for backwards
   // compatibility (which matches PHP <= 5.4)
-#if TIMELIB_VERSION >= TIMELIB_MODERN
   int error_code = TIMELIB_ERROR_NO_ERROR;
   m_tzi = GetTimeZoneInfoRaw(tzname, GetDatabase(), &error_code);
-#else
-  m_tzi = GetTimeZoneInfoRaw(tzname, GetDatabase());
-#endif
   if (m_tzi) {
     m_tztype = TIMELIB_ZONETYPE_ID;
     return;
@@ -359,7 +336,6 @@ String TimeZone::name() const {
     case TIMELIB_ZONETYPE_OFFSET: {
       char buf[sizeof("+00:00")];
 
-#if TIMELIB_VERSION >= TIMELIB_MODERN
       snprintf(
         buf,
         sizeof("+00:00"),
@@ -368,16 +344,6 @@ String TimeZone::name() const {
         abs(m_offset / 3600) % 100, // % 100 to convince compiler we have 2 digits
         abs((m_offset % 3600) / 60)
       );
-#else
-      snprintf(
-        buf,
-        sizeof("+00:00"),
-        "%c%02d:%02d",
-        (m_offset > 0 ? '-' : '+'),
-        abs(m_offset / 60) % 100, // % 100 to convince compiler we have 2 digits
-        abs(m_offset % 60)
-      );
-#endif
       return String(buf, sizeof("+00:00") - 1, CopyString);
     }
   }

--- a/hphp/runtime/base/timezone.h
+++ b/hphp/runtime/base/timezone.h
@@ -27,11 +27,6 @@ extern "C" {
 #include <timelib.h>
 }
 
-// NOTE: The "timelib" library underwent at least one major revision between
-// versions 201102 and 202002.  We use "TIMELIB_MODERN" to test for a modern
-// version, when we do not know exactly when a particular change occurred.
-#define TIMELIB_MODERN 202002
-
 namespace HPHP {
 
 struct Array;
@@ -150,11 +145,7 @@ private:
   /**
    * Look up cache and if found return it, otherwise, read it from database.
    */
-#if TIMELIB_VERSION >= TIMELIB_MODERN
   static timelib_tzinfo* GetTimeZoneInfoRaw(const char* name, const timelib_tzdb* db, int* error_code);
-#else
-  static timelib_tzinfo* GetTimeZoneInfoRaw(char* name, const timelib_tzdb* db);
-#endif
 
   unsigned int m_tztype = 0;
   timelib_tzinfo* m_tzi = nullptr;


### PR DESCRIPTION
These checks were added when Facebook was internally using a much newer
timelib than our open source builds. Our open source builds have since
been updated, so the `#else` paths are dead code.

Closes https://github.com/facebook/hhvm/pull/8802

Test plan: lego-*, local build on my mac
