### PR TITLE
Make update-first-party.sh be compatible with macOS

### DIFF
--- a/third-party/update-first-party.sh
+++ b/third-party/update-first-party.sh
@@ -12,9 +12,9 @@ if [ -z "$1" ] || [ -z "$2" ]; then
   exit 0
 fi
 
-sed -i "s/$OLD/$NEW/g" -- */CMakeLists.txt
+sed -i.orig -e "s/$OLD/$NEW/g" -- */CMakeLists.txt
 
-grep --only-matching -P  "https://github.com/.+$NEW.+\.gz" -- */CMakeLists.txt | \
+egrep --only-matching "https://github.com/.+$NEW.+\.gz" -- */CMakeLists.txt | \
 while read -r MATCH; do
   CMAKE_FILE="${MATCH%%:*}"
   URL="${MATCH#*:}"


### PR DESCRIPTION
- The `-i` flag in `sed` on macOS requires an extension.
- The `-P` flag is not supported in `grep` on macOS, use `egrep`.

Test Plan:
```
./update-first-party.sh 2022.01.31.00 2022.03.14.00
```