### PR TITLE
Add type annotation quickfix for global constant variable

### DIFF
--- a/hphp/hack/src/errors/errors.ml
+++ b/hphp/hack/src/errors/errors.ml
@@ -1790,15 +1790,23 @@ let typeconst_concrete_concrete_override pos parent_pos =
       (parent_pos, "Previously defined here");
     ]
 
-let const_without_typehint sid =
+let const_without_typehint sid type_ =
   let (pos, name) = sid in
-  let msg =
-    Printf.sprintf
-      "Please add a type hint `const SomeType %s`"
-      (Utils.strip_all_ns name)
+  let name = Utils.strip_all_ns name in
+  let msg = Printf.sprintf "Please add a type hint `const SomeType %s`" name in
+  let (title, new_text) =
+    match type_ with
+    | "string" -> ("Add string type annotation", "string " ^ name)
+    | "int" -> ("Add integer type annotation", "int " ^ name)
+    | "float" -> ("Add float type annotation", "float " ^ name)
+    | _ -> ("Add mixed type annotation", "mixed " ^ name)
   in
-  add (Naming.err_code Naming.AddATypehint) pos msg
-
+  add_list
+    (Naming.err_code Naming.AddATypehint)
+    ~quickfixes:[Quickfix.make ~title ~new_text pos]
+    (pos, msg)
+    []
+  
 let prop_without_typehint visibility sid =
   let (pos, name) = sid in
   let msg =

--- a/hphp/hack/src/errors/errors.mli
+++ b/hphp/hack/src/errors/errors.mli
@@ -513,7 +513,7 @@ val interface_typeconst_multiple_defs :
   error_from_reasons_callback ->
   unit
 
-val const_without_typehint : Pos.t * string -> unit
+val const_without_typehint : Pos.t * string -> string -> unit
 
 val prop_without_typehint : string -> Pos.t * string -> unit
 

--- a/hphp/hack/src/typing/nast_check/global_const_check.ml
+++ b/hphp/hack/src/typing/nast_check/global_const_check.ml
@@ -9,9 +9,17 @@
 open Hh_prelude
 open Aast
 
-let error_if_no_typehint { cst_mode; cst_type; cst_name; _ } =
+let error_if_no_typehint { cst_mode; cst_type; cst_name; cst_value; _ } =
   if (not (FileInfo.is_hhi cst_mode)) && Option.is_none cst_type then
-    Errors.const_without_typehint cst_name
+    let (_, _, expr) = cst_value in
+    let type_ =
+      match expr with
+      | String _ -> "string"
+      | Int _ -> "int"
+      | Float _ -> "float"
+      | _ -> "mixed"
+    in
+    Errors.const_without_typehint cst_name type_
 
 let error_if_pseudo_constant gconst =
   if Option.is_some gconst.cst_namespace.Namespace_env.ns_name then

--- a/hphp/hack/test/quickfixes/type_annotation_float.php
+++ b/hphp/hack/test/quickfixes/type_annotation_float.php
@@ -1,0 +1,4 @@
+<?hh
+
+const MY_CONST = 1.0;
+

--- a/hphp/hack/test/quickfixes/type_annotation_float.php.exp
+++ b/hphp/hack/test/quickfixes/type_annotation_float.php.exp
@@ -1,0 +1,4 @@
+<?hh
+
+const float MY_CONST = 1.0;
+

--- a/hphp/hack/test/quickfixes/type_annotation_int.php
+++ b/hphp/hack/test/quickfixes/type_annotation_int.php
@@ -1,0 +1,4 @@
+<?hh
+
+const MY_CONST = 0;
+

--- a/hphp/hack/test/quickfixes/type_annotation_int.php.exp
+++ b/hphp/hack/test/quickfixes/type_annotation_int.php.exp
@@ -1,0 +1,4 @@
+<?hh
+
+const int MY_CONST = 0;
+

--- a/hphp/hack/test/quickfixes/type_annotation_mixed.php
+++ b/hphp/hack/test/quickfixes/type_annotation_mixed.php
@@ -1,0 +1,4 @@
+<?hh
+
+const MY_CONST = vec[1,2,3];
+

--- a/hphp/hack/test/quickfixes/type_annotation_mixed.php.exp
+++ b/hphp/hack/test/quickfixes/type_annotation_mixed.php.exp
@@ -1,0 +1,4 @@
+<?hh
+
+const mixed MY_CONST = vec[1,2,3];
+

--- a/hphp/hack/test/quickfixes/type_annotation_string.php
+++ b/hphp/hack/test/quickfixes/type_annotation_string.php
@@ -1,0 +1,4 @@
+<?hh
+
+const MY_CONST = "";
+

--- a/hphp/hack/test/quickfixes/type_annotation_string.php.exp
+++ b/hphp/hack/test/quickfixes/type_annotation_string.php.exp
@@ -1,0 +1,4 @@
+<?hh
+
+const string MY_CONST = "";
+


### PR DESCRIPTION
This PR does:
- Provide a quickfix when a global constant is declared without a type annotation, the quickfix currently supports `int`, `float` and `string` literals
- Add test files for respective type annotation
- #8919 