### PR TITLE
Stop submoduling re2

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,9 +13,6 @@
 [submodule "libafdt"]
 	path = third-party/libafdt/src
 	url = https://github.com/facebook/libafdt
-[submodule "re2"]
-	path = third-party/re2/src
-	url = https://github.com/google/re2.git
 [submodule "xed-mbuild"]
 	path = third-party/xed/mbuild
 	url = https://github.com/intelxed/mbuild.git

--- a/third-party/CMakeLists.txt
+++ b/third-party/CMakeLists.txt
@@ -73,16 +73,8 @@ endif()
 add_subdirectory(lz4)
 
 # fb-mysql must go after lz4 and zstd because it needs to know its <INSTALL_DIR>
+add_subdirectory(re2)
 add_subdirectory(fb-mysql)
-find_package(RE2)
-if(NOT RE2_LIBRARY)
-  message(STATUS "Building RE2 from third-party")
-  add_subdirectory(re2)
-else()
-  add_library(re2 INTERFACE)
-  target_link_libraries(re2 INTERFACE ${RE2_LIBRARY})
-  target_include_directories(re2 INTERFACE ${RE2_INCLUDE_DIR})
-endif()
 add_subdirectory(squangle)
 
 if (ENABLE_MCROUTER)

--- a/third-party/fb-mysql/CMakeLists.txt
+++ b/third-party/fb-mysql/CMakeLists.txt
@@ -40,22 +40,22 @@ ExternalProject_Add(
   -DWITH_LZ4=system
   "-DLZ4_SYSTEM_LIBRARY=$<TARGET_PROPERTY:lz4,INTERFACE_LINK_LIBRARIES>"
   "-DPATH_TO_LZ4=$<TARGET_PROPERTY:lz4,INTERFACE_INCLUDE_DIRECTORIES>"
+  -DWITH_RE2=system
+  "-DRE2_SYSTEM_LIBRARY=$<TARGET_PROPERTY:re2,INTERFACE_LINK_LIBRARIES>"
+  "-DPATH_TO_RE2=$<TARGET_PROPERTY:re2,INTERFACE_INCLUDE_DIRECTORIES>"
   -DWITH_ZSTD=system
   "-DZSTD_SYSTEM_LIBRARY=$<TARGET_PROPERTY:zstd,INTERFACE_LINK_LIBRARIES>"
   "-DPATH_TO_ZSTD=$<TARGET_PROPERTY:zstd,INTERFACE_INCLUDE_DIRECTORIES>"
   ${EXTRA_ARGS}
 )
 
-# TODO: re2 is also a dependency, but first it needs to be split into
-# re2 + re2Build -- otherwise putting them here would force
-# them to always be built, instead of using the system ones where available.
-set(DEPS lz4 zstd)
+set(DEPS lz4 re2 zstd)
 add_dependencies(bundled_fbmysqlclient ${DEPS})
 
 # This extra indirection is needed because if the fbmysqlclient target links
 # ${DEPS} directly, the correct linking order is not guaranteed.
-add_library(fbmysqlclientDeps INTERFACE)
-target_link_libraries(fbmysqlclientDeps INTERFACE ${DEPS})
+add_library(fbmysqlclient_deps INTERFACE)
+target_link_libraries(fbmysqlclient_deps INTERFACE ${DEPS})
 
 ExternalProject_Get_Property(bundled_fbmysqlclient INSTALL_DIR)
 
@@ -63,5 +63,5 @@ add_dependencies(fbmysqlclient bundled_fbmysqlclient)
 target_include_directories(fbmysqlclient INTERFACE "${INSTALL_DIR}/include")
 target_link_libraries(fbmysqlclient INTERFACE
   "${INSTALL_DIR}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}mysqlclient${CMAKE_STATIC_LIBRARY_SUFFIX}"
-  fbmysqlclientDeps
+  fbmysqlclient_deps
 )

--- a/third-party/re2/CMakeLists.txt
+++ b/third-party/re2/CMakeLists.txt
@@ -1,15 +1,44 @@
-cmake_minimum_required(VERSION 2.8.0)
-project(re2 CXX C)
+add_library(re2 INTERFACE)
 
-auto_sources(sources "*.cc" "${CMAKE_CURRENT_SOURCE_DIR}/src/re2")
-SET(util_sources
-  src/util/rune.cc
-  src/util/strutil.cc
+find_package(RE2)
+if(RE2_LIBRARY)
+  target_link_libraries(re2 INTERFACE ${RE2_LIBRARY})
+  target_include_directories(re2 INTERFACE ${RE2_INCLUDE_DIR})
+  return() # from File
+endif()
+
+include(ExternalProject)
+include(HPHPFunctions)
+
+SET_HHVM_THIRD_PARTY_SOURCE_ARGS(
+  RE2_SOURCE_ARGS
+  SOURCE_URL
+  "https://github.com/google/re2/archive/refs/tags/2021-11-01.tar.gz"
+  SOURCE_HASH
+  "SHA256=8c45f7fba029ab41f2a7e6545058d9eec94eef97ce70df58e92d85cfc08b4669"
+  FILENAME_PREFIX "re2-"
 )
 
-set(RE2_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/src" CACHE STRING "RE2 include path")
-# Blow away the global include directories - eg both hhvm and re2 have a
-# util/arena.h
-SET_PROPERTY(DIRECTORY PROPERTY INCLUDE_DIRECTORIES "${RE2_INCLUDE_DIR}")
-add_library(re2 STATIC ${util_sources} ${sources})
-target_include_directories(re2 PUBLIC ${RE2_INCLUDE_DIR})
+ExternalProject_Add(
+  bundled_re2
+  ${RE2_SOURCE_ARGS}
+  EXCLUDE_FROM_ALL
+  CMAKE_ARGS
+    "-DCMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH}"
+    -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+    -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+    -DCMAKE_INSTALL_INCLUDEDIR=include
+    -DCMAKE_INSTALL_LIBDIR=lib
+
+    -DBUILD_TESTING=OFF
+    -DRE2_BUILD_TESTING=OFF
+)
+ExternalProject_Get_property(bundled_re2 INSTALL_DIR)
+
+add_dependencies(re2 bundled_re2)
+target_include_directories(re2 INTERFACE "${INSTALL_DIR}/include")
+target_link_libraries(
+  re2
+  INTERFACE
+  "${INSTALL_DIR}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}re2${CMAKE_STATIC_LIBRARY_SUFFIX}"
+)


### PR DESCRIPTION
- Use release tarball instead of stale submodule
- faster builds
- more consistent with other stuff
- always defines re2 target, conditionally defines bundled_re2 target
- resolve re2 build TODO in fbmysqlclient CMake, which required this split (fooBuild was the old name for bundled_foo targets) by making it depend on re2 (but not bundled_re2)
- clean up fbmysqlclient's cmake to get it up to speed with our current conventions while I'm here

The net effect is that:
- build of re2 should be faster, as we'll be fetching a source tarball instead of gitsubmodule - and in FB infra, it's cached locally
- we won't spend time fetching re2 sources at all if the system version is new enough
- fbmysqlclient will also build faster if system re2 does not exist or is too old: previously HHVM and fbmysqlclient would each build their own copy

Test plan:

*castle and built on AWS worker.