### PR TITLE
Support top-level constants

### DIFF
--- a/hphp/hack/CMakeLists.txt
+++ b/hphp/hack/CMakeLists.txt
@@ -177,6 +177,9 @@ endforeach()
 set(HHBC_AST_HEADER "${RUST_FFI_BUILD_ROOT}/hphp/hack/src/hackc/hhbc-ast.h")
 set(FFI_HEADER "${RUST_FFI_BUILD_ROOT}/hphp/hack/src/utils/ffi.h")
 set(NAMING_SPECIAL_NAMES_HEADER "${RUST_FFI_BUILD_ROOT}/hphp/hack/src/naming/naming-special-names.h")
+set(TYPE_CONSTRAINT_HEADER "${CMAKE_SOURCE_DIR}/hphp/runtime/vm/type-constraint-flags.h")
+set(ATTR_HEADER "${CMAKE_SOURCE_DIR}/hphp/runtime/base/attr.h")
+
 add_custom_command(
   OUTPUT ${HHBC_AST_HEADER}
   COMMAND
@@ -189,7 +192,7 @@ add_custom_command(
       --namespaces "HPHP,hackc" &&
     ${CARGO_BUILD} ffi_cbindgen ffi_cbindgen --exe
       --header "${HHBC_AST_HEADER}" --srcs "${HHBC_AST_SRC_ARG}" --namespaces "HPHP,hackc,hhbc"
-      --includes "${FFI_HEADER},${NAMING_SPECIAL_NAMES_HEADER}"
+      --includes "${FFI_HEADER},${NAMING_SPECIAL_NAMES_HEADER},${TYPE_CONSTRAINT_HEADER},${ATTR_HEADER}"
   DEPENDS rustc cargo
   COMMENT "Generating hhbc-ast.h"
 )

--- a/hphp/hack/src/hackc/bytecode_printer/print.rs
+++ b/hphp/hack/src/hackc/bytecode_printer/print.rs
@@ -399,12 +399,7 @@ fn print_property_type_info(w: &mut dyn Write, p: &HhasProperty<'_>) -> Result<(
     w.write_all(b" ")
 }
 
-fn print_property(
-    ctx: &Context<'_>,
-    w: &mut dyn Write,
-    class_def: &HhasClass<'_>,
-    property: &HhasProperty<'_>,
-) -> Result<()> {
+fn print_property(ctx: &Context<'_>, w: &mut dyn Write, property: &HhasProperty<'_>) -> Result<()> {
     newline(w)?;
     w.write_all(b"  .property ")?;
     print_special_and_user_attrs(
@@ -419,7 +414,7 @@ fn print_property(
     w.write_all(property.name.to_raw_string().as_bytes())?;
     w.write_all(b" =\n    ")?;
     let initial_value = property.initial_value.as_ref();
-    if class_def.is_closure() || initial_value == Just(&TypedValue::Uninit) {
+    if initial_value == Just(&TypedValue::Uninit) {
         w.write_all(b"uninit;")
     } else {
         triple_quotes(w, |w| match initial_value {
@@ -715,7 +710,7 @@ fn print_class_def<'arena>(
             print_ctx_constant(c, w, x)?;
         }
         for x in class_def.properties.as_ref() {
-            print_property(c, w, class_def, x)?;
+            print_property(c, w, x)?;
         }
         for m in class_def.methods.as_ref() {
             print_method_def(c, w, m)?;

--- a/hphp/hack/src/hackc/emitter/emit_class.rs
+++ b/hphp/hack/src/hackc/emitter/emit_class.rs
@@ -246,6 +246,7 @@ fn from_class_elt_classvars<'a, 'arena, 'decl>(
     ast_class: &'a ast::Class_,
     class_is_const: bool,
     tparams: &[&str],
+    is_closure: bool,
 ) -> Result<Vec<HhasProperty<'arena>>> {
     // TODO: we need to emit doc comments for each property,
     // not one per all properties on the same line
@@ -266,6 +267,7 @@ fn from_class_elt_classvars<'a, 'arena, 'decl>(
                 ast_class,
                 tparams,
                 class_is_const,
+                is_closure,
                 emit_property::FromAstArgs {
                     user_attributes: &cv.user_attributes,
                     id: &cv.id,
@@ -757,7 +759,8 @@ pub fn emit_class<'a, 'arena, 'decl>(
         )?)
     }
     emitter.label_gen_mut().reset();
-    let mut properties = from_class_elt_classvars(emitter, ast_class, is_const, &tparams)?;
+    let mut properties =
+        from_class_elt_classvars(emitter, ast_class, is_const, &tparams, is_closure)?;
     let constants = from_class_elt_constants(emitter, &env, ast_class)?;
 
     let requirements = from_class_elt_requirements(alloc, ast_class);
@@ -904,7 +907,7 @@ pub fn emit_class<'a, 'arena, 'decl>(
 
     if !no_xhp_attributes {
         properties.extend(emit_xhp::properties_for_cache(
-            emitter, ast_class, is_const,
+            emitter, ast_class, is_const, is_closure,
         )?);
     }
     let info = emit_memoize_method::make_info(ast_class, name, &ast_class.methods)?;

--- a/hphp/hack/src/hackc/emitter/emit_property.rs
+++ b/hphp/hack/src/hackc/emitter/emit_property.rs
@@ -33,6 +33,7 @@ pub fn from_ast<'ast, 'arena, 'decl>(
     class: &'ast ast::Class_,
     tparams: &[&str],
     class_is_const: bool,
+    class_is_closure: bool,
     args: FromAstArgs<'_>,
 ) -> Result<HhasProperty<'arena>> {
     let alloc = emitter.alloc;
@@ -88,7 +89,7 @@ pub fn from_ast<'ast, 'arena, 'decl>(
     let env = Env::make_class_env(alloc, class);
     let (initial_value, initializer_instrs, mut hhas_property_flags) = match args.initial_value {
         None => {
-            let initial_value = if is_late_init {
+            let initial_value = if is_late_init || class_is_closure {
                 Some(TypedValue::Uninit)
             } else {
                 None
@@ -106,6 +107,7 @@ pub fn from_ast<'ast, 'arena, 'decl>(
             ));
         }
         Some(e) => {
+            assert!(!class_is_closure);
             let is_collection_map = match e.2.as_collection() {
                 Some(c) if (c.0).1 == "Map" || (c.0).1 == "ImmMap" => true,
                 _ => false,

--- a/hphp/hack/src/hackc/emitter/emit_xhp.rs
+++ b/hphp/hack/src/hackc/emitter/emit_xhp.rs
@@ -16,6 +16,7 @@ pub fn properties_for_cache<'a, 'arena, 'decl>(
     emitter: &mut Emitter<'arena, 'decl>,
     class: &'a Class_,
     class_is_const: bool,
+    class_is_closure: bool,
 ) -> Result<Option<HhasProperty<'arena>>> {
     let initial_value = Some(Expr((), Pos::make_none(), Expr_::mk_null()));
     let property = emit_property::from_ast(
@@ -23,6 +24,7 @@ pub fn properties_for_cache<'a, 'arena, 'decl>(
         class,
         &[],
         class_is_const,
+        class_is_closure,
         emit_property::FromAstArgs {
             initial_value: &initial_value,
             visibility: Visibility::Private,

--- a/hphp/runtime/base/runtime-option.h
+++ b/hphp/runtime/base/runtime-option.h
@@ -841,7 +841,7 @@ struct RuntimeOption {
   F(bool, EnableImplicitContext,       false)                           \
   F(bool, MoreAccurateMemStats,        true)                            \
   F(bool, AllowScopeBinding,           false)                           \
-  F(bool, AssembleHhasProgram,         false)                           \
+  F(bool, TranslateHackC,              false)                           \
   F(bool, JitNoGdb,                    true)                            \
   F(bool, SpinOnCrash,                 false)                           \
   F(uint32_t, DumpRingBufferOnCrash,   0)                               \

--- a/hphp/runtime/vm/as.cpp
+++ b/hphp/runtime/vm/as.cpp
@@ -3330,10 +3330,7 @@ void parse_constant(AsmState& as) {
   as.in.skipWhitespace();
 
   Constant constant;
-  Attr attrs = parse_attribute_list(as, AttrContext::Constant);
-  if (!SystemLib::s_inited) {
-    attrs |= AttrPersistent;
-  }
+  Attr attrs = SystemLib::s_inited ? AttrNone : AttrPersistent;
 
   std::string name;
   if (!as.in.readword(name)) {

--- a/hphp/runtime/vm/disas.cpp
+++ b/hphp/runtime/vm/disas.cpp
@@ -701,8 +701,11 @@ void print_class_constant(Output& out, const PreClass::Const* cns) {
   }
 }
 
+const StaticString s_coeffectsProp("86coeffects");
+
 template<class T>
-void print_prop_or_field_impl(Output& out, const T& f) {
+void print_prop_or_field_impl(Output& out, const T& f, bool isTest) {
+  if (isTest && f.name() == s_coeffectsProp.get()) return;
   out.fmtln(".property{}{} {}{} =",
     opt_attrs(AttrContext::Prop, f.attrs(), &f.userAttributes()),
     RuntimeOption::EvalDisassemblerDocComments &&
@@ -716,8 +719,9 @@ void print_prop_or_field_impl(Output& out, const T& f) {
   });
 }
 
+template<bool isTest = false>
 void print_property(Output& out, const PreClass::Prop* prop) {
-  print_prop_or_field_impl(out, *prop);
+  print_prop_or_field_impl(out, *prop, isTest);
 }
 
 void print_method(Output& out, const Func* func) {
@@ -838,6 +842,11 @@ void print_cls_directives(Output& out, const PreClass* cls) {
   for (auto* m : cls->allMethods())    print_method(out, m);
 }
 
+void print_cls_directives_test(Output& out, const PreClass* cls) {
+  for (auto& p : cls->allProperties()) print_property<true>(out, &p);
+}
+
+template<bool isTest = false>
 void print_cls(Output& out, const PreClass* cls) {
   out.indent();
   auto name = cls->name()->toCppString();
@@ -865,7 +874,11 @@ void print_cls(Output& out, const PreClass* cls) {
   print_enum_includes(out, cls);
   out.fmt(" {{");
   out.nl();
-  indented(out, [&] { print_cls_directives(out, cls); });
+  if (isTest) {
+    indented(out, [&] { print_cls_directives_test(out, cls); });
+  } else {
+    indented(out, [&] { print_cls_directives(out, cls); });
+  }
   out.fmtln("}}");
   out.nl();
 }
@@ -945,6 +958,13 @@ void print_unit(Output& out, const Unit* unit) {
   out.fmtln("# {} ends here", unit->origFilepath());
 }
 
+void print_unit_test(Output& out, const Unit* unit) {
+  out.fmtln("# {} starts here", unit->origFilepath());
+  out.nl();
+  for (auto& cls : unit->preclasses()) print_cls<true>(out, cls.get());
+  out.fmtln("# {} ends here", unit->origFilepath());
+}
+
 //////////////////////////////////////////////////////////////////////
 
 }
@@ -956,10 +976,14 @@ void print_unit(Output& out, const Unit* unit) {
  * - .line/.srcpos directives
  */
 
-std::string disassemble(const Unit* unit) {
+std::string disassemble(const Unit* unit, bool isTest) {
   std::ostringstream os;
   Output out { os };
-  print_unit(out, unit);
+  if (isTest) {
+    print_unit_test(out, unit);
+  } else {
+    print_unit(out, unit);
+  }
   return os.str();
 }
 

--- a/hphp/runtime/vm/disas.cpp
+++ b/hphp/runtime/vm/disas.cpp
@@ -962,6 +962,7 @@ void print_unit_test(Output& out, const Unit* unit) {
   out.fmtln("# {} starts here", unit->origFilepath());
   out.nl();
   for (auto& cls : unit->preclasses()) print_cls<true>(out, cls.get());
+  for (auto& c : unit->constants())    print_constant(out, c);
   out.fmtln("# {} ends here", unit->origFilepath());
 }
 

--- a/hphp/runtime/vm/disas.h
+++ b/hphp/runtime/vm/disas.h
@@ -26,10 +26,9 @@ struct UserAttributeMap;
 
 //////////////////////////////////////////////////////////////////////
 
-std::string disassemble(const Unit*);
+std::string disassemble(const Unit* unit, bool isTest=false);
 std::string user_attrs(const UserAttributeMap*);
 
 //////////////////////////////////////////////////////////////////////
 
 }
-

--- a/hphp/runtime/vm/hackc-translator.cpp
+++ b/hphp/runtime/vm/hackc-translator.cpp
@@ -1,0 +1,433 @@
+/*
+   +----------------------------------------------------------------------+
+   | HipHop for PHP                                                       |
+   +----------------------------------------------------------------------+
+   | Copyright (c) 2010-present Facebook, Inc. (http://www.facebook.com)  |
+   +----------------------------------------------------------------------+
+   | This source file is subject to version 3.01 of the PHP license,      |
+   | that is bundled with this package in the file LICENSE, and is        |
+   | available through the world-wide-web at the following url:           |
+   | http://www.php.net/license/3_01.txt                                  |
+   | If you did not receive a copy of the PHP license and are unable to   |
+   | obtain it through the world-wide-web, please send a note to          |
+   | license@php.net so we can mail you a copy immediately.               |
+   +----------------------------------------------------------------------+
+*/
+
+#include "hphp/runtime/base/array-init.h"
+#include "hphp/runtime/vm/as.h"
+#include "hphp/runtime/vm/as-shared.h"
+#include "hphp/runtime/vm/disas.h"
+#include "hphp/runtime/vm/hackc-translator.h"
+#include "hphp/runtime/vm/preclass.h"
+#include "hphp/runtime/vm/preclass-emitter.h"
+#include "hphp/zend/zend-string.h"
+
+namespace HPHP {
+
+TRACE_SET_MOD(translate);
+
+namespace {
+
+using namespace HPHP::hackc;
+using namespace HPHP::hackc::hhbc;
+
+struct TranslationException : Exception {
+  template<class... A>
+  explicit TranslationException(A&&... args)
+    : Exception(folly::sformat(std::forward<A>(args)...))
+  {}
+};
+
+[[noreturn]] void error(const char* what) {
+  throw TranslationException("{}: {}", what, folly::errnoStr(errno));
+}
+
+struct TranslationState {
+  UnitEmitter* ue;
+  PreClassEmitter* pce{nullptr};
+};
+
+///////////////////////////////////////////////////////////////////////////////
+// hhbc::Slice helpers
+template <class T>
+struct Range {
+  Slice<T> s;
+  const T* begin() { return s.data; }
+  const T* end() { return s.data + s.len; }
+};
+
+template <class T>
+Range<T> mk_range(Slice<T> const& s) {
+  return Range<T>{s};
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// hhbc::Maybe helpers
+
+template<typename T>
+Optional<T> maybe(hackc::Maybe<T> m) {
+  if (m.tag == hackc::Maybe<T>::Tag::Nothing) return std::nullopt;
+  return m.just._0;
+}
+
+template<typename T, typename Fn, typename ElseFn>
+auto maybeOrElse(hackc::Maybe<T> m, Fn fn, ElseFn efn) {
+  auto opt = maybe(m);
+  return opt ? fn(opt.value()) : efn();
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// hhbc::Str Helpers
+
+std::string toString(const Str& str) {
+  assertx(str.data != nullptr);
+  std::string res {(char*)str.data, 0, str.len};
+  return res;
+}
+
+StringData* toStaticString(const Str& str) {
+  return makeStaticString((char*)str.data, str.len);
+}
+
+StringData* makeDocComment(const Str& str) {
+  if (RuntimeOption::EvalGenerateDocComments) return toStaticString(str);
+  return staticEmptyString();
+}
+
+void escapeChar(std::string& res, const Str& str, int& i) {
+  auto is_oct = [&] (int i) { return i >= '0' && i <= '7'; };
+  auto is_hex = [&] (int i) {
+    return (i >= '0' && i <= '9') ||
+            (i >= 'a' && i <= 'f') ||
+            (i >= 'A' && i <= 'F');
+  };
+  auto hex_val = [&] (int i) -> uint32_t {
+    assertx(is_hex(i));
+    return i >= '0' && i <= '9' ? i - '0' :
+            i >= 'a' && i <= 'f' ? i - 'a' + 10 : i - 'A' + 10;
+  };
+
+  auto c = str.data[++i];
+
+  switch (c) {
+  case 'a':  res.push_back('\a'); break;
+  case 'b':  res.push_back('\b'); break;
+  case 'f':  res.push_back('\f'); break;
+  case 'n':  res.push_back('\n'); break;
+  case 'r':  res.push_back('\r'); break;
+  case 't':  res.push_back('\t'); break;
+  case 'v':  res.push_back('\v'); break;
+  case '\'': res.push_back('\''); break;
+  case '\"': res.push_back('\"'); break;
+  case '\?': res.push_back('\?'); break;
+  case '\\': res.push_back('\\'); break;
+  case '\r': /* ignore */         break;
+  case '\n': /* ignore */         break;
+  default:
+    if (is_oct(c)) {
+      auto val = int64_t{c} - '0';
+      for (auto j = int{1}; j < 3; ++j) {
+        c = str.data[++i];
+        if (!is_oct(c)) { i--; break; }
+        val *= 8;
+        val += c - '0';
+      }
+      if (val > std::numeric_limits<uint8_t>::max()) {
+        error("octal escape sequence overflowed");
+      }
+      res.push_back(static_cast<uint8_t>(val));
+      return;
+    }
+
+    if (c == 'x' || c == 'X') {
+      auto val = uint64_t{0};
+      if (!is_hex(str.data[i+1])) error("\\x used without no following hex digits");
+      for (auto j = int{0}; j < 2; ++j) {
+        c = str.data[++i];
+        if (!is_hex(c)) {i--; break; }
+        val *= 0x10;
+        val += hex_val(c);
+      }
+      if (val > std::numeric_limits<uint8_t>::max()) {
+        error("hex escape sequence overflowed");
+      }
+      res.push_back(static_cast<uint8_t>(val));
+      return;
+    }
+
+    error("unrecognized character escape");
+  }
+}
+
+StringData* handleQuotedString(const Str& str) {
+  if (str.len == 0) return staticEmptyString();
+  std::string res;
+  int i = 0;
+  while (i < str.len) {
+    switch (str.data[i]) {
+      case '\"': goto finish;
+      case '\\': escapeChar(res, str, i); break;
+      default  : res.push_back(str.data[i]); break;
+    }
+    i++;
+  }
+  finish:
+  return makeStaticString(res);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+using kind = hhbc::TypedValue::Tag;
+
+// TODO make arrays static
+HPHP::TypedValue toTypedValue(const hackc::hhbc::TypedValue& tv) {
+  switch(tv.tag) {
+  case kind::Uninit:
+    return make_tv<KindOfUninit>();
+  case kind::Int:
+    return make_tv<KindOfInt64>(tv.int_._0);
+  case kind::Bool:
+    return make_tv<KindOfBoolean>(tv.bool_._0);
+  case kind::Float: {
+    uint8_t buf[8];
+    for (int i = 0; i < 8; i++) {
+      buf[i] = tv.float_._0._0[7-i];
+    }
+    double d;
+    memcpy(&d, buf, sizeof(buf));
+    return make_tv<KindOfDouble>(d);
+  }
+  case kind::String: {
+    auto const s = toStaticString(tv.string._0);
+    return make_tv<KindOfPersistentString>(s);
+  }
+  case kind::Null:
+    return make_tv<KindOfNull>();
+  case kind::Vec: {
+    VecInit v(tv.vec._0.len);
+    auto set = mk_range(tv.vec._0);
+    for (auto const& elt : set) {
+      v.append(toTypedValue(elt));
+    }
+    return make_tv<KindOfVec>(v.create());
+  }
+  case kind::Dict: {
+    DictInit d(tv.dict._0.len);
+    auto set = mk_range(tv.dict._0);
+    for (auto const& elt : set) {
+        switch (elt._0.tag) {
+          case kind::Int:
+            d.set(elt._0.int_._0, toTypedValue(elt._1));
+            break;
+          case kind::String: {
+            auto const s = toStaticString(elt._0.string._0);
+            d.set(s, toTypedValue(elt._1));
+            break;
+          }
+          default:
+            always_assert(false);
+        }
+    }
+    return make_tv<KindOfDict>(d.create());
+  }
+  case kind::Keyset: {
+    KeysetInit k(tv.keyset._0.len);
+    auto set = mk_range(tv.keyset._0);
+    for (auto const& elt : set) {
+      k.add(toTypedValue(elt));
+    }
+    return make_tv<KindOfKeyset>(k.create());
+  }
+  case kind::LazyClass: {
+    auto const lc = LazyClassData::create(toStaticString(tv.lazy_class._0));
+    return make_tv<KindOfLazyClass>(lc);
+  }
+  case kind::HhasAdata:
+    error("toTypedValue unimplemented for HhasAdata");
+  }
+  not_reached();
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// Field translaters
+
+void translateUserAttributes(Slice<HhasAttribute> attributes, UserAttributeMap& userAttrs) {
+  Trace::Indent indent;
+  auto attrs = mk_range(attributes);
+  for (auto const& attr : attrs) {
+    auto const name = handleQuotedString(attr.name);
+    VecInit v(attr.arguments.len);
+    auto args = mk_range(attr.arguments);
+    for (auto const& arg : args) {
+      v.append(toTypedValue(arg));
+    }
+    auto tv = v.create();
+    ArrayData::GetScalarArray(&tv);
+    userAttrs[name] = make_tv<KindOfVec>(tv);
+  };
+}
+
+std::pair<const StringData*, TypeConstraint> translateTypeInfo(const HhasTypeInfo& t) {
+  auto const user_type = maybeOrElse(t.user_type,
+    [&](Str& s) {return toStaticString(s);},
+    [&]() {return staticEmptyString();});
+
+  const StringData* type_name = maybeOrElse(t.type_constraint.name,
+    [&](Str& s) {return toStaticString(s);},
+    [&]() {return nullptr;});
+
+  auto flags = t.type_constraint.flags;
+  return std::make_pair(user_type, TypeConstraint{type_name, flags});
+}
+
+using TParamNameVec = CompactVector<const StringData*>;
+using UpperBoundVec = CompactVector<TypeConstraint>;
+using UpperBoundMap = std::unordered_map<const StringData*, UpperBoundVec>;
+
+UpperBoundVec getRelevantUpperBounds(const TypeConstraint& tc,
+                                     const UpperBoundMap& ubs,
+                                     const UpperBoundMap& class_ubs,
+                                     const TParamNameVec& shadowed_tparams) {
+  UpperBoundVec ret;
+  if (!tc.isTypeVar()) return ret;
+  auto const typeName = tc.typeName();
+  auto it = ubs.find(typeName);
+  if (it != ubs.end()) return it->second;
+  if (std::find(shadowed_tparams.begin(), shadowed_tparams.end(), typeName) ==
+                shadowed_tparams.end()) {
+    it = class_ubs.find(typeName);
+    if (it != class_ubs.end()) return it->second;
+  }
+  return UpperBoundVec{};
+}
+
+void translateProperty(TranslationState& ts, const HhasProperty& p, const UpperBoundMap& class_ubs) {
+  UserAttributeMap userAttributes;
+  translateUserAttributes(p.attributes, userAttributes);
+
+  auto const heredoc = maybeOrElse(p.doc_comment,
+    [&](Str& s) {return makeDocComment(s);},
+    [&]() {return staticEmptyString();});
+
+  TypeConstraint typeConstraint;
+  const StringData* userTy;
+  std::tie(userTy, typeConstraint) = translateTypeInfo(p.type_info);
+
+  auto const hasReifiedGenerics =
+    userAttributes.find(s___Reified.get()) != userAttributes.end();
+
+  auto ub = getRelevantUpperBounds(typeConstraint, class_ubs, {}, {});
+
+  auto needsMultiUBs = false;
+  if (ub.size() == 1 && !hasReifiedGenerics) {
+    applyFlagsToUB(ub[0], typeConstraint);
+    typeConstraint = ub[0];
+  } else if (!ub.empty()) {
+    needsMultiUBs = true;
+  }
+
+  auto const tv = maybeOrElse(p.initial_value,
+    [&](hhbc::TypedValue& s) {return toTypedValue(s);},
+    [&]() {return make_tv<KindOfNull>();});
+
+  auto const name = toStaticString(p.name._0);
+  ITRACE(2, "Translating property {} {}\n", name, tv.pretty());
+
+  ts.pce->addProperty(
+      name,
+      p.flags,
+      userTy,
+      typeConstraint,
+      needsMultiUBs ? std::move(ub) : UpperBoundVec{},
+      heredoc,
+      &tv,
+      HPHP::RepoAuthType{},
+      userAttributes);
+}
+
+void translateClassBody(TranslationState& ts, const HhasClass& c, const UpperBoundMap& class_ubs) {
+  auto props = mk_range(c.properties);
+  for (auto const& p : props) {
+    translateProperty(ts, p, class_ubs);
+  }
+}
+
+using TypeInfoPair = Pair<Str, Slice<HhasTypeInfo>>;
+
+void translateUbs(const TypeInfoPair& ub, UpperBoundMap& ubs) {
+  auto const& name = toStaticString(ub._0);
+  CompactVector<TypeConstraint> ret;
+
+  auto infos = mk_range(ub._1);
+  for (auto const& i : infos) {
+    ubs[name].push_back(translateTypeInfo(i).second);
+  }
+}
+
+void translateClass(TranslationState& ts, const HhasClass& c) {
+  UpperBoundMap ubs;
+  auto upper_bounds = mk_range(c.upper_bounds);
+  for (auto const& u : upper_bounds) {
+    translateUbs(u, ubs);
+  }
+
+  std::string name = toString(c.name._0);
+  ITRACE(1, "Translating class {}\n", name);
+  ts.pce = ts.ue->newPreClassEmitter(name);
+
+  UserAttributeMap userAttrs;
+  ITRACE(2, "Translating attribute list {}\n", c.attributes.len);
+  translateUserAttributes(c.attributes, userAttrs);
+  auto attrs = c.flags;
+  if (!SystemLib::s_inited) attrs |= AttrUnique | AttrPersistent | AttrBuiltin;
+
+  auto parentName = maybeOrElse(c.base,
+    [&](ClassType& s) { return toStaticString(s._0); },
+    [&]() { return staticEmptyString(); });
+
+  ts.pce->init(c.span._0,
+               c.span._1,
+               attrs,
+               parentName,
+               staticEmptyString());
+
+  auto impls = mk_range(c.implements);
+  for (auto const& i : impls) {
+    ts.pce->addInterface(toStaticString(i._0));
+  }
+  auto incl = mk_range(c.enum_includes);
+  for (auto const& in : incl) {
+    ts.pce->addEnumInclude(toStaticString(in._0));
+  }
+  ts.pce->setUserAttributes(userAttrs);
+  translateClassBody(ts, c, ubs);
+}
+
+void translate(TranslationState& ts, const HhasProgram& prog) {
+  auto classes = mk_range(prog.classes);
+  for (auto const& c : classes) {
+    translateClass(ts, c);
+  }
+}
+}
+
+std::unique_ptr<UnitEmitter> unitEmitterFromHhasProgram(
+  const HhasProgram& prog,
+  const char* filename,
+	const SHA1& sha1,
+  const Native::FuncTable& nativeFuncs,
+  const std::string& hhasString
+) {
+  auto const bcSha1 = SHA1{string_sha1(hhasString)};
+  auto ue = std::make_unique<UnitEmitter>(sha1, bcSha1, nativeFuncs, false);
+  StringData* sd = makeStaticString(filename);
+  ue->m_filepath = sd;
+
+  TranslationState ts{};
+  ts.ue = ue.get();
+  translate(ts, prog);
+  ue->finish();
+  return ue;
+}
+}

--- a/hphp/runtime/vm/hackc-translator.h
+++ b/hphp/runtime/vm/hackc-translator.h
@@ -23,6 +23,10 @@
 
 namespace HPHP {
 
+struct TranslationFatal : std::runtime_error {
+  explicit TranslationFatal(const std::string& msg) : std::runtime_error(msg) {}
+};
+
 inline const hackc::hhbc::HhasProgram* hhasProgramRaw(const ::rust::Box<HhasProgramWrapper>& program) {
   return (const hackc::hhbc::HhasProgram*)(&(*program));
 }

--- a/hphp/runtime/vm/hackc-translator.h
+++ b/hphp/runtime/vm/hackc-translator.h
@@ -18,11 +18,21 @@
 
 #include "hphp/hack/src/hackc/ffi_bridge/compiler_ffi.rs"
 #include "hphp/hack/src/hackc/hhbc-ast.h"
+#include "hphp/runtime/vm/native-func-table.h"
+#include "hphp/runtime/vm/unit-emitter.h"
 
-namespace HPHP::hackc::hhbc {
+namespace HPHP {
 
-inline const HhasProgram* hhasProgramRaw(const ::rust::Box<HhasProgramWrapper>& program) {
-  return (const HhasProgram*)(&(*program));
+inline const hackc::hhbc::HhasProgram* hhasProgramRaw(const ::rust::Box<HhasProgramWrapper>& program) {
+  return (const hackc::hhbc::HhasProgram*)(&(*program));
 }
+
+std::unique_ptr<UnitEmitter> unitEmitterFromHhasProgram(
+  const hackc::hhbc::HhasProgram& prog,
+  const char* filename,
+	const SHA1& sha1,
+  const Native::FuncTable& nativeFuncs,
+  const std::string& hhasString
+);
 
 }

--- a/hphp/runtime/vm/verifier/check-unit.cpp
+++ b/hphp/runtime/vm/verifier/check-unit.cpp
@@ -24,6 +24,8 @@
 #include "hphp/runtime/vm/verifier/util.h"
 #include "hphp/runtime/vm/verifier/pretty.h"
 
+#include <boost/algorithm/string/predicate.hpp>
+
 namespace HPHP {
 namespace Verifier {
 
@@ -86,6 +88,8 @@ UnitChecker::UnitChecker(const UnitEmitter* unit, ErrorMode mode)
 }
 
 bool UnitChecker::verify() {
+  // For incremental testing HhasProgram Parser, its helpful to not need to pass verifier
+  if (!boost::ends_with(m_unit->m_filepath->data(), ".hhas") && RO::EvalTranslateHackC) return true;
   return checkStrings() &&
          checkArrays() &&
          //checkSourceLocs() &&

--- a/hphp/util/trace.h
+++ b/hphp/util/trace.h
@@ -109,7 +109,6 @@ namespace Trace {
       TM(dispatchBB)    \
       TM(ehframe)       \
       TM(emitter)       \
-      TM(extern_compiler) \
       TM(facts)         \
       TM(fixup)         \
       TM(fr)            \
@@ -196,10 +195,12 @@ namespace Trace {
       TM(targetcache)   \
       TM(tcspace)       \
       TM(trans)         \
+      TM(translate)     \
       TM(treadmill)     \
       TM(txdeps)        \
       TM(txlease)       \
       TM(typeProfile)   \
+      TM(unit_parse)    \
       TM(unwind)        \
       TM(ustubs)        \
       TM(vasm)          \


### PR DESCRIPTION
Summary:
Support top-level contants.
Match a fatal for checking the size on typed values. CheckSize() largely similar to what we do in as.cpp

Differential Revision: D33993605

