### PR TITLE
Update first-party dependency pins to 2022.03.14.00

### DIFF
--- a/third-party/fizz/CMakeLists.txt
+++ b/third-party/fizz/CMakeLists.txt
@@ -23,9 +23,9 @@ get_target_property(JEMALLOC_INCLUDE_DIR jemalloc INTERFACE_INCLUDE_DIRECTORIES)
 SET_HHVM_THIRD_PARTY_SOURCE_ARGS(
   FIZZ_SOURCE_ARGS
   SOURCE_URL
-  "https://github.com/facebookincubator/fizz/releases/download/v2022.01.31.00/fizz-v2022.01.31.00.tar.gz"
+  "https://github.com/facebookincubator/fizz/releases/download/v2022.03.14.00/fizz-v2022.03.14.00.tar.gz"
   SOURCE_HASH
-  "SHA256=32a60e78d41ea2682ce7e5d741b964f0ea83642656e42d4fea90c0936d6d0c7d"
+  "SHA256=10fe63db9ac8ee06723d1aa95101f0f156a8db677a729170bca0bab12f1cc279"
 )
 
 set(

--- a/third-party/folly/CMakeLists.txt
+++ b/third-party/folly/CMakeLists.txt
@@ -4,9 +4,9 @@ include(HPHPFunctions)
 SET_HHVM_THIRD_PARTY_SOURCE_ARGS(
   FOLLY_SOURCE_ARGS
   SOURCE_URL
-  "https://github.com/facebook/folly/releases/download/v2022.01.31.00/folly-v2022.01.31.00.tar.gz"
+  "https://github.com/facebook/folly/releases/download/v2022.03.14.00/folly-v2022.03.14.00.tar.gz"
   SOURCE_HASH
-  "SHA256=7b8d5dd2eb51757858247af0ad27af2e3e93823f84033a628722b01e06cd68a9"
+  "SHA256=dfa2bf72ef166b2f52a5d5ef6b0e728d3658aff090fb273c7f4fed5541c3e54a"
 )
 
 get_target_property(BOOST_INCLUDE_DIR boost INTERFACE_INCLUDE_DIRECTORIES)

--- a/third-party/mcrouter/CMakeLists.txt
+++ b/third-party/mcrouter/CMakeLists.txt
@@ -5,8 +5,8 @@ include(HPHPFunctions)
 
 SET_HHVM_THIRD_PARTY_SOURCE_ARGS(
   MCROUTER_DOWNLOAD_ARGS
-  SOURCE_URL "https://github.com/facebook/mcrouter/archive/refs/tags/v2022.01.31.00.tar.gz"
-  SOURCE_HASH "SHA256=478b8d0b88bdca7c65863764b50dc46f92d849c39f8b34ecc657884106c9b4e6"
+  SOURCE_URL "https://github.com/facebook/mcrouter/archive/refs/tags/v2022.03.14.00.tar.gz"
+  SOURCE_HASH "SHA256=f5e74e03c3523947eae64d2536898910438d611d91ac7494472b80469a1bec77"
   # The tarball name is just the tag name, which can conflict in the cache
   FILENAME_PREFIX "mcrouter-"
 )

--- a/third-party/proxygen/CMakeLists.txt
+++ b/third-party/proxygen/CMakeLists.txt
@@ -19,9 +19,9 @@ get_target_property(JEMALLOC_INCLUDE_DIR jemalloc INTERFACE_INCLUDE_DIRECTORIES)
 SET_HHVM_THIRD_PARTY_SOURCE_ARGS(
   PROXYGEN_SOURCE_ARGS
   SOURCE_URL
-  "https://github.com/facebook/proxygen/releases/download/v2022.01.31.00/proxygen-v2022.01.31.00.tar.gz"
+  "https://github.com/facebook/proxygen/releases/download/v2022.03.14.00/proxygen-v2022.03.14.00.tar.gz"
   SOURCE_HASH
-  "SHA256=5360a8ccdfb2f5a6c7b3eed331ec7ab0e2c792d579c6fff499c85c516c11fe14"
+  "SHA256=775a7cb74b80b6a088f8fb700938f6faac18a1e853246e085c1669e7618b8adb"
 )
 
 ExternalProject_Add(

--- a/third-party/squangle/CMakeLists.txt
+++ b/third-party/squangle/CMakeLists.txt
@@ -17,9 +17,9 @@ get_target_property(re2_INCLUDE_DIR re2 INTERFACE_INCLUDE_DIRECTORIES)
 SET_HHVM_THIRD_PARTY_SOURCE_ARGS(
   SQUANGLE_SOURCE_ARGS
   SOURCE_URL
-  "https://github.com/facebook/squangle/archive/refs/tags/v2022.01.31.00.tar.gz"
+  "https://github.com/facebook/squangle/archive/refs/tags/v2022.03.14.00.tar.gz"
   SOURCE_HASH
-  "SHA256=78988eacf99d380da4c660161bcb20305e4b54369e17b1bb866c5fb188acff76"
+  "SHA256=b74e9f2f481f18d4f7ae41ab801fa7bfa36a76a7bbeda3d468fa6937436ebba1"
   FILENAME_PREFIX
   "squangle-"
 )

--- a/third-party/thrift/CMakeLists.txt
+++ b/third-party/thrift/CMakeLists.txt
@@ -21,9 +21,9 @@ find_package(BISON 3.0 REQUIRED)
 SET_HHVM_THIRD_PARTY_SOURCE_ARGS(
   THRIFT_SOURCE_ARGS
   SOURCE_URL
-  "https://github.com/facebook/fbthrift/archive/refs/tags/v2022.01.31.00.tar.gz"
+  "https://github.com/facebook/fbthrift/archive/refs/tags/v2022.03.14.00.tar.gz"
   SOURCE_HASH
-  "SHA256=6194127fd9e6771bd34f502a84b292278bf3a6ee7b87377afd1ae287a5572f48"
+  "SHA256=20d1efabb57678f8fe4aa3ae49c620ede5c2f154ea068a54b3c048394f9a691e"
   FILENAME_PREFIX
   "fbthrift-"
 )

--- a/third-party/wangle/CMakeLists.txt
+++ b/third-party/wangle/CMakeLists.txt
@@ -21,9 +21,9 @@ get_target_property(JEMALLOC_INCLUDE_DIR jemalloc INTERFACE_INCLUDE_DIRECTORIES)
 SET_HHVM_THIRD_PARTY_SOURCE_ARGS(
   WANGLE_SOURCE_ARGS
   SOURCE_URL
-  "https://github.com/facebook/wangle/releases/download/v2022.01.31.00/wangle-v2022.01.31.00.tar.gz"
+  "https://github.com/facebook/wangle/releases/download/v2022.03.14.00/wangle-v2022.03.14.00.tar.gz"
   SOURCE_HASH
-  "SHA256=1002e9c32b6f4837f6a760016e3b3e22f3509880ef3eaad191c80dc92655f23f"
+  "SHA256=3586bcd5132c9eb7b7656b7de7164ffbe4d8fd24877cdf5101450758b9a2b4a0"
 )
 
 ExternalProject_Add(

--- a/third-party/watchman/CMakeLists.txt
+++ b/third-party/watchman/CMakeLists.txt
@@ -5,8 +5,8 @@ include(HPHPFunctions)
 
 SET_HHVM_THIRD_PARTY_SOURCE_ARGS(
   WATCHMAN_DOWNLOAD_ARGS
-  SOURCE_URL "https://github.com/facebook/watchman/archive/refs/tags/v2022.01.31.00.tar.gz"
-  SOURCE_HASH "SHA256=5a253c289141d19b8c6fb05e4d12a75343c62d236f98dbbf6af4a50dc0550d90"
+  SOURCE_URL "https://github.com/facebook/watchman/archive/refs/tags/v2022.03.14.00.tar.gz"
+  SOURCE_HASH "SHA256=baa98fb0963f42140d4f5735b694284b4c0a23f35bd41412289f3df4e3bd4391"
   # The tarball name is just the tag name, which can conflict in the cache
   FILENAME_PREFIX "watchman-"
 )


### PR DESCRIPTION
The CMakeLists.txt files are updated by the following command

```
cd third-party && ./update-first-party.sh 2022.01.31.00 2022.03.14.00
```