### PR TITLE
Suppress the error about `no rule to make target libfmt.a` due to `cmake -DCMAKE_BUILD_TYPE=Debug`

### DIFF
--- a/third-party/fmt/CMakeLists.txt
+++ b/third-party/fmt/CMakeLists.txt
@@ -26,6 +26,6 @@ add_library(fmt INTERFACE)
 add_dependencies(fmt bundled_fmt)
 target_include_directories(fmt INTERFACE "${INSTALL_DIR}/include")
 target_link_libraries(fmt INTERFACE
-  "${INSTALL_DIR}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}fmt${CMAKE_STATIC_LIBRARY_SUFFIX}"
+  "${INSTALL_DIR}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}fmt$<$<CONFIG:Debug>:d>${CMAKE_STATIC_LIBRARY_SUFFIX}"
 )
 set(FMT_INSTALL_DIR "${INSTALL_DIR}" PARENT_SCOPE)


### PR DESCRIPTION
This commit should fix #8982