### PR TITLE
add quickfix when an abstract static method is called using self

### DIFF
--- a/hphp/hack/src/errors/errors.ml
+++ b/hphp/hack/src/errors/errors.ml
@@ -3009,9 +3009,15 @@ let parent_abstract_call meth_name call_pos decl_pos =
       ^ "; it is abstract" )
     [(decl_pos, "Declaration is here")]
 
-let self_abstract_call meth_name call_pos decl_pos =
+let self_abstract_call meth_name self_pos call_pos decl_pos =
   add_list
     (Typing.err_code Typing.AbstractCall)
+    ~quickfixes:[
+      Quickfix.make
+      ~title:("Change to -> static::" ^ meth_name)
+      ~new_text:("static")
+      self_pos;
+    ]
     ( call_pos,
       "Cannot call "
       ^ Markdown_lite.md_codify ("self::" ^ meth_name ^ "()")

--- a/hphp/hack/src/errors/errors.mli
+++ b/hphp/hack/src/errors/errors.mli
@@ -597,7 +597,7 @@ val parent_outside_class : Pos.t -> unit
 
 val parent_abstract_call : string -> Pos.t -> Pos_or_decl.t -> unit
 
-val self_abstract_call : string -> Pos.t -> Pos_or_decl.t -> unit
+val self_abstract_call : string -> Pos.t -> Pos.t -> Pos_or_decl.t -> unit
 
 val classname_abstract_call : string -> string -> Pos.t -> Pos_or_decl.t -> unit
 

--- a/hphp/hack/src/typing/typing.ml
+++ b/hphp/hack/src/typing/typing.ml
@@ -805,7 +805,7 @@ let is_hack_collection env ty =
     ty
     (MakeType.const_collection Reason.Rnone (MakeType.mixed Reason.Rnone))
 
-let check_class_get env p def_pos cid mid ce e function_pointer =
+let check_class_get env p def_pos cid mid ce (_, _cid_pos, e) function_pointer =
   match e with
   | CIself when get_ce_abstract ce ->
     begin
@@ -825,12 +825,12 @@ let check_class_get env p def_pos cid mid ce e function_pointer =
              * implementation. *)
             (match Decl_provider.get_class (Env.get_ctx env) ce.ce_origin with
             | Some meth_cls when Ast_defs.is_c_trait (Cls.kind meth_cls) ->
-              Errors.self_abstract_call mid p def_pos
+              Errors.self_abstract_call mid _cid_pos p def_pos
             | _ -> ())
           | _ ->
             (* Ban self::some_abstract_method() in a class. This will
              *  always error. *)
-            Errors.self_abstract_call mid p def_pos
+            Errors.self_abstract_call mid _cid_pos p def_pos
         end
       | None -> ()
     end
@@ -6817,7 +6817,7 @@ and class_get_inner
             cid_
             class_;
           TVis.check_deprecated ~use_pos:p ~def_pos ce_deprecated;
-          check_class_get env p def_pos c mid ce cid_ is_function_pointer;
+          check_class_get env p def_pos c mid ce cid is_function_pointer;
           let (env, member_ty, et_enforced, tal) =
             match deref member_decl_ty with
             (* We special case Tfun here to allow passing in explicit tparams to localize_ft. *)

--- a/hphp/hack/test/quickfixes/bad_abstract_static.php
+++ b/hphp/hack/test/quickfixes/bad_abstract_static.php
@@ -1,0 +1,9 @@
+<?hh
+
+abstract class MyClass {
+    abstract public static function childImplements(): void;
+
+    public static function foo(): void {
+    self::childImplements();
+    }
+}

--- a/hphp/hack/test/quickfixes/bad_abstract_static.php.exp
+++ b/hphp/hack/test/quickfixes/bad_abstract_static.php.exp
@@ -1,0 +1,9 @@
+<?hh
+
+abstract class MyClass {
+    abstract public static function childImplements(): void;
+
+    public static function foo(): void {
+    static::childImplements();
+    }
+}


### PR DESCRIPTION
This PR:
- Pass `quickfixes` argument to `self_abstract_call`
- Find the position of keyword `self` that is stored in `_cid_pos` of `class_get_inner` then pass to `check_class_get` then pass it to `self_abstract_call` 
- Link to #8916 