### PR TITLE
Make the `ext_os_fork_execve` test support Ubuntu

### DIFF
--- a/hphp/test/slow/ext_hsl/ext_os_fork_execve.php
+++ b/hphp/test/slow/ext_hsl/ext_os_fork_execve.php
@@ -86,8 +86,8 @@ function main(): void {
   list($er, $ew) = _OS\pipe();
   list($fd42r, $fd42w) = _OS\pipe();
   $pid = _OS\fork_and_execve(
-    '/bin/sh',
-    vec['/bin/sh', '-c', 'echo Foo; echo Bar >&2; echo Baz >&42'],
+    '/bin/bash',
+    vec['/bin/bash', '-c', 'echo Foo; echo Bar >&2; echo Baz >&42'],
     vec[],
     dict[
       _OS\STDOUT_FILENO => $ow,

--- a/hphp/test/slow/ext_hsl/ext_os_fork_execve.php.expectf
+++ b/hphp/test/slow/ext_hsl/ext_os_fork_execve.php.expectf
@@ -5,7 +5,7 @@
 --- Expecting BAR
 BAR
 --- Not in PATH
-STDERR: /bin/sh: cat: No such file or directory
+STDERR: /bin/sh:%scat: %s
 --- Bad STDOUT
 STDERR: %s: Bad file descriptor
 --- Custom ARGV[0]


### PR DESCRIPTION
This diff should fix errors due to error message difference between Ubuntu and CentOS, as reported at https://github.com/facebook/hhvm/issues/8996

Test Plan:
On Ubuntu 21.04:
```
cd hphp && test/run test/slow/ext_hsl/ext_os_fork_execve.php
```
