### PR TITLE
By default open a login shell in VS Code

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,14 @@
+{
+  "terminal.integrated.profiles.linux": {
+    "bash": {
+      "path": "/bin/bash",
+      "args": [
+        // This argument is necessary,
+        // because hhvm crashes in a non-login shell.
+        // See https://github.com/hhvm/packaging/issues/276
+        "--login",
+      ]
+    }
+  },
+  "terminal.integrated.defaultProfile.linux": "bash"
+}


### PR DESCRIPTION
This PR would fix https://github.com/hhvm/packaging/issues/276

Test Plan:
Allocate an EC2 instance from template, and select a Docker image of successful build snapshot, then cherry-pick this PR, then run:

```
cd hphp && test/run test/slow/ext_hsl/ext_os_fork_execve.php
```

It should not core dump any more.