### PR TITLE
Add `\HH\hhvm_config()` and `\HH\hhvm_config_hdf()`

### DIFF
--- a/hphp/runtime/base/config.cpp
+++ b/hphp/runtime/base/config.cpp
@@ -266,6 +266,7 @@ void Config::Bind(T& loc, const IniSetting::Map &ini, const Hdf& config, \
                   const T defValue /* = 0ish */, \
                   const bool prepend_hhvm /* = true */) { \
   loc = Get##METHOD(ini, config, name, defValue, prepend_hhvm); \
+  IniSetting::Bind(IniSetting::CORE, IniSetting::HHVM_HDF, name, &loc); \
   IniSetting::Bind(IniSetting::CORE, IniSetting::PHP_INI_SYSTEM, \
                    IniName(name, prepend_hhvm), &loc); \
 }
@@ -316,6 +317,7 @@ void Config::Bind(T& loc, const IniSetting::Map& ini, const Hdf& config, \
                   const T& defValue /* = T() */, \
                   const bool prepend_hhvm /* = true */) { \
   loc = Get##METHOD(ini, config, name, defValue, prepend_hhvm); \
+  IniSetting::Bind(IniSetting::CORE, IniSetting::HHVM_HDF, name, &loc); \
   IniSetting::Bind(IniSetting::CORE, IniSetting::PHP_INI_SYSTEM, \
                    IniName(name, prepend_hhvm), &loc); \
 }

--- a/hphp/runtime/base/ini-setting.h
+++ b/hphp/runtime/base/ini-setting.h
@@ -246,9 +246,12 @@ public:
     PHP_INI_ONLY   = (1u << 3),
     PHP_INI_ALL    = (1u << 4),
 
+    HHVM_HDF       = (1u << 5),
+
     PHP_INI_SET_USER   = PHP_INI_USER | PHP_INI_ALL,
     PHP_INI_SET_EVERY  = PHP_INI_ONLY | PHP_INI_SYSTEM | PHP_INI_PERDIR |
                          PHP_INI_SET_USER,
+
   };
 
 public:
@@ -266,6 +269,7 @@ public:
   static std::string Get(const String& name);
   static Array GetAll(const String& extension, bool details);
   static std::string GetAllAsJSON();
+  static void GetAll(Hdf& config);
 
   /**
    * Change an INI setting as if it was in the php.ini file

--- a/hphp/runtime/ext/hh/ext_hh.php
+++ b/hphp/runtime/ext/hh/ext_hh.php
@@ -473,6 +473,12 @@ function collect_function_coverage(): dict<string, string>;
 <<__Native>>
 function root_options(string $repo): dict<string, mixed>;
 
+<<__Native>>
+function hhvm_config_hdf(?string $path = null): string;
+
+<<__Native>>
+function hhvm_config(?string $path = null): mixed;
+
 } // HH
 
 namespace HH\Rx {


### PR DESCRIPTION
Summary:
- both are keyed by HDF names
- `HH\hhvm_config_hdf()` returns a pretty-printed HDF file
- `HH\hhvm_config()` returns `string|dict<string, RECURSIVE>`

These are meant to provide an HDF-friendly alternatively to ini_get() and ini_get_all(), and to provide a migration path from INI to HDF: use `HH\hhvm_config_hdf()` to generate an HDF matching your current configuration - though you probably want to diff it against the results when running with `--no-config` to save only the changes you want.

The HDF reading is currently just `Foo = hdf.get('Eval.Bar')` behind several levels of abstractions - but we don't maintain the map. Given we have one for inisettings, we can just hook into that.

TODO
 - audit all explicit IniSetting::Bind() calls to make sure they're still in here
 - HHI
- unit tests

Differential Revision: D31872311

