### PR TITLE
Add quickfix for inout type annotation

### DIFF
--- a/hphp/hack/src/errors/errors.ml
+++ b/hphp/hack/src/errors/errors.ml
@@ -4758,9 +4758,16 @@ let override_no_default_typeconst pos_child pos_parent =
 let inout_annotation_missing pos1 pos2 =
   let msg1 = (pos1, "This argument should be annotated with `inout`") in
   let msg2 = (pos2, "Because this is an `inout` parameter") in
-  add_list (Typing.err_code Typing.InoutAnnotationMissing) msg1 [msg2]
+  let (_, start_column) = Pos.line_column pos1 in
+  let pos = Pos.set_col_end start_column pos1 in
+  add_list
+    (Typing.err_code Typing.InoutAnnotationMissing)
+    ~quickfixes:
+      [Quickfix.make ~title:"Insert `inout` annotation" ~new_text:"inout " pos]
+    msg1
+    [msg2]
 
-let inout_annotation_unexpected pos1 pos2 pos2_is_variadic =
+let inout_annotation_unexpected pos1 pos2 pos2_is_variadic pos3 =
   let msg1 = (pos1, "Unexpected `inout` annotation for argument") in
   let msg2 =
     ( pos2,
@@ -4769,7 +4776,12 @@ let inout_annotation_unexpected pos1 pos2 pos2_is_variadic =
       else
         "This is a normal parameter (does not have `inout`)" )
   in
-  add_list (Typing.err_code Typing.InoutAnnotationUnexpected) msg1 [msg2]
+  add_list
+    (Typing.err_code Typing.InoutAnnotationUnexpected)
+    ~quickfixes:
+      [Quickfix.make ~title:"Remove `inout` annotation" ~new_text:"" pos3]
+    msg1
+    [msg2]
 
 let inoutness_mismatch pos1 pos2 (on_error : error_from_reasons_callback) =
   let msg1 = (pos1, "This is an `inout` parameter") in

--- a/hphp/hack/src/errors/errors.mli
+++ b/hphp/hack/src/errors/errors.mli
@@ -1334,7 +1334,8 @@ val inout_params_memoize : Pos.t -> Pos.t -> unit
 
 val inout_annotation_missing : Pos.t -> Pos_or_decl.t -> unit
 
-val inout_annotation_unexpected : Pos.t -> Pos_or_decl.t -> bool -> unit
+val inout_annotation_unexpected :
+  Pos.t -> Pos_or_decl.t -> bool -> Pos.t -> unit
 
 val inoutness_mismatch :
   Pos_or_decl.t -> Pos_or_decl.t -> error_from_reasons_callback -> unit

--- a/hphp/hack/src/typing/typing.ml
+++ b/hphp/hack/src/typing/typing.ml
@@ -1026,7 +1026,7 @@ let param_modes
   | (FPnormal, Ast_defs.Pnormal) -> ()
   | (FPinout, Ast_defs.Pinout _) -> ()
   | (FPnormal, Ast_defs.Pinout p) ->
-    Errors.inout_annotation_unexpected (Pos.merge p pos) fp_pos is_variadic
+    Errors.inout_annotation_unexpected (Pos.merge p pos) fp_pos is_variadic p
   | (FPinout, Ast_defs.Pnormal) -> Errors.inout_annotation_missing pos fp_pos
 
 let split_remaining_params_required_optional ft remaining_params =

--- a/hphp/hack/src/utils/pos.ml
+++ b/hphp/hack/src/utils/pos.ml
@@ -382,6 +382,14 @@ let rec set_file pos_file pos =
   | Pos_tiny { pos_span; pos_file = _ } -> Pos_tiny { pos_file; pos_span }
   | Pos_from_reason p -> Pos_from_reason (set_file pos_file p)
 
+let set_col_end pos_cnum pos =
+  let pos = as_large_pos pos in
+  match pos with
+  | Pos_large { pos_file; pos_start; pos_end } ->
+    let pos_end = File_pos_large.set_column pos_cnum pos_end in
+    Pos_large { pos_file; pos_start; pos_end }
+  | _ -> pos
+
 let set_from_reason pos =
   match pos with
   | Pos_from_reason _ -> pos

--- a/hphp/hack/src/utils/pos.mli
+++ b/hphp/hack/src/utils/pos.mli
@@ -141,6 +141,8 @@ val compare : t -> t -> int
 
 val set_file : 'a -> 'b pos -> 'a pos
 
+val set_col_end : int -> 'a pos -> 'a pos
+
 val make_from_lnum_bol_cnum :
   pos_file:Relative_path.t ->
   pos_start:int * int * int ->

--- a/hphp/hack/test/quickfixes/missing_inout_type_annotation.php
+++ b/hphp/hack/test/quickfixes/missing_inout_type_annotation.php
@@ -1,0 +1,8 @@
+<?hh
+
+function takes_param(inout int $x): void {}
+
+function call_it(): void {
+  $x = 1;
+  takes_param($x);
+}

--- a/hphp/hack/test/quickfixes/missing_inout_type_annotation.php.exp
+++ b/hphp/hack/test/quickfixes/missing_inout_type_annotation.php.exp
@@ -1,0 +1,8 @@
+<?hh
+
+function takes_param(inout int $x): void {}
+
+function call_it(): void {
+  $x = 1;
+  takes_param(inout $x);
+}

--- a/hphp/hack/test/quickfixes/unexpected_inout_type_annotation.php
+++ b/hphp/hack/test/quickfixes/unexpected_inout_type_annotation.php
@@ -1,0 +1,8 @@
+<?hh
+
+function takes_param(int $x): void {}
+
+function call_it(): void {
+  $x = 1;
+  takes_param(inout $x);
+}

--- a/hphp/hack/test/quickfixes/unexpected_inout_type_annotation.php.exp
+++ b/hphp/hack/test/quickfixes/unexpected_inout_type_annotation.php.exp
@@ -1,0 +1,8 @@
+<?hh
+
+function takes_param(int $x): void {}
+
+function call_it(): void {
+  $x = 1;
+  takes_param( $x);
+}


### PR DESCRIPTION
This draft PR:
- Implement removing unexpected `inout` type annotation
- Implement inserting `inout` type annotation for call site of function that requires arguments of type `inout`
- Add test files for these two implementations
