### PR TITLE
Add quickfix for removing `async` on interfaces

### DIFF
--- a/hphp/hack/src/errors/parsing_error.ml
+++ b/hphp/hack/src/errors/parsing_error.ml
@@ -12,6 +12,7 @@ type t =
   | Parsing_error of {
       pos: Pos.t;
       msg: string;
+      quickfixes: Quickfix.t list;
     }
   | Xhp_parsing_error of {
       pos: Pos.t;
@@ -24,7 +25,7 @@ let to_user_error = function
       Error_code.(to_enum FixmeFormat)
       (pos, "`HH_FIXME` wrong format, expected `/* HH_FIXME[ERROR_NUMBER] */`")
       []
-  | Parsing_error { pos; msg } ->
-    User_error.make Error_code.(to_enum ParsingError) (pos, msg) []
+  | Parsing_error { pos; msg; quickfixes } ->
+    User_error.make Error_code.(to_enum ParsingError) ~quickfixes (pos, msg) []
   | Xhp_parsing_error { pos; msg } ->
     User_error.make Error_code.(to_enum XhpParsingError) (pos, msg) []

--- a/hphp/hack/src/errors/parsing_error.mli
+++ b/hphp/hack/src/errors/parsing_error.mli
@@ -11,6 +11,7 @@ type t =
   | Parsing_error of {
       pos: Pos.t;
       msg: string;
+      quickfixes: Quickfix.t list;
     }
   | Xhp_parsing_error of {
       pos: Pos.t;

--- a/hphp/hack/src/errors/quickfix.ml
+++ b/hphp/hack/src/errors/quickfix.ml
@@ -26,6 +26,12 @@ type t = {
 
 let make ~title ~new_text pos = { title; edits = [(new_text, Qpos pos)] }
 
+let make_with_edits ~title ~edits =
+  {
+    title;
+    edits = List.map edits ~f:(fun (new_text, pos) -> (new_text, Qpos pos));
+  }
+
 let make_classish ~title ~new_text ~classish_name =
   { title; edits = [(new_text, Qclassish_start classish_name)] }
 

--- a/hphp/hack/src/errors/quickfix.mli
+++ b/hphp/hack/src/errors/quickfix.mli
@@ -10,6 +10,8 @@ type t [@@deriving eq, ord, show]
 
 val make : title:string -> new_text:string -> Pos.t -> t
 
+val make_with_edits : title:string -> edits:(string * Pos.t) list -> t
+
 val make_classish : title:string -> new_text:string -> classish_name:string -> t
 
 val get_edits : classish_starts:Pos.t SMap.t -> t -> (string * Pos.t) list

--- a/hphp/hack/src/hh_single_type_check.ml
+++ b/hphp/hack/src/hh_single_type_check.ml
@@ -1135,7 +1135,11 @@ let check_file ctx errors files_info ~profile_type_check_twice ~memtrace =
 
 let create_nasts ctx files_info =
   let build_nast fn _ =
-    let ast = Ast_provider.get_ast ~full:true ctx fn in
+    let (syntax_errors, ast) =
+      Ast_provider.get_ast_with_error ~full:true ctx fn
+    in
+    let error_list = Errors.get_sorted_error_list syntax_errors in
+    List.iter error_list ~f:Errors.add_error;
     Naming.program ctx ast
   in
   Relative_path.Map.mapi ~f:build_nast files_info

--- a/hphp/hack/src/parser/aast_check.rs
+++ b/hphp/hack/src/parser/aast_check.rs
@@ -75,7 +75,7 @@ impl Checker {
     fn add_error(&mut self, pos: &Pos, msg: ErrorMsg) {
         let (start_offset, end_offset) = pos.info_raw();
         self.errors
-            .push(SyntaxError::make(start_offset, end_offset, msg));
+            .push(SyntaxError::make(start_offset, end_offset, msg, vec![]));
     }
 
     fn name_eq_this_and_in_static_method(c: &Context, name: impl AsRef<str>) -> bool {

--- a/hphp/hack/src/parser/coeffects_check.rs
+++ b/hphp/hack/src/parser/coeffects_check.rs
@@ -291,7 +291,7 @@ impl Checker {
     fn add_error(&mut self, pos: &Pos, msg: ErrorMsg) {
         let (start_offset, end_offset) = pos.info_raw();
         self.errors
-            .push(SyntaxError::make(start_offset, end_offset, msg));
+            .push(SyntaxError::make(start_offset, end_offset, msg, vec![]));
     }
 
     fn do_write_props_check(&mut self, e: &aast::Expr<(), ()>) {

--- a/hphp/hack/src/parser/core/expression_parser.rs
+++ b/hphp/hack/src/parser/core/expression_parser.rs
@@ -704,6 +704,7 @@ where
                         start_offset,
                         end_offset,
                         Errors::illegal_interpolated_brace_with_embedded_dollar_expression,
+                        vec![],
                     );
                     self.add_error(error);
                 };

--- a/hphp/hack/src/parser/core/lexer.rs
+++ b/hphp/hack/src/parser/core/lexer.rs
@@ -189,7 +189,7 @@ where
     }
 
     fn with_error(&mut self, error: Error) {
-        let error = SyntaxError::make(self.start(), self.offset(), error);
+        let error = SyntaxError::make(self.start(), self.offset(), error, vec![]);
         self.errors.push(error)
     }
 

--- a/hphp/hack/src/parser/core/parser_trait.rs
+++ b/hphp/hack/src/parser/core/parser_trait.rs
@@ -175,7 +175,7 @@ where
     // in cases like "flagging an entire token as an extra".
     fn with_error_impl(&mut self, on_whole_token: bool, message: Error) {
         let (start_offset, end_offset) = self.error_offsets(on_whole_token);
-        let error = SyntaxError::make(start_offset, end_offset, message);
+        let error = SyntaxError::make(start_offset, end_offset, message, vec![]);
         self.add_error(error)
     }
 

--- a/hphp/hack/src/parser/expression_tree_check.rs
+++ b/hphp/hack/src/parser/expression_tree_check.rs
@@ -28,8 +28,12 @@ impl<'ast> Visitor<'ast> for Checker {
                 let msg = "Splice syntax ${...} can only occur inside expression trees Foo``...``.";
                 let p = e.1.clone();
                 let (start_offset, end_offset) = p.info_raw();
-                self.errors
-                    .push(SyntaxError::make(start_offset, end_offset, msg.into()));
+                self.errors.push(SyntaxError::make(
+                    start_offset,
+                    end_offset,
+                    msg.into(),
+                    vec![],
+                ));
 
                 // Don't recurse further on this subtree, to prevent
                 // cascading errors that are all the same issue.

--- a/hphp/hack/src/parser/full_fidelity_syntax_error.ml
+++ b/hphp/hack/src/parser/full_fidelity_syntax_error.ml
@@ -14,20 +14,32 @@ type error_type =
   | RuntimeError
 [@@deriving show]
 
+type syntax_quickfix = {
+  title: string;
+  edits: (int * int * string) list;
+}
+[@@deriving show]
+
 type t = {
   child: t option;
   start_offset: int;
   end_offset: int;
   error_type: error_type;
   message: string;
+  quickfixes: syntax_quickfix list;
 }
 [@@deriving show]
 
 exception ParserFatal of t * Pos.t
 
 let make
-    ?(child = None) ?(error_type = ParseError) start_offset end_offset message =
-  { child; error_type; start_offset; end_offset; message }
+    ?(child = None)
+    ?(error_type = ParseError)
+    ?(quickfixes = [])
+    start_offset
+    end_offset
+    message =
+  { child; error_type; start_offset; end_offset; message; quickfixes }
 
 let rec to_positioned_string error offset_to_position =
   let child =

--- a/hphp/hack/src/parser/full_fidelity_syntax_error.mli
+++ b/hphp/hack/src/parser/full_fidelity_syntax_error.mli
@@ -12,19 +12,32 @@ type error_type =
   | RuntimeError
 [@@deriving show]
 
+type syntax_quickfix = {
+  title: string;
+  edits: (int * int * string) list;
+}
+[@@deriving show]
+
 type t = {
   child: t option;
   start_offset: int;
   end_offset: int;
   error_type: error_type;
   message: string;
+  quickfixes: syntax_quickfix list;
 }
 [@@deriving show]
 
 exception ParserFatal of t * Pos.t
 
 val make :
-  ?child:t option -> ?error_type:error_type -> int -> int -> string -> t
+  ?child:t option ->
+  ?error_type:error_type ->
+  ?quickfixes:syntax_quickfix list ->
+  int ->
+  int ->
+  string ->
+  t
 
 val to_positioned_string : t -> (int -> int * int) -> string
 

--- a/hphp/hack/src/parser/readonly_check.rs
+++ b/hphp/hack/src/parser/readonly_check.rs
@@ -499,7 +499,7 @@ impl Checker {
     fn add_error(&mut self, pos: &Pos, msg: ErrorMsg) {
         let (start_offset, end_offset) = pos.info_raw();
         self.errors
-            .push(SyntaxError::make(start_offset, end_offset, msg));
+            .push(SyntaxError::make(start_offset, end_offset, msg, vec![]));
     }
 
     fn subtype(&mut self, pos: &Pos, r_sub: &Rty, r_sup: &Rty, reason: &str) {

--- a/hphp/hack/src/parser/rust_parser_errors.rs
+++ b/hphp/hack/src/parser/rust_parser_errors.rs
@@ -684,7 +684,7 @@ fn make_error_from_nodes(
 ) -> SyntaxError {
     let s = start_offset(start_node);
     let e = end_offset(end_node);
-    SyntaxError::make_with_child_and_type(child, s, e, error_type, error)
+    SyntaxError::make_with_child_and_type(child, s, e, error_type, error, vec![])
 }
 
 fn make_error_from_node(node: S<'_>, error: errors::Error) -> SyntaxError {
@@ -775,6 +775,7 @@ fn make_name_already_used_error(
         original_location.start_offset,
         original_location.end_offset,
         errors::original_definition,
+        vec![],
     );
 
     let s = start_offset(node);
@@ -785,6 +786,7 @@ fn make_name_already_used_error(
         e,
         ErrorType::ParseError,
         report_error(name, short_name),
+        vec![],
     )
 }
 
@@ -4678,6 +4680,7 @@ impl<'a, State: 'a + Clone> ParserErrors<'a, State> {
                         start_offset,
                         end_offset,
                         errors::error2057,
+                        vec![],
                     ));
                     self.errors.push(SyntaxError::make_with_child_and_type(
                         child,
@@ -4685,6 +4688,7 @@ impl<'a, State: 'a + Clone> ParserErrors<'a, State> {
                         e,
                         ErrorType::ParseError,
                         errors::error2052,
+                        vec![],
                     ))
                 }
             }
@@ -4700,6 +4704,7 @@ impl<'a, State: 'a + Clone> ParserErrors<'a, State> {
                         start_offset,
                         end_offset,
                         errors::error2056,
+                        vec![],
                     ));
                     self.errors.push(SyntaxError::make_with_child_and_type(
                         child,
@@ -4707,6 +4712,7 @@ impl<'a, State: 'a + Clone> ParserErrors<'a, State> {
                         e,
                         ErrorType::ParseError,
                         errors::error2052,
+                        vec![],
                     ))
                 }
             }

--- a/hphp/hack/src/parser/syntax_error.rs
+++ b/hphp/hack/src/parser/syntax_error.rs
@@ -29,6 +29,14 @@ pub enum LvalRoot {
     Foreach,
 }
 
+/// Equivalent to `Quickfix` but uses offsets rather than the `Pos` type,
+/// so this type is Send.
+#[derive(Debug, Clone, FromOcamlRep, ToOcamlRep, PartialEq, Eq)]
+pub struct SyntaxQuickfix {
+    pub title: String,
+    pub edits: Vec<(usize, usize, String)>,
+}
+
 #[derive(Debug, Clone, FromOcamlRep, ToOcamlRep, PartialEq, Eq)]
 pub struct SyntaxError {
     pub child: Option<Box<SyntaxError>>,
@@ -36,6 +44,7 @@ pub struct SyntaxError {
     pub end_offset: usize,
     pub error_type: ErrorType,
     pub message: Error,
+    pub quickfixes: Vec<SyntaxQuickfix>,
 }
 
 impl SyntaxError {
@@ -45,6 +54,7 @@ impl SyntaxError {
         end_offset: usize,
         error_type: ErrorType,
         message: Error,
+        quickfixes: Vec<SyntaxQuickfix>,
     ) -> Self {
         Self {
             child: child.map(Box::new),
@@ -52,16 +62,23 @@ impl SyntaxError {
             end_offset,
             error_type,
             message,
+            quickfixes,
         }
     }
 
-    pub fn make(start_offset: usize, end_offset: usize, message: Error) -> Self {
+    pub fn make(
+        start_offset: usize,
+        end_offset: usize,
+        message: Error,
+        quickfixes: Vec<SyntaxQuickfix>,
+    ) -> Self {
         Self::make_with_child_and_type(
             None,
             start_offset,
             end_offset,
             ErrorType::ParseError,
             message,
+            quickfixes,
         )
     }
 

--- a/hphp/hack/test/quickfixes/bad_async.php
+++ b/hphp/hack/test/quickfixes/bad_async.php
@@ -1,0 +1,5 @@
+<?hh
+
+interface MyIface {
+  async function foo(): Awaitable<void>;
+}

--- a/hphp/hack/test/quickfixes/bad_async.php.exp
+++ b/hphp/hack/test/quickfixes/bad_async.php.exp
@@ -1,0 +1,7 @@
+Remove `async`
+
+<?hh
+
+interface MyIface {
+   function foo(): Awaitable<void>;
+}


### PR DESCRIPTION
Summary: Methods on interfaces do not use `async`, they only have an `Awaitable<...>` return type. Provide a quickfix for this syntax error.

Reviewed By: shayne-fletcher

Differential Revision: D34664676

