### PR TITLE
Fix clone method cannot take arguments error message

### DIFF
--- a/hphp/hack/src/errors/errors.ml
+++ b/hphp/hack/src/errors/errors.ml
@@ -1556,12 +1556,6 @@ let expected_variable pos =
     pos
     "Was expecting a variable name"
 
-let clone_too_many_arguments pos =
-  add
-    (Naming.err_code Naming.NamingTooManyArguments)
-    pos
-    "`__clone` method cannot take arguments"
-
 let naming_too_few_arguments pos =
   add (Naming.err_code Naming.NamingTooFewArguments) pos "Too few arguments"
 

--- a/hphp/hack/src/errors/errors.mli
+++ b/hphp/hack/src/errors/errors.mli
@@ -448,8 +448,6 @@ val missing_typehint : Pos.t -> unit
 
 val expected_variable : Pos.t -> unit
 
-val clone_too_many_arguments : Pos.t -> unit
-
 val naming_too_few_arguments : Pos.t -> unit
 
 val naming_too_many_arguments : Pos.t -> unit

--- a/hphp/hack/src/typing/nast_check/nast_class_method_check.ml
+++ b/hphp/hack/src/typing/nast_check/nast_class_method_check.ml
@@ -25,13 +25,6 @@ let error_if_duplicate_method_names methods =
   in
   ()
 
-let error_if_clone_has_arguments method_ =
-  match (method_.m_name, method_.m_params) with
-  | ((pos, name), _ :: _)
-    when String.equal name Naming_special_names.Members.__clone ->
-    Errors.clone_too_many_arguments pos
-  | _ -> ()
-
 let error_if_abstract_method_is_memoized method_ =
   if method_.m_abstract && is_memoizable method_.m_user_attributes then
     Errors.abstract_method_memoize (fst method_.m_name)
@@ -44,6 +37,5 @@ let handler =
       error_if_duplicate_method_names class_.c_methods
 
     method! at_method_ _ method_ =
-      error_if_clone_has_arguments method_;
       error_if_abstract_method_is_memoized method_
   end

--- a/hphp/hack/test/typecheck/class_clone_function_with_one_param.php.exp
+++ b/hphp/hack/test/typecheck/class_clone_function_with_one_param.php.exp
@@ -1,4 +1,2 @@
 File "class_clone_function_with_one_param.php", line 5, characters 3-14:
 Method `A1::__clone` cannot accept any arguments (Parsing[1002])
-File "class_clone_function_with_one_param.php", line 5, characters 25-31:
-`__clone` method cannot take arguments (Naming[2038])


### PR DESCRIPTION
This PR does
- Remove the error message at `__clone()...` and keep the error message at `public function ...` when arguments are passed to `__clone()` method
- Update expect test files