### PR TITLE
Delete hhvm/hphp/doc/inconsistencies

### DIFF
--- a/hphp/doc/inconsistencies
+++ b/hphp/doc/inconsistencies
@@ -1,3 +1,0 @@
-Please visit http://docs.hhvm.com/hhvm/inconsistencies/introduction to view the inconsistencies.
-
-Please visit https://github.com/hhvm/user-documentation/tree/master/guides/hhvm/06-inconsistencies to update the inconsistencies.


### PR DESCRIPTION
it was originally a list of inconsistencies with php5.. now it just contains broken links