### PR TITLE
Introduce extern-worker framework

### DIFF
--- a/hphp/hhvm/main.cpp
+++ b/hphp/hhvm/main.cpp
@@ -26,6 +26,7 @@
 
 #include "hphp/util/embedded-data.h"
 #include "hphp/util/embedded-vfs.h"
+#include "hphp/util/extern-worker.h"
 #include "hphp/util/logger.h"
 #include "hphp/util/process.h"
 #include "hphp/util/process-exec.h"
@@ -76,6 +77,10 @@ int main(int argc, char** argv) {
   if (argc > 1 && !strcmp(argv[1], "--hhbbc")) {
     argv[1] = "hhbbc";
     return HPHP::HHBBC::main(argc - 1, argv + 1);
+  }
+
+  if (argc > 1 && !strcmp(argv[1], HPHP::extern_worker::s_option)) {
+    return HPHP::extern_worker::main(argc, argv);
   }
 
   HPHP::register_process_init();

--- a/hphp/util/extern-worker-detail.h
+++ b/hphp/util/extern-worker-detail.h
@@ -1,0 +1,322 @@
+/*
+   +----------------------------------------------------------------------+
+   | HipHop for PHP                                                       |
+   +----------------------------------------------------------------------+
+   | Copyright (c) 2010-present Facebook, Inc. (http://www.facebook.com)  |
+   +----------------------------------------------------------------------+
+   | This source file is subject to version 3.01 of the PHP license,      |
+   | that is bundled with this package in the file LICENSE, and is        |
+   | available through the world-wide-web at the following url:           |
+   | http://www.php.net/license/3_01.txt                                  |
+   | If you did not receive a copy of the PHP license and are unable to   |
+   | obtain it through the world-wide-web, please send a note to          |
+   | license@php.net so we can mail you a copy immediately.               |
+   +----------------------------------------------------------------------+
+*/
+
+#ifndef incl_HPHP_EXTERN_WORKER_DETAIL_H_
+#error "extern-worker-detail.h should only be included by extern-worker.h"
+#endif
+
+#include "hphp/util/assertions.h"
+#include "hphp/util/blob-encoder.h"
+
+#include <folly/String.h>
+#include <folly/portability/Filesystem.h>
+
+#include <chrono>
+#include <string>
+#include <tuple>
+#include <type_traits>
+#include <vector>
+
+/*
+ * Implementation details for extern_worker that don't need to be
+ * exposed to users.
+ */
+
+namespace HPHP::extern_worker {
+
+//////////////////////////////////////////////////////////////////////
+
+// This header gets included before any others, so these need to be
+// forward declared.
+template <typename T> struct Opt;
+template <typename T> struct Variadic;
+template <typename... Ts> struct Multi;
+
+template <typename T> struct Ref;
+
+extern int main(int, char**);
+
+//////////////////////////////////////////////////////////////////////
+
+namespace detail {
+
+//////////////////////////////////////////////////////////////////////
+
+// Scoped timing in debug builds. The emitted messages are supplied
+// with lambdas to avoid overhead when the code is compiled out.
+struct Timer {
+  Timer() : m_msg{nullptr} {
+    ONTRACE(2, [this] { m_begin = std::chrono::steady_clock::now(); }());
+  }
+
+  explicit Timer(const char* msg) : m_msg{msg} {
+    ONTRACE(2, [this] { m_begin = std::chrono::steady_clock::now(); }());
+  }
+
+  template <typename F>
+  explicit Timer(const F& f) {
+    ONTRACE(2, [&] {
+      m_str = f();
+      m_msg = m_str.c_str();
+      m_begin = std::chrono::steady_clock::now();
+    }());
+  }
+
+  // Stop the timer early before destruction with the given message.
+  template<typename F>
+  void stopWithMessage(const F& f) {
+    ONTRACE(2, [&] {
+      m_msg = nullptr;
+      FTRACE(2, "{} (took {})\n", f(), elapsed());
+    }());
+  }
+
+  ~Timer() {
+    ONTRACE(2, [this] {
+      if (!m_msg) return;
+      FTRACE(2, "{} took {}\n", m_msg, elapsed());
+    }());
+  }
+
+private:
+  std::string elapsed() const {
+    auto const d = std::chrono::duration_cast<std::chrono::duration<double>>(
+      std::chrono::steady_clock::now() - m_begin
+    ).count();
+    return folly::prettyPrint(d, folly::PRETTY_TIME, false);
+  }
+
+  std::chrono::steady_clock::time_point m_begin;
+  const char* m_msg;
+  std::string m_str;
+
+  TRACE_SET_MOD(extern_worker);
+};
+
+// Execute the given lambda, wrapping it with a Timer.
+template <typename F> auto time(const char* msg, const F& f) {
+  Timer _{msg};
+  return f();
+}
+
+template <typename F1, typename F2> auto time(const F1& f1, const F2& f2) {
+  Timer _{f1};
+  return f2();
+}
+
+//////////////////////////////////////////////////////////////////////
+
+// Read/write to a file
+extern std::string readFile(const folly::fs::path&);
+extern void writeFile(const folly::fs::path&, const char*, size_t);
+
+//////////////////////////////////////////////////////////////////////
+
+// Matchers for the special "marker" classes
+
+template <typename T>
+struct IsVariadic : std::false_type {};
+template <typename T>
+struct IsVariadic<Variadic<T>> : std::true_type {};
+
+template <typename T>
+struct IsOpt : std::false_type {};
+template <typename T>
+struct IsOpt<Opt<T>> : std::true_type {};
+
+template <typename... Ts>
+struct IsMulti : std::false_type {};
+template <typename... Ts>
+struct IsMulti<Multi<Ts...>> : std::true_type {};
+
+template <typename T>
+using IsMarker = std::disjunction<IsVariadic<T>, IsOpt<T>, IsMulti<T>>;
+
+//////////////////////////////////////////////////////////////////////
+
+// Matchers for special non-marker classes
+
+template <typename T>
+struct IsRef : std::false_type {};
+template <typename T>
+struct IsRef<Ref<T>> : std::true_type {};
+
+template <typename T>
+struct IsVector : std::false_type {};
+template <typename T>
+struct IsVector<std::vector<T>> : std::true_type {};
+
+template <typename T>
+struct IsOptional : std::false_type {};
+template <typename T>
+struct IsOptional<Optional<T>> : std::true_type {};
+
+template <typename T>
+struct IsTuple : std::false_type {};
+template <typename... Ts>
+struct IsTuple<std::tuple<Ts...>> : std::true_type {};
+
+//////////////////////////////////////////////////////////////////////
+
+// Given a callable, Params<>::type is the callable's parameter types
+// as a tuple.
+template <typename> struct Params;
+template <typename R, typename... P>
+struct Params<R(P...)> {
+  using type = std::tuple<
+    typename std::remove_cv<typename std::remove_reference<P>::type>::type...
+  >;
+};
+
+// Given a callable, Return<>::type is the callable's return type.
+template <typename> struct Return;
+template <typename R, typename... P>
+struct Return<R(P...)> {
+  using type =
+    typename std::remove_cv<typename std::remove_reference<R>::type>::type;
+};
+
+//////////////////////////////////////////////////////////////////////
+
+// Given a type T, ToRef<T>::type is equivalent Ref type. For most
+// types this is just Ref<T>, but the variadic marker becomes a
+// std::vector of Refs, and an optional marker becomes an Optional
+// Ref.
+template <typename T> struct ToRef {
+  using type = Ref<T>;
+};
+template <typename T> struct ToRef<Variadic<T>> {
+  using type = std::vector<typename ToRef<T>::type>;
+};
+template <typename T> struct ToRef<Opt<T>> {
+  using type = Optional<typename ToRef<T>::type>;
+};
+
+//////////////////////////////////////////////////////////////////////
+
+// Given a tuple of types, ToRefTuple<T>::type is a tuple with every
+// type converted to its ToRef equivalent.
+template <typename> struct ToRefTuple {};
+template <typename... Ts> struct ToRefTuple<std::tuple<Ts...>> {
+  using type = std::tuple<typename ToRef<Ts>::type...>;
+};
+
+// Same as ToRefTuple, except meant for return types. The only
+// difference is that a return type of the Multi marker becomes a
+// tuple.
+template <typename T> struct ToRefReturn {
+  using type = typename ToRef<T>::type;
+};
+template <typename... Ts> struct ToRefReturn<Multi<Ts...>> {
+  using type = std::tuple<typename ToRef<Ts>::type...>;
+};
+
+//////////////////////////////////////////////////////////////////////
+
+// Given a class (presumed to have static functions called init and
+// run), return their parameters or return values, transformed with
+// ToRef.
+template <typename C> struct ConfigRefs {
+  using type =
+    typename ToRefTuple<typename Params<decltype(C::init)>::type>::type;
+};
+
+template <typename C> struct InputRefs {
+  using type =
+    typename ToRefTuple<typename Params<decltype(C::run)>::type>::type;
+};
+
+template <typename C> struct ReturnRefs {
+  using type =
+    typename ToRefReturn<typename Return<decltype(C::run)>::type>::type;
+};
+
+//////////////////////////////////////////////////////////////////////
+
+// Iterate over a tuple. Just a wrapper around folly::for_each, which
+// doesn't work on empty tuples for some reason.
+template <typename F, typename... Ts>
+void for_each(std::tuple<Ts...>&& tuple, F&& f) {
+  if constexpr (sizeof...(Ts) != 0) {
+    folly::for_each(std::move(tuple), std::forward<F>(f));
+  }
+}
+template <typename F, typename... Ts>
+void for_each(std::tuple<Ts...>& tuple, F&& f) {
+  if constexpr (sizeof...(Ts) != 0) {
+    folly::for_each(tuple, std::forward<F>(f));
+  }
+}
+template <typename F, typename... Ts>
+void for_each(const std::tuple<Ts...>& tuple, F&& f) {
+  if constexpr (sizeof...(Ts) != 0) {
+    folly::for_each(tuple, std::forward<F>(f));
+  }
+}
+
+//////////////////////////////////////////////////////////////////////
+
+// Empty class wrapping a Type. Meant to allow passing the type from
+// typesToValues as an argument.
+template <typename T> struct Tag { using Type = T; };
+
+//////////////////////////////////////////////////////////////////////
+
+// Instantiated on a tuple, and given a callable, call the callable
+// for each type in that tuple. The callable is called with the tuple
+// index as the first parameter, and Tag<T> as the second (where T is
+// the type at that tuple index).
+template <typename Tuple, typename F, size_t... Is>
+auto typesToValuesImpl(F&& f,
+                       std::index_sequence<Is...>) {
+  return std::make_tuple(f(Is, Tag<std::tuple_element_t<Is, Tuple>>{})...);
+}
+
+template <typename Tuple, typename F>
+auto typesToValues(F&& f) {
+  return typesToValuesImpl<Tuple>(
+    std::forward<F>(f),
+    std::make_index_sequence<std::tuple_size<Tuple>{}>{}
+  );
+}
+
+//////////////////////////////////////////////////////////////////////
+
+// Base class for Jobs. This provide a consistent interface to invoke
+// through.
+struct JobBase {
+  const std::string& name() const { return m_name; }
+protected:
+  explicit JobBase(const std::string& name);
+
+  template <typename T> static T deserialize(const folly::fs::path&);
+  template <typename T> static void serialize(const T&,
+                                              size_t,
+                                              const folly::fs::path&);
+
+private:
+  virtual void init(const folly::fs::path&) const = 0;
+  virtual void fini() const = 0;
+  virtual void run(const folly::fs::path&, const folly::fs::path&) const = 0;
+
+  std::string m_name;
+
+  friend int HPHP::extern_worker::main(int, char**);
+};
+
+//////////////////////////////////////////////////////////////////////
+
+}}

--- a/hphp/util/extern-worker-inl.h
+++ b/hphp/util/extern-worker-inl.h
@@ -1,0 +1,1164 @@
+/*
+   +----------------------------------------------------------------------+
+   | HipHop for PHP                                                       |
+   +----------------------------------------------------------------------+
+   | Copyright (c) 2010-present Facebook, Inc. (http://www.facebook.com)  |
+   +----------------------------------------------------------------------+
+   | This source file is subject to version 3.01 of the PHP license,      |
+   | that is bundled with this package in the file LICENSE, and is        |
+   | available through the world-wide-web at the following url:           |
+   | http://www.php.net/license/3_01.txt                                  |
+   | If you did not receive a copy of the PHP license and are unable to   |
+   | obtain it through the world-wide-web, please send a note to          |
+   | license@php.net so we can mail you a copy immediately.               |
+   +----------------------------------------------------------------------+
+*/
+
+#ifndef incl_HPHP_EXTERN_WORKER_INL_H_
+#error "extern-worker-inl.h should only be included by extern-worker.h"
+#endif
+
+#include "hphp/util/assertions.h"
+#include "hphp/util/logger.h"
+#include "hphp/util/process.h"
+#include "hphp/util/trace.h"
+
+#include <folly/Conv.h>
+#include <folly/container/Foreach.h>
+#include <folly/gen/Base.h>
+#include <folly/portability/Filesystem.h>
+
+#include <boost/filesystem.hpp>
+
+#include <tuple>
+#include <type_traits>
+
+namespace HPHP::extern_worker {
+
+//////////////////////////////////////////////////////////////////////
+
+template <typename C>
+Job<C>::Job() : detail::JobBase{C::name()} {}
+
+// These functions in Job are responsible for taking paths
+// representing the data, turning them into whatever types that "C"
+// expects, then invoke the function with those types.
+
+template <typename C>
+void Job<C>::init(const folly::fs::path& root) const {
+  using namespace detail;
+  using Args = typename Params<decltype(C::init)>::type;
+
+  // For each expected input, load the file, and deserialize it into
+  // the appropriate type. Return the types as a tuple, which can then
+  // std::apply to C::init, passing the inputs.
+  std::apply(
+    C::init,
+    typesToValues<Args>(
+      [&] (size_t idx, auto tag) {
+        return deserialize<typename decltype(tag)::Type>(
+          root / folly::to<std::string>(idx)
+        );
+      }
+    )
+  );
+
+  using Ret = typename Return<decltype(C::init)>::type;
+  static_assert(std::is_void_v<Ret>, "init() must return void");
+}
+
+template <typename C>
+void Job<C>::fini() const {
+  using Ret = typename detail::Return<decltype(C::fini)>::type;
+  static_assert(std::is_void_v<Ret>, "fini() must return void");
+  // fini() is easy since it doesn't receive nor return anything.
+  C::fini();
+}
+
+template <typename C>
+void Job<C>::run(const folly::fs::path& inputRoot,
+                 const folly::fs::path& outputRoot) const {
+  using namespace detail;
+
+  // For each expected input, load the file, and deserialize it into
+  // the appropriate type, turning all of the types into a tuple.
+  using Args = typename Params<decltype(C::run)>::type;
+  auto inputs = time(
+    "loading inputs",
+    [&] {
+      return typesToValues<Args>(
+        [&] (size_t idx, auto tag) {
+          return deserialize<typename decltype(tag)::Type>(
+            inputRoot / folly::to<std::string>(idx)
+          );
+        }
+      );
+    }
+  );
+
+  // Apply the tuple to C::run, passing the types as parameters.
+  auto outputs = time(
+    "actual run",
+    [&] { return std::apply(C::run, std::move(inputs)); }
+  );
+
+  using Ret = typename Return<decltype(C::run)>::type;
+  static_assert(!std::is_void_v<Ret>, "run() must return something");
+
+  // Serialize the outputs into the output directory.
+  time("writing outputs", [&] { return serialize(outputs, 0, outputRoot); });
+}
+
+//////////////////////////////////////////////////////////////////////
+
+namespace detail {
+
+//////////////////////////////////////////////////////////////////////
+
+// Given a file path, load the contents of the file, deserialize them
+// into the type T, and return it.
+template <typename T>
+T JobBase::deserialize(const folly::fs::path& path) {
+  using namespace detail;
+  if constexpr (std::is_same<T, std::string>::value) {
+    // A std::string is always stored as itself (this lets us store
+    // files as their contents without having to encode them).
+    return readFile(path);
+  } else if constexpr (IsVariadic<T>::value) {
+    static_assert(!IsMarker<typename T::Type>::value,
+                  "Special markers cannot be nested");
+    // Variadic<T> is actually a directory, not a file. Recurse into
+    // it, and do the deserialization for every file within it.
+    T out;
+    for (size_t i = 0;; ++i) {
+      auto const valPath = path / folly::to<std::string>(i);
+      // A break in the numbering means the end of the vector.
+      if (!folly::fs::exists(valPath)) break;
+      out.vals.emplace_back(deserialize<typename T::Type>(valPath));
+    }
+    return out;
+  } else if constexpr (IsOpt<T>::value) {
+    static_assert(!IsMarker<typename T::Type>::value,
+                  "Special markers cannot be nested");
+    // Opt<T> is like T, except the file may not exist (so is nullopt
+    // otherwise).
+    T out;
+    if (folly::fs::exists(path)) {
+      out.val.emplace(deserialize<typename T::Type>(path));
+    }
+    return out;
+  } else {
+    // For most types, the data is encoded using BlobEncoder, so undo
+    // that.
+    static_assert(!IsMulti<T>::value, "Multi can only be used as return type");
+    auto const data = readFile(path);
+    BlobDecoder decoder{data.data(), data.size(), false};
+    return decoder.makeWhole<T>();
+  }
+}
+
+// Given a value, an index of that value (its positive in the output
+// values), and an output root, serialize the value, and write its
+// contents to the appropriate file.
+template <typename T>
+void JobBase::serialize(const T& v,
+                        size_t idx,
+                        const folly::fs::path& root) {
+  using namespace detail;
+  if constexpr (std::is_same<T, std::string>::value) {
+    // std::string isn't serialized, but written as itself as
+    // root/idx.
+    return writeFile(root / folly::to<std::string>(idx), v.data(), v.size());
+  } else if constexpr (IsVariadic<T>::value) {
+    // For Variadic<T>, we create a directory root/idx, and under it,
+    // write a file for every element in the vector.
+    static_assert(!IsMarker<typename T::Type>::value,
+                  "Special markers cannot be nested");
+    auto const path = root / folly::to<std::string>(idx);
+    folly::fs::create_directory(path, root);
+    for (size_t i = 0; i < v.vals.size(); ++i) {
+      serialize(v.vals[i], i, path);
+    }
+  } else if constexpr (IsOpt<T>::value) {
+    // Opt<T> is like T, except nothing is written if the value isn't
+    // present.
+    static_assert(!IsMarker<typename T::Type>::value,
+                  "Special markers cannot be nested");
+    if (!v.val.has_value()) return;
+    serialize(*v.val, idx, root);
+  } else if constexpr (IsMulti<T>::value) {
+    // Treat Multi as equivalent to std::tuple (IE, write each element
+    // to a separate file).
+    assertx(idx == 0);
+    for_each(
+      v.vals,
+      [&] (auto const& elem, size_t tupleIdx) {
+        static_assert(
+          !IsMulti<
+            std::remove_cv_t<std::remove_reference_t<decltype(elem)>>
+          >::value,
+         "Multi cannot be nested"
+        );
+        serialize(elem, tupleIdx, root);
+      }
+    );
+  } else {
+    // Most types are just encoded with BlobEncoder and written as
+    // root/idx
+    BlobEncoder encoder{false};
+    encoder(v);
+    writeFile(
+      root / folly::to<std::string>(idx),
+      (const char*)encoder.data(), encoder.size()
+    );
+  }
+}
+
+//////////////////////////////////////////////////////////////////////
+
+}
+
+//////////////////////////////////////////////////////////////////////
+
+inline RefId::RefId(std::string id, size_t size)
+  : m_id{std::move(id)}, m_size{size}
+{}
+
+inline bool RefId::operator==(const RefId& o) const {
+  return std::tie(m_id, m_size) == std::tie(o.m_id, o.m_size);
+}
+
+inline bool RefId::operator!=(const RefId& o) const {
+  return !(*this == o);
+}
+
+inline std::string RefId::toString() const {
+  return folly::sformat("{}:{}", m_id, m_size);
+}
+
+//////////////////////////////////////////////////////////////////////
+
+template <typename T>
+inline Ref<T>::Ref(RefId id, bool fromFallback)
+  : m_id{std::move(id)}
+  , m_fromFallback{fromFallback}
+{
+  static_assert(!detail::IsMarker<T>::value,
+                "Special markers cannot be used in a Ref");
+}
+
+//////////////////////////////////////////////////////////////////////
+
+inline RequestId::RequestId(const char* type)
+  : m_id{s_next++}
+  , m_type{type}
+{
+  ++s_active;
+  FTRACE(2, "{} begin\n", tracePrefix());
+  m_timer.emplace();
+}
+
+inline RequestId::~RequestId() {
+  m_timer->stopWithMessage(
+    [this] { return folly::sformat("{} done", tracePrefix()); }
+  );
+  --s_active;
+}
+
+inline std::string RequestId::tracePrefix() const {
+  return folly::sformat(
+    "[{} req #{} {} ({} active)]",
+    std::chrono::duration_cast<std::chrono::microseconds>(
+      std::chrono::steady_clock::now().time_since_epoch()
+    ).count(),
+    m_id,
+    m_type,
+    s_active.load()
+  );
+}
+
+inline std::string RequestId::toString() const {
+  return folly::to<std::string>(m_id);
+}
+
+//////////////////////////////////////////////////////////////////////
+
+inline const std::string& Client::implName() const {
+  return m_impl->name();
+}
+
+inline bool Client::usingSubprocess() const {
+  return m_impl->isSubprocess();
+}
+
+// Run the given callable F with the normal implementation. If it
+// throws an Error, set didFallback to true, and attempt to re-run F
+// with the fallback implementation.
+template <typename T, typename F>
+coro::Task<T> Client::tryWithFallback(F f, bool& didFallback) {
+  // If we're forcing fallbacks, or if the main implementation has
+  // disabled itself, go straight to the fallback case.
+  if (!m_forceFallback && !m_impl->isDisabled()) {
+    try {
+      // Attempt the normal implementation.
+      didFallback = false;
+      HPHP_CORO_RETURN(HPHP_CORO_AWAIT(f(*m_impl, false)));
+    } catch (const Error& exn) {
+      // It failed. If the main implementation *is* the subprocess
+      // implementation, there's no point in trying again. Just
+      // rethrow the error. Likewise, if Options has determined we
+      // shouldn't use the subprocess implementaiton, rethrow the
+      // error.
+      if (m_impl->isSubprocess()) throw;
+      if (m_options.m_useSubprocess == Options::UseSubprocess::Never) throw;
+      // Check this again. The implementation could have disabled
+      // itself while using it above, and in that case, its the
+      // implementation's responsibility to print something to the
+      // log.
+      if (!m_impl->isDisabled()) {
+        Logger::FError(
+          "Error: \"{}\". Attempting to retry with local fallback...",
+          exn.what()
+        );
+      }
+    }
+  }
+  // Fallback case. Make a fallback implementation if we haven't
+  // already (LockFreeLazy will ensure this), and call it. If it
+  // throws, nothing to be done, it will be propagated to the caller.
+  didFallback = true;
+  auto& fallback = *m_fallbackImpl.get([this] { return makeFallbackImpl(); });
+  HPHP_CORO_RETURN(HPHP_CORO_AWAIT(f(fallback, true)));
+}
+
+template <typename T>
+coro::Task<T> Client::load(Ref<T> r) {
+  RequestId requestId{"load blob"};
+
+  // Get the appropriate implementation (it could have been created by
+  // a fallback implementation), and forward the request to it.
+  auto& impl = r.m_fromFallback ? *m_fallbackImpl.rawGet() : *m_impl;
+  auto result = HPHP_CORO_AWAIT(impl.load(requestId, IdVec{std::move(r.m_id)}));
+  assertx(result.size() == 1);
+  FTRACE(4, "{} blob is {} bytes\n",
+         requestId.tracePrefix(), result[0].size());
+  HPHP_CORO_RETURN(unblobify<T>(std::move(result[0])));
+}
+
+template <typename T, typename... Ts>
+coro::Task<std::tuple<T, Ts...>> Client::load(Ref<T> r, Ref<Ts>... rs) {
+  using namespace detail;
+
+  RequestId requestId{"load blobs"};
+  FTRACE(2, "{} {} blobs requested\n",
+         requestId.tracePrefix(), sizeof...(Ts) + 1);
+
+  // Retrieve the ids from the Refs, and split them into a set from
+  // the main implementation, and a set from the fallback
+  // implementation.
+  IdVec main;
+  IdVec fallback;
+  // Keep the indices of the original list, so we can restore it
+  // afterwards. If a mapping isn't present,it's an identity mapping
+  // for the non-fallback implementation (which conveniently means we
+  // don't need to store anything for the common case of there being
+  // no fallbacks).
+  hphp_fast_map<size_t, std::pair<bool, size_t>> indexMappings;
+  for_each(
+    std::make_tuple(std::move(r), std::move(rs)...),
+    [&] (auto&& r, size_t idx) {
+      if (r.m_fromFallback) {
+        indexMappings.emplace(idx, std::make_pair(true, fallback.size()));
+        fallback.emplace_back(std::move(r.m_id));
+      } else {
+        if (idx != main.size()) {
+          indexMappings.emplace(idx, std::make_pair(false, main.size()));
+        }
+        main.emplace_back(std::move(r.m_id));
+      }
+    }
+  );
+
+  auto const DEBUG_ONLY mainSize = main.size();
+  auto const DEBUG_ONLY fallbackSize = fallback.size();
+  assertx(mainSize + fallbackSize == sizeof...(Ts) + 1);
+
+  // Do the loads from either implementation (in the normal case, only
+  // one of these will be executed).
+  auto mainBlobs = !main.empty()
+    ? HPHP_CORO_AWAIT(m_impl->load(requestId, std::move(main)))
+    : BlobVec{};
+  auto fallbackBlobs = !fallback.empty()
+    ? HPHP_CORO_AWAIT(
+        m_fallbackImpl.rawGet()->load(requestId, std::move(fallback))
+      )
+    : BlobVec{};
+
+  assertx(mainBlobs.size() == mainSize);
+  assertx(fallbackBlobs.size() == fallbackSize);
+  using OutTuple = std::tuple<T, Ts...>;
+
+  // Now restore the results back into the output tuple.
+  auto ret = typesToValues<OutTuple>(
+    [&] (size_t idx, auto tag) {
+      assertx(idx < mainBlobs.size() + fallbackBlobs.size());
+
+      // For tuple position idx, use indexMappings to figure out which
+      // of mainBlobs or fallbackBlobs entry corresponds to this
+      // entry.
+      auto& blob = [&] () -> std::string& {
+        // In the common case, we'll have no mappings, and idx will be
+        // an identity mapping into mainBlobs.
+        if (indexMappings.empty()) {
+          assertx(idx < mainBlobs.size());
+          return mainBlobs[idx];
+        }
+        // Otherwise do the lookup.
+        auto const it = indexMappings.find(idx);
+        if (it == indexMappings.end()) {
+          // No entry means idx maps to idx in mainBlobs.
+          assertx(idx < mainBlobs.size());
+          return mainBlobs[idx];
+        }
+        // Otherwise use the entry to find the right blob.
+        if (it->second.first) {
+          assertx(it->second.second < fallbackBlobs.size());
+          return fallbackBlobs[it->second.second];
+        } else {
+          assertx(it->second.second < mainBlobs.size());
+          return mainBlobs[it->second.second];
+        }
+      }();
+
+      FTRACE(4, "{} blob #{} is {} bytes\n",
+             requestId.tracePrefix(), idx, blob.size());
+      // Turn it into the value.
+      return unblobify<typename decltype(tag)::Type>(std::move(blob));
+    }
+  );
+  HPHP_CORO_MOVE_RETURN(ret);
+}
+
+template <typename T>
+coro::Task<std::vector<T>> Client::load(std::vector<Ref<T>> rs) {
+  using namespace folly::gen;
+
+  RequestId requestId{"load blobs"};
+  FTRACE(2, "{} {} blobs requested\n",
+         requestId.tracePrefix(), rs.size());
+
+  // Retrieve the RefId from the refs and split them into the ones
+  // which come from the main implementation and the fallback
+  // implementation.
+  IdVec main;
+  IdVec fallback;
+  for (auto& r : rs) {
+    if (r.m_fromFallback) {
+      fallback.emplace_back(std::move(r.m_id));
+    } else {
+      main.emplace_back(std::move(r.m_id));
+    }
+  }
+
+  auto const DEBUG_ONLY mainSize = main.size();
+  auto const DEBUG_ONLY fallbackSize = fallback.size();
+  assertx(mainSize + fallbackSize == rs.size());
+
+  // Do the loads from either implementation (in the normal case, only
+  // one of these will be executed).
+  auto mainBlobs = !main.empty()
+    ? HPHP_CORO_AWAIT(m_impl->load(requestId, std::move(main)))
+    : BlobVec{};
+  auto fallbackBlobs = !fallback.empty()
+    ? HPHP_CORO_AWAIT(
+        m_fallbackImpl.rawGet()->load(requestId, std::move(fallback))
+      )
+    : BlobVec{};
+
+  assertx(mainBlobs.size() == mainSize);
+  assertx(fallbackBlobs.size() == fallbackSize);
+
+  std::vector<T> out;
+  out.reserve(rs.size());
+
+  // Stitch together mainBlobs and fallbackBlobs back together in the
+  // same order their Refs were passed to this function. We can
+  // reconstruct the order using the input Ref vector.
+  size_t mainIdx = 0;
+  size_t fallbackIdx = 0;
+  for (auto const& r : rs) {
+    auto& blob = [&] () -> std::string& {
+      if (r.m_fromFallback) {
+        assertx(fallbackIdx < fallbackBlobs.size());
+        return fallbackBlobs[fallbackIdx++];
+      } else {
+        assertx(mainIdx < mainBlobs.size());
+        return mainBlobs[mainIdx++];
+      }
+    }();
+    FTRACE(4, "{} blob #{} is {} bytes\n",
+           requestId.tracePrefix(), out.size(), blob.size());
+    out.emplace_back(unblobify<T>(std::move(blob)));
+  }
+  assertx(out.size() == rs.size());
+  assertx(mainIdx == mainBlobs.size());
+  assertx(fallbackIdx == fallbackBlobs.size());
+
+  HPHP_CORO_MOVE_RETURN(out);
+}
+
+template <typename T, typename... Ts>
+coro::Task<std::vector<std::tuple<T, Ts...>>>
+Client::load(std::vector<std::tuple<Ref<T>, Ref<Ts>...>> rs) {
+  using namespace detail;
+  using namespace folly::gen;
+
+  using OutTuple = std::tuple<T, Ts...>;
+  auto constexpr tupleSize = std::tuple_size<OutTuple>{};
+
+  RequestId requestId{"load blobs"};
+  FTRACE(2, "{} {} blobs requested\n",
+         requestId.tracePrefix(), rs.size() * tupleSize);
+
+  // This is a hybrid of the variadic case and the vector case:
+
+  // Retrieve the RefId from the refs and split them into the ones
+  // which come from the main implementation and the fallback
+  // implementation. "Flatten" out the refs into flat lists,
+  // disregarding the tuple structure (which will be rebuilt later).
+  IdVec main;
+  IdVec fallback;
+  hphp_fast_map<size_t, std::pair<bool, size_t>> indexMappings;
+  for (size_t i = 0; i < rs.size(); ++i) {
+    for_each(
+      std::move(rs[i]),
+      [&] (auto&& r, size_t tupleIdx) {
+        auto const idx = i * tupleSize + tupleIdx;
+        if (r.m_fromFallback) {
+          indexMappings.emplace(idx, std::make_pair(true, fallback.size()));
+          fallback.emplace_back(std::move(r.m_id));
+        } else {
+          if (idx != main.size()) {
+            indexMappings.emplace(idx, std::make_pair(false, main.size()));
+          }
+          main.emplace_back(std::move(r.m_id));
+        }
+      }
+    );
+  }
+
+  auto const DEBUG_ONLY mainSize = main.size();
+  auto const DEBUG_ONLY fallbackSize = fallback.size();
+  assertx(mainSize + fallbackSize == rs.size() * tupleSize);
+
+  // Do the loads from either implementation (in the normal case, only
+  // one of these will be executed).
+  auto mainBlobs = !main.empty()
+    ? HPHP_CORO_AWAIT(m_impl->load(requestId, std::move(main)))
+    : BlobVec{};
+  auto fallbackBlobs = !fallback.empty()
+    ? HPHP_CORO_AWAIT(
+        m_fallbackImpl.rawGet()->load(requestId, std::move(fallback))
+      )
+    : BlobVec{};
+
+  assertx(mainBlobs.size() == mainSize);
+  assertx(fallbackBlobs.size() == fallbackSize);
+
+  // Now combine mainBlobs and fallbackBlobs back together, in the
+  // same order as their associated Refs were given (also restoring
+  // the tuple structure of the inputs).
+  std::vector<OutTuple> out;
+  out.reserve(rs.size());
+
+  for (size_t i = 0; i < rs.size(); ++i) {
+    out.emplace_back(
+      typesToValues<OutTuple>(
+        [&] (size_t tupleIdx, auto tag) {
+          // This is similar to logic for load(Ref<T>, Ref<T2>, ...)
+          auto const idx = i * tupleSize + tupleIdx;
+          assertx(idx < mainBlobs.size() + fallbackBlobs.size());
+
+          auto& blob = [&] () -> std::string& {
+            if (indexMappings.empty()) {
+              assertx(idx < mainBlobs.size());
+              return mainBlobs[idx];
+            }
+            auto const it = indexMappings.find(idx);
+            if (it == indexMappings.end()) {
+              assertx(idx < mainBlobs.size());
+              return mainBlobs[idx];
+            }
+            if (it->second.first) {
+              assertx(it->second.second < fallbackBlobs.size());
+              return fallbackBlobs[it->second.second];
+            } else {
+              assertx(it->second.second < mainBlobs.size());
+              return mainBlobs[it->second.second];
+            }
+          }();
+
+          FTRACE(4, "{} blob #{} is {} bytes\n",
+                 requestId.tracePrefix(), idx, blob.size());
+          return unblobify<typename decltype(tag)::Type>(std::move(blob));
+        }
+      )
+    );
+  }
+  assertx(out.size() == rs.size());
+
+  HPHP_CORO_MOVE_RETURN(out);
+}
+
+// All of the store functions are similar: Serialize the inputs into
+// blobs, call (with fallback) the store function on the
+// implementation, then wrap the output RefIds into Refs with the
+// appropriate types.
+
+template <typename T>
+coro::Task<Ref<T>> Client::store(T t) {
+  RequestId requestId{"store blob"};
+
+  auto wasFallback = false;
+  auto ids = HPHP_CORO_AWAIT(tryWithFallback<IdVec>(
+    [&] (Impl& i, bool) {
+      auto blob = blobify(t);
+      FTRACE(2, "{} blob is {} bytes\n", requestId.tracePrefix(), blob.size());
+      return i.store(requestId, {}, BlobVec{std::move(blob)}, nullptr, nullptr);
+    },
+    wasFallback
+  ));
+  assertx(ids.size() == 1);
+
+  Ref<T> ref{std::move(ids[0]), wasFallback};
+  HPHP_CORO_MOVE_RETURN(ref);
+}
+
+template <typename T, typename... Ts>
+coro::Task<std::tuple<Ref<T>, Ref<Ts>...>> Client::store(T t, Ts... ts) {
+  using namespace detail;
+  RequestId requestId{"store blobs"};
+
+  FTRACE(2, "{} storing {} blobs\n",
+         requestId.tracePrefix(), sizeof...(Ts) + 1);
+
+  auto wasFallback = false;
+  auto ids = HPHP_CORO_AWAIT(tryWithFallback<IdVec>(
+    [&] (Impl& i, bool) {
+      BlobVec blobs{{ blobify(t), blobify(ts)... }};
+      ONTRACE(4, [&] {
+        for (auto const& b : blobs) {
+          FTRACE(4, "{} storing {} byte blob\n",
+                 requestId.tracePrefix(), b.size());
+        }
+      }());
+      return i.store(requestId, {}, std::move(blobs), nullptr, nullptr);
+    },
+    wasFallback
+  ));
+  assertx(ids.size() == sizeof...(Ts) + 1);
+
+  using OutTuple = std::tuple<T, Ts...>;
+  auto ret = typesToValues<OutTuple>(
+    [&] (size_t idx, auto tag) {
+      assertx(idx < ids.size());
+      return Ref<typename decltype(tag)::Type>{
+        std::move(ids[idx]), wasFallback
+      };
+    }
+  );
+  HPHP_CORO_MOVE_RETURN(ret);
+}
+
+template <typename T>
+coro::Task<std::vector<Ref<T>>> Client::storeMulti(std::vector<T> ts) {
+  using namespace folly::gen;
+
+  RequestId requestId{"store blobs"};
+
+  FTRACE(2, "{} storing {} blobs\n",
+         requestId.tracePrefix(), ts.size());
+
+  auto wasFallback = false;
+  auto ids = HPHP_CORO_AWAIT(tryWithFallback<IdVec>(
+    [&] (Impl& i, bool) {
+      auto blobs = from(ts)
+        | mapped([&] (const T& t) {
+            auto blob = blobify(t);
+            FTRACE(4, "{} storing {} byte blob\n",
+                   requestId.tracePrefix(), blob.size());
+            return blob;
+          })
+        | as<std::vector>();
+      assertx(blobs.size() == ts.size());
+      return i.store(requestId, {}, std::move(blobs), nullptr, nullptr);
+    },
+    wasFallback
+  ));
+  assertx(ids.size() == ts.size());
+
+  auto out = from(ids)
+    | move
+    | mapped([&] (RefId&& id) { return Ref<T>{std::move(id), wasFallback}; })
+    | as<std::vector>();
+  HPHP_CORO_MOVE_RETURN(out);
+}
+
+template <typename T, typename... Ts>
+coro::Task<std::vector<std::tuple<Ref<T>, Ref<Ts>...>>>
+Client::storeMultiTuple(std::vector<std::tuple<T, Ts...>> ts) {
+  using namespace folly::gen;
+  using namespace detail;
+
+  RequestId requestId{"store blobs"};
+
+  using OutTuple = std::tuple<T, Ts...>;
+  auto constexpr tupleSize = std::tuple_size<OutTuple>{};
+
+  FTRACE(2, "{} storing {} blobs\n",
+         requestId.tracePrefix(), ts.size() * tupleSize);
+
+  auto wasFallback = false;
+  auto ids = HPHP_CORO_AWAIT(tryWithFallback<IdVec>(
+    [&] (Impl& i, bool) {
+      // Map each tuple to a vector of RefIds, then concat all of the
+      // vectors together to get one flat list.
+      auto blobs = from(ts)
+        | mapped([&] (auto const& tuple) {
+            BlobVec blobs;
+            blobs.reserve(tupleSize);
+            for_each(
+              tuple,
+              [&] (auto const& t) {
+                auto blob = blobify(t);
+                FTRACE(4, "{} storing {} byte blob\n",
+                       requestId.tracePrefix(), blob.size());
+                blobs.emplace_back(std::move(blob));
+              }
+            );
+            return fromCopy(std::move(blobs));
+          })
+        | concat
+        | as<std::vector>();
+      assertx(blobs.size() == ts.size() * tupleSize);
+      return i.store(requestId, {}, std::move(blobs), nullptr, nullptr);
+    },
+    wasFallback
+  ));
+  assertx(ids.size() == ts.size() * tupleSize);
+
+  // Do the opposite to the output. Batch the output into the
+  // tupleSize, then turn each one into a tuple of Refs.
+  auto out = from(ids)
+    | move
+    | batch(tupleSize)
+    | move
+    | mapped([&] (std::vector<RefId>&& ids) {
+        assertx(ids.size() == tupleSize);
+        return typesToValues<OutTuple>(
+          [&] (size_t idx, auto tag) {
+            assertx(idx < ids.size());
+            return Ref<typename decltype(tag)::Type>{
+              std::move(ids[idx]), wasFallback
+            };
+          }
+        );
+      })
+    | as<std::vector>();
+  HPHP_CORO_MOVE_RETURN(out);
+}
+
+template <typename C> coro::Task<std::vector<typename Job<C>::ReturnT>>
+Client::exec(const Job<C>& job,
+             typename Job<C>::ConfigT config,
+             std::vector<typename Job<C>::InputsT> inputs,
+             bool* cached) {
+  using namespace folly::gen;
+  using namespace detail;
+
+  RequestId requestId{"exec"};
+  FTRACE(2, "{} executing \"{}\" ({} runs)\n",
+         requestId.tracePrefix(), job.name(),
+         inputs.size());
+
+  // Return true if a Ref (or some container of them allowed as
+  // inputs) came from the fallback implementation. If so, we'll force
+  // everything to come from the fallback implementation (loading and
+  // storing as required), and exec on the fallback
+  // implementation. One fallback Ref "poisons" everything.
+  auto const isFallback = [] (auto const& r) {
+    using Type = std::remove_cv_t<std::remove_reference_t<decltype(r)>>;
+    if constexpr (IsVector<Type>::value) {
+      for (auto const& e : r) {
+        if (e.m_fromFallback) return true;
+      }
+      return false;
+    } else if constexpr (IsOptional<Type>::value) {
+      if (!r.has_value()) return false;
+      return r->m_fromFallback;
+    } else {
+      static_assert(IsRef<Type>::value);
+      return r.m_fromFallback;
+    }
+  };
+  auto const tupleIsFallback = [&] (auto const& tuple) {
+    auto f = false;
+    for_each(tuple, [&] (auto const& r) { f |= isFallback(r); });
+    return f;
+  };
+  auto const vecIsFallback = [&] (auto const& v) {
+    return std::any_of(v.begin(), v.end(), tupleIsFallback);
+  };
+
+  // Make all of the inputs come from the fallback
+  // implementation. This is a lambda because we might have to do it
+  // two different places.
+  auto const makeAllFallback = [&] () -> coro::Task<void> {
+    // Vector of all RefIds which come from the non-fallback
+    // implementation.
+    IdVec ids;
+
+    // For every input, if the Ref doesn't come from the fallback
+    // implementation, add it to "ids".
+    auto const addNonFallback = [&] (auto const& r) {
+      using Type = std::remove_cv_t<std::remove_reference_t<decltype(r)>>;
+      if constexpr (IsVector<Type>::value) {
+        for (auto const& e : r) {
+          if (e.m_fromFallback) continue;
+          ids.emplace_back(e.m_id);
+        }
+      } else if constexpr (IsOptional<Type>::value) {
+        if (r.has_value() && !r->m_fromFallback) {
+          ids.emplace_back(r->m_id);
+        }
+      } else {
+        static_assert(IsRef<Type>::value);
+        if (!r.m_fromFallback) ids.emplace_back(r.m_id);
+      }
+    };
+    for_each(config, addNonFallback);
+    for (auto const& t : inputs) for_each(t, addNonFallback);
+
+    // If there's nothing there, everything is already from the
+    // fallback implementation, so we're done.
+    if (ids.empty()) HPHP_CORO_RETURN_VOID;
+
+    // Otherwise load just those from the non-fallback implementation
+    // (if this fails, there's nothing we can do).
+    auto const DEBUG_ONLY size = ids.size();
+    auto blobs = HPHP_CORO_AWAIT(m_impl->load(requestId, std::move(ids)));
+    assertx(blobs.size() == size);
+
+    // Then store them with the fallback implementation.
+    auto stores = HPHP_CORO_AWAIT(
+      m_fallbackImpl.rawGet()->store(
+        requestId,
+        {},
+        std::move(blobs),
+        nullptr,
+        nullptr
+      )
+    );
+    assertx(stores.size() == size);
+
+    // Iterate over all the inputs again. If the input came from the
+    // non-fallback implementation, then overwrite (in place) it's
+    // RefId with the new RefId we got from storing it in the fallback
+    // implementation.
+    size_t idx = 0;
+    auto const setToFallback = [&] (auto& r) {
+      using Type = std::remove_cv_t<std::remove_reference_t<decltype(r)>>;
+      if constexpr (IsVector<Type>::value) {
+        for (auto& e : r) {
+          if (e.m_fromFallback) continue;
+          assertx(idx < stores.size());
+          e.m_fromFallback = true;
+          e.m_id = std::move(stores[idx++]);
+        }
+      } else if constexpr (IsOptional<Type>::value) {
+        if (r.has_value() && !r->m_fromFallback) {
+          assertx(idx < stores.size());
+          r->m_fromFallback = true;
+          r->m_id = std::move(stores[idx++]);
+        }
+        } else {
+        static_assert(IsRef<Type>::value);
+        if (!r.m_fromFallback) {
+          assertx(idx < stores.size());
+          r.m_fromFallback = true;
+          r.m_id = std::move(stores[idx++]);
+        }
+      }
+    };
+    for_each(config, setToFallback);
+    for (auto& t : inputs) for_each(t, setToFallback);
+    assertx(idx == stores.size());
+
+    // At this point, all Refs should be from the fallback
+    // implementation.
+    HPHP_CORO_RETURN_VOID;
+  };
+
+  // Do we need to execute on the fallback implementation? If the
+  // fallback implementation isn't created, then obviously not (common
+  // case). Otherwise, if the main implementation is disabled, we're
+  // forced to. If any input RefId is from the fallback
+  // implementation, we're also forced to.
+  auto useFallback = false;
+  if (m_fallbackImpl.present() &&
+      (m_impl->isDisabled() ||
+       tupleIsFallback(config) ||
+       vecIsFallback(inputs))) {
+    // If we're executing on the fallback implementation, all inputs
+    // need to be from there.
+    HPHP_CORO_AWAIT(makeAllFallback());
+    useFallback = true;
+  }
+
+  // RefVals are wrappers around a RefId. They provide the RefId,
+  // along with the knowledge of whether that RefId corresponds to a
+  // Variadic, Opt, or a normal type (the implementation does not know
+  // anything about the types of the job its executing). They're just
+  // a variant of RefId, Optional<RefId>, or std::vector<RefId>,
+  // mirroring the special types.
+
+  auto const toRefVal = [] (auto const& t) -> RefVal {
+    using Type = std::remove_cv_t<std::remove_reference_t<decltype(t)>>;
+    if constexpr (IsVector<Type>::value) {
+      IdVec v;
+      v.reserve(t.size());
+      for (auto const& e : t) v.emplace_back(e.m_id);
+      return v;
+    } else if constexpr (IsOptional<Type>::value) {
+      if (!t.has_value()) return std::nullopt;
+      return make_optional(t->m_id);
+    } else {
+      static_assert(IsRef<Type>::value);
+      return t.m_id;
+    }
+  };
+
+  auto const toRefVals = [&] (auto const& tuple) {
+    RefValVec v;
+    v.reserve(std::tuple_size<std::remove_reference_t<decltype(tuple)>>{});
+    for_each(
+      std::move(tuple),
+      [&] (auto const& t) { v.emplace_back(toRefVal(t)); }
+    );
+    return v;
+  };
+
+  using RetT = typename Job<C>::ReturnT;
+
+  // OutputType is similar to RefVals, but for outputs. Since there's
+  // no RefId (yet) for the outputs, we can use a simple enum to
+  // describe the output format.
+  auto const outputTypes = [&] () -> folly::Range<const OutputType*> {
+    // For the common cases, we can just use a pointer to a static
+    // OutputType.
+    if constexpr (IsVector<RetT>::value) {
+      return s_vecOutputType;
+    } else if constexpr (IsOptional<RetT>::value) {
+      return s_optOutputType;
+    } else if constexpr (IsTuple<RetT>::value) {
+      // Tuple output types are still static, but they're calculated
+      // at compile time for each instantiation of the job.
+      return std::apply(
+        [] (auto&&... v) -> folly::Range<const OutputType*> {
+          static std::array<OutputType, sizeof...(v)> a{std::move(v)...};
+          return a;
+        },
+        typesToValues<RetT>(
+          [] (size_t, auto tag) {
+            using T = typename decltype(tag)::Type;
+            if constexpr (IsVector<T>::value) {
+              return OutputType::Vec;
+            } else if constexpr (IsOptional<T>::value) {
+              return OutputType::Opt;
+            } else {
+              static_assert(IsRef<T>::value);
+              return OutputType::Val;
+            }
+          }
+        )
+      );
+    } else {
+      static_assert(IsRef<RetT>::value);
+      return s_valOutputType;
+    }
+  }();
+
+  // Execute the job using the appropriate executor, receiving the
+  // outputs as RefVals (with the format prescribed by the
+  // OutputTypes).
+  auto outputs = HPHP_CORO_AWAIT(coro::invoke(
+    [&] () -> coro::Task<std::vector<RefValVec>> {
+      if (useFallback) {
+        auto configRefVals = toRefVals(config);
+        auto inputsRefVals = from(inputs)
+          | mapped(toRefVals)
+          | as<std::vector>();
+        HPHP_CORO_RETURN(
+          HPHP_CORO_AWAIT(
+            m_fallbackImpl.rawGet()->exec(
+              requestId,
+              job.name(),
+              std::move(configRefVals),
+              std::move(inputsRefVals),
+              outputTypes,
+              cached
+            )
+          )
+        );
+      } else {
+        // Not using the fallback executor. Use tryWithFallback since
+        // the execution can fail.
+        HPHP_CORO_RETURN(
+          HPHP_CORO_AWAIT(
+            tryWithFallback<std::vector<RefValVec>>(
+              [&] (Impl& i, bool fallback)
+              -> coro::Task<std::vector<RefValVec>> {
+                // If we've failed and we're now trying the fallback,
+                // we need to make all of the inputs be from the
+                // fallback executor.
+                if (fallback) HPHP_CORO_AWAIT(makeAllFallback());
+                // Note we calculate the RefVals here within the
+                // lambda. This lets us move them into the exec call
+                // (so we don't need to copy in the common case where
+                // nothing fails).
+                auto configRefVals = toRefVals(config);
+                auto inputsRefVals = from(inputs)
+                  | mapped(toRefVals)
+                  | as<std::vector>();
+                HPHP_CORO_RETURN(HPHP_CORO_AWAIT(i.exec(
+                  requestId,
+                  job.name(),
+                  std::move(configRefVals),
+                  std::move(inputsRefVals),
+                  outputTypes,
+                  cached
+                )));
+              },
+              useFallback
+            )
+          )
+        );
+      }
+    }
+  ));
+  assertx(outputs.size() == inputs.size());
+
+  // Map a RefVal for a particular output into a Ref<T>, where T is
+  // the type corresponding to their output.
+  auto const toRetTSingle = [&] (RefVal&& v, auto tag)
+    -> typename decltype(tag)::Type {
+    using T = typename decltype(tag)::Type;
+    if constexpr (IsVector<T>::value) {
+      auto r = boost::get<IdVec>(&v);
+      assertx(r);
+      return from(*r)
+        | move
+        | mapped([&] (RefId&& id) {
+            return typename T::value_type{std::move(id), useFallback};
+          })
+        | as<std::vector>();
+    } else if constexpr (IsOptional<T>::value) {
+      auto r = boost::get<Optional<RefId>>(&v);
+      assertx(r);
+      using Elem = std::remove_cv_t<
+        std::remove_reference_t<decltype(*std::declval<T>())>
+      >;
+      static_assert(IsRef<Elem>::value);
+      if (!r->has_value()) return std::nullopt;
+      return Elem{std::move(**r), useFallback};
+    } else {
+      static_assert(IsRef<T>::value);
+      auto r = boost::get<RefId>(&v);
+      assertx(r);
+      return T{std::move(*r), useFallback};
+    }
+  };
+
+  // The return type for the job can either be a single type, or a
+  // tuple. This takes all the RefVals corresponding to the output and
+  // maps them to that return type as appropriate.
+  auto const toRetT = [&] (RefValVec&& v) -> RetT {
+    if constexpr (IsVector<RetT>::value ||
+                  IsOptional<RetT>::value ||
+                  IsRef<RetT>::value) {
+      // Non-tuple. There should be only one output RefVal.
+      assertx(v.size() == 1);
+      return toRetTSingle(std::move(v[0]), Tag<RetT>{});
+    } else {
+      // Otherwise there should be enough RefVals for the tuple
+      // size. Build the tuple from converting the components.
+      static_assert(IsTuple<RetT>::value);
+      assertx(v.size() == std::tuple_size<RetT>{});
+      return typesToValues<RetT>(
+        [&] (size_t idx, auto tag) {
+          assertx(idx < v.size());
+          return toRetTSingle(std::move(v[idx]), tag);
+        }
+      );
+    }
+  };
+
+  // Map over the outputs for each input set, and map them to Refs.
+  auto out = from(outputs)
+    | move
+    | mapped(toRetT)
+    | as<std::vector>();
+  HPHP_CORO_MOVE_RETURN(out);
+}
+
+// Turn the given blob into a value of type T.
+template <typename T> T Client::unblobify(std::string&& blob) {
+  static_assert(!detail::IsMarker<T>::value,
+                "Special markers cannot be unblobified");
+  if constexpr (std::is_same<T, std::string>::value) {
+    return std::move(blob);
+  } else {
+    BlobDecoder decoder{blob.data(), blob.size(), false};
+    return decoder.makeWhole<T>();
+  }
+}
+
+// Turn the given value into a blob.
+template <typename T> std::string Client::blobify(T&& t) {
+  using BaseT =
+    typename std::remove_cv<typename std::remove_reference<T>::type>::type;
+  static_assert(!detail::IsMarker<BaseT>::value,
+                "Special markers cannot be blobified");
+  if constexpr (std::is_same<BaseT, std::string>::value) {
+    return std::forward<T>(t);
+  } else {
+    BlobEncoder encoder{false};
+    encoder(t);
+    // It's a shame we have to copy this, but there's no way to
+    // "attach" the BlobEncoder's buffer into the std::string without
+    // copying.
+    return std::string{(const char*)encoder.data(), encoder.size()};
+  }
+}
+
+//////////////////////////////////////////////////////////////////////
+
+template <typename K, typename V>
+RefCache<K, V>::RefCache(Client& client)
+  : m_client{client} {}
+
+template <typename K, typename V>
+coro::Task<Ref<V>> RefCache<K, V>::get(const K& key,
+                                       const V& val,
+                                       folly::Executor::KeepAlive<> e) {
+  // This indirection avoids copying val unless we actually need to.
+  return m_map.get(
+    key,
+    [&] { return [this, val] { return m_client.store(std::move(val)); }; },
+    std::move(e)
+  );
+}
+
+//////////////////////////////////////////////////////////////////////
+
+}

--- a/hphp/util/extern-worker.cpp
+++ b/hphp/util/extern-worker.cpp
@@ -1,0 +1,784 @@
+/*
+   +----------------------------------------------------------------------+
+   | HipHop for PHP                                                       |
+   +----------------------------------------------------------------------+
+   | Copyright (c) 2010-present Facebook, Inc. (http://www.facebook.com)  |
+   +----------------------------------------------------------------------+
+   | This source file is subject to version 3.01 of the PHP license,      |
+   | that is bundled with this package in the file LICENSE, and is        |
+   | available through the world-wide-web at the following url:           |
+   | http://www.php.net/license/3_01.txt                                  |
+   | If you did not receive a copy of the PHP license and are unable to   |
+   | obtain it through the world-wide-web, please send a note to          |
+   | license@php.net so we can mail you a copy immediately.               |
+   +----------------------------------------------------------------------+
+*/
+
+#include "extern-worker.h"
+
+#include "hphp/util/assertions.h"
+#include "hphp/util/current-executable.h"
+#include "hphp/util/hash-map.h"
+#include "hphp/util/logger.h"
+#include "hphp/util/match.h"
+#include "hphp/util/trace.h"
+
+#include <folly/FileUtil.h>
+#include <folly/Subprocess.h>
+#include <folly/gen/Base.h>
+
+#include <boost/filesystem.hpp>
+
+#include <mutex>
+
+namespace HPHP::extern_worker {
+
+//////////////////////////////////////////////////////////////////////
+
+using namespace detail;
+using namespace folly::gen;
+
+//////////////////////////////////////////////////////////////////////
+
+const char* const s_option = "--extern-worker";
+
+std::atomic<uint64_t> RequestId::s_next{0};
+std::atomic<uint64_t> RequestId::s_active{0};
+
+const std::array<OutputType, 1> Client::s_valOutputType{OutputType::Val};
+const std::array<OutputType, 1> Client::s_vecOutputType{OutputType::Vec};
+const std::array<OutputType, 1> Client::s_optOutputType{OutputType::Opt};
+
+ImplHook g_impl_hook{nullptr};
+
+//////////////////////////////////////////////////////////////////////
+
+namespace {
+
+//////////////////////////////////////////////////////////////////////
+
+TRACE_SET_MOD(extern_worker);
+
+//////////////////////////////////////////////////////////////////////
+
+struct Registry {
+  hphp_fast_string_map<JobBase*> registry;
+  std::mutex lock;
+};
+
+Registry& registry() {
+  static Registry registry;
+  return registry;
+}
+
+//////////////////////////////////////////////////////////////////////
+
+// folly::writeFile expects a container-like input, so this makes a
+// ptr/length pair behave like one (without copying).
+struct Adaptor {
+  size_t size() const { return m_size; }
+  bool empty() const { return !size(); }
+  const char& operator[](size_t idx) const { return m_ptr[idx]; }
+  const char* m_ptr;
+  size_t m_size;
+};
+
+//////////////////////////////////////////////////////////////////////
+
+}
+
+//////////////////////////////////////////////////////////////////////
+
+namespace detail {
+
+//////////////////////////////////////////////////////////////////////
+
+// Wrappers around the folly functions with error handling
+
+std::string readFile(const folly::fs::path& path) {
+  std::string s;
+  if (!folly::readFile(path.c_str(), s)) {
+    throw Error{
+      folly::sformat(
+        "Unable to read input from {} [{}]",
+        path.c_str(), std::strerror(errno)
+      )
+    };
+  }
+  return s;
+}
+
+void writeFile(const folly::fs::path& path,
+               const char* ptr, size_t size) {
+  if (!folly::writeFile(Adaptor{ptr, size}, path.c_str())) {
+    throw Error{
+      folly::sformat(
+        "Unable to write output to {} [{}]",
+        path.c_str(), std::strerror(errno)
+      )
+    };
+  }
+}
+
+//////////////////////////////////////////////////////////////////////
+
+JobBase::JobBase(const std::string& name)
+  : m_name{name}
+{
+  FTRACE(4, "registering remote worker command \"{}\"\n", m_name);
+  auto& r = registry();
+  std::lock_guard<std::mutex> _{r.lock};
+  auto const insert = r.registry.emplace(m_name, this);
+  always_assert(insert.second);
+}
+
+//////////////////////////////////////////////////////////////////////
+
+}
+
+//////////////////////////////////////////////////////////////////////
+
+/*
+ * A note on conventions: A worker expects to be invoked with the name
+ * of the command, followed by 3 paths to directories. The directories
+ * represent the config inputs (for init()), the inputs (for multiple
+ * runs()), and the last is the output directory, which will be
+ * written to.
+ *
+ * All three directories use the same format for representing
+ * data:
+ *
+ * - The first level contains numbered directories (from 0 to N). Each
+ * numbered directory represents a set of inputs/outputs. For outputs,
+ * the number corresponds to the matching number of the inputs. The
+ * config directory does not have this level, as there's only ever one
+ * of them.
+ *
+ * - The next level contains numbered files or directories (from 0 to
+ * N). Each file/directory specifies a particular input. The exact
+ * number depends on the job being executed (both sides need to
+ * agree). The format of the file or directory depends on that
+ * input/output's type.
+ *
+ * - If the input/output is a "normal" type, it will be a file
+ * containing the serialized data (using BlobEncoder) for that
+ * input/output. Strings are a special case. If the type is a
+ * std::string, it will not be serialized and the string will be
+ * stored directly (this makes it easier to represent files as their
+ * contents).
+ *
+ * - If the input/output is an Opt<T>, it will be represented like a
+ * "normal" type of type T, except it is not required to be
+ * present. If the file is present (so a gap in the numbering), it is
+ * assumed to be std::nullopt.
+ *
+ * - If the input/output is a Variadic<T>, it will be a
+ * directory. Inside of that directory will be numbered files from
+ * 0-N, one for each element of the vector. The vector elements will
+ * be encoded as "normal" types.
+ *
+ * NB: Marker types cannot nest, so there is no possible deeper levels
+ * than this.
+ *
+ * All implementations must follow this layout when setting up
+ * execution. The actual execution on the worker side is completely
+ * agnostic to the implementation.
+ */
+
+int main(int argc, char** argv) {
+  try {
+    always_assert(argc > 1);
+    always_assert(!strcmp(argv[1], s_option));
+
+    if (argc != 6) {
+      std::cerr << "Usage: "
+                << argv[0]
+                << " " << s_option << " <command name>"
+                << " <config dir>"
+                << " <output dir>"
+                << " <input dir>"
+                << std::endl;
+      return EXIT_FAILURE;
+    }
+
+    std::string name{argv[2]};
+    folly::fs::path configPath{argv[3]};
+    folly::fs::path outputPath{argv[4]};
+    folly::fs::path inputPath{argv[5]};
+
+    FTRACE(2, "extern worker run(\"{}\", {}, {}, {})\n",
+           name, configPath.native(), outputPath.native(),
+           inputPath.native());
+
+    // Lookup the registered job for the requested name.
+    auto const worker = [&] {
+      auto& r = registry();
+      std::lock_guard<std::mutex> _{r.lock};
+      auto const it = r.registry.find(name);
+      if (it == r.registry.end()) {
+        throw Error{folly::sformat("No command named `{}` registered", name)};
+      }
+      return it->second;
+    }();
+
+    // We insist on a clean output directory.
+    if (!folly::fs::create_directory(outputPath)) {
+      throw Error{
+        folly::sformat("Output directory {} already exists", outputPath.native())
+      };
+    }
+
+    // First do any global initialization.
+    time("init", [&] { worker->init(configPath); });
+    time("run-all", [&] {
+        // Then execute run() for each given set of inputs.
+      for (size_t i = 0;; ++i) {
+        auto const thisInput = inputPath / folly::to<std::string>(i);
+        if (!folly::fs::exists(thisInput)) break;
+
+        auto const thisOutput = outputPath / folly::to<std::string>(i);
+        FTRACE(4, "executing #{} ({} -> {})\n",
+               i, thisInput.native(), thisOutput.native());
+        folly::fs::create_directory(thisOutput, outputPath);
+
+        time(
+          [&]{ return folly::sformat("run {}", i); },
+          [&] { worker->run(thisInput, thisOutput); }
+        );
+      }
+    });
+    // Do any cleanup
+    time("fini", [&] { worker->fini(); });
+
+    return 0;
+  } catch (const std::exception& exn) {
+    std::cerr << "Error: " << exn.what() << std::endl;
+    return EXIT_FAILURE;
+  }
+}
+
+//////////////////////////////////////////////////////////////////////
+
+namespace {
+
+//////////////////////////////////////////////////////////////////////
+
+/*
+ * The builtin implementation which uses fork+exec (and stores data on
+ * disk). It is always available, reasonably efficient, and assumed to
+ * be "reliable" (IE, never needs a fallback).
+ *
+ * All data is stored under the "root" (which is the working-dir
+ * specified in Options). The two sub-directories are "blobs" and
+ * "execs".
+ *
+ * Data is stored under blobs/, using files with numerically
+ * increasing names. Stored files are not stored at all (since they're
+ * already on disk). The RefIds are just the path to the file (either
+ * under blobs/ or where-ever the stored file was).
+ *
+ * Executions are stored under execs/. Each entry is a sub-directory
+ * with numerically increasing names. Within each sub-directory is the
+ * directory layout that the worker expects (see comment above int
+ * main()). The data is not actually copied into the input
+ * directories. Instead symlinks are created using the path in the
+ * RefId. Outputs are not copied either, they just "live" in their
+ * output directory.
+ */
+struct SubprocessImpl : public Client::Impl {
+  explicit SubprocessImpl(const Options&);
+  ~SubprocessImpl() override;
+
+  bool isSubprocess() const override { return true; }
+  bool isDisabled() const override { return false; }
+
+  coro::Task<BlobVec> load(const RequestId&, IdVec) override;
+  coro::Task<IdVec> store(const RequestId&, PathVec, BlobVec,
+                          size_t*, size_t*) override;
+  coro::Task<std::vector<RefValVec>>
+  exec(const RequestId&,
+       const std::string&,
+       RefValVec,
+       std::vector<RefValVec>,
+       const folly::Range<const OutputType*>&,
+       bool*) override;
+
+private:
+  folly::fs::path newBlob();
+  folly::fs::path newExec();
+  static folly::fs::path newRoot(const Options&);
+
+  void doSubprocess(const RequestId&,
+                    const std::string&,
+                    const folly::fs::path&,
+                    const folly::fs::path&,
+                    const folly::fs::path&,
+                    const folly::fs::path&);
+
+  Options m_options;
+
+  folly::fs::path m_root;
+  // SubprocessImpl doesn't need the m_size portion of RefId. So we
+  // store an unique integer in it to help verify that the RefId came
+  // from this implementation instance.
+  size_t m_marker;
+
+  std::atomic<size_t> m_nextBlob;
+  std::atomic<size_t> m_nextExec;
+};
+
+SubprocessImpl::SubprocessImpl(const Options& options)
+  : Impl{"subprocess"}
+  , m_options{options}
+  , m_root{newRoot(m_options)}
+    // Cheap way of generating semi-unique integer:
+  , m_marker{std::hash<std::string>{}(m_root.native())}
+  , m_nextBlob{0}
+  , m_nextExec{0}
+{
+  FTRACE(2, "Using subprocess extern-worker impl with root at {}\n",
+         m_root.native());
+  Logger::FInfo("Using subprocess extern-worker at {}", m_root.native());
+
+  folly::fs::create_directory(m_root / "blobs");
+  folly::fs::create_directory(m_root / "execs");
+}
+
+SubprocessImpl::~SubprocessImpl() {
+  // Deleting everything under blobs/ and execs/ can take quite a
+  // while...
+  if (m_options.m_cleanup) {
+    Logger::FInfo(
+      "Cleaning up subprocess extern-worker at {}...",
+      m_root.native()
+    );
+    auto const before = std::chrono::steady_clock::now();
+    auto const removed = time(
+      "subprocess cleanup",
+      [&] {
+        std::error_code ec; // Suppress exceptions
+        return folly::fs::remove_all(m_root, ec);
+      }
+    );
+    auto const elapsed = std::chrono::duration_cast<std::chrono::duration<double>>(
+      std::chrono::steady_clock::now() - before
+    ).count();
+    FTRACE(2, "removed {} files\n", removed);
+    Logger::FInfo(
+      "Done cleaning up subprocess extern-worker. "
+      "({} files removed) (took {})",
+      removed, folly::prettyPrint(elapsed, folly::PRETTY_TIME_HMS, false)
+    );
+  }
+}
+
+// Create paths for a new blob or a new execution. I lied a little bit
+// above in the description of the directory layout. It's true that
+// blobs and execs use numerically increasing names, but I shard them
+// into directories of 10000 each, to keep their sizes reasonable.
+folly::fs::path SubprocessImpl::newBlob() {
+  auto const id = m_nextBlob++;
+  auto const blobRoot = m_root / "blobs";
+  auto const mid = blobRoot / folly::sformat("{:05}", id / 10000);
+  folly::fs::create_directory(mid, blobRoot);
+  return mid / folly::sformat("{:04}", id % 10000);
+}
+
+folly::fs::path SubprocessImpl::newExec() {
+  auto const id = m_nextExec++;
+  auto const execRoot = m_root / "execs";
+  auto const mid = execRoot / folly::sformat("{:05}", id / 10000);
+  folly::fs::create_directory(mid, execRoot);
+  auto const full = mid / folly::sformat("{:04}", id % 10000);
+  folly::fs::create_directory(full, mid);
+  return full;
+}
+
+// Ensure we always have an unique root under the working directory.
+folly::fs::path SubprocessImpl::newRoot(const Options& opts) {
+  auto const base = opts.m_workingDir / "hphp-extern-worker";
+  folly::fs::create_directory(base);
+  auto const full = base /  boost::filesystem::unique_path(
+    "%%%%-%%%%-%%%%-%%%%-%%%%-%%%%"
+  ).native();
+  folly::fs::create_directory(full, base);
+  return folly::fs::canonical(full);
+}
+
+coro::Task<BlobVec> SubprocessImpl::load(const RequestId& requestId,
+                                         IdVec ids) {
+  // Read every file corresponding to the id and return their
+  // contents.
+  auto out = from(ids)
+    | mapped([&] (const RefId& id) {
+        assertx(id.m_size == m_marker);
+        FTRACE(4, "{} reading blob from {}\n",
+               requestId.tracePrefix(), id.m_id);
+        auto blob = readFile(id.m_id);
+        FTRACE(4, "{} blob is {} bytes\n",
+               requestId.tracePrefix(), blob.size());
+        return blob;
+      })
+    | as<std::vector>();
+  HPHP_CORO_MOVE_RETURN(out);
+}
+
+coro::Task<IdVec> SubprocessImpl::store(const RequestId& requestId,
+                                        PathVec paths,
+                                        BlobVec blobs,
+                                        size_t* read,
+                                        size_t* uploaded) {
+  // SubprocessImpl always "reads" and "uploads" the data (there's no
+  // caching of any kind).
+  if (read) *read = paths.size();
+  if (uploaded) *uploaded = paths.size() + blobs.size();
+  // Create RefIds from the given paths, then write the blobs to disk,
+  // then use their paths.
+  auto out =
+    ((from(paths)
+      | mapped([&] (const folly::fs::path& p) {
+          return RefId{folly::fs::canonical(p).native(), m_marker};
+        })
+    ) +
+    (from(blobs)
+     | mapped([&] (const std::string& b) {
+         auto const path = newBlob();
+         FTRACE(4, "{} writing size {} blob to {}\n",
+                requestId.tracePrefix(), b.size(), path.native());
+         writeFile(path, b.data(), b.size());
+         return RefId{folly::fs::canonical(path).native(), m_marker};
+       })
+    ))
+    | as<std::vector>();
+  HPHP_CORO_MOVE_RETURN(out);
+}
+
+coro::Task<std::vector<RefValVec>>
+SubprocessImpl::exec(const RequestId& requestId,
+                     const std::string& command,
+                     RefValVec config,
+                     std::vector<RefValVec> inputs,
+                     const folly::Range<const OutputType*>& output,
+                     bool* cached = nullptr) {
+  auto const execPath = newExec();
+  auto const configPath = execPath / "config";
+  auto const inputsPath = execPath / "input";
+  auto const outputsPath = execPath / "output";
+
+  FTRACE(4, "{} executing \"{}\" inside {} ({} runs)\n",
+         requestId.tracePrefix(), command,
+         execPath.native(), inputs.size());
+
+  // SubprocessImpl never caches
+  if (cached) *cached = false;
+
+  // Set up the directory structure that the worker expects:
+
+  auto const symlink = [&] (const RefId& id,
+                            const folly::fs::path& path) {
+    assertx(id.m_size == m_marker);
+    folly::fs::create_symlink(id.m_id, path);
+    FTRACE(4, "{} symlinked {} to {}\n",
+           requestId.tracePrefix(), id.m_id, path.native());
+  };
+
+  auto const prepare = [&] (const RefValVec& params,
+                            const folly::fs::path& parent) {
+    for (size_t paramIdx = 0; paramIdx < params.size(); ++paramIdx) {
+      auto const& p = params[paramIdx];
+      auto const path = parent / folly::to<std::string>(paramIdx);
+      match<void>(
+        p,
+        [&] (const RefId& id) { symlink(id, path); },
+        [&] (const Optional<RefId>& id) {
+          if (!id.has_value()) return;
+          symlink(*id, path);
+        },
+        [&] (const IdVec& ids) {
+          folly::fs::create_directory(path, parent);
+          for (size_t vecIdx = 0; vecIdx < ids.size(); ++vecIdx) {
+            symlink(ids[vecIdx], path / folly::to<std::string>(vecIdx));
+          }
+        }
+      );
+    }
+  };
+
+  folly::fs::create_directory(configPath, execPath);
+  prepare(config, configPath);
+
+  // Each set of inputs should always have the same size.
+  if (debug && !inputs.empty()) {
+    auto const size = inputs[0].size();
+    for (size_t i = 1; i < inputs.size(); ++i) {
+      always_assert(inputs[i].size() == size);
+    }
+  }
+
+  folly::fs::create_directory(inputsPath, execPath);
+  for (size_t i = 0; i < inputs.size(); ++i) {
+    auto const path = inputsPath / folly::to<std::string>(i);
+    folly::fs::create_directory(path, inputsPath);
+    prepare(inputs[i], path);
+  }
+
+  // Do the actual fork+exec.
+  doSubprocess(
+    requestId,
+    command,
+    execPath,
+    configPath,
+    inputsPath,
+    outputsPath
+  );
+
+  // Make RefIds corresponding to the outputs.
+
+  auto const makeOutput =
+    [&] (OutputType type, folly::fs::path path) -> RefVal {
+    switch (type) {
+      case OutputType::Val:
+        assertx(folly::fs::exists(path));
+        return RefId{std::move(path), m_marker};
+      case OutputType::Opt:
+        if (!folly::fs::exists(path)) return std::nullopt;
+        return make_optional(RefId{std::move(path), m_marker});
+      case OutputType::Vec: {
+        assertx(folly::fs::exists(path));
+        IdVec vec;
+        size_t i = 0;
+        while (true) {
+          auto valPath = path / folly::to<std::string>(i);
+          if (!folly::fs::exists(valPath)) break;
+          vec.emplace_back(valPath.native(), m_marker);
+          ++i;
+        }
+        return vec;
+      }
+    }
+    always_assert(false);
+  };
+
+  auto const makeOutputs = [&] (const folly::fs::path& path) {
+    RefValVec vec;
+    vec.reserve(output.size());
+    for (size_t i = 0; i < output.size(); ++i) {
+      vec.emplace_back(
+        makeOutput(
+          output[i],
+          path / folly::to<std::string>(i)
+        )
+      );
+    }
+    return vec;
+  };
+
+  std::vector<RefValVec> out;
+  out.reserve(inputs.size());
+  for (size_t i = 0; i < inputs.size(); ++i) {
+    out.emplace_back(makeOutputs(outputsPath / folly::to<std::string>(i)));
+  }
+  HPHP_CORO_MOVE_RETURN(out);
+}
+
+void SubprocessImpl::doSubprocess(const RequestId& requestId,
+                                  const std::string& command,
+                                  const folly::fs::path& execPath,
+                                  const folly::fs::path& configPath,
+                                  const folly::fs::path& inputPath,
+                                  const folly::fs::path& outputPath) {
+  std::vector<std::string> args{
+    current_executable_path(),
+    s_option,
+    command,
+    configPath,
+    outputPath,
+    inputPath
+  };
+
+  // Propagate the TRACE option in the environment. We'll copy the
+  // trace output into this process' trace output.
+  std::vector<std::string> env;
+  Optional<folly::fs::path> traceFile;
+  if (auto const trace = getenv("TRACE")) {
+    traceFile = execPath / "trace.log";
+    env.emplace_back(folly::sformat("TRACE={}", trace));
+    env.emplace_back(folly::sformat("HPHP_TRACE_FILE={}", traceFile->c_str()));
+  }
+
+  FTRACE(4, "{} executing subprocess\n",
+         requestId.tracePrefix());
+
+  auto const DEBUG_ONLY before = std::chrono::steady_clock::now();
+
+  // Do the actual fork+exec.
+  folly::Subprocess subprocess{
+    args,
+    folly::Subprocess::Options{}
+      .stdinFd(folly::Subprocess::DEV_NULL)
+      .pipeStdout()
+      .pipeStderr()
+      .closeOtherFds(),
+    nullptr,
+    &env
+  };
+
+  auto const [_, stderr] = subprocess.communicate();
+  auto const returnCode = subprocess.wait();
+
+  FTRACE(
+    4,
+    "{} subprocess finished (took {}). Return code: {}, Stderr: {}\n",
+    requestId.tracePrefix(),
+    prettyPrint(
+      std::chrono::duration_cast<std::chrono::duration<double>>(
+        std::chrono::steady_clock::now() - before
+      ).count(),
+      folly::PRETTY_TIME,
+      false
+    ),
+    returnCode.str(),
+    stderr
+  );
+
+  // Do this before checking the return code. If the process failed,
+  // we want to capture anything it logged before throwing.
+  if (traceFile && folly::fs::exists(*traceFile)) {
+    auto const contents = readFile(*traceFile);
+    if (!contents.empty()) {
+      Trace::ftraceRelease(
+        "vvvvvvvvvvvvvvvvvv remote-exec ({} \"{}\" {}) vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv\n"
+        "{}"
+        "^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+        requestId.toString(),
+        command,
+        execPath.native(),
+        contents
+      );
+    }
+  }
+
+  if (!returnCode.exited() || returnCode.exitStatus() != 0) {
+    throw Error{
+      folly::sformat(
+        "Execution of `{}` failed: {}\nstderr:\n{}",
+        command,
+        returnCode.str(),
+        stderr
+      )
+    };
+  }
+}
+
+//////////////////////////////////////////////////////////////////////
+
+}
+
+//////////////////////////////////////////////////////////////////////
+
+Client::Client(folly::Executor::KeepAlive<> executor,
+               const Options& options)
+  : m_options{options}
+  , m_forceFallback{false}
+{
+  Timer _{"create impl"};
+  // Look up which implementation to use. If a hook has been
+  // registered, and we're allowed to use it according to the Options,
+  // try to use it.
+  if (g_impl_hook &&
+      m_options.m_useSubprocess != Options::UseSubprocess::Always) {
+    m_impl = g_impl_hook(m_options, executor);
+  }
+  // The hook can return nullptr even if registered. In each case, we
+  // have no special implementation to use.
+  if (!m_impl) {
+    // Use the subprocess implementation (which is always available),
+    // unless the Options specifies we shouldn't. If not, it's a fatal
+    // error.
+    if (m_options.m_useSubprocess == Options::UseSubprocess::Never) {
+      throw Error{"No non-subprocess impl available"};
+    }
+    m_impl = std::make_unique<SubprocessImpl>(m_options);
+  }
+  FTRACE(2, "created \"{}\" impl\n", m_impl->name());
+}
+
+Client::~Client() {
+  Timer _{[&] { return folly::sformat("destroy impl {}", m_impl->name()); }};
+  m_impl.reset();
+  m_fallbackImpl.reset();
+}
+
+std::unique_ptr<Client::Impl> Client::makeFallbackImpl() const {
+  // This will be called once from within LockFreeLazy, so we only
+  // emit this warning once.
+  Logger::Warning(
+    "Certain operations will use local fallback from this "
+    "point on and may run slower."
+  );
+  return std::make_unique<SubprocessImpl>(m_options);
+}
+
+coro::Task<Ref<std::string>> Client::storeFile(folly::fs::path path,
+                                               bool* read,
+                                               bool* uploaded) {
+  RequestId requestId{"store file"};
+
+  FTRACE(2, "{} storing {}\n", requestId.tracePrefix(), path.native());
+
+  size_t readCount;
+  size_t uploadedCount;
+  auto wasFallback = false;
+  auto ids = HPHP_CORO_AWAIT(tryWithFallback<IdVec>(
+    [&] (Impl& i, bool) {
+      return i.store(requestId, PathVec{path}, {}, &readCount, &uploadedCount);
+    },
+    wasFallback
+  ));
+  assertx(ids.size() == 1);
+  assertx(readCount <= 1);
+  assertx(uploadedCount <= 1);
+  if (read) *read = (readCount > 0);
+  if (uploaded) *uploaded = (uploadedCount > 0);
+
+  Ref<std::string> ref{std::move(ids[0]), wasFallback};
+  HPHP_CORO_MOVE_RETURN(ref);
+}
+
+coro::Task<std::vector<Ref<std::string>>>
+Client::storeFile(std::vector<folly::fs::path> paths,
+                  size_t* read,
+                  size_t* uploaded) {
+  RequestId requestId{"store files"};
+
+  FTRACE(2, "{} storing {} files\n", requestId.tracePrefix(), paths.size());
+  ONTRACE(4, [&] {
+    for (auto const& p : paths) {
+      FTRACE(4, "{} storing {}\n", requestId.tracePrefix(), p.native());
+    }
+  }());
+
+  auto const DEBUG_ONLY size = paths.size();
+  auto wasFallback = false;
+  auto ids = HPHP_CORO_AWAIT(tryWithFallback<IdVec>(
+    [&] (Impl& i, bool) {
+      return i.store(requestId, paths, {}, read, uploaded);
+    },
+    wasFallback
+  ));
+  assertx(ids.size() == size);
+  assertx(!read || *read <= ids.size());
+  assertx(!uploaded || *uploaded <= ids.size());
+
+  auto out = from(ids)
+    | move
+    | mapped([&] (auto&& id) {
+        return Ref<std::string>{std::move(id), wasFallback};
+      })
+    | as<std::vector>();
+  HPHP_CORO_MOVE_RETURN(out);
+}
+
+//////////////////////////////////////////////////////////////////////
+
+}

--- a/hphp/util/extern-worker.h
+++ b/hphp/util/extern-worker.h
@@ -1,0 +1,560 @@
+/*
+   +----------------------------------------------------------------------+
+   | HipHop for PHP                                                       |
+   +----------------------------------------------------------------------+
+   | Copyright (c) 2010-present Facebook, Inc. (http://www.facebook.com)  |
+   +----------------------------------------------------------------------+
+   | This source file is subject to version 3.01 of the PHP license,      |
+   | that is bundled with this package in the file LICENSE, and is        |
+   | available through the world-wide-web at the following url:           |
+   | http://www.php.net/license/3_01.txt                                  |
+   | If you did not receive a copy of the PHP license and are unable to   |
+   | obtain it through the world-wide-web, please send a note to          |
+   | license@php.net so we can mail you a copy immediately.               |
+   +----------------------------------------------------------------------+
+*/
+
+#pragma once
+
+#include "hphp/util/coro.h"
+#include "hphp/util/optional.h"
+#include "hphp/util/trace.h"
+
+#include <folly/portability/Filesystem.h>
+
+#include <string>
+#include <vector>
+
+#include <boost/variant.hpp>
+
+/*
+ * Framework for executing work outside of the HHVM process.
+ *
+ * The main use case for this framework is to provide a mechanism to
+ * execute work in a distributed manner on remote machines. This can
+ * allow for greater parallelism than just running locally, and allow
+ * for datasets which exceed the memory available on any one
+ * machine. However, it has been designed to be agnostic (as much as
+ * possible) as to the exact mechanism used for execution, meaning it
+ * can be expanded for other use cases we forsee in the future.
+ *
+ * Terminology:
+ *
+ * "Job" - Encapsulate some piece of work. A Job has a typed set of
+ * inputs, and produces a typed set of outputs. Multiple instances of
+ * the same job can be run in one "execution" (with different
+ * inputs). A job also has a separate set of "init" inputs, which are
+ * run once per execution (used for global initialization). Exactly
+ * where/how the job "executes" is not specified (depends on
+ * implementation and config), but it will be outside of the
+ * process. Some implementations may cache the results of an
+ * execution, meaning that it can produce the output without having to
+ * actually run the job.
+ *
+ * "Ref" - Refs represent some piece of data. You do not provide
+ * inputs or read outputs from a job directly. Instead these are
+ * represented by refs to the data. You "store" a piece of data to
+ * obtain its ref (which can then be provided to a job
+ * execution). Likewise, given a ref, you can "load" it to obtain the
+ * data. This lets you feed data from one job to the next without
+ * having to explicitly load it. Refs are type-safe. They know which
+ * type of data they point to, meaning you know (at compile time) that
+ * you're passing the right kind of data to a job). Refs contain a
+ * "RefId", which is a string/size pair. This uniquely identifies the
+ * data, but the meaning of the pair is up to the implementation. Any
+ * data stored needs to be serializable with BlobEncoder/BlobDecoder.
+ *
+ * "Markers" - In some situations, you want to be able to represent a
+ * variadic list of data, or an optional piece of data. You could use
+ * std::vector or Optional for this, but you would get a
+ * Ref<std::vector>, which means a ref to a std::vector. It might be
+ * more useful to have a std::vector<Ref>, which means you know how
+ * many refs were produced without having to load everything. A
+ * special set of "marker" types can be used for this. They're
+ * "Variadic", "Opt", and "Multi", which have similar meanings as
+ * std::vector, Optional, and std::tuple, but are new types to avoid
+ * ambiguity. These can only be used as input/outputs of jobs. Multi
+ * can only be used as a return type.
+ *
+ * "Client" - Represents an instance of a extern-worker
+ * framework. Responsible for producing/consuming refs, and executing
+ * jobs. A client is backed by a particular implementation, which does
+ * the actual work. The default implementation uses fork+exec, but
+ * others can be provided by a hook mechanism.
+ *
+ * To use the extern-worker framework, you must provide a handler in
+ * your main() function. If passed extern_worker::s_option as argv[1],
+ * call extern_worker::main(), passing in the argv and argc.
+ */
+
+//////////////////////////////////////////////////////////////////////
+
+// Implementation details to avoid cluttering interface
+#define incl_HPHP_EXTERN_WORKER_DETAIL_H_
+#include "hphp/util/extern-worker-detail.h"
+#undef incl_HPHP_EXTERN_WORKER_DETAIL_H_
+
+//////////////////////////////////////////////////////////////////////
+
+namespace HPHP::extern_worker {
+
+//////////////////////////////////////////////////////////////////////
+
+extern const char* const s_option;
+
+// Entry point for workers
+extern int main(int argc, char** argv);
+
+//////////////////////////////////////////////////////////////////////
+
+// Thrown by any of extern-worker functions to indicate an error
+struct Error : public std::runtime_error {
+  using std::runtime_error::runtime_error;
+};
+
+//////////////////////////////////////////////////////////////////////
+
+/*
+ * Represents a job which can be executed. The implementation of the
+ * job is provided by a separate class, which Job is instantiated on.
+ * That class is meant to provide 4 static member functions:
+ *
+ * std::string name() - Returns the name of the job. There's no
+ * restrictions on the name, but it must be globally unique across all
+ * Jobs in the executable.
+ *
+ * void init(<inputs>) - Called once per worker invocation. Used to
+ * set up global state before run() is called.
+ *
+ * <outputs> run(<inputs>) - Run the job. This may be called multiple
+ * times per work invocation (with different inputs). init() will only
+ * be called once beforehand.
+ *
+ * void fini() - Called once when work is cleaning up. Meant to tear
+ * down any global state.
+ *
+ * The inputs of init() and the inputs/outputs of run() can be any set
+ * of types which are blob serializable/deserializable, in addition to
+ * the special marker types (described below). run() normally returns
+ * one type. If you want to return multiple types, use Multi<>.
+ *
+ * To create a Job, instantiate it with the appropriate class and
+ * declare a static instance of it. The Job *must* have static
+ * lifetime.
+ */
+template <typename C>
+struct Job : public detail::JobBase {
+  Job();
+
+  // The inferred Ref types from the declared inputs/outputs of C's
+  // member functions.
+  using ConfigT = typename detail::ConfigRefs<C>::type;
+  using InputsT = typename detail::InputRefs<C>::type;
+  using ReturnT = typename detail::ReturnRefs<C>::type;
+
+private:
+  void init(const folly::fs::path&) const override;
+  void fini() const override;
+  void run(const folly::fs::path&, const folly::fs::path&) const override;
+};
+
+//////////////////////////////////////////////////////////////////////
+
+// "Marker" types. These are used to control how types are mapped to
+// Refs. Useful, for example, of returning a vector of Refs instead of
+// a Ref of a vector. Note that marker types never appear within a
+// Ref.
+
+// By default: T -> Ref<T>
+
+template <typename T>
+struct Variadic {
+  // Variadic<T> -> std::vector<Ref<T>>
+  using Type = T;
+  std::vector<T> vals;
+};
+
+template <typename T>
+struct Opt {
+  // Opt<T> -> Optional<Ref<T>>
+  using Type = T;
+  Optional<T> val;
+};
+
+// Multi is only valid as a return type.
+template <typename... Ts>
+struct Multi {
+  // Multi<T1, T2, ...> -> std::tuple<Ref<T1>, Ref<T2>, ....>
+  template <typename... Us> Multi(std::tuple<Us...> t) : vals{std::move(t)} {}
+  std::tuple<Ts...> vals;
+};
+
+//////////////////////////////////////////////////////////////////////
+
+// Identifier for a Ref. Used by the implementation to track them. The
+// meaning of the identifier is private to the implementation.
+struct RefId {
+  RefId(std::string, size_t);
+
+  std::string toString() const;
+  bool operator==(const RefId&) const;
+  bool operator!=(const RefId&) const;
+
+  // Despite their names, these fields can be used for anything.
+  std::string m_id;
+  size_t m_size;
+};
+
+// Represents a piece of data "inside" the extern-worker
+// framework. The data may not even exist locally (it could be on disk
+// or in the network). A Ref is basically a RefId and the type of the
+// data. Only Client can create Refs, so "type-punning" is
+// impossible. A Ref is only usable with the Client that produced it
+// and cannot outlive the Client.
+template <typename T>
+struct Ref {
+  const RefId& id() const { return m_id; }
+  // Whether this ref came from a "fallback" operation (see below with
+  // Client). This is exposed mainly for testing. Users shouldn't
+  // care.
+  bool fromFallback() const { return m_fromFallback; }
+private:
+  Ref(RefId, bool);
+  RefId m_id;
+  bool m_fromFallback;
+  friend struct Client;
+};
+
+//////////////////////////////////////////////////////////////////////
+
+// This is meant for internal usage and is here (and not in detail) so
+// implementations outside of these files can use it. It represents a
+// particular operation and has some stuff for tracking time and
+// TRACE.
+struct RequestId {
+  explicit RequestId(const char* type);
+  ~RequestId();
+
+  RequestId(const RequestId&) = delete;
+  RequestId(RequestId&&) = default;
+  RequestId& operator=(const RequestId&) = delete;
+  RequestId& operator=(RequestId&&) = default;
+
+  std::string tracePrefix() const;
+  std::string toString() const;
+
+private:
+  uint64_t m_id;
+  const char* m_type;
+  Optional<detail::Timer> m_timer;
+
+  static std::atomic<uint64_t> s_next;
+  static std::atomic<uint64_t> s_active;
+
+  TRACE_SET_MOD(extern_worker);
+};
+
+//////////////////////////////////////////////////////////////////////
+
+// More stuff for the Client/Client::Impl interface here out of
+// convenience.
+using IdVec = std::vector<RefId>;
+// A "blob" is a string containing some arbitrary binary data
+using BlobVec = std::vector<std::string>;
+using PathVec = std::vector<folly::fs::path>;
+
+// These are used to describe inputs in a generic way to
+// Client::Impl. An input can be a RefId, an optional RefId, or a
+// vector of RefIds.
+using RefVal = boost::variant<RefId, Optional<RefId>, IdVec>;
+using RefValVec = std::vector<RefVal>;
+
+// Likewise, these describe outputs to Client::Impl. We only need to
+// represent the type since there's no id beforehand.
+enum class OutputType { Val, Opt, Vec };
+
+//////////////////////////////////////////////////////////////////////
+
+// Configeration controlling the behavior of Client.
+struct Options {
+  // Whether to use the always available "subprocess"
+  // implementation. This uses fork+exec (and stores data on disk).
+  enum class UseSubprocess {
+    Always, // Always use subprocess
+    Fallback, // Attempt to use another backend, but if not available,
+              // use subprocess.
+    Never // Never use subprocess. Throw error if nothing else is
+          // available.
+  };
+  Options& setUseSubprocess(UseSubprocess u) {
+    m_useSubprocess = u;
+    return *this;
+  }
+
+  // The implementation may need to store data on disk (subprocess for
+  // example). Location where to store such things.
+  Options& setWorkingDir(folly::fs::path dir) {
+    m_workingDir = std::move(dir);
+    return *this;
+  }
+
+  // Time out on job execution. Best effort, implementations may not
+  // support it (subprocess does not).
+  Options& setTimeout(std::chrono::seconds s) {
+    m_timeout = s;
+    return *this;
+  }
+
+  // Whether to cache execution of jobs. Not all implementations cache
+  // execution (subprocess does not), so is a noop on those.
+  Options& setCacheExecs(bool c) {
+    m_cacheExecs = c;
+    return *this;
+  }
+
+  // Implementations which rely on hashing can use EdenFS to avoid
+  // hashing the file. This controls that.
+  Options& setUseEdenFS(bool u) {
+    m_useEdenFS = u;
+    return *this;
+  }
+
+  // Whether to cleanup data stored on disk when Client is
+  // destroyed. This can take a very long time for lots of data (and
+  // can hinder debugging), so can be disabled.
+  Options& setCleanup(bool c) {
+    m_cleanup = c;
+    return *this;
+  }
+
+  // Some implementations have a notion of "use-case". This provides
+  // one which can control whether those implementations are enabled.
+  Options& setUseCase(std::string u) {
+    m_useCase = std::move(u);
+    return *this;
+  }
+
+  UseSubprocess m_useSubprocess{UseSubprocess::Fallback};
+  folly::fs::path m_workingDir{folly::fs::temp_directory_path()};
+  std::chrono::seconds m_timeout{std::chrono::minutes{15}};
+  bool m_cacheExecs{true};
+  bool m_useEdenFS{true};
+  bool m_cleanup{true};
+  std::string m_useCase;
+};
+
+//////////////////////////////////////////////////////////////////////
+
+// Encapsulates an instance of the extern-worker framework. This is
+// responsible for producing/consuming Refs, and executing jobs with
+// those Refs as inputs. The actual behavior of the Client (IE, where
+// it stores the data, and where the workers run), depends on the
+// specific Client::Impl in use. An implementation which uses
+// fork+exec (and stores data on disk) is always available and will be
+// used if nothing else is available (if so requested in Options). The
+// fork+exec implementation can also serve as a "fallback"
+// implementation if the main implementation throws an error. The
+// assumption is that the fork+exec implementation is more reliable
+// than anything else. For the most part, this is invisible to the
+// user (though it may cause performance degradation).
+
+struct Client {
+  // Create a new Client with the given set of Options, and an
+  // Executor. The executor will be used for any coro things if the
+  // implementation requires it.
+  Client(folly::Executor::KeepAlive<>, const Options& = {});
+  ~Client();
+
+  // Return a descriptive string of the implementation currently in
+  // use. Mainly for logging.
+  const std::string& implName() const;
+  // Return true if the implementation in use is the built-in
+  // fork+exec implementation.
+  bool usingSubprocess() const;
+
+  // Loading. These take various different permutations of Refs, load
+  // them, deserialize the blobs into the appropriate types, and
+  // return the data in a matching format. Using the variations which
+  // take multiple at once is more efficient than using multiple
+  // calls.
+  template <typename T> coro::Task<T> load(Ref<T>);
+
+  template <typename T, typename... Ts>
+  coro::Task<std::tuple<T, Ts...>> load(Ref<T>, Ref<Ts>...);
+
+  template <typename T> coro::Task<std::vector<T>> load(std::vector<Ref<T>>);
+
+  template <typename T, typename... Ts>
+  coro::Task<std::vector<std::tuple<T, Ts...>>>
+  load(std::vector<std::tuple<Ref<T>, Ref<Ts>...>>);
+
+  // Storing files. These take either a path, or a vector of paths,
+  // and upload the contents. This is semantically equivalent to
+  // reading the file yourself and uploading the data as
+  // blobs. However, it might be more efficient as some
+  // implementations can deal with on-disk files specially. Note that
+  // the returned Refs are for strings, since you're uploading the
+  // contents of the file. If provided, "read" and/or "uploaded" will
+  // be set to true if the file was read and whether it was actually
+  // uploaded. If the file has been cached, neither may need to be
+  // done. For the vector variant, the out params will be set to the
+  // number of files actually read or uploaded.
+  coro::Task<Ref<std::string>> storeFile(folly::fs::path,
+                                         bool* read = nullptr,
+                                         bool* uploaded = nullptr);
+
+  coro::Task<std::vector<Ref<std::string>>>
+  storeFile(std::vector<folly::fs::path>,
+            size_t* read = nullptr,
+            size_t* uploaded = nullptr);
+
+  // Storing blobs. These take various different permutations of data,
+  // serialize them (using BlobEncoder), store however the
+  // implementation does, and return the appropriate Refs for
+  // them. These have different names to avoid ambiguities (do you
+  // want to upload a single vector of T, or multiple Ts passed as
+  // vector?).
+  template <typename T> coro::Task<Ref<T>> store(T);
+
+  template <typename T, typename... Ts>
+  coro::Task<std::tuple<Ref<T>, Ref<Ts>...>> store(T, Ts...);
+
+  template <typename T>
+  coro::Task<std::vector<Ref<T>>> storeMulti(std::vector<T>);
+
+  template <typename T, typename... Ts>
+  coro::Task<std::vector<std::tuple<Ref<T>, Ref<Ts>...>>>
+  storeMultiTuple(std::vector<std::tuple<T, Ts...>>);
+
+  // Execute a job with the given sets of inputs (and any config setup
+  // params). The output of those job executions will be returned as a
+  // vector of Refs. The exact format of the inputs and outputs is
+  // determined (at compile time) by the job being run and matches the
+  // job's specification. If "cached" is provided, it will be set to
+  // true if the outputs are coming from a cached job and the job
+  // isn't actually run.
+  template <typename C> coro::Task<std::vector<typename Job<C>::ReturnT>>
+  exec(const Job<C>& job,
+       typename Job<C>::ConfigT config,
+       std::vector<typename Job<C>::InputsT> inputs,
+       bool* cached = nullptr);
+
+  // Synthetically force a fallback event when storing data or
+  // executing a job, as if the implementation failed. This is for
+  // tests to force the fallback path to be exercised. You don't need
+  // this otherwise.
+  void forceFallback()   { m_forceFallback = true; }
+  void unforceFallback() { m_forceFallback = false; }
+
+  struct Impl;
+
+private:
+  std::unique_ptr<Impl> m_impl;
+  LockFreeLazy<std::unique_ptr<Impl>> m_fallbackImpl;
+  Options m_options;
+  bool m_forceFallback;
+
+  template <typename T, typename F> coro::Task<T> tryWithFallback(F, bool&);
+
+  template <typename T> static T unblobify(std::string&&);
+  template <typename T> static std::string blobify(T&&);
+
+  static const std::array<OutputType, 1> s_valOutputType;
+  static const std::array<OutputType, 1> s_vecOutputType;
+  static const std::array<OutputType, 1> s_optOutputType;
+
+  std::unique_ptr<Impl> makeFallbackImpl() const;
+
+  TRACE_SET_MOD(extern_worker);
+};
+
+//////////////////////////////////////////////////////////////////////
+
+// Actual implementation for Client. Implementations of Client::Impl
+// control how data is stored and where the work is actually
+// executed. Client always provides a "subprocess" implementation
+// which uses the disk and fork+exec.
+struct Client::Impl {
+  virtual ~Impl() = default;
+
+  // Name of the implementation. Mainly for logging.
+  const std::string& name() const { return m_name; }
+
+  // Whether this is a the special subprocess impl. Its treated
+  // specially when it comes to falling back.
+  virtual bool isSubprocess() const = 0;
+  // An implementation can declare itself "disabled" at any point (for
+  // example, due to some internal error). After that point, either
+  // Client will fail, or the fallback subprocess implementation will
+  // be used instead (depending on config).
+  virtual bool isDisabled() const = 0;
+
+  // Load some number of RefIds, returning them as blobs (in the same
+  // order as requested).
+  virtual coro::Task<BlobVec> load(const RequestId& requestId,
+                                   IdVec ids) = 0;
+  // Store some number of files and/or blobs, returning their
+  // associated RefIds (in the same order as requested, with files
+  // before blobs). "read" and "uploaded", if provided, are set to the
+  // number of files actually read, and the number of items actually
+  // uploaded to some storage. Some implementations can avoid reading
+  // files directly, and others can use caching to avoid having to
+  // upload already present data.
+  virtual coro::Task<IdVec> store(const RequestId& requestId,
+                                  PathVec files,
+                                  BlobVec blobs,
+                                  size_t* read,
+                                  size_t* uploaded) = 0;
+
+  // Execute a job with the given sets of inputs. The job will be
+  // executed on a worker, with the job's run function called once for
+  // each set of inputs. "cache", if provided, will be set to true if
+  // the output comes from a cached result and the job didn't actually
+  // run.
+  virtual coro::Task<std::vector<RefValVec>>
+  exec(const RequestId& requestId,
+       const std::string& command,
+       RefValVec config,
+       std::vector<RefValVec> inputs,
+       const folly::Range<const OutputType*>& output,
+       bool* cached) = 0;
+protected:
+  explicit Impl(std::string name) : m_name{std::move(name)} {}
+private:
+  std::string m_name;
+};
+
+// Hook for providing an implementation. An implementation can set
+// g_impl_hook to a function which optionally creates a Client::Impl.
+using ImplHook =
+  std::unique_ptr<Client::Impl>(*)(
+    const Options&,
+    folly::Executor::KeepAlive<>
+  );
+extern ImplHook g_impl_hook;
+
+//////////////////////////////////////////////////////////////////////
+
+// Maps a key to a Ref<V>, automatically storing the data if needed.
+template <typename K, typename V>
+struct RefCache {
+  explicit RefCache(Client&);
+
+  // Lookup the associated Ref for the given key. If there's no entry,
+  // store the given value (using the Client provided in the ctor) and
+  // return the Ref created.
+  coro::Task<Ref<V>> get(const K&, const V&, folly::Executor::KeepAlive<>);
+private:
+  coro::AsyncMap<K, Ref<V>> m_map;
+  Client& m_client;
+};
+
+//////////////////////////////////////////////////////////////////////
+
+}
+
+//////////////////////////////////////////////////////////////////////
+
+#define incl_HPHP_EXTERN_WORKER_INL_H_
+#include "hphp/util/extern-worker-inl.h"
+#undef incl_HPHP_EXTERN_WORKER_INL_H_

--- a/hphp/util/test/extern-worker.cpp
+++ b/hphp/util/test/extern-worker.cpp
@@ -1,0 +1,1333 @@
+/*
+   +----------------------------------------------------------------------+
+   | HipHop for PHP                                                       |
+   +----------------------------------------------------------------------+
+   | Copyright (c) 2010-present Facebook, Inc. (http://www.facebook.com)  |
+   +----------------------------------------------------------------------+
+   | This source file is subject to version 3.01 of the PHP license,      |
+   | that is bundled with this package in the file LICENSE, and is        |
+   | available through the world-wide-web at the following url:           |
+   | http://www.php.net/license/3_01.txt                                  |
+   | If you did not receive a copy of the PHP license and are unable to   |
+   | obtain it through the world-wide-web, please send a note to          |
+   | license@php.net so we can mail you a copy immediately.               |
+   +----------------------------------------------------------------------+
+*/
+
+#include "hphp/util/coro.h"
+#include "hphp/util/extern-worker.h"
+
+#include <folly/FileUtil.h>
+#include <folly/init/Init.h>
+#include <folly/executors/GlobalExecutor.h>
+
+#include <gtest/gtest.h>
+
+namespace HPHP {
+
+using namespace extern_worker;
+
+namespace {
+
+struct C1 {
+  C1() : m_int{0} {}
+  C1(int i, std::string s) : m_int{i}, m_str{s} {}
+  int m_int;
+  std::string m_str;
+
+  template <typename SerDe> void serde(SerDe& sd) {
+    sd(m_int)
+      (m_str);
+  }
+};
+
+struct C2 {
+  C2() : m_int{0} {}
+  C2(int i, std::string s) : m_str{s}, m_int{i} {}
+
+  C2(const C2&) = delete;
+  C2(C2&&) = default;
+  C2& operator=(const C2&) = delete;
+  C2& operator=(C2&&) = default;
+
+  std::string m_str;
+  int m_int;
+
+  template <typename SerDe> void serde(SerDe& sd) {
+    sd(m_str)
+      (m_int);
+  }
+};
+
+}
+
+TEST(ExternWorker, Blobs) {
+  Options options;
+  options.setUseSubprocess(Options::UseSubprocess::Always);
+
+  Client client{folly::getGlobalCPUExecutor(), options};
+
+  EXPECT_TRUE(client.usingSubprocess());
+  EXPECT_EQ(client.implName(), "subprocess");
+
+  Ref<int> i123 = coro::wait(client.store(123));
+  Ref<int> i456 = coro::wait(client.store(456));
+  Ref<int> i789 = coro::wait(client.store(789));
+  std::tuple<Ref<int>, Ref<int>> t1 = coro::wait(client.store(314, 737));
+
+  Ref<std::string> sABC = coro::wait(client.store(std::string{"abc"}));
+  Ref<std::string> sDEF = coro::wait(client.store(std::string{"def"}));
+  std::tuple<Ref<std::string>, Ref<std::string>> t2 =
+    coro::wait(client.store(std::string{"hello"}, std::string{"good-bye"}));
+
+  Ref<C1> c1_1 = coro::wait(client.store(C1{1, "a"}));
+  Ref<C1> c1_2 = coro::wait(client.store(C1{2, "zzzzz"}));
+
+  Ref<C2> c2_1 = coro::wait(client.store(C2{500, "qwerty"}));
+  Ref<C2> c2_2 = coro::wait(client.store(C2{101, ""}));
+
+  std::tuple<Ref<std::string>, Ref<int>> t3 =
+    coro::wait(client.store(std::string{"118"}, 118));
+  std::tuple<Ref<int>, Ref<std::string>> t4 =
+    coro::wait(client.store(476, std::string{"476"}));
+
+  std::tuple<Ref<int>, Ref<std::string>, Ref<C1>, Ref<C2>> t5 =
+    coro::wait(client.store(845, std::string{"str1"}, C1{591, "str2"}, C2{229, "str3"}));
+
+  std::vector<int> i_list1;
+  std::vector<std::string> s_list1;
+  std::vector<C1> c1_list1;
+  std::vector<C2> c2_list1;
+  for (int i = 0; i < 10; ++i) {
+    i_list1.emplace_back(500+i);
+    s_list1.emplace_back(folly::sformat("list-str-{}", i));
+    c1_list1.emplace_back(700+i, folly::sformat("c1-str-{}", i));
+    c2_list1.emplace_back(1900+i, folly::sformat("c2-str-{}", i));
+  }
+
+  std::tuple<
+    std::vector<Ref<int>>,
+    std::vector<Ref<std::string>>,
+    std::vector<Ref<C1>>,
+    std::vector<Ref<C2>>
+  > t6 =
+  coro::wait(coro::collect(
+    client.storeMulti(std::move(i_list1)),
+    client.storeMulti(std::move(s_list1)),
+    client.storeMulti(std::move(c1_list1)),
+    client.storeMulti(std::move(c2_list1))
+  ));
+  EXPECT_EQ(std::get<0>(t6).size(), 10);
+  EXPECT_EQ(std::get<1>(t6).size(), 10);
+  EXPECT_EQ(std::get<2>(t6).size(), 10);
+  EXPECT_EQ(std::get<3>(t6).size(), 10);
+
+  std::vector<std::tuple<std::string, C2, int, C1>> t_list1;
+  for (int i = 0; i < 12; ++i) {
+    t_list1.emplace_back(
+      folly::sformat("t_list1-str1-{}", i),
+      C2{863321+i, folly::sformat("t_list1-str2-{}", i)},
+      991134+i,
+      C1{11345+i, folly::sformat("t_list1-str3-{}", i)}
+    );
+  }
+
+  std::vector<std::tuple<Ref<std::string>, Ref<C2>, Ref<int>, Ref<C1>>> t_list2 =
+    coro::wait(client.storeMultiTuple(std::move(t_list1)));
+  EXPECT_EQ(t_list2.size(), 12);
+
+  Ref<std::tuple<C1, C2, std::string, int>> t7 =
+    coro::wait(client.store(std::make_tuple(C1{375, "t100"}, C2{376, "t101"}, std::string{"t102"}, 573)));
+
+  std::vector<int> i_list2{{2000, 2001, 2002}};
+  Ref<std::vector<int>> i_list3 = coro::wait(client.store(std::move(i_list2)));
+
+  std::vector<std::tuple<std::string, int>> s_list2{
+    { std::make_tuple("x200", 3001), std::make_tuple("x201", 3002) }
+  };
+
+  std::vector<Ref<std::tuple<std::string, int>>> t_list4 =
+    coro::wait(client.storeMulti(std::move(s_list2)));
+  EXPECT_EQ(t_list4.size(), 2);
+
+  std::tuple<int, int, int> t8 = coro::wait(coro::collect(
+    client.load(i789),
+    client.load(i123),
+    client.load(i456)
+  ));
+  EXPECT_EQ(std::get<0>(t8), 789);
+  EXPECT_EQ(std::get<1>(t8), 123);
+  EXPECT_EQ(std::get<2>(t8), 456);
+
+  EXPECT_EQ(coro::wait(client.load(sDEF)), "def");
+  EXPECT_EQ(coro::wait(client.load(sABC)), "abc");
+
+  EXPECT_EQ(coro::wait(client.load(std::get<0>(t3))), "118");
+  EXPECT_EQ(coro::wait(client.load(std::get<1>(t3))), 118);
+  EXPECT_EQ(coro::wait(client.load(std::get<0>(t4))), 476);
+  EXPECT_EQ(coro::wait(client.load(std::get<1>(t4))), "476");
+
+  C1 c1_3 = coro::wait(client.load(c1_1));
+  EXPECT_EQ(c1_3.m_str, "a");
+  EXPECT_EQ(c1_3.m_int, 1);
+
+  C2 c2_3 = coro::wait(client.load(c2_2));
+  EXPECT_EQ(c2_3.m_str, "");
+  EXPECT_EQ(c2_3.m_int, 101);
+
+  std::tuple<C1, int, C2, std::string> t9 =
+    coro::wait(client.load(c1_2, std::get<0>(t1), c2_1, std::get<1>(t2)));
+  EXPECT_EQ(std::get<0>(t9).m_int, 2);
+  EXPECT_EQ(std::get<0>(t9).m_str, "zzzzz");
+  EXPECT_EQ(std::get<1>(t9), 314);
+  EXPECT_EQ(std::get<2>(t9).m_int, 500);
+  EXPECT_EQ(std::get<2>(t9).m_str, "qwerty");
+  EXPECT_EQ(std::get<3>(t9), "good-bye");
+
+  std::vector<int> i_list5 = coro::wait(client.load(std::get<0>(t6)));
+  std::vector<std::string> s_list5 = coro::wait(client.load(std::get<1>(t6)));
+  std::vector<C1> c1_list5 = coro::wait(client.load(std::get<2>(t6)));
+  std::vector<C2> c2_list5 = coro::wait(client.load(std::get<3>(t6)));
+  ASSERT_EQ(i_list5.size(), 10);
+  ASSERT_EQ(s_list5.size(), 10);
+  ASSERT_EQ(c1_list5.size(), 10);
+  ASSERT_EQ(c2_list5.size(), 10);
+
+  for (size_t i = 0; i < i_list5.size(); ++i) {
+    EXPECT_EQ(i_list5[i], 500+i);
+    EXPECT_EQ(s_list5[i], folly::sformat("list-str-{}", i));
+    EXPECT_EQ(c1_list5[i].m_int, 700+i);
+    EXPECT_EQ(c1_list5[i].m_str, folly::sformat("c1-str-{}", i));
+    EXPECT_EQ(c2_list5[i].m_int, 1900+i);
+    EXPECT_EQ(c2_list5[i].m_str, folly::sformat("c2-str-{}", i));
+  }
+
+  std::vector<std::tuple<std::string, C2, int, C1>> t_list5 =
+    coro::wait(client.load(t_list2));
+  ASSERT_EQ(t_list5.size(), 12);
+  for (size_t i = 0; i < 12; ++i){
+    EXPECT_EQ(std::get<0>(t_list5[i]), folly::sformat("t_list1-str1-{}", i));
+    EXPECT_EQ(std::get<1>(t_list5[i]).m_int, 863321+i);
+    EXPECT_EQ(std::get<1>(t_list5[i]).m_str, folly::sformat("t_list1-str2-{}", i));
+    EXPECT_EQ(std::get<2>(t_list5[i]), 991134+i);
+    EXPECT_EQ(std::get<3>(t_list5[i]).m_int, 11345+i);
+    EXPECT_EQ(std::get<3>(t_list5[i]).m_str, folly::sformat("t_list1-str3-{}", i));
+  }
+
+  std::tuple<C1, C2, std::string, int> t10 =
+    coro::wait(client.load(t7));
+  EXPECT_EQ(std::get<0>(t10).m_int, 375);
+  EXPECT_EQ(std::get<0>(t10).m_str, "t100");
+  EXPECT_EQ(std::get<1>(t10).m_int, 376);
+  EXPECT_EQ(std::get<1>(t10).m_str, "t101");
+  EXPECT_EQ(std::get<2>(t10), "t102");
+  EXPECT_EQ(std::get<3>(t10), 573);
+
+  std::vector<std::tuple<std::string, int>> t_list6 =
+    coro::wait(client.load(t_list4));
+  ASSERT_EQ(t_list6.size(), 2);
+  EXPECT_EQ(std::get<0>(t_list6[0]), "x200");
+  EXPECT_EQ(std::get<1>(t_list6[0]), 3001);
+  EXPECT_EQ(std::get<0>(t_list6[1]), "x201");
+  EXPECT_EQ(std::get<1>(t_list6[1]), 3002);
+
+  std::vector<int> i_list6 = coro::wait(client.load(i_list3));
+  ASSERT_EQ(i_list6.size(), 3);
+  EXPECT_EQ(i_list6[0], 2000);
+  EXPECT_EQ(i_list6[1], 2001);
+  EXPECT_EQ(i_list6[2], 2002);
+}
+
+TEST(ExternWorker, Files) {
+  auto const tmpDir = folly::fs::temp_directory_path();
+  auto const base = tmpDir / "hphp-extern-worker-test";
+  auto const root =
+    base / boost::filesystem::unique_path("%%%%-%%%%-%%%%-%%%%").native();
+
+  folly::fs::create_directory(base, tmpDir);
+  folly::fs::create_directory(root, base);
+
+  auto const makeString = [] (folly::fs::path p) {
+    return folly::sformat("This file is called: \"{}\"", p.native());
+  };
+  auto const makeFile = [&] {
+    auto const p =
+      root / boost::filesystem::unique_path("%%%%-%%%%-%%%%-%%%%").native();
+    folly::writeFile(makeString(p), p.c_str());
+    return p;
+  };
+
+  Options options;
+  options.setUseSubprocess(Options::UseSubprocess::Always);
+
+  Client client{folly::getGlobalCPUExecutor(), options};
+
+  EXPECT_TRUE(client.usingSubprocess());
+  EXPECT_EQ(client.implName(), "subprocess");
+
+  auto const p1 = makeFile();
+  auto const p2 = makeFile();
+  auto const p3 = makeFile();
+  std::vector<folly::fs::path> ps;
+  for (size_t i = 0; i < 5; ++i) ps.emplace_back(makeFile());
+
+  bool read1;
+  bool read2;
+  bool uploaded1;
+  bool uploaded2;
+
+  Ref<std::string> r1 = coro::wait(client.storeFile(p1, &read1, &uploaded1));
+  EXPECT_TRUE(read1);
+  EXPECT_TRUE(uploaded1);
+
+  std::tuple<Ref<std::string>, Ref<std::string>> t1 = coro::wait(coro::collect(
+    client.storeFile(p2, &read1, &uploaded1),
+    client.storeFile(p3, &read2, &uploaded2)
+  ));
+  EXPECT_TRUE(read1);
+  EXPECT_TRUE(uploaded1);
+  EXPECT_TRUE(read2);
+  EXPECT_TRUE(uploaded2);
+  Ref<std::string> r2 = std::get<0>(t1);
+  Ref<std::string> r3 = std::get<1>(t1);
+
+  size_t readCount;
+  size_t uploadedCount;
+  std::vector<Ref<std::string>> refs =
+    coro::wait(client.storeFile(ps, &readCount, &uploadedCount));
+  EXPECT_EQ(refs.size(), ps.size());
+  EXPECT_EQ(readCount, ps.size());
+  EXPECT_EQ(uploadedCount, ps.size());
+
+  std::string s1 = coro::wait(client.load(r1));
+  EXPECT_EQ(s1, makeString(p1));
+
+  std::tuple<std::string, std::string> t2 = coro::wait(client.load(r2, r3));
+  EXPECT_EQ(std::get<0>(t2), makeString(p2));
+  EXPECT_EQ(std::get<1>(t2), makeString(p3));
+
+  std::vector<std::string> strs = coro::wait(client.load(refs));
+  ASSERT_EQ(strs.size(), ps.size());
+
+  for (size_t i = 0; i < strs.size(); ++i) {
+    EXPECT_EQ(strs[i], makeString(ps[i]));
+  }
+
+  folly::fs::remove_all(root);
+}
+
+namespace {
+
+struct Test1 {
+  static std::string name() { return "test-job1"; }
+  static void fini() {}
+  static void init() {}
+  static int run() { return 123; }
+};
+struct Test2 {
+  static std::string name() { return "test-job2"; }
+  static void fini() {}
+  static void init() {}
+  static std::string run() { return "abc"; }
+};
+struct Test3 {
+  static std::string name() { return "test-job3"; }
+  static void fini() {}
+  static void init(int i) { s_add = i; }
+  static int run(int x) { return s_add + x; }
+  static int s_add;
+};
+struct Test4 {
+  static std::string name() { return "test-job4"; }
+  static void fini() {}
+  static void init(const std::string& s) { s_add = s; }
+  static std::string run(const std::string& x) { return s_add + x; }
+  static std::string s_add;
+};
+struct Test5 {
+  static std::string name() { return "test-job5"; }
+  static void fini() {}
+  static void init(const std::string& s, int i) {
+    s_add = folly::sformat("{}-{}", s, i);
+  }
+  static std::string run(int i, const std::string& s) {
+    return folly::sformat("{}-{}-{}", s_add, i, s);
+  }
+  static std::string s_add;
+};
+struct Test6 {
+  static std::string name() { return "test-job6"; }
+  static void fini() {}
+  static void init(const C1& c1, const C2& c2) {
+    s_add = folly::sformat("{}/{}/{}/{}",
+                           c1.m_int, c1.m_str,
+                           c2.m_int, c2.m_str);
+  }
+  static std::string run(const C2& c2, const C1& c1) {
+    return folly::sformat("{}/{}/{}/{}/{}",
+                          s_add,
+                          c2.m_int, c2.m_str,
+                          c1.m_int, c1.m_str);
+  }
+  static std::string s_add;
+};
+struct Test7 {
+  static std::string name() { return "test-job7"; }
+  static void fini() {}
+  static void init() {}
+  static Opt<std::string> run(Opt<int> x) {
+    if (!x.val.has_value()) return Opt<std::string>{};
+    return Opt<std::string>{std::to_string(*x.val)};
+  }
+};
+struct Test8 {
+  static std::string name() { return "test-job8"; }
+  static void fini() {}
+  static void init() {}
+  static Variadic<std::string> run(Variadic<int> v) {
+    Variadic<std::string> out;
+    for (auto x : v.vals) {
+      out.vals.emplace_back(std::to_string(x));
+    }
+    return out;
+  }
+};
+struct Test9 {
+  static std::string name() { return "test-job9"; }
+  static void fini() {}
+  static void init() {}
+  static Multi<std::string, int> run(int x) {
+    return Multi<std::string, int>{std::make_tuple(std::to_string(x), x)};
+  }
+};
+struct Test10 {
+  static std::string name() { return "test-job10"; }
+  static void fini() {}
+  static void init() {}
+  static Multi<int, std::string, Variadic<std::string>, Opt<C1>, C2>
+  run(int x,
+      std::string s,
+      Variadic<std::string> v,
+      Opt<C1> o,
+      C2 c) {
+    return Multi<int, std::string, Variadic<std::string>, Opt<C1>, C2>{
+      std::make_tuple(x, s, v, o, std::move(c))
+    };
+  }
+};
+struct Test11 {
+  static std::string name() { return "test-job11"; }
+  static void fini() {}
+  static void init() {}
+  static Optional<int> run(const Optional<int>& x) { return x; }
+};
+struct Test12 {
+  static std::string name() { return "test-job12"; }
+  static void fini() {}
+  static void init() {}
+  static std::vector<int> run(const std::vector<int>& x) { return x; }
+};
+struct Test13 {
+  static std::string name() { return "test-job13"; }
+  static void fini() {}
+  static void init() {}
+  static std::tuple<int, std::string>
+  run(const std::tuple<int, std::string>& x) { return x; }
+};
+
+int Test3::s_add{0};
+std::string Test4::s_add;
+std::string Test5::s_add;
+std::string Test6::s_add;
+
+Job<Test1> s_test1;
+Job<Test2> s_test2;
+Job<Test3> s_test3;
+Job<Test4> s_test4;
+Job<Test5> s_test5;
+Job<Test6> s_test6;
+Job<Test7> s_test7;
+Job<Test8> s_test8;
+Job<Test9> s_test9;
+Job<Test10> s_test10;
+Job<Test11> s_test11;
+Job<Test12> s_test12;
+Job<Test13> s_test13;
+
+}
+
+TEST(ExternWorker, Exec) {
+  Options options;
+  options.setUseSubprocess(Options::UseSubprocess::Always);
+
+  Client client{folly::getGlobalCPUExecutor(), options};
+
+  EXPECT_TRUE(client.usingSubprocess());
+  EXPECT_EQ(client.implName(), "subprocess");
+
+  auto const testJob1_2 = [&] (size_t size) {
+    std::vector<std::tuple<>> inputs;
+    for (size_t i = 0; i < size; ++i) {
+      inputs.emplace_back(std::tuple<>{});
+    }
+
+    std::tuple<std::vector<Ref<int>>, std::vector<Ref<std::string>>> outputsT =
+      coro::wait(coro::collect(
+        client.exec(s_test1, {}, inputs),
+        client.exec(s_test2, {}, inputs)
+      ));
+
+    ASSERT_EQ(std::get<0>(outputsT).size(), size);
+    ASSERT_EQ(std::get<1>(outputsT).size(), size);
+
+    std::vector<int> outputs1 =
+      coro::wait(client.load(std::get<0>(outputsT)));
+    std::vector<std::string> outputs2 =
+      coro::wait(client.load(std::get<1>(outputsT)));
+    ASSERT_EQ(outputs1.size(), size);
+    ASSERT_EQ(outputs2.size(), size);
+
+    for (size_t i = 0; i < size; ++i) {
+      EXPECT_EQ(outputs1[i], 123);
+      EXPECT_EQ(outputs2[i], "abc");
+    }
+  };
+  testJob1_2(0);
+  testJob1_2(1);
+  testJob1_2(2);
+  testJob1_2(5);
+
+  auto const testJob3_4 = [&] (size_t size, int add, std::string prefix) {
+    std::vector<std::tuple<Ref<int>>> inputs1;
+    std::vector<std::tuple<Ref<std::string>>> inputs2;
+    for (size_t i = 0; i < size; ++i) {
+      inputs1.emplace_back(std::make_tuple(coro::wait(client.store(int(i+100)))));
+      inputs2.emplace_back(std::make_tuple(coro::wait(client.store(folly::sformat("str-{}", i+100)))));
+    }
+
+    Ref<int> addRef = coro::wait(client.store(add));
+    Ref<std::string> prefixRef = coro::wait(client.store(prefix));
+
+    std::vector<Ref<int>> refs1 =
+      coro::wait(client.exec(s_test3, std::make_tuple(addRef), inputs1));
+    std::vector<Ref<std::string>> refs2 =
+      coro::wait(client.exec(s_test4, std::make_tuple(prefixRef), inputs2));
+    ASSERT_EQ(refs1.size(), size);
+    ASSERT_EQ(refs2.size(), size);
+
+    std::vector<int> outputs1 = coro::wait(client.load(refs1));
+    std::vector<std::string> outputs2 = coro::wait(client.load(refs2));
+    ASSERT_EQ(outputs1.size(), size);
+    ASSERT_EQ(outputs2.size(), size);
+
+    for (size_t i = 0; i < size; ++i) {
+      EXPECT_EQ(outputs1[i], i+100+add);
+      EXPECT_EQ(outputs2[i], folly::sformat("{}str-{}", prefix, i+100));
+    }
+  };
+  testJob3_4(0, 1, "prefix1");
+  testJob3_4(1, 50, "prefix2");
+  testJob3_4(2, 1111, "prefix3");
+  testJob3_4(7, 1234, "prefix4");
+
+  auto const testJob5 = [&] (size_t size, int init1, std::string init2) {
+    std::tuple<Ref<std::string>, Ref<int>> inits =
+      coro::wait(client.store(init2, init1));
+
+    std::vector<std::tuple<Ref<int>, Ref<std::string>>> inputs;
+    for (size_t i = 0; i < size; ++i) {
+      inputs.emplace_back(
+        coro::wait(client.store(int(i + 891), folly::sformat("hello-{}", i)))
+      );
+    }
+
+    std::vector<Ref<std::string>> refs =
+      coro::wait(client.exec(s_test5, inits, inputs));
+    ASSERT_EQ(refs.size(), size);
+
+    std::vector<std::string> outputs = coro::wait(client.load(refs));
+    ASSERT_EQ(outputs.size(), size);
+
+    for (size_t i = 0; i < size; ++i) {
+      EXPECT_EQ(outputs[i], folly::sformat("{}-{}-{}-hello-{}", init2, init1, i+891, i));
+    }
+  };
+  testJob5(0, 1, "bye1");
+  testJob5(1, 27, "bye2");
+  testJob5(3, 91, "bye3");
+
+  auto const testJob6 = [&] (size_t size, C1 c1, C2 c2) {
+    C2 c2_copy{c2.m_int, c2.m_str};
+
+    std::tuple<Ref<C1>, Ref<C2>> inits =
+      coro::wait(client.store(c1, std::move(c2)));
+
+    std::vector<std::tuple<Ref<C2>, Ref<C1>>> inputs;
+    for (size_t i = 0; i < size; ++i) {
+      C1 c1_2{int(i*2+1), std::to_string(i*2+1)};
+      C2 c2_2{int(i*2), std::to_string(i*2)};
+      inputs.emplace_back(
+        coro::wait(client.store(std::move(c2_2), c1_2))
+      );
+    }
+
+    std::vector<Ref<std::string>> refs =
+      coro::wait(client.exec(s_test6, inits, inputs));
+    ASSERT_EQ(refs.size(), size);
+
+    std::vector<std::string> outputs = coro::wait(client.load(refs));
+    ASSERT_EQ(outputs.size(), size);
+
+    for (size_t i = 0; i < size; ++i) {
+      C1 c1_2{int(i*2+1), std::to_string(i*2+1)};
+      C2 c2_2{int(i*2), std::to_string(i*2)};
+      EXPECT_EQ(
+        outputs[i],
+        folly::sformat("{}/{}/{}/{}/{}/{}/{}/{}",
+                       c1.m_int, c1.m_str,
+                       c2_copy.m_int, c2_copy.m_str,
+                       c2_2.m_int, c2_2.m_str,
+                       c1_2.m_int, c1_2.m_str)
+      );
+    }
+  };
+  testJob6(0, C1{1, "a"}, C2{7, "b"});
+  testJob6(1, C1{3, "c"}, C2{9, "d"});
+  testJob6(2, C1{5, "e"}, C2{11, "f"});
+
+  auto const testJob7 = [&] (size_t size) {
+    std::vector<std::tuple<Optional<Ref<int>>>> inputs;
+    for (size_t i = 0; i < size; ++i) {
+      if ((i % 2) == 0) {
+        inputs.emplace_back(std::nullopt);
+      } else {
+        inputs.emplace_back(std::make_tuple(coro::wait(client.store(int(i)))));
+      }
+    }
+
+    std::vector<Optional<Ref<std::string>>> refs =
+      coro::wait(client.exec(s_test7, {}, inputs));
+    ASSERT_EQ(refs.size(), size);
+
+    std::vector<Ref<std::string>> filtered;
+    for (size_t i = 0; i < size; ++i) {
+      if ((i % 2) == 0) {
+        EXPECT_FALSE(refs[i].has_value());
+      } else {
+        ASSERT_TRUE(refs[i].has_value());
+        filtered.emplace_back(*refs[i]);
+      }
+    }
+    EXPECT_EQ(filtered.size(), size / 2);
+
+    std::vector<std::string> outputs = coro::wait(client.load(filtered));
+    ASSERT_EQ(outputs.size(), size / 2);
+    for (size_t i = 0; i < size; ++i) {
+      if ((i % 2) == 0) continue;
+      EXPECT_EQ(outputs[i / 2], std::to_string(i));
+    }
+  };
+  testJob7(0);
+  testJob7(1);
+  testJob7(2);
+  testJob7(8);
+
+  auto const testJob8 = [&] (size_t size) {
+    std::vector<Ref<int>> inputs;
+    for (size_t i = 0; i < size; ++i) {
+      inputs.emplace_back(coro::wait(client.store(int(i))));
+    }
+
+    std::vector<std::vector<Ref<std::string>>> refs =
+      coro::wait(client.exec(s_test8, {}, {std::make_tuple(inputs)}));
+    ASSERT_EQ(refs.size(), 1);
+    ASSERT_EQ(refs[0].size(), size);
+
+    std::vector<std::string> outputs = coro::wait(client.load(refs[0]));
+    ASSERT_EQ(outputs.size(), size);
+
+    for (size_t i = 0; i < size; ++i) {
+      EXPECT_EQ(outputs[i], std::to_string(i));
+    }
+  };
+  testJob8(0);
+  testJob8(1);
+  testJob8(2);
+  testJob8(7);
+
+  auto const testJob9 = [&] (size_t size) {
+    std::vector<std::tuple<Ref<int>>> inputs;
+    for (size_t i = 0; i < size; ++i) {
+      inputs.emplace_back(
+        std::make_tuple(coro::wait(client.store(int(i+123))))
+      );
+    }
+
+    std::vector<std::tuple<Ref<std::string>, Ref<int>>> refs =
+      coro::wait(client.exec(s_test9, {}, inputs));
+    ASSERT_EQ(refs.size(), size);
+
+    std::vector<std::tuple<std::string, int>> outputs =
+      coro::wait(client.load(refs));
+    ASSERT_EQ(outputs.size(), size);
+
+    for (size_t i = 0; i < size; ++i) {
+      EXPECT_EQ(std::get<0>(outputs[i]), std::to_string(i+123));
+      EXPECT_EQ(std::get<1>(outputs[i]), i+123);
+    }
+  };
+  testJob9(0);
+  testJob9(1);
+  testJob9(2);
+  testJob9(3);
+  testJob9(5);
+
+  auto const testJob10 = [&] (size_t size, size_t numStrs) {
+    std::vector<
+      std::tuple<
+        Ref<int>,
+        Ref<std::string>,
+        std::vector<Ref<std::string>>,
+        Optional<Ref<C1>>,
+        Ref<C2>
+      >
+    > inputs;
+
+    for (size_t i = 0; i < size; ++i) {
+      std::vector<std::string> strs;
+      for (size_t j = 0; j < numStrs; ++j) {
+        strs.emplace_back(folly::sformat("some-str-{}", j));
+      }
+      std::vector<Ref<std::string>> strRefs =
+        coro::wait(client.storeMulti(strs));
+
+      Optional<Ref<C1>> opt;
+      if ((i % 2) == 0) {
+        opt.emplace(
+          coro::wait(client.store(C1{int(i+200), std::to_string(i+200)}))
+        );
+      }
+
+      std::tuple<Ref<int>, Ref<std::string>, Ref<C2>> stores =
+        coro::wait(
+          client.store(
+            int(i),
+            folly::sformat("another-str-{}", i),
+            C2{int(i+300), std::to_string(i+300)}
+          )
+        );
+
+      inputs.emplace_back(
+        std::get<0>(stores),
+        std::get<1>(stores),
+        strRefs,
+        opt,
+        std::get<2>(stores)
+      );
+    }
+
+    std::vector<
+      std::tuple<
+        Ref<int>,
+        Ref<std::string>,
+        std::vector<Ref<std::string>>,
+        Optional<Ref<C1>>,
+        Ref<C2>
+      >
+    > refs = coro::wait(client.exec(s_test10, {}, inputs));
+
+    ASSERT_EQ(refs.size(), size);
+    for (size_t i = 0; i < size; ++i) {
+      auto const& r = refs[i];
+
+      ASSERT_EQ(std::get<2>(r).size(), numStrs);
+      std::vector<std::string> strs = coro::wait(client.load(std::get<2>(r)));
+      ASSERT_EQ(strs.size(), numStrs);
+      for (size_t j = 0; j < numStrs; ++j) {
+        EXPECT_EQ(strs[j], folly::sformat("some-str-{}", j));
+      }
+
+      if ((i % 2) == 0) {
+        ASSERT_TRUE(std::get<3>(r).has_value());
+        C1 c = coro::wait(client.load(*std::get<3>(r)));
+        EXPECT_EQ(c.m_int, i+200);
+        EXPECT_EQ(c.m_str, std::to_string(i+200));
+      } else {
+        ASSERT_FALSE(std::get<3>(r).has_value());
+      }
+
+      std::tuple<int, std::string, C2> t =
+        coro::wait(
+          client.load(
+            std::get<0>(r),
+            std::get<1>(r),
+            std::get<4>(r)
+          )
+        );
+      EXPECT_EQ(std::get<0>(t), i);
+      EXPECT_EQ(std::get<1>(t), folly::sformat("another-str-{}", i));
+      EXPECT_EQ(std::get<2>(t).m_int, i+300);
+      EXPECT_EQ(std::get<2>(t).m_str, std::to_string(i+300));
+    }
+  };
+  testJob10(0, 1);
+  testJob10(1, 0);
+  testJob10(1, 1);
+  testJob10(1, 10);
+  testJob10(3, 5);
+  testJob10(3, 0);
+  testJob10(5, 7);
+  testJob10(5, 1);
+
+  auto const testJob11 = [&] {
+    std::vector<std::tuple<Ref<Optional<int>>>> inputs;
+    inputs.emplace_back(
+      std::make_tuple(coro::wait(client.store(Optional<int>{})))
+    );
+    inputs.emplace_back(
+      std::make_tuple(coro::wait(client.store(Optional<int>{11223344})))
+    );
+
+    std::vector<Ref<Optional<int>>> refs =
+      coro::wait(client.exec(s_test11, {}, inputs));
+    ASSERT_EQ(refs.size(), 2);
+
+    std::vector<Optional<int>> outputs = coro::wait(client.load(refs));
+    ASSERT_EQ(outputs.size(), 2);
+
+    ASSERT_FALSE(outputs[0].has_value());
+    ASSERT_TRUE(outputs[1].has_value());
+    EXPECT_EQ(*outputs[1], 11223344);
+  };
+  testJob11();
+
+  auto const testJob12 = [&] {
+    std::vector<std::tuple<Ref<std::vector<int>>>> inputs;
+    inputs.emplace_back(
+      std::make_tuple(coro::wait(client.store(std::vector<int>{})))
+    );
+    inputs.emplace_back(
+      std::make_tuple(coro::wait(client.store(std::vector<int>{99})))
+    );
+    inputs.emplace_back(
+      std::make_tuple(coro::wait(client.store(std::vector<int>{97, 32})))
+    );
+
+    std::vector<Ref<std::vector<int>>> refs =
+      coro::wait(client.exec(s_test12, {}, inputs));
+    ASSERT_EQ(refs.size(), 3);
+
+    std::vector<std::vector<int>> outputs = coro::wait(client.load(refs));
+    ASSERT_EQ(outputs.size(), 3);
+
+    ASSERT_EQ(outputs[0].size(), 0);
+    ASSERT_EQ(outputs[1].size(), 1);
+    ASSERT_EQ(outputs[2].size(), 2);
+
+    EXPECT_EQ(outputs[1][0], 99);
+    EXPECT_EQ(outputs[2][0], 97);
+    EXPECT_EQ(outputs[2][1], 32);
+  };
+  testJob12();
+
+  auto const testJob13 = [&] {
+    Ref<std::tuple<int, std::string>> inputs =
+      coro::wait(client.store(std::make_tuple(582, std::string{"tuple"})));
+
+    std::vector<Ref<std::tuple<int, std::string>>> refs =
+      coro::wait(client.exec(s_test13, {}, {std::make_tuple(inputs)}));
+    ASSERT_EQ(refs.size(), 1);
+
+    std::tuple<int, std::string> output = coro::wait(client.load(refs[0]));
+    EXPECT_EQ(std::get<0>(output), 582);
+    EXPECT_EQ(std::get<1>(output), "tuple");
+  };
+  testJob13();
+}
+
+TEST(ExternWorker, RefCache) {
+  Options options;
+  options.setUseSubprocess(Options::UseSubprocess::Always);
+
+  Client client{folly::getGlobalCPUExecutor(), options};
+
+  EXPECT_TRUE(client.usingSubprocess());
+  EXPECT_EQ(client.implName(), "subprocess");
+
+  RefCache<int, std::string> cache{client};
+
+  std::vector<coro::Task<Ref<std::string>>> tasks;
+  tasks.emplace_back(cache.get(1, "1", folly::getGlobalCPUExecutor()));
+  tasks.emplace_back(cache.get(2, "2", folly::getGlobalCPUExecutor()));
+  tasks.emplace_back(cache.get(3, "3", folly::getGlobalCPUExecutor()));
+  tasks.emplace_back(cache.get(2, "2", folly::getGlobalCPUExecutor()));
+  tasks.emplace_back(cache.get(1, "1", folly::getGlobalCPUExecutor()));
+
+  std::vector<Ref<std::string>> refs =
+    coro::wait(coro::collectRange(std::move(tasks)));
+  ASSERT_EQ(refs.size(), 5);
+
+  EXPECT_EQ(refs[0].id(), refs[4].id());
+  EXPECT_EQ(refs[1].id(), refs[3].id());
+
+  std::vector<std::string> strs = coro::wait(client.load(refs));
+  ASSERT_EQ(strs.size(), 5);
+  EXPECT_EQ(strs[0], "1");
+  EXPECT_EQ(strs[1], "2");
+  EXPECT_EQ(strs[2], "3");
+  EXPECT_EQ(strs[3], "2");
+  EXPECT_EQ(strs[4], "1");
+}
+
+TEST(ExternWorker, Fallback) {
+  Options options;
+  options.setUseSubprocess(Options::UseSubprocess::Always);
+
+  Client client{folly::getGlobalCPUExecutor(), options};
+  client.forceFallback();
+
+  auto str1 = coro::wait(client.store(std::string{"str1"}));
+  auto [str2, int1] = coro::wait(client.store(std::string{"str2"}, 100));
+
+  auto strs = coro::wait(
+    client.storeMulti(std::vector<std::string>{"str3", "str4", "str5"})
+  );
+  ASSERT_EQ(strs.size(), 3);
+  auto str3 = std::move(strs[0]);
+  auto str4 = std::move(strs[1]);
+  auto str5 = std::move(strs[2]);
+
+  auto tuples = coro::wait(
+    client.storeMultiTuple(
+      std::vector<std::tuple<std::string, int>>{
+        std::make_tuple(std::string{"str6"}, 200),
+        std::make_tuple(std::string{"str7"}, 300),
+        std::make_tuple(std::string{"str8"}, 400)
+      }
+    )
+  );
+  ASSERT_EQ(tuples.size(), 3);
+  auto [str6, int2] = std::move(tuples[0]);
+  auto [str7, int3] = std::move(tuples[1]);
+  auto [str8, int4] = std::move(tuples[2]);
+
+  auto const tmpDir = folly::fs::temp_directory_path();
+  auto const base = tmpDir / "hphp-extern-worker-test";
+  auto const root =
+    base / boost::filesystem::unique_path("%%%%-%%%%-%%%%-%%%%").native();
+
+  folly::fs::create_directory(base, tmpDir);
+  folly::fs::create_directory(root, base);
+
+  auto const makeString = [] (folly::fs::path p) {
+    return folly::sformat("This file is called: \"{}\"", p.native());
+  };
+  auto const makeFile = [&] {
+    auto const p =
+      root / boost::filesystem::unique_path("%%%%-%%%%-%%%%-%%%%").native();
+    folly::writeFile(makeString(p), p.c_str());
+    return p;
+  };
+
+  auto const file1 = makeFile();
+  auto const file2 = makeFile();
+  auto const file3 = makeFile();
+
+  auto str9 = coro::wait(client.storeFile(file1));
+  auto strs2 = coro::wait(
+    client.storeFile(std::vector<folly::fs::path>{file2, file3})
+  );
+  ASSERT_EQ(strs2.size(), 2);
+  auto str10 = std::move(strs2[0]);
+  auto str11 = std::move(strs2[1]);
+
+  client.unforceFallback();
+
+  auto [str12, str13, str14] = coro::wait(
+    client.store(
+      std::string{"str12"},
+      std::string{"str13"},
+      std::string{"str14"}
+    )
+  );
+  auto [int5, int6, int7, int8, int9, int10] = coro::wait(
+    client.store(500, 600, 700, 800, 900, 1000)
+  );
+
+  auto const file4 = makeFile();
+  auto const file5 = makeFile();
+
+  auto strs3 = coro::wait(
+    client.storeFile(std::vector<folly::fs::path>{file4, file5})
+  );
+  ASSERT_EQ(strs3.size(), 2);
+  auto str15 = std::move(strs3[0]);
+  auto str16 = std::move(strs3[1]);
+
+  auto str17 = coro::wait(client.store(std::string{"str17"}));
+
+  EXPECT_TRUE(str1.fromFallback());
+  EXPECT_TRUE(str2.fromFallback());
+  EXPECT_TRUE(str3.fromFallback());
+  EXPECT_TRUE(str4.fromFallback());
+  EXPECT_TRUE(str5.fromFallback());
+  EXPECT_TRUE(str6.fromFallback());
+  EXPECT_TRUE(str7.fromFallback());
+  EXPECT_TRUE(str8.fromFallback());
+  EXPECT_TRUE(str9.fromFallback());
+  EXPECT_TRUE(str10.fromFallback());
+  EXPECT_TRUE(str11.fromFallback());
+
+  EXPECT_TRUE(int1.fromFallback());
+  EXPECT_TRUE(int2.fromFallback());
+  EXPECT_TRUE(int3.fromFallback());
+  EXPECT_TRUE(int4.fromFallback());
+
+  EXPECT_FALSE(str12.fromFallback());
+  EXPECT_FALSE(str13.fromFallback());
+  EXPECT_FALSE(str14.fromFallback());
+  EXPECT_FALSE(str15.fromFallback());
+  EXPECT_FALSE(str16.fromFallback());
+  EXPECT_FALSE(str17.fromFallback());
+
+  EXPECT_FALSE(int5.fromFallback());
+  EXPECT_FALSE(int6.fromFallback());
+  EXPECT_FALSE(int7.fromFallback());
+  EXPECT_FALSE(int8.fromFallback());
+
+  EXPECT_EQ(coro::wait(client.load(str1)), "str1");
+  EXPECT_EQ(coro::wait(client.load(str12)), "str12");
+
+  auto [l1, l2, l3] = coro::wait(client.load(str2, str3, str9));
+  EXPECT_EQ(l1, "str2");
+  EXPECT_EQ(l2, "str3");
+  EXPECT_EQ(l3, makeString(file1));
+
+  auto [l4, l5, l6] = coro::wait(client.load(str1, str12, str3));
+  EXPECT_EQ(l4, "str1");
+  EXPECT_EQ(l5, "str12");
+  EXPECT_EQ(l6, "str3");
+
+  auto [l7, l8, l9] = coro::wait(client.load(str13, str3, str14));
+  EXPECT_EQ(l7, "str13");
+  EXPECT_EQ(l8, "str3");
+  EXPECT_EQ(l9, "str14");
+
+  auto [l10, l11, l12] = coro::wait(client.load(int5, str14, int2));
+  EXPECT_EQ(l10, 500);
+  EXPECT_EQ(l11, "str14");
+  EXPECT_EQ(l12, 200);
+
+  auto [l13, l14,l15] = coro::wait(client.load(str10, int2, str16));
+  EXPECT_EQ(l13, makeString(file2));
+  EXPECT_EQ(l14, 200);
+  EXPECT_EQ(l15, makeString(file5));
+
+  auto strs4 = coro::wait(
+    client.load(std::vector<Ref<std::string>>{str2, str3, str1})
+  );
+  ASSERT_EQ(strs4.size(), 3);
+  EXPECT_EQ(strs4[0], "str2");
+  EXPECT_EQ(strs4[1], "str3");
+  EXPECT_EQ(strs4[2], "str1");
+
+  auto strs5 = coro::wait(
+    client.load(std::vector<Ref<std::string>>{str4, str13, str2})
+  );
+  ASSERT_EQ(strs5.size(), 3);
+  EXPECT_EQ(strs5[0], "str4");
+  EXPECT_EQ(strs5[1], "str13");
+  EXPECT_EQ(strs5[2], "str2");
+
+  auto strs6 = coro::wait(
+    client.load(std::vector<Ref<std::string>>{str12, str4, str15})
+  );
+  ASSERT_EQ(strs6.size(), 3);
+  EXPECT_EQ(strs6[0], "str12");
+  EXPECT_EQ(strs6[1], "str4");
+  EXPECT_EQ(strs6[2], makeString(file4));
+
+  auto strs7 = coro::wait(
+    client.load(std::vector<Ref<std::string>>{str3, str6, str14})
+  );
+  ASSERT_EQ(strs7.size(), 3);
+  EXPECT_EQ(strs7[0], "str3");
+  EXPECT_EQ(strs7[1], "str6");
+  EXPECT_EQ(strs7[2], "str14");
+
+  auto strs8 = coro::wait(
+    client.load(std::vector<Ref<std::string>>{str12, str15, str1})
+  );
+  ASSERT_EQ(strs8.size(), 3);
+  EXPECT_EQ(strs8[0], "str12");
+  EXPECT_EQ(strs8[1], makeString(file4));
+  EXPECT_EQ(strs8[2], "str1");
+
+  auto v1 = coro::wait(
+    client.load(
+      std::vector<std::tuple<Ref<std::string>, Ref<int>>>{
+        std::make_tuple(str1, int1),
+        std::make_tuple(str2, int2),
+        std::make_tuple(str3, int3)
+      }
+    )
+  );
+  ASSERT_EQ(v1.size(), 3);
+  EXPECT_EQ(std::get<0>(v1[0]), "str1");
+  EXPECT_EQ(std::get<0>(v1[1]), "str2");
+  EXPECT_EQ(std::get<0>(v1[2]), "str3");
+  EXPECT_EQ(std::get<1>(v1[0]), 100);
+  EXPECT_EQ(std::get<1>(v1[1]), 200);
+  EXPECT_EQ(std::get<1>(v1[2]), 300);
+
+  auto v2 = coro::wait(
+    client.load(
+      std::vector<std::tuple<Ref<std::string>, Ref<int>>>{
+        std::make_tuple(str13, int3),
+        std::make_tuple(str2, int6),
+        std::make_tuple(str14, int1)
+      }
+    )
+  );
+  ASSERT_EQ(v2.size(), 3);
+  EXPECT_EQ(std::get<0>(v2[0]), "str13");
+  EXPECT_EQ(std::get<0>(v2[1]), "str2");
+  EXPECT_EQ(std::get<0>(v2[2]), "str14");
+  EXPECT_EQ(std::get<1>(v2[0]), 300);
+  EXPECT_EQ(std::get<1>(v2[1]), 600);
+  EXPECT_EQ(std::get<1>(v2[2]), 100);
+
+  auto v3 = coro::wait(
+    client.load(
+      std::vector<std::tuple<Ref<std::string>, Ref<int>>>{
+        std::make_tuple(str1, int5),
+        std::make_tuple(str2, int6),
+        std::make_tuple(str3, int7)
+      }
+    )
+  );
+  ASSERT_EQ(v3.size(), 3);
+  EXPECT_EQ(std::get<0>(v3[0]), "str1");
+  EXPECT_EQ(std::get<0>(v3[1]), "str2");
+  EXPECT_EQ(std::get<0>(v3[2]), "str3");
+  EXPECT_EQ(std::get<1>(v3[0]), 500);
+  EXPECT_EQ(std::get<1>(v3[1]), 600);
+  EXPECT_EQ(std::get<1>(v3[2]), 700);
+
+  auto o1 = coro::wait(
+    client.exec(
+      s_test5,
+      std::make_tuple(str1, int1),
+      std::vector<std::tuple<Ref<int>, Ref<std::string>>>{
+        std::make_tuple(int2, str2),
+        std::make_tuple(int3, str3),
+        std::make_tuple(int4, str4)
+      }
+    )
+  );
+  ASSERT_EQ(o1.size(), 3);
+  EXPECT_TRUE(o1[0].fromFallback());
+  EXPECT_TRUE(o1[1].fromFallback());
+  EXPECT_TRUE(o1[2].fromFallback());
+
+  EXPECT_EQ(coro::wait(client.load(o1[0])), "str1-100-200-str2");
+  EXPECT_EQ(coro::wait(client.load(o1[1])), "str1-100-300-str3");
+  EXPECT_EQ(coro::wait(client.load(o1[2])), "str1-100-400-str4");
+
+  auto o2 = coro::wait(
+    client.exec(
+      s_test5,
+      std::make_tuple(str17, int8),
+      std::vector<std::tuple<Ref<int>, Ref<std::string>>>{
+        std::make_tuple(int5, str12),
+        std::make_tuple(int6, str13),
+        std::make_tuple(int7, str14)
+      }
+    )
+  );
+  ASSERT_EQ(o2.size(), 3);
+  EXPECT_FALSE(o2[0].fromFallback());
+  EXPECT_FALSE(o2[1].fromFallback());
+  EXPECT_FALSE(o2[2].fromFallback());
+
+  EXPECT_EQ(coro::wait(client.load(o2[0])), "str17-800-500-str12");
+  EXPECT_EQ(coro::wait(client.load(o2[1])), "str17-800-600-str13");
+  EXPECT_EQ(coro::wait(client.load(o2[2])), "str17-800-700-str14");
+
+  auto o3 = coro::wait(
+    client.exec(
+      s_test5,
+      std::make_tuple(str17, int1),
+      std::vector<std::tuple<Ref<int>, Ref<std::string>>>{
+        std::make_tuple(int5, str12),
+        std::make_tuple(int6, str13),
+        std::make_tuple(int7, str14)
+      }
+    )
+  );
+  ASSERT_EQ(o3.size(), 3);
+  EXPECT_TRUE(o3[0].fromFallback());
+  EXPECT_TRUE(o3[1].fromFallback());
+  EXPECT_TRUE(o3[2].fromFallback());
+
+  EXPECT_EQ(coro::wait(client.load(o3[0])), "str17-100-500-str12");
+  EXPECT_EQ(coro::wait(client.load(o3[1])), "str17-100-600-str13");
+  EXPECT_EQ(coro::wait(client.load(o3[2])), "str17-100-700-str14");
+
+  auto o4 = coro::wait(
+    client.exec(
+      s_test5,
+      std::make_tuple(str17, int8),
+      std::vector<std::tuple<Ref<int>, Ref<std::string>>>{
+        std::make_tuple(int5, str12),
+        std::make_tuple(int6, str3),
+        std::make_tuple(int7, str14)
+      }
+    )
+  );
+  ASSERT_EQ(o4.size(), 3);
+  EXPECT_TRUE(o4[0].fromFallback());
+  EXPECT_TRUE(o4[1].fromFallback());
+  EXPECT_TRUE(o4[2].fromFallback());
+
+  EXPECT_EQ(coro::wait(client.load(o4[0])), "str17-800-500-str12");
+  EXPECT_EQ(coro::wait(client.load(o4[1])), "str17-800-600-str3");
+  EXPECT_EQ(coro::wait(client.load(o4[2])), "str17-800-700-str14");
+
+  auto o5 = coro::wait(
+    client.exec(
+      s_test7, std::make_tuple(),
+      std::vector<std::tuple<Optional<Ref<int>>>>{
+        std::make_tuple(int7),
+        std::make_tuple(int8),
+        std::make_tuple(int2)
+      }
+    )
+  );
+  ASSERT_EQ(o5.size(), 3);
+  ASSERT_TRUE(o5[0].has_value());
+  ASSERT_TRUE(o5[1].has_value());
+  ASSERT_TRUE(o5[2].has_value());
+
+  EXPECT_TRUE(o5[0]->fromFallback());
+  EXPECT_TRUE(o5[1]->fromFallback());
+  EXPECT_TRUE(o5[2]->fromFallback());
+
+  EXPECT_EQ(coro::wait(client.load(*o5[0])), "700");
+  EXPECT_EQ(coro::wait(client.load(*o5[1])), "800");
+  EXPECT_EQ(coro::wait(client.load(*o5[2])), "200");
+
+  auto o6 = coro::wait(
+    client.exec(
+      s_test7, std::make_tuple(),
+      std::vector<std::tuple<Optional<Ref<int>>>>{
+        std::make_tuple(int7),
+        std::make_tuple(int8),
+        std::make_tuple(int6)
+      }
+    )
+  );
+  ASSERT_EQ(o6.size(), 3);
+  ASSERT_TRUE(o6[0].has_value());
+  ASSERT_TRUE(o6[1].has_value());
+  ASSERT_TRUE(o6[2].has_value());
+
+  EXPECT_FALSE(o6[0]->fromFallback());
+  EXPECT_FALSE(o6[1]->fromFallback());
+  EXPECT_FALSE(o6[2]->fromFallback());
+
+  EXPECT_EQ(coro::wait(client.load(*o6[0])), "700");
+  EXPECT_EQ(coro::wait(client.load(*o6[1])), "800");
+  EXPECT_EQ(coro::wait(client.load(*o6[2])), "600");
+
+  auto o7 = coro::wait(
+    client.exec(
+      s_test8, std::make_tuple(),
+      std::vector<std::tuple<std::vector<Ref<int>>>>{
+        std::make_tuple(std::vector<Ref<int>>{ int5, int6 }),
+        std::make_tuple(std::vector<Ref<int>>{ int7, int8 }),
+        std::make_tuple(std::vector<Ref<int>>{ int9, int10 })
+      }
+    )
+  );
+  ASSERT_EQ(o7.size(), 3);
+  ASSERT_EQ(o7[0].size(), 2);
+  ASSERT_EQ(o7[1].size(), 2);
+  ASSERT_EQ(o7[2].size(), 2);
+
+  EXPECT_FALSE(o7[0][0].fromFallback());
+  EXPECT_FALSE(o7[0][1].fromFallback());
+  EXPECT_FALSE(o7[1][0].fromFallback());
+  EXPECT_FALSE(o7[1][1].fromFallback());
+  EXPECT_FALSE(o7[2][0].fromFallback());
+  EXPECT_FALSE(o7[2][1].fromFallback());
+
+  EXPECT_EQ(coro::wait(client.load(o7[0][0])), "500");
+  EXPECT_EQ(coro::wait(client.load(o7[0][1])), "600");
+  EXPECT_EQ(coro::wait(client.load(o7[1][0])), "700");
+  EXPECT_EQ(coro::wait(client.load(o7[1][1])), "800");
+  EXPECT_EQ(coro::wait(client.load(o7[2][0])), "900");
+  EXPECT_EQ(coro::wait(client.load(o7[2][1])), "1000");
+
+  auto o8 = coro::wait(
+    client.exec(
+      s_test8, std::make_tuple(),
+      std::vector<std::tuple<std::vector<Ref<int>>>>{
+        std::make_tuple(std::vector<Ref<int>>{ int5, int6 }),
+        std::make_tuple(std::vector<Ref<int>>{ int7, int8 }),
+        std::make_tuple(std::vector<Ref<int>>{ int1, int10 })
+      }
+    )
+  );
+  ASSERT_EQ(o8.size(), 3);
+  ASSERT_EQ(o8[0].size(), 2);
+  ASSERT_EQ(o8[1].size(), 2);
+  ASSERT_EQ(o8[2].size(), 2);
+
+  EXPECT_TRUE(o8[0][0].fromFallback());
+  EXPECT_TRUE(o8[0][1].fromFallback());
+  EXPECT_TRUE(o8[1][0].fromFallback());
+  EXPECT_TRUE(o8[1][1].fromFallback());
+  EXPECT_TRUE(o8[2][0].fromFallback());
+  EXPECT_TRUE(o8[2][1].fromFallback());
+
+  EXPECT_EQ(coro::wait(client.load(o8[0][0])), "500");
+  EXPECT_EQ(coro::wait(client.load(o8[0][1])), "600");
+  EXPECT_EQ(coro::wait(client.load(o8[1][0])), "700");
+  EXPECT_EQ(coro::wait(client.load(o8[1][1])), "800");
+  EXPECT_EQ(coro::wait(client.load(o8[2][0])), "100");
+  EXPECT_EQ(coro::wait(client.load(o8[2][1])), "1000");
+
+  client.forceFallback();
+
+  auto o9 = coro::wait(
+    client.exec(
+      s_test5,
+      std::make_tuple(str17, int7),
+      std::vector<std::tuple<Ref<int>, Ref<std::string>>>{
+        std::make_tuple(int8, str12),
+        std::make_tuple(int9, str13),
+        std::make_tuple(int10, str14)
+      }
+    )
+  );
+  ASSERT_EQ(o9.size(), 3);
+  EXPECT_TRUE(o9[0].fromFallback());
+  EXPECT_TRUE(o9[1].fromFallback());
+  EXPECT_TRUE(o9[2].fromFallback());
+
+  EXPECT_EQ(coro::wait(client.load(o9[0])), "str17-700-800-str12");
+  EXPECT_EQ(coro::wait(client.load(o9[1])), "str17-700-900-str13");
+  EXPECT_EQ(coro::wait(client.load(o9[2])), "str17-700-1000-str14");
+}
+
+}
+
+int main(int argc, char** argv) {
+  if (argc > 1 && !strcmp(argv[1], HPHP::extern_worker::s_option)) {
+    return HPHP::extern_worker::main(argc, argv);
+  }
+  ::testing::InitGoogleTest(&argc, argv);
+  folly::init(&argc, &argv);
+  return RUN_ALL_TESTS();
+}

--- a/hphp/util/trace.h
+++ b/hphp/util/trace.h
@@ -109,6 +109,7 @@ namespace Trace {
       TM(dispatchBB)    \
       TM(ehframe)       \
       TM(emitter)       \
+      TM(extern_worker) \
       TM(facts)         \
       TM(fixup)         \
       TM(fr)            \


### PR DESCRIPTION
Summary:
Introduce the new extern-worker framework. This is a framework which
allows you run work out of process. You "upload" data into the
framework and receive an abstract "Ref" to the data. You can then
invoke various "jobs" with those Refs as inputs,and receive more Refs
as outputs. This lets you pipe data from one job to the next without
needing to have it be present locally.

It supports different "implementations" which can store the data and
execute the jobs different ways. The implementation which is always
available stores data on disk and uses fork+exec to execute the
jobs. Most of the framework is agnostic to the implementation, keeping
the logic an implementation needs to implement to a minimum.

For extra reliability, the framework supports "fallbacks". Depending
on configuration, if executing a job using the normal implementation
fails, we can retry the job using the "fallback" implementation, which
is always the fork+exec implementation. This (might be) slower, but is
considered more reliable, and is designed to prevent spurious failures
from stopping execution. This fallback is invisible to the user of the
framework.

For the most part, jobs can be written as normal functions within a
C++ class. They receive/return normal C++ types and don't have to
worry about serialization or how the data is transported around. The
only requirement is that the types must be usable with
BlobEncoder/BlobDecoder.

Implementations besides the builtin fork+exec one can be provided by a
creation hook. This hook can be overwritten and used to register a
creation function. So, additional implementations can be separate from
the framework proper.

Differential Revision: D34710025

