### PR TITLE
Fix complation error when building HHVM with ICU 70+

### DIFF
--- a/hphp/runtime/ext/icu/CodePointBreakIterator.h
+++ b/hphp/runtime/ext/icu/CodePointBreakIterator.h
@@ -37,7 +37,12 @@ struct CodePointBreakIterator : icu::BreakIterator {
     clearCurrentCharIter();
   }
 
-  UBool operator==(const BreakIterator& that) const override {
+#if U_ICU_VERSION_MAJOR_NUM >= 70
+  bool
+#else
+  UBool
+#endif
+  operator==(const BreakIterator& that) const override {
     if (typeid(*this) != typeid(that)) {
       return false;
     }


### PR DESCRIPTION
Now macOS build failures seem due to backward incompatible changes in ICU:
https://unicode-org.atlassian.net/browse/ICU-20973
The return type of `operator==` has changed from `UBool` to `bool` in ICU 70+.

This PR adds a `#if` to support both the old versions and the new version of ICU.