### PR TITLE
Add getopt_with_optind native function to support simple subparsers

### DIFF
--- a/hphp/hack/hhi/stdlib/builtins_options.hhi
+++ b/hphp/hack/hhi/stdlib/builtins_options.hhi
@@ -53,7 +53,7 @@ function getmyuid();
 function getopt(string $options, $longopts = null);
 <<__PHPStdLib>>
 function getopt_with_optind(
-  string $options, $longopts vec<string>, inout int $optind): dict<string, mixed>;
+  string $options, ?vec<string> $longopts, inout int $optind): dict<string, mixed>;
 <<__PHPStdLib>>
 function getrusage(int $who = 0);
 <<__PHPStdLib>>

--- a/hphp/hack/hhi/stdlib/builtins_options.hhi
+++ b/hphp/hack/hhi/stdlib/builtins_options.hhi
@@ -52,6 +52,9 @@ function getmyuid();
 <<__PHPStdLib>>
 function getopt(string $options, $longopts = null);
 <<__PHPStdLib>>
+function getopt_with_optind(
+  string $options, $longopts vec<string>, inout int $optind): dict<string, mixed>;
+<<__PHPStdLib>>
 function getrusage(int $who = 0);
 <<__PHPStdLib>>
 function clock_getres(int $clk_id, inout $sec, inout $nsec);

--- a/hphp/runtime/ext/std/ext_std_options.cpp
+++ b/hphp/runtime/ext/std/ext_std_options.cpp
@@ -414,10 +414,11 @@ static Array HHVM_FUNCTION(getopt_with_optind,
                            const Variant& longopts,
                            int64_t& optind) {
   if (optind <= 0) {
-    raise_warning("optind must be positive");
-    // Be conservative and return an empty dict
-    return Array::CreateDict();
+    SystemLib::throwInvalidArgumentExceptionObject(
+      "Parameter optind must be a positive integer"
+    );
   }
+
   auto opt_vec = parse_opts(options.data(), options.size());
 
   if (!longopts.isNull()) {

--- a/hphp/runtime/ext/std/ext_std_options.cpp
+++ b/hphp/runtime/ext/std/ext_std_options.cpp
@@ -409,9 +409,15 @@ static req::vector<opt_struct> parse_opts(const char *opts, int opts_len) {
 
 const StaticString s_argv("argv");
 
-static Array hhvm_getopt_impl(const String& options,
-                              const Variant& longopts,
-                              int64_t& optind) {
+static Array HHVM_FUNCTION(getopt_with_optind,
+                           const String& options,
+                           const Variant& longopts,
+                           int64_t& optind) {
+  if (optind <= 0) {
+    raise_warning("optind must be positive");
+    // Be conservative and return an empty dict
+    return Array::CreateDict();
+  }
   auto opt_vec = parse_opts(options.data(), options.size());
 
   if (!longopts.isNull()) {
@@ -549,19 +555,7 @@ static Array hhvm_getopt_impl(const String& options,
 static Array HHVM_FUNCTION(getopt, const String& options,
                                    const Variant& longopts /*=null */) {
   int64_t optind = 1;
-  return hhvm_getopt_impl(options, longopts, optind);
-}
-
-static Array HHVM_FUNCTION(getopt_with_optind,
-                           const String& options,
-                           const Variant& longopts,
-                           int64_t& optind) {
-  if (optind <= 0) {
-    raise_warning("optind must be positive");
-    // Be conservative and return an empty dict
-    return Array::CreateDict();
-  }
-  return hhvm_getopt_impl(options, longopts, optind);
+  return HHVM_FN(getopt_with_optind)(options, longopts, optind);
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/hphp/runtime/ext/std/ext_std_options.php
+++ b/hphp/runtime/ext/std/ext_std_options.php
@@ -112,8 +112,8 @@ function getopt(string $options,
  */
 <<__Native>>
 function getopt_with_optind(string $options,
-                            mixed $longopts,
-                            inout int $optind): darray;
+                            ?vec<string> $longopts,
+                            inout int $optind): dict<string, mixed>;
 
 /* This is an interface to getrusage(2). It gets data returned from the system
  * call.

--- a/hphp/runtime/ext/std/ext_std_options.php
+++ b/hphp/runtime/ext/std/ext_std_options.php
@@ -105,6 +105,11 @@ function getmyuid(): mixed;
 <<__Native>>
 function getopt(string $options,
                 mixed $longopts = null): darray;
+
+/* Similar to getopt but accepts an inout optind which controls the argument
+ * at which parsing begins. Sets the optind to the index of the first unparsed
+ * option.
+ */
 <<__Native>>
 function getopt_with_optind(string $options,
                             mixed $longopts,

--- a/hphp/runtime/ext/std/ext_std_options.php
+++ b/hphp/runtime/ext/std/ext_std_options.php
@@ -105,6 +105,10 @@ function getmyuid(): mixed;
 <<__Native>>
 function getopt(string $options,
                 mixed $longopts = null): darray;
+<<__Native>>
+function getopt_with_optind(string $options,
+                            mixed $longopts,
+                            inout int $optind): darray;
 
 /* This is an interface to getrusage(2). It gets data returned from the system
  * call.

--- a/hphp/test/zend/good/ext/standard/tests/general_functions/getopt_basic.php
+++ b/hphp/test/zend/good/ext/standard/tests/general_functions/getopt_basic.php
@@ -1,0 +1,28 @@
+<?hh
+
+<<__EntryPoint>> function main(): void {
+echo "Simple testcase for getopt() function\n";
+
+$argv = HH\global_get('argv');
+$argv[] = '-f';
+$argv[] = '-g';
+$argv[] = 'value_for_g';
+$argv[] = '-k';
+$argv[] = 'value_for_k';
+$argv[] = '-mno';
+HH\global_set('argv', $argv);
+
+// Parse `f`
+var_dump(getopt('f::'));
+
+// Try to parse `g`
+var_dump(getopt('g:'));
+
+// Try to parse `k`
+var_dump(getopt('k:'));
+
+// Try to parse `mno`
+var_dump(getopt('mno::'));
+
+echo "Done\n";
+}

--- a/hphp/test/zend/good/ext/standard/tests/general_functions/getopt_basic.php.expectf
+++ b/hphp/test/zend/good/ext/standard/tests/general_functions/getopt_basic.php.expectf
@@ -1,0 +1,14 @@
+Simple testcase for getopt() function
+dict(1) {
+  ["f"]=>
+  bool(false)
+}
+dict(1) {
+  ["g"]=>
+  string(11) "value_for_g"
+}
+dict(0) {
+}
+dict(0) {
+}
+Done

--- a/hphp/test/zend/good/ext/standard/tests/general_functions/getopt_with_optind_basic.php
+++ b/hphp/test/zend/good/ext/standard/tests/general_functions/getopt_with_optind_basic.php
@@ -7,7 +7,7 @@ $argv = HH\global_get('argv');
 $argv[] = '-f';
 $argv[] = '-g';
 $argv[] = 'value_for_g';
-$argv[] = '-k';
+$argv[] = '--k_long';
 $argv[] = 'value_for_k';
 $argv[] = '-mno';
 HH\global_set('argv', $argv);
@@ -23,7 +23,7 @@ var_dump(getopt_with_optind('g:', null, inout $optind));
 var_dump($optind);
 
 // Parse `k`
-var_dump(getopt_with_optind('k:', null, inout $optind));
+var_dump(getopt_with_optind('', vec['k_long:'], inout $optind));
 var_dump($optind);
 
 // Parse `mno`

--- a/hphp/test/zend/good/ext/standard/tests/general_functions/getopt_with_optind_basic.php
+++ b/hphp/test/zend/good/ext/standard/tests/general_functions/getopt_with_optind_basic.php
@@ -1,0 +1,34 @@
+<?hh
+
+<<__EntryPoint>> function main(): void {
+echo "Simple testcase for getopt_with_optind() function\n";
+
+$argv = HH\global_get('argv');
+$argv[] = '-f';
+$argv[] = '-g';
+$argv[] = 'value_for_g';
+$argv[] = '-k';
+$argv[] = 'value_for_k';
+$argv[] = '-mno';
+HH\global_set('argv', $argv);
+
+$optind = 1;
+
+// Parse `f`
+var_dump(getopt_with_optind('f::', null, inout $optind));
+var_dump($optind);
+
+// Parse `g`
+var_dump(getopt_with_optind('g:', null, inout $optind));
+var_dump($optind);
+
+// Parse `k`
+var_dump(getopt_with_optind('k:', null, inout $optind));
+var_dump($optind);
+
+// Parse `mno`
+var_dump(getopt_with_optind('mno::', null, inout $optind));
+var_dump($optind);
+
+echo "Done\n";
+}

--- a/hphp/test/zend/good/ext/standard/tests/general_functions/getopt_with_optind_basic.php.expectf
+++ b/hphp/test/zend/good/ext/standard/tests/general_functions/getopt_with_optind_basic.php.expectf
@@ -10,7 +10,7 @@ dict(1) {
 }
 int(4)
 dict(1) {
-  ["k"]=>
+  ["k_long"]=>
   string(11) "value_for_k"
 }
 int(6)

--- a/hphp/test/zend/good/ext/standard/tests/general_functions/getopt_with_optind_basic.php.expectf
+++ b/hphp/test/zend/good/ext/standard/tests/general_functions/getopt_with_optind_basic.php.expectf
@@ -1,0 +1,26 @@
+Simple testcase for getopt_with_optind() function
+dict(1) {
+  ["f"]=>
+  bool(false)
+}
+int(2)
+dict(1) {
+  ["g"]=>
+  string(11) "value_for_g"
+}
+int(4)
+dict(1) {
+  ["k"]=>
+  string(11) "value_for_k"
+}
+int(6)
+dict(3) {
+  ["m"]=>
+  bool(false)
+  ["n"]=>
+  bool(false)
+  ["o"]=>
+  bool(false)
+}
+int(7)
+Done

--- a/hphp/test/zend/good/ext/standard/tests/general_functions/getopt_with_optind_invalid.php
+++ b/hphp/test/zend/good/ext/standard/tests/general_functions/getopt_with_optind_invalid.php
@@ -1,0 +1,31 @@
+<?hh
+
+<<__EntryPoint>> function main(): void {
+echo "Testcase for getopt_with_optind() function with invalid optind\n";
+
+$argv = HH\global_get('argv');
+$argv[] = '-f';
+HH\global_set('argv', $argv);
+
+$optind = -1;
+var_dump(getopt_with_optind('f::', null, inout $optind));
+var_dump($optind);
+
+$optind = -1;
+var_dump(getopt_with_optind('g::', null, inout $optind));
+var_dump($optind);
+
+$optind = 0;
+var_dump(getopt_with_optind('f::', null, inout $optind));
+var_dump($optind);
+
+$optind = 10000;
+var_dump(getopt_with_optind('f::', null, inout $optind));
+var_dump($optind);
+
+$optind = 1000000000000000;
+var_dump(getopt_with_optind('f::', null, inout $optind));
+var_dump($optind);
+
+echo "Done\n";
+}

--- a/hphp/test/zend/good/ext/standard/tests/general_functions/getopt_with_optind_invalid.php
+++ b/hphp/test/zend/good/ext/standard/tests/general_functions/getopt_with_optind_invalid.php
@@ -8,15 +8,27 @@ $argv[] = '-f';
 HH\global_set('argv', $argv);
 
 $optind = -1;
-var_dump(getopt_with_optind('f::', null, inout $optind));
+try {
+    getopt_with_optind('f::', null, inout $optind);
+} catch (InvalidArgumentException $e) {
+    echo $e->getMessage()."\n";
+}
 var_dump($optind);
 
 $optind = -1;
-var_dump(getopt_with_optind('g::', null, inout $optind));
+try {
+    getopt_with_optind('g::', null, inout $optind);
+} catch (InvalidArgumentException $e) {
+    echo $e->getMessage()."\n";
+}
 var_dump($optind);
 
 $optind = 0;
-var_dump(getopt_with_optind('f::', null, inout $optind));
+try {
+    getopt_with_optind('f::', null, inout $optind);
+} catch (InvalidArgumentException $e) {
+    echo $e->getMessage()."\n";
+}
 var_dump($optind);
 
 $optind = 10000;

--- a/hphp/test/zend/good/ext/standard/tests/general_functions/getopt_with_optind_invalid.php.expectf
+++ b/hphp/test/zend/good/ext/standard/tests/general_functions/getopt_with_optind_invalid.php.expectf
@@ -1,18 +1,9 @@
 Testcase for getopt_with_optind() function with invalid optind
-
-Warning: optind must be positive in /build/hhvm/hphp/test/zend/good/ext/standard/tests/general_functions/getopt_with_optind_invalid.php on line 11
-dict(0) {
-}
+Parameter optind must be a positive integer
 int(-1)
-
-Warning: optind must be positive in /build/hhvm/hphp/test/zend/good/ext/standard/tests/general_functions/getopt_with_optind_invalid.php on line 15
-dict(0) {
-}
+Parameter optind must be a positive integer
 int(-1)
-
-Warning: optind must be positive in /build/hhvm/hphp/test/zend/good/ext/standard/tests/general_functions/getopt_with_optind_invalid.php on line 19
-dict(0) {
-}
+Parameter optind must be a positive integer
 int(0)
 dict(0) {
 }

--- a/hphp/test/zend/good/ext/standard/tests/general_functions/getopt_with_optind_invalid.php.expectf
+++ b/hphp/test/zend/good/ext/standard/tests/general_functions/getopt_with_optind_invalid.php.expectf
@@ -1,0 +1,20 @@
+Testcase for getopt_with_optind() function with invalid optind
+Warning: optind must be positive in /build/hhvm/hphp/test/zend/good/ext/standard/tests/general_functions/getopt_with_optind_invalid.php on line 11
+dict(0) {
+}
+int(-1)
+Warning: optind must be positive in /build/hhvm/hphp/test/zend/good/ext/standard/tests/general_functions/getopt_with_optind_invalid.php on line 15
+dict(0) {
+}
+int(-1)
+Warning: optind must be positive in /build/hhvm/hphp/test/zend/good/ext/standard/tests/general_functions/getopt_with_optind_invalid.php on line 19
+dict(0) {
+}
+int(0)
+dict(0) {
+}
+int(10000)
+dict(0) {
+}
+int(1000000000000000)
+Done

--- a/hphp/test/zend/good/ext/standard/tests/general_functions/getopt_with_optind_invalid.php.expectf
+++ b/hphp/test/zend/good/ext/standard/tests/general_functions/getopt_with_optind_invalid.php.expectf
@@ -1,12 +1,15 @@
 Testcase for getopt_with_optind() function with invalid optind
+
 Warning: optind must be positive in /build/hhvm/hphp/test/zend/good/ext/standard/tests/general_functions/getopt_with_optind_invalid.php on line 11
 dict(0) {
 }
 int(-1)
+
 Warning: optind must be positive in /build/hhvm/hphp/test/zend/good/ext/standard/tests/general_functions/getopt_with_optind_invalid.php on line 15
 dict(0) {
 }
 int(-1)
+
 Warning: optind must be positive in /build/hhvm/hphp/test/zend/good/ext/standard/tests/general_functions/getopt_with_optind_invalid.php on line 19
 dict(0) {
 }


### PR DESCRIPTION
# Rationale

The `getopt()` function as defined in PHP and C returns an `optind` argument by reference. This `optind` indicates the index of the next argument to parse, should `getopt()` be invoked again. This means it's possible to call `getopt()` multiple times, each time passing in the `optind` returned from the previous call, to incrementally parse a set of arguments. Similarly, it's possible to pass a different value for `getopt()` than the value returned from the previous call in order to start parsing at a different offset within the arguments vector.

We can implement simple subcommands on top of this behavior: for example, if we encounter a certain command, we can look for different options in subsequent calls to `getopt()` than we'd look for if we had encountered some other command. Obviously `getopt()` is not the most robust tool atop which to build a CLI framework — I'm aware we have [hh-clilib](https://github.com/hhvm/hh-clilib) for that — but given that `getopt()` is widely used, I think supporting this kind of parsing would be useful. It would be useful where I work, where `getopt()` remains our primary method of parsing command line input across thousands of CLI scripts, and where a migration to a better tool would be non-trivial. https://github.com/facebook/hhvm/pull/7906 also requested this feature.

# Implementation

We'd like to continue using `getopt()` in the usual way, since that suffices for most cases. Furthermore, we want to pass in an `inout int $optind`, and inout variables cannot be optional. Therefore, we introduce a new function, `getopt_with_optind()`. I refactored `ext_std_options.cpp` to share code between `getopt()` and `getopt_with_optind()`. I'm not much of a C++ programmer though, so if I missed something please let me know.