### PR TITLE
Fix static method used as instance error message

### DIFF
--- a/hphp/hack/src/errors/errors.ml
+++ b/hphp/hack/src/errors/errors.ml
@@ -3179,10 +3179,13 @@ let unknown_type description pos r =
   let msg = "Was expecting " ^ description ^ " but type is unknown" in
   add_list (Typing.err_code Typing.UnknownType) (pos, msg) r
 
-let not_found_suggestion orig similar =
+let not_found_suggestion orig similar kind =
   match similar with
   | (`static, pos, v) ->
-    suggestion_message ~modifier:"static method " orig v pos
+  begin match kind with
+    | `method_ -> suggestion_message ~modifier:"static method " orig v pos
+    | `property -> suggestion_message ~modifier:"static property " orig v pos
+  end
   | (`instance, pos, v) -> suggestion_message orig v pos
 
 let snot_found_suggestion orig similar =
@@ -3260,6 +3263,7 @@ let member_not_found
     reason
     (on_error : typing_error_callback) =
   let type_name = strip_ns type_name |> Markdown_lite.md_codify in
+  let kind_record = kind in
   let kind =
     match kind with
     | `method_ -> "instance method"
@@ -3276,7 +3280,7 @@ let member_not_found
     match similar with
     | None -> ([], [])
     | Some ((_, _, similar_name) as similar) ->
-      ( [not_found_suggestion member_name similar],
+      ( [not_found_suggestion member_name similar kind_record],
         [
           { title = "Change to ->" ^ similar_name; new_text = similar_name; pos };
         ] )


### PR DESCRIPTION
This PR:
- Update the error message for the case where a static method/property is called as an instance method, the error message should say it is a `static method` or `static property` depending on whether the static method or a static property is being called
- Link to #8701 