### PR TITLE
Expand the accessibility level of protected to super classes

### DIFF
--- a/hphp/hack/src/server/serverHover.ml
+++ b/hphp/hack/src/server/serverHover.ml
@@ -353,7 +353,7 @@ let keyword_info (khi : SymbolOccurrence.keyword_with_hover_docs) : string =
     "A `public` method or property has no restrictions on access. It can be accessed from any part of the codebase."
     ^ "\n\nSee also `protected` and `private`."
   | SymbolOccurrence.Protected ->
-    "A `protected` method or property can only be accessed from methods defined on the current class, or methods on subclasses."
+    "A `protected` method or property can only be accessed from methods defined on the current class, or methods on subclasses, or methods on super classes that declare a method with the same name."
     ^ "\n\nIf the current class `use`s a trait, the trait methods can also access `protected` methods and properties."
     ^ "\n\nSee also `public` and `private`."
   | SymbolOccurrence.Private ->

--- a/hphp/hack/src/server/serverHover.ml
+++ b/hphp/hack/src/server/serverHover.ml
@@ -353,7 +353,7 @@ let keyword_info (khi : SymbolOccurrence.keyword_with_hover_docs) : string =
     "A `public` method or property has no restrictions on access. It can be accessed from any part of the codebase."
     ^ "\n\nSee also `protected` and `private`."
   | SymbolOccurrence.Protected ->
-    "A `protected` method or property can only be accessed from methods defined on the current class, or methods on subclasses, or methods on super classes that declare a method with the same name."
+    "A `protected` method or property can only be accessed from methods defined on the current class, or methods on subclasses, or methods on superclasses that declare a method with the same name."
     ^ "\n\nIf the current class `use`s a trait, the trait methods can also access `protected` methods and properties."
     ^ "\n\nSee also `public` and `private`."
   | SymbolOccurrence.Private ->

--- a/hphp/hack/test/hover/visibility_protected.php.exp
+++ b/hphp/hack/test/hover/visibility_protected.php.exp
@@ -1,5 +1,5 @@
 protected
-A `protected` method or property can only be accessed from methods defined on the current class, or methods on subclasses.
+A `protected` method or property can only be accessed from methods defined on the current class, or methods on subclasses, or methods on superclasses that declare a method with the same name.
 
 If the current class `use`s a trait, the trait methods can also access `protected` methods and properties.
 


### PR DESCRIPTION
Super classes can call protected methods of sub classes
if the method is an override of a method in the super class.

```HACK
class A {
  public function example(A $can_be_b): void {
    $can_be_b->protec();
  }
  protected function protec(): void {}
}

class B extends A {
  <<__Override>>
  protected function protec(): void {
    echo 'I was called from ' . static::class;
  }
}
```