### PR TITLE
Add quickfix for nonexistent type name in params

### DIFF
--- a/hphp/hack/src/errors/typing_error.ml
+++ b/hphp/hack/src/errors/typing_error.ml
@@ -7243,7 +7243,7 @@ end = struct
     @@ Primary.Rigid_tvar_escape { pos; what }
 
   let invalid_type_hint pos =
-    retain_quickfixes @@ of_primary_error @@ Primary.Invalid_type_hint pos
+    of_primary_error @@ Primary.Invalid_type_hint pos
 
   let type_constant_mismatch t =
     retain_quickfixes @@ with_code ~code:Error_code.TypeConstantMismatch t

--- a/hphp/hack/test/quickfixes/non-existent-type-const-name-in-params.php
+++ b/hphp/hack/test/quickfixes/non-existent-type-const-name-in-params.php
@@ -1,0 +1,6 @@
+class MyClass {
+  const type TFooBar = int;
+  public function foo(this::TFooBaz $_) {
+    throw new Exception();
+  }
+}

--- a/hphp/hack/test/quickfixes/non-existent-type-const-name-in-params.php.exp
+++ b/hphp/hack/test/quickfixes/non-existent-type-const-name-in-params.php.exp
@@ -1,0 +1,8 @@
+Change type to `TFooBar`
+
+class MyClass {
+  const type TFooBar = int;
+  public function foo(this::TFooBar $_) {
+    throw new Exception();
+  }
+}


### PR DESCRIPTION
Second part of #9007, adding quickfix for nonexistent typeconst name in params 