### PR TITLE
Add truncate to writable files

### DIFF
--- a/hphp/hsl/src/file/Handle.php
+++ b/hphp/hsl/src/file/Handle.php
@@ -49,6 +49,7 @@ interface ReadHandle extends Handle, IO\SeekableReadFDHandle {
 }
 
 interface WriteHandle extends Handle, IO\SeekableWriteFDHandle {
+  public function truncate(?int $length = null): void;
 }
 
 interface ReadWriteHandle extends WriteHandle, ReadHandle, IO\SeekableReadWriteFDHandle {

--- a/hphp/hsl/src/file/_Private/CloseableReadWriteHandle.php
+++ b/hphp/hsl/src/file/_Private/CloseableReadWriteHandle.php
@@ -18,4 +18,5 @@ final class CloseableReadWriteHandle
   implements File\CloseableReadWriteHandle {
   use _IO\FileDescriptorReadHandleTrait;
   use _IO\FileDescriptorWriteHandleTrait;
+  use TruncateTrait;
 }

--- a/hphp/hsl/src/file/_Private/CloseableWriteHandle.php
+++ b/hphp/hsl/src/file/_Private/CloseableWriteHandle.php
@@ -17,4 +17,5 @@ final class CloseableWriteHandle
   extends CloseableFileHandle
   implements File\CloseableWriteHandle {
   use _IO\FileDescriptorWriteHandleTrait;
+  use TruncateTrait;
 }

--- a/hphp/hsl/src/file/_Private/TruncateTrait.php
+++ b/hphp/hsl/src/file/_Private/TruncateTrait.php
@@ -1,0 +1,28 @@
+<?hh
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the hphp/hsl/ subdirectory of this source tree.
+ *
+ */
+
+namespace HH\Lib\_Private\_File;
+
+use namespace HH\Lib\{IO, OS};
+use namespace HH\Lib\_Private\_IO;
+
+/**
+ * This method can't be added directly to `_IO\FileDescriptorWriteHandleTrait`,
+ * because the only real files can be truncated on both MacOS and Linux.
+ * On Linux you can also truncate posix shared memory, but that is not
+ * supported on MacOS.
+ */
+trait TruncateTrait {
+  require extends _IO\FileDescriptorHandle;
+
+  final public function truncate(?int $length = null): void {
+    OS\ftruncate($this->impl, $length ?? 0);
+  }
+}

--- a/hphp/hsl/src/os/ftruncate.php
+++ b/hphp/hsl/src/os/ftruncate.php
@@ -1,0 +1,18 @@
+<?hh
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the hphp/hsl/ subdirectory of this source tree.
+ *
+ */
+
+namespace HH\Lib\OS;
+
+use namespace HH\Lib\_Private\_OS;
+
+function ftruncate(FileDescriptor $fd, int $length): void {
+  _OS\arg_assert($length >= 0, '$length must be >= 0, got %d', $length);
+  _OS\wrap_impl(() ==> _OS\ftruncate($fd, $length));
+}

--- a/hphp/hsl/tests/file/FileTest.php
+++ b/hphp/hsl/tests/file/FileTest.php
@@ -179,4 +179,20 @@ final class FileTest extends HackTest {
     // - the lock's __dispose didn't throw
     // - the temporary file's __dispose didn't throw
   }
+
+  public async function testTruncateAsync(): Awaitable<void> {
+    $filename = sys_get_temp_dir().'/'.bin2hex(random_bytes(16));
+    $f = File\open_write_only($filename);
+    using ($f->closeWhenDisposed()) {
+      await $f->writeAllAsync('Hello, World!');
+    }
+    $f = File\open_read_write($filename);
+    using ($f->closeWhenDisposed()) {
+      $f->truncate(5);
+      expect(await $f->readAllAsync())->toEqual('Hello');
+      $f->truncate(2);
+      $f->seek(0);
+      expect(await $f->readAllAsync())->toEqual('He');
+    }
+  }
 }


### PR DESCRIPTION
Fixes hhvm/hsl-experimental#165

I had great difficulty reading the manpage for ftruncate. I believe there are no errno errors that we need to wrap for the caller. But because I am very inexperienced with this, I have included my reasoning below.
[manpage used](https://www.man7.org/linux/man-pages/man3/ftruncate.3p.html)

_EINTR  A signal was caught during execution._
From src/os/README.md
```
### Performance

- constructing an exception requires constructing the backtrace; it should be
  avoided for 'expected' cases. For example, if it is safe to, calls are
  retried on EINTR 5 times.
  - only do this if it is transparent - i.e. the user can't easily tell if
    the call was retried or was just slow.
```
Would this be a candidate for automatic retry?

_EINVAL The length argument was less than 0._
Caught this with `_OS\arg_assert()`.

_EFBIG or EINVAL The length argument was greater than the maximum file size._
I can't know what the maximum file size is. It might throw EINVAL (which is what `_OS\arg_assert($length <= $MAX_FILE_SIZE, '...')` would have thrown) or `EFBIG`. I would catch EFBIG and throw EINVAL instead, but the next entry would incorrectly have its error code changed.

_EFBIG  The file is a regular file and length is greater than the offset maximum established in the open file description associated with fildes._
See previous entry.

_EIO    An I/O error occurred while reading from or writing to a file system._
This is disks being disks...

_EBADF or EINVAL The fildes argument is not a file descriptor open for writing._
`File\open_write_only()` already checked for write permission.