### PR TITLE
Use pkg-config to find extra paths for LibElf

### DIFF
--- a/CMake/FindLibElf.cmake
+++ b/CMake/FindLibElf.cmake
@@ -18,10 +18,14 @@ if (LIBELF_LIBRARIES AND LIBELF_INCLUDE_DIRS)
   set (LibElf_FIND_QUIETLY TRUE)
 endif (LIBELF_LIBRARIES AND LIBELF_INCLUDE_DIRS)
 
+find_package(PkgConfig)
+pkg_check_modules(PkgConfig_LibElf QUIET libelf)
+
 find_path (LIBELF_INCLUDE_DIRS
   NAMES
     libelf.h
   PATHS
+    ${PkgConfig_LibElf_INCLUDE_DIRS}
     /usr/include
     /usr/include/libelf
     /usr/local/include
@@ -40,6 +44,7 @@ find_library (LIBELF_LIBRARIES
     /usr/local/lib
     /opt/local/lib
     /sw/lib
+    ${PkgConfig_LibElf_LIBRARY_DIRS}
     ENV LIBRARY_PATH
     ENV LD_LIBRARY_PATH)
 


### PR DESCRIPTION
Similar to https://github.com/facebook/hhvm/commit/1d99b206b8fc78184cc771129a02b3fdaa3fcc4e, this PR uses `pkg-config` to resolve libelf.

This PR should fix https://github.com/hhvm/homebrew-hhvm/issues/139