### PR TITLE
fix error message when instance method/property called as static method/property

### DIFF
--- a/hphp/hack/src/errors/errors.ml
+++ b/hphp/hack/src/errors/errors.ml
@@ -3177,10 +3177,19 @@ let not_found_suggestion orig similar kind =
     end
   | (`instance, pos, v) -> suggestion_message orig v pos
 
-let snot_found_suggestion orig similar =
+let snot_found_suggestion orig similar kind =
   match similar with
   | (`instance, pos, v) ->
-    suggestion_message ~modifier:"instance method " orig v pos
+    begin
+      match kind with 
+      | `static_method -> 
+      suggestion_message ~modifier:"instance method " orig v pos
+      | `class_constant -> 
+      suggestion_message ~modifier:"instance property " orig v pos
+      | `class_variable 
+      | `class_typeconst -> 
+      suggestion_message orig v pos
+    end
   | (`static, pos, v) -> suggestion_message orig v pos
 
 let string_of_class_member_kind = function
@@ -3192,6 +3201,7 @@ let string_of_class_member_kind = function
   | `property -> "property"
 
 let smember_not_found_messages pos kind (cpos, class_name) member_name similar =
+  let kind_record = kind in
   let kind = string_of_class_member_kind kind in
   let class_name = strip_ns class_name in
   let msg =
@@ -3216,7 +3226,7 @@ let smember_not_found_messages pos kind (cpos, class_name) member_name similar =
           ]
         | None -> []
       in
-      ([snot_found_suggestion member_name similar], quickfixes)
+      ([snot_found_suggestion member_name similar kind_record], quickfixes)
   in
   ( Typing.err_code Typing.SmemberNotFound,
     quickfixes,

--- a/hphp/hack/test/typecheck/instance_property_as_class_constant.php
+++ b/hphp/hack/test/typecheck/instance_property_as_class_constant.php
@@ -1,0 +1,18 @@
+<?hh // strict
+/**
+ * Copyright (c) 2014, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the "hack" directory of this source tree.
+ *
+ *
+ */
+
+class X {                                                                                  
+    public ?string $foo;                                                                   
+}                                                                                          
+                                                                                           
+function main(): void {                                                                    
+    var_dump(X::foo);                                                                      
+}

--- a/hphp/hack/test/typecheck/instance_property_as_class_constant.php.exp
+++ b/hphp/hack/test/typecheck/instance_property_as_class_constant.php.exp
@@ -1,0 +1,6 @@
+File "instance_property_as_class_constant.php", line 17, characters 17-19:
+No class constant `foo` in `X` (Typing[4090])
+  File "instance_property_as_class_constant.php", line 13, characters 12-18:
+  Did you mean instance property `foo` instead?
+  File "instance_property_as_class_constant.php", line 12, characters 7-7:
+  Declaration of `X` is here


### PR DESCRIPTION
This PR: 
- Update error message when an instance method/property is used as a static method/property
- Link to this [Issue](https://gist.github.com/shayne-fletcher/4cece69915f546ea68983172aaa7318e)