### PR TITLE
[security][CVE-2022-27809] Builtins should always take int64_t, not int

### DIFF
--- a/hphp/runtime/base/array-init.h
+++ b/hphp/runtime/base/array-init.h
@@ -146,8 +146,9 @@ protected:
    * Only used by the constructors of derived classes.
    */
   ArrayInitBase(size_t n, CheckAllocation)
+    : m_arr{nullptr}
 #ifndef NDEBUG
-    : m_addCount(0)
+    , m_addCount(0)
     , m_expectedCount(n)
 #endif
   {}

--- a/hphp/runtime/ext/array/ext_array.cpp
+++ b/hphp/runtime/ext/array/ext_array.cpp
@@ -129,7 +129,7 @@ TypedValue HHVM_FUNCTION(array_change_key_case,
 
 TypedValue HHVM_FUNCTION(array_chunk,
                          const Variant& input,
-                         int chunkSize,
+                         int64_t chunkSize,
                          bool preserve_keys /* = false */) {
   const auto& cellInput = *input.asTypedValue();
   if (UNLIKELY(!isClsMethCompactContainer(cellInput))) {
@@ -139,7 +139,7 @@ TypedValue HHVM_FUNCTION(array_chunk,
   }
 
   if (chunkSize < 1) {
-    raise_invalid_argument_warning("size: %d", chunkSize);
+    raise_invalid_argument_warning("size: %ld", chunkSize);
     return make_tv<KindOfNull>();
   }
 
@@ -332,8 +332,8 @@ Array HHVM_FUNCTION(array_fill_keys,
 }
 
 TypedValue HHVM_FUNCTION(array_fill,
-                         int start_index,
-                         int num,
+                         int64_t start_index,
+                         int64_t num,
                          const Variant& value) {
   if (num < 0) {
     raise_invalid_argument_warning("Number of elements can't be negative");
@@ -351,7 +351,7 @@ TypedValue HHVM_FUNCTION(array_fill,
   } else {
     DictInit ret(num, CheckAllocation{});
     ret.set(start_index, value);
-    auto const base = std::max(start_index + 1, 0);
+    auto const base = std::max<int64_t>(start_index + 1, 0);
     for (auto i = 1; i < num; i++) {
       ret.set(base + i - 1, value);
     }
@@ -721,7 +721,7 @@ TypedValue HHVM_FUNCTION(array_replace_recursive,
 
 TypedValue HHVM_FUNCTION(array_pad,
                          const Variant& input,
-                         int pad_size,
+                         int64_t pad_size,
                          const Variant& pad_value) {
   getCheckedArray(input);
   auto arr = arr_input.isKeyset() ? arr_input.toDict() : arr_input;
@@ -890,7 +890,7 @@ TypedValue HHVM_FUNCTION(array_push,
 
 TypedValue HHVM_FUNCTION(array_rand,
                          const Variant& input,
-                         int num_req /* = 1 */) {
+                         int64_t num_req /* = 1 */) {
   getCheckedArray(input);
   return tvReturn(ArrayUtil::RandomKeys(arr_input, num_req));
 }
@@ -1011,7 +1011,7 @@ TypedValue HHVM_FUNCTION(array_slice,
   return tvReturn(std::move(ret));
 }
 
-Variant array_splice(Variant& input, int offset,
+Variant array_splice(Variant& input, int64_t offset,
                      const Variant& length, const Variant& replacement) {
   getCheckedArrayVariant(input);
   Array ret = Array::CreateDict();
@@ -1022,7 +1022,7 @@ Variant array_splice(Variant& input, int offset,
 
 TypedValue HHVM_FUNCTION(array_splice,
                          Variant& input,
-                         int offset,
+                         int64_t offset,
                          const Variant& length,
                          const Variant& replacement) {
   return tvReturn(array_splice(input, offset, length, replacement));
@@ -2604,42 +2604,42 @@ php_ksort(Variant& container, int sort_flags, bool ascending) {
 
 bool HHVM_FUNCTION(sort,
                   Variant& array,
-                  int sort_flags /* = 0 */) {
+                  int64_t sort_flags /* = 0 */) {
   if (checkIsClsMethAndRaise( __FUNCTION__+2, array)) return false;
   return php_sort(array, sort_flags, true);
 }
 
 bool HHVM_FUNCTION(rsort,
                    Variant& array,
-                   int sort_flags /* = 0 */) {
+                   int64_t sort_flags /* = 0 */) {
   if (checkIsClsMethAndRaise( __FUNCTION__+2, array)) return false;
   return php_sort(array, sort_flags, false);
 }
 
 bool HHVM_FUNCTION(asort,
                    Variant& array,
-                   int sort_flags /* = 0 */) {
+                   int64_t sort_flags /* = 0 */) {
   if (checkIsClsMethAndRaise( __FUNCTION__+2, array)) return false;
   return php_asort(array, sort_flags, true);
 }
 
 bool HHVM_FUNCTION(arsort,
                    Variant& array,
-                   int sort_flags /* = 0 */) {
+                   int64_t sort_flags /* = 0 */) {
   if (checkIsClsMethAndRaise( __FUNCTION__+2, array)) return false;
   return php_asort(array, sort_flags, false);
 }
 
 bool HHVM_FUNCTION(ksort,
                    Variant& array,
-                   int sort_flags /* = 0 */) {
+                   int64_t sort_flags /* = 0 */) {
   if (checkIsClsMethAndRaise( __FUNCTION__+2, array)) return false;
   return php_ksort(array, sort_flags, true);
 }
 
 bool HHVM_FUNCTION(krsort,
                    Variant& array,
-                   int sort_flags /* = 0 */) {
+                   int64_t sort_flags /* = 0 */) {
   if (checkIsClsMethAndRaise( __FUNCTION__+2, array)) return false;
   return php_ksort(array, sort_flags, false);
 }
@@ -2739,7 +2739,7 @@ bool HHVM_FUNCTION(uksort,
 
 TypedValue HHVM_FUNCTION(array_unique,
                          const Variant& array,
-                         int sort_flags /* = 2 */) {
+                         int64_t sort_flags /* = 2 */) {
   getCheckedArray(array);
   switch (sort_flags) {
   case SORT_STRING:

--- a/hphp/runtime/ext/array/ext_array.h
+++ b/hphp/runtime/ext/array/ext_array.h
@@ -27,7 +27,7 @@ namespace HPHP {
 
 TypedValue HHVM_FUNCTION(array_chunk,
                          const Variant& input,
-                         int size,
+                         int64_t size,
                          bool preserve_keys = false);
 TypedValue HHVM_FUNCTION(array_combine,
                          const Variant& keys,
@@ -36,8 +36,8 @@ Array HHVM_FUNCTION(array_fill_keys,
                     const Variant& keys,
                     const Variant& value);
 TypedValue HHVM_FUNCTION(array_fill,
-                         int start_index,
-                         int num,
+                         int64_t start_index,
+                         int64_t num,
                          const Variant& value);
 TypedValue HHVM_FUNCTION(array_flip,
                          const Variant& trans);
@@ -63,7 +63,7 @@ TypedValue HHVM_FUNCTION(array_replace,
                          const Array& args = null_array);
 TypedValue HHVM_FUNCTION(array_pad,
                          const Variant& input,
-                         int pad_size,
+                         int64_t pad_size,
                          const Variant& pad_value);
 TypedValue HHVM_FUNCTION(array_product,
                          const Variant& array);
@@ -73,7 +73,7 @@ TypedValue HHVM_FUNCTION(array_push,
                          const Array& args = null_array);
 TypedValue HHVM_FUNCTION(array_rand,
                          const Variant& input,
-                         int num_req = 1);
+                         int64_t num_req = 1);
 TypedValue HHVM_FUNCTION(array_search,
                          const Variant& needle,
                          const Variant& haystack,
@@ -82,14 +82,14 @@ TypedValue HHVM_FUNCTION(array_shift,
                          Variant& array);
 TypedValue HHVM_FUNCTION(array_splice,
                          Variant& input,
-                         int offset,
+                         int64_t offset,
                          const Variant& length = uninit_variant,
                          const Variant& replacement = uninit_variant);
 TypedValue HHVM_FUNCTION(array_sum,
                          const Variant& array);
 TypedValue HHVM_FUNCTION(array_unique,
                          const Variant& array,
-                         int sort_flags = 2);
+                         int64_t sort_flags = 2);
 TypedValue HHVM_FUNCTION(array_unshift,
                          Variant& array,
                          const Variant& var,
@@ -189,22 +189,22 @@ TypedValue HHVM_FUNCTION(array_intersect_ukey,
                          const Array& args = null_array);
 bool HHVM_FUNCTION(sort,
                    Variant& array,
-                   int sort_flags = 0);
+                   int64_t sort_flags = 0);
 bool HHVM_FUNCTION(rsort,
                    Variant& array,
-                   int sort_flags = 0);
+                   int64_t sort_flags = 0);
 bool HHVM_FUNCTION(asort,
                    Variant& array,
-                   int sort_flags = 0);
+                   int64_t sort_flags = 0);
 bool HHVM_FUNCTION(arsort,
                    Variant& array,
-                   int sort_flags = 0);
+                   int64_t sort_flags = 0);
 bool HHVM_FUNCTION(ksort,
                    Variant& array,
-                   int sort_flags = 0);
+                   int64_t sort_flags = 0);
 bool HHVM_FUNCTION(krsort,
                    Variant& array,
-                   int sort_flags = 0);
+                   int64_t sort_flags = 0);
 bool HHVM_FUNCTION(usort,
                    Variant& array,
                    const Variant& cmp_function);

--- a/hphp/runtime/ext/asio/ext_asio.cpp
+++ b/hphp/runtime/ext/asio/ext_asio.cpp
@@ -64,7 +64,7 @@ int64_t HHVM_FUNCTION(asio_get_current_context_idx) {
   return AsioSession::Get()->getCurrentContextIdx();
 }
 
-Object HHVM_FUNCTION(asio_get_running_in_context, int ctx_idx) {
+Object HHVM_FUNCTION(asio_get_running_in_context, int64_t ctx_idx) {
   auto session = AsioSession::Get();
 
   if (ctx_idx <= 0) {

--- a/hphp/runtime/ext/async_mysql/ext_async_mysql.cpp
+++ b/hphp/runtime/ext/async_mysql/ext_async_mysql.cpp
@@ -423,7 +423,7 @@ HHVM_METHOD(AsyncMysqlConnectionOptions, setConnectTcpTimeout, int64_t timeout) 
 }
 
 static void
-HHVM_METHOD(AsyncMysqlConnectionOptions, setConnectAttempts, int32_t attempts) {
+HHVM_METHOD(AsyncMysqlConnectionOptions, setConnectAttempts, int64_t attempts) {
   auto* data = Native::data<AsyncMysqlConnectionOptions>(this_);
   data->m_conn_opts.setConnectAttempts(attempts);
 }
@@ -668,7 +668,7 @@ Object HHVM_STATIC_METHOD(
     AsyncMysqlClient,
     connect,
     const String& host,
-    int port,
+    int64_t port,
     const String& dbname,
     const String& user,
     const String& password,
@@ -720,7 +720,7 @@ Object HHVM_STATIC_METHOD(
     AsyncMysqlClient,
     connectWithOpts,
     const String& host,
-    int port,
+    int64_t port,
     const String& dbname,
     const String& user,
     const String& password,
@@ -745,7 +745,7 @@ Object HHVM_STATIC_METHOD(
     connectAndQuery,
     const Variant& queries,
     const String& host,
-    int port,
+    int64_t port,
     const String& dbname,
     const String& user,
     const String& password,
@@ -877,7 +877,7 @@ static Object HHVM_METHOD(
     AsyncMysqlConnectionPool,
     connect,
     const String& host,
-    int port,
+    int64_t port,
     const String& dbname,
     const String& user,
     const String& password,
@@ -931,7 +931,7 @@ static Object HHVM_METHOD(
     AsyncMysqlConnectionPool,
     connectWithOpts,
     const String& host,
-    int port,
+    int64_t port,
     const String& dbname,
     const String& user,
     const String& password,
@@ -959,7 +959,7 @@ static Object HHVM_METHOD(
     connectAndQuery,
     const Variant& queries,
     const String& host,
-    int port,
+    int64_t port,
     const String& dbname,
     const String& user,
     const String& password,
@@ -1229,7 +1229,7 @@ static bool HHVM_METHOD(AsyncMysqlConnection, isSSL) {
   return data->m_conn->isSSL();
 }
 
-static int HHVM_METHOD(AsyncMysqlConnection, warningCount) {
+static int64_t HHVM_METHOD(AsyncMysqlConnection, warningCount) {
   auto* data = Native::data<AsyncMysqlConnection>(this_);
 
   int count = 0;
@@ -1246,7 +1246,7 @@ static String HHVM_METHOD(AsyncMysqlConnection, host) {
   return data->m_host;
 }
 
-static int HHVM_METHOD(AsyncMysqlConnection, port) {
+static int64_t HHVM_METHOD(AsyncMysqlConnection, port) {
   auto* data = Native::data<AsyncMysqlConnection>(this_);
   return data->m_port;
 }
@@ -1519,7 +1519,7 @@ Object AsyncMysqlErrorResult::newInstance(std::shared_ptr<am::Operation> op,
 
 EXTENDS_ASYNC_MYSQL_RESULT(AsyncMysqlErrorResult)
 
-static int HHVM_METHOD(AsyncMysqlErrorResult, mysql_errno) {
+static int64_t HHVM_METHOD(AsyncMysqlErrorResult, mysql_errno) {
   auto* data = Native::data<AsyncMysqlErrorResult>(this_);
   return data->m_op->mysql_errno();
 }
@@ -1575,7 +1575,7 @@ void AsyncMysqlQueryErrorResult::create(std::shared_ptr<am::Operation> op,
   m_query_results = results;
 }
 
-static int HHVM_METHOD(AsyncMysqlQueryErrorResult, numSuccessfulQueries) {
+static int64_t HHVM_METHOD(AsyncMysqlQueryErrorResult, numSuccessfulQueries) {
   auto* data = Native::data<AsyncMysqlQueryErrorResult>(this_);
   return std::dynamic_pointer_cast<am::FetchOperation>(data->m_parent.m_op)
       ->numQueriesExecuted();

--- a/hphp/runtime/ext/bz2/ext_bz2.cpp
+++ b/hphp/runtime/ext/bz2/ext_bz2.cpp
@@ -79,12 +79,12 @@ bool HHVM_FUNCTION(bzclose, const Resource& bz) {
   return HHVM_FN(fclose)(bz);
 }
 
-Variant HHVM_FUNCTION(bzread, const Resource& bz, int length /* = 1024 */) {
+Variant HHVM_FUNCTION(bzread, const Resource& bz, int64_t length /* = 1024 */) {
   return HHVM_FN(fread)(bz, length);
 }
 
 Variant HHVM_FUNCTION(bzwrite, const Resource& bz, const String& data,
-                               int length /* = 0 */) {
+                               int64_t length /* = 0 */) {
   return HHVM_FN(fwrite)(bz, data, length);
 }
 
@@ -176,8 +176,8 @@ Variant HHVM_FUNCTION(bzerrno, const Resource& bz) {
   return f->errnu();
 }
 
-Variant HHVM_FUNCTION(bzcompress, const String& source, int blocksize /* = 4 */,
-                                  int workfactor /* = 0 */) {
+Variant HHVM_FUNCTION(bzcompress, const String& source, int64_t blocksize /* = 4 */,
+                                  int64_t workfactor /* = 0 */) {
   unsigned int source_len, dest_len;
 
   source_len = source.length();
@@ -197,7 +197,7 @@ Variant HHVM_FUNCTION(bzcompress, const String& source, int blocksize /* = 4 */,
   }
 }
 
-Variant HHVM_FUNCTION(bzdecompress, const String& source, int small /* = 0 */) {
+Variant HHVM_FUNCTION(bzdecompress, const String& source, int64_t small /* = 0 */) {
   int source_len = source.length();
   int error;
   uint64_t size = 0;

--- a/hphp/runtime/ext/curl/ext_curl.cpp
+++ b/hphp/runtime/ext/curl/ext_curl.cpp
@@ -88,7 +88,7 @@ const StaticString
   s_libz_version("libz_version"),
   s_protocols("protocols");
 
-Variant HHVM_FUNCTION(curl_version, int uversion /* = CURLVERSION_NOW */) {
+Variant HHVM_FUNCTION(curl_version, int64_t uversion /* = CURLVERSION_NOW */) {
   curl_version_info_data *d = curl_version_info((CURLversion)uversion);
   if (d == nullptr) {
     return false;
@@ -114,7 +114,7 @@ Variant HHVM_FUNCTION(curl_version, int uversion /* = CURLVERSION_NOW */) {
   return ret.toVariant();
 }
 
-bool HHVM_FUNCTION(curl_setopt, const Resource& ch, int option, const Variant& value) {
+bool HHVM_FUNCTION(curl_setopt, const Resource& ch, int64_t option, const Variant& value) {
   CHECK_RESOURCE(curl);
   return curl->setOption(option, value);
 }
@@ -195,7 +195,7 @@ const StaticString
   s_certinfo("certinfo"),
   s_request_header("request_header");
 
-Variant HHVM_FUNCTION(curl_getinfo, const Resource& ch, int opt /* = 0 */) {
+Variant HHVM_FUNCTION(curl_getinfo, const Resource& ch, int64_t opt /* = 0 */) {
   CHECK_RESOURCE(curl);
   CURL *cp = curl->get();
 
@@ -391,7 +391,7 @@ Variant HHVM_FUNCTION(curl_error, const Resource& ch) {
   return curl->getErrorString();
 }
 
-String HHVM_FUNCTION(curl_strerror, int code) {
+String HHVM_FUNCTION(curl_strerror, int64_t code) {
   return curl_easy_strerror((CURLcode)code);
 }
 
@@ -484,7 +484,7 @@ Variant HHVM_FUNCTION(curl_multi_exec, const Resource& mh,
 }
 
 bool HHVM_FUNCTION(curl_multi_setopt, const Resource& mh,
-                   int option, const Variant& value) {
+                   int64_t option, const Variant& value) {
   CHECK_MULTI_RESOURCE_THROW(curlm);
   return curlm->setOption(option, value);
 }
@@ -647,7 +647,7 @@ void HHVM_FUNCTION(curl_share_close, const Resource& sh) {
 }
 
 bool HHVM_FUNCTION(curl_share_setopt, const Resource& sh,
-                   int option, const Variant& value) {
+                   int64_t option, const Variant& value) {
   auto curlsh = dyn_cast_or_null<CurlShareResource>(sh);
   if (!curlsh || curlsh->isInvalid())
     SystemLib::throwExceptionObject(CURL_SHARE_Warning);

--- a/hphp/runtime/ext/curl/ext_curl.h
+++ b/hphp/runtime/ext/curl/ext_curl.h
@@ -30,15 +30,15 @@ namespace HPHP {
 ///////////////////////////////////////////////////////////////////////////////
 
 Variant HHVM_FUNCTION(curl_init, const Variant& url = null_string);
-Variant HHVM_FUNCTION(curl_version, int uversion = CURLVERSION_NOW);
-bool HHVM_FUNCTION(curl_setopt, const Resource& ch, int option, const Variant& value);
+Variant HHVM_FUNCTION(curl_version, int64_t uversion = CURLVERSION_NOW);
+bool HHVM_FUNCTION(curl_setopt, const Resource& ch, int64_t option, const Variant& value);
 bool HHVM_FUNCTION(curl_setopt_array, const Resource& ch, const Array& options);
 Variant HHVM_FUNCTION(fb_curl_getopt, const Resource& ch, int64_t opt = 0);
 Variant HHVM_FUNCTION(curl_exec, const Resource& ch);
-Variant HHVM_FUNCTION(curl_getinfo, const Resource& ch, int opt = 0);
+Variant HHVM_FUNCTION(curl_getinfo, const Resource& ch, int64_t opt = 0);
 Variant HHVM_FUNCTION(curl_errno, const Resource& ch);
 Variant HHVM_FUNCTION(curl_error, const Resource& ch);
-String HHVM_FUNCTION(curl_strerror, int code);
+String HHVM_FUNCTION(curl_strerror, int64_t code);
 Variant HHVM_FUNCTION(curl_close, const Resource& ch);
 void HHVM_FUNCTION(curl_reset, const Resource& ch);
 Resource HHVM_FUNCTION(curl_multi_init);
@@ -57,14 +57,13 @@ Variant HHVM_FUNCTION(curl_multi_info_read, const Resource& mh,
                                int64_t& msgs_in_queue);
 Variant HHVM_FUNCTION(curl_multi_close, const Resource& mh);
 bool HHVM_FUNCTION(curl_multi_setopt, const Resource& mh,
-                              int option,
+                              int64_t option,
                               const Variant& value);
 Resource HHVM_FUNCTION(curl_share_init);
 void HHVM_FUNCTION(curl_share_close, const Resource& sh);
 bool HHVM_FUNCTION(curl_share_setopt, const Resource& sh,
-                    int option,
+                    int64_t option,
                     const Variant& value);
 
 ///////////////////////////////////////////////////////////////////////////////
 }
-

--- a/hphp/runtime/ext/datetime/ext_datetime.cpp
+++ b/hphp/runtime/ext/datetime/ext_datetime.cpp
@@ -806,8 +806,8 @@ bool HHVM_FUNCTION(date_default_timezone_set,
 
 Variant HHVM_FUNCTION(timezone_name_from_abbr,
                       const String& abbr,
-                      int gmtoffset /* = -1 */,
-                      int isdst /* = 1 */) {
+                      int64_t gmtoffset /* = -1 */,
+                      int64_t isdst /* = 1 */) {
   String ret = TimeZone::AbbreviationToName(abbr, gmtoffset, isdst);
   if (ret.isNull()) {
     return false;
@@ -823,9 +823,9 @@ String HHVM_FUNCTION(timezone_version_get) {
 // datetime
 
 bool HHVM_FUNCTION(checkdate,
-                   int month,
-                   int day,
-                   int year) {
+                   int64_t month,
+                   int64_t day,
+                   int64_t year) {
   return DateTime::IsValid(year, month, day);
 }
 

--- a/hphp/runtime/ext/datetime/ext_datetime.h
+++ b/hphp/runtime/ext/datetime/ext_datetime.h
@@ -224,17 +224,17 @@ bool HHVM_FUNCTION(date_default_timezone_set,
                    const String& name);
 Variant HHVM_FUNCTION(timezone_name_from_abbr,
                       const String& abbr,
-                      int gmtoffset = -1,
-                      int isdst = 1);
+                      int64_t gmtoffset = -1,
+                      int64_t isdst = 1);
 String HHVM_FUNCTION(timezone_version_get);
 
 ///////////////////////////////////////////////////////////////////////////////
 // datetime
 
 bool HHVM_FUNCTION(checkdate,
-                   int month,
-                   int day,
-                   int year);
+                   int64_t month,
+                   int64_t day,
+                   int64_t year);
 Variant HHVM_FUNCTION(date_create,
                       const Variant& time = uninit_variant,
                       const Variant& timezone = uninit_variant);
@@ -254,4 +254,3 @@ Array HHVM_FUNCTION(date_sun_info,
 
 ///////////////////////////////////////////////////////////////////////////////
 }
-

--- a/hphp/runtime/ext/hotprofiler/ext_hotprofiler.cpp
+++ b/hphp/runtime/ext/hotprofiler/ext_hotprofiler.cpp
@@ -1350,7 +1350,7 @@ IMPLEMENT_REQUEST_LOCAL(ProfilerFactory, s_profiler_factory);
 ///////////////////////////////////////////////////////////////////////////////
 // main functions
 
-void f_hotprofiler_enable(int ikind) {
+void f_hotprofiler_enable(int64_t ikind) {
   auto kind = static_cast<ProfilerKind>(ikind);
   long flags = 0;
   if (kind == ProfilerKind::Hierarchical) {
@@ -1368,7 +1368,7 @@ Variant f_hotprofiler_disable() {
   return s_profiler_factory->stop();
 }
 
-void f_phprof_enable(int flags /* = 0 */) {
+void f_phprof_enable(int64_t flags /* = 0 */) {
   if (RuntimeOption::EnableHotProfiler) {
     s_profiler_factory->start(ProfilerKind::Hierarchical, flags);
   }

--- a/hphp/runtime/ext/imagick/imagick.cpp
+++ b/hphp/runtime/ext/imagick/imagick.cpp
@@ -3770,7 +3770,7 @@ static bool HHVM_METHOD(Imagick, writeImagesFile,
 }
 
 // Countable interface
-static int HHVM_METHOD(Imagick, count) {
+static int64_t HHVM_METHOD(Imagick, count) {
   return HHVM_MN(Imagick, getNumberImages)(this_);
 }
 
@@ -3779,7 +3779,7 @@ static Object HHVM_METHOD(Imagick, current) {
   return Object{this_};
 }
 
-static int HHVM_METHOD(Imagick, key) {
+static int64_t HHVM_METHOD(Imagick, key) {
   return HHVM_MN(Imagick, getIteratorIndex)(this_);
 }
 

--- a/hphp/runtime/ext/imagick/imagickdraw.cpp
+++ b/hphp/runtime/ext/imagick/imagickdraw.cpp
@@ -198,7 +198,7 @@ static double HHVM_METHOD(ImagickDraw, getFontSize) {
   return DrawGetFontSize(wand->getWand());
 }
 
-static int HHVM_METHOD(ImagickDraw, getFontStretch) {
+static int64_t HHVM_METHOD(ImagickDraw, getFontStretch) {
   auto wand = getDrawingWandResource(Object{this_});
   return DrawGetFontStretch(wand->getWand());
 }

--- a/hphp/runtime/ext/imagick/imagickpixeliterator.cpp
+++ b/hphp/runtime/ext/imagick/imagickpixeliterator.cpp
@@ -164,7 +164,7 @@ static Array HHVM_METHOD(ImagickPixelIterator, current) {
   return HHVM_MN(ImagickPixelIterator, getCurrentIteratorRow)(this_);
 }
 
-static int HHVM_METHOD(ImagickPixelIterator, key) {
+static int64_t HHVM_METHOD(ImagickPixelIterator, key) {
   return HHVM_MN(ImagickPixelIterator, getIteratorRow)(this_);
 }
 

--- a/hphp/runtime/ext/ldap/ext_ldap.cpp
+++ b/hphp/runtime/ext/ldap/ext_ldap.cpp
@@ -739,7 +739,7 @@ static void get_attributes(Array &ret, LDAP *ldap,
 
 Variant HHVM_FUNCTION(ldap_connect,
                       const Variant& hostname /* = uninit_variant */,
-                      int port /* = 389 */) {
+                      int64_t port /* = 389 */) {
   const String& str_hostname = hostname.isNull()
                              ? null_string
                              : hostname.toString();
@@ -774,7 +774,7 @@ Variant HHVM_FUNCTION(ldap_connect,
 
 Variant HHVM_FUNCTION(ldap_explode_dn,
                       const String& dn,
-                      int with_attrib) {
+                      int64_t with_attrib) {
   char **ldap_value;
   if (!(ldap_value = ldap_explode_dn((char*)dn.data(), with_attrib))) {
     /* Invalid parameters were passed to ldap_explode_dn */
@@ -807,7 +807,7 @@ Variant HHVM_FUNCTION(ldap_dn2ufn,
 }
 
 String HHVM_FUNCTION(ldap_err2str,
-                     int errnum) {
+                     int64_t errnum) {
   return String(ldap_err2string(errnum), CopyString);
 }
 
@@ -1255,7 +1255,7 @@ bool HHVM_FUNCTION(ldap_unbind, const Resource& link) {
 
 bool HHVM_FUNCTION(ldap_get_option,
                    const Resource& link,
-                   int option,
+                   int64_t option,
                    Variant& retval) {
   auto ld = get_valid_ldap_link_resource(link);
   if (!ld) {
@@ -1349,7 +1349,7 @@ const StaticString
 
 bool HHVM_FUNCTION(ldap_set_option,
                    const Variant& link,
-                   int option,
+                   int64_t option,
                    const Variant& newval) {
   LDAP *ldap = nullptr;
   if (!link.isNull()) {
@@ -1508,10 +1508,10 @@ Variant HHVM_FUNCTION(ldap_list,
                       const Variant& base_dn,
                       const Variant& filter,
                       const Variant& attributes /* = uninit_variant */,
-                      int attrsonly /* = 0 */,
-                      int sizelimit /* = -1 */,
-                      int timelimit /* = -1 */,
-                      int deref /* = -1 */) {
+                      int64_t attrsonly /* = 0 */,
+                      int64_t sizelimit /* = -1 */,
+                      int64_t timelimit /* = -1 */,
+                      int64_t deref /* = -1 */) {
   return php_ldap_do_search(link, base_dn, filter, attributes, attrsonly,
                             sizelimit, timelimit, deref, LDAP_SCOPE_ONELEVEL);
 }
@@ -1521,10 +1521,10 @@ Variant HHVM_FUNCTION(ldap_read,
                       const Variant& base_dn,
                       const Variant& filter,
                       const Variant& attributes /* = uninit_variant */,
-                      int attrsonly /* = 0 */,
-                      int sizelimit /* = -1 */,
-                      int timelimit /* = -1 */,
-                      int deref /* = -1 */) {
+                      int64_t attrsonly /* = 0 */,
+                      int64_t sizelimit /* = -1 */,
+                      int64_t timelimit /* = -1 */,
+                      int64_t deref /* = -1 */) {
   return php_ldap_do_search(link, base_dn, filter, attributes, attrsonly,
                             sizelimit, timelimit, deref, LDAP_SCOPE_BASE);
 }
@@ -1534,10 +1534,10 @@ Variant HHVM_FUNCTION(ldap_search,
                       const Variant& base_dn,
                       const Variant& filter,
                       const Variant& attributes /* = uninit_variant */,
-                      int attrsonly /* = 0 */,
-                      int sizelimit /* = -1 */,
-                      int timelimit /* = -1 */,
-                      int deref /* = -1 */) {
+                      int64_t attrsonly /* = 0 */,
+                      int64_t sizelimit /* = -1 */,
+                      int64_t timelimit /* = -1 */,
+                      int64_t deref /* = -1 */) {
   return php_ldap_do_search(link, base_dn, filter, attributes, attrsonly,
                             sizelimit, timelimit, deref, LDAP_SCOPE_SUBTREE);
 }
@@ -1993,7 +1993,7 @@ Variant HHVM_FUNCTION(ldap_get_values,
 
 bool HHVM_FUNCTION(ldap_control_paged_result,
                    const Resource& link,
-                   int pagesize,
+                   int64_t pagesize,
                    bool iscritical,
                    const String& cookie) {
   auto ld = get_valid_ldap_link_resource(link);
@@ -2121,7 +2121,7 @@ bool HHVM_FUNCTION(ldap_control_paged_result_response,
 String HHVM_FUNCTION(ldap_escape,
                      const String& value,
                      const String& ignores /* = "" */,
-                     int flags /* = 0 */) {
+                     int64_t flags /* = 0 */) {
   char esc[256] = {};
 
   if (flags & k_LDAP_ESCAPE_FILTER) { // llvm.org/bugs/show_bug.cgi?id=18389

--- a/hphp/runtime/ext/ldap/ext_ldap.h
+++ b/hphp/runtime/ext/ldap/ext_ldap.h
@@ -24,14 +24,14 @@ namespace HPHP {
 
 Variant HHVM_FUNCTION(ldap_connect,
                       const Variant& hostname = uninit_variant,
-                      int port = 389);
+                      int64_t port = 389);
 Variant HHVM_FUNCTION(ldap_explode_dn,
                       const String& dn,
-                      int with_attrib);
+                      int64_t with_attrib);
 Variant HHVM_FUNCTION(ldap_dn2ufn,
                       const String& db);
 String HHVM_FUNCTION(ldap_err2str,
-                     int errnum);
+                     int64_t errnum);
 bool HHVM_FUNCTION(ldap_add,
                    const Resource& link,
                    const String& dn,
@@ -73,11 +73,11 @@ bool HHVM_FUNCTION(ldap_unbind,
                    const Resource& link);
 bool HHVM_FUNCTION(ldap_get_option,
                    const Resource& link,
-                   int option,
+                   int64_t option,
                    Variant& retval);
 bool HHVM_FUNCTION(ldap_set_option,
                    const Variant& link,
-                   int option,
+                   int64_t option,
                    const Variant& newval);
 bool HHVM_FUNCTION(ldap_close,
                    const Resource& link);
@@ -86,28 +86,28 @@ Variant HHVM_FUNCTION(ldap_list,
                       const Variant& base_dn,
                       const Variant& filter,
                       const Variant& attributes = uninit_variant,
-                      int attrsonly = 0,
-                      int sizelimit = -1,
-                      int timelimit = -1,
-                      int deref = -1);
+                      int64_t attrsonly = 0,
+                      int64_t sizelimit = -1,
+                      int64_t timelimit = -1,
+                      int64_t deref = -1);
 Variant HHVM_FUNCTION(ldap_read,
                       const Variant& link,
                       const Variant& base_dn,
                       const Variant& filter,
                       const Variant& attributes = uninit_variant,
-                      int attrsonly = 0,
-                      int sizelimit = -1,
-                      int timelimit = -1,
-                      int deref = -1);
+                      int64_t attrsonly = 0,
+                      int64_t sizelimit = -1,
+                      int64_t timelimit = -1,
+                      int64_t deref = -1);
 Variant HHVM_FUNCTION(ldap_search,
                       const Variant& link,
                       const Variant& base_dn,
                       const Variant& filter,
                       const Variant& attributes = uninit_variant,
-                      int attrsonly = 0,
-                      int sizelimit = -1,
-                      int timelimit = -1,
-                      int deref = -1);
+                      int64_t attrsonly = 0,
+                      int64_t sizelimit = -1,
+                      int64_t timelimit = -1,
+                      int64_t deref = -1);
 bool HHVM_FUNCTION(ldap_rename,
                    const Resource& link,
                    const String& dn,
@@ -179,7 +179,7 @@ Variant HHVM_FUNCTION(ldap_get_values,
                       const String& attribute);
 bool HHVM_FUNCTION(ldap_control_paged_result,
                    const Resource& link,
-                   int pagesize,
+                   int64_t pagesize,
                    bool iscritical = false,
                    const String& cookie = empty_string_ref);
 bool HHVM_FUNCTION(ldap_control_paged_result_response,
@@ -190,8 +190,7 @@ bool HHVM_FUNCTION(ldap_control_paged_result_response,
 String HHVM_FUNCTION(ldap_escape,
                      const String& value,
                      const String& ignores = empty_string(),
-                     int flags = 0);
+                     int64_t flags = 0);
 
 ///////////////////////////////////////////////////////////////////////////////
 }
-

--- a/hphp/runtime/ext/mbstring/ext_mbstring.cpp
+++ b/hphp/runtime/ext/mbstring/ext_mbstring.cpp
@@ -1222,7 +1222,7 @@ bool HHVM_FUNCTION(mb_check_encoding,
 
 Variant HHVM_FUNCTION(mb_convert_case,
                       const String& str,
-                      int mode,
+                      int64_t mode,
                       const Variant& opt_encoding) {
   const String encoding = convertArg(opt_encoding);
 
@@ -1653,7 +1653,7 @@ Variant HHVM_FUNCTION(mb_encode_mimeheader,
                       const Variant& opt_charset,
                       const Variant& opt_transfer_encoding,
                       const String& linefeed /* = "\r\n" */,
-                      int indent /* = 0 */) {
+                      int64_t indent /* = 0 */) {
   const String charset = convertArg(opt_charset);
   const String transfer_encoding = convertArg(opt_transfer_encoding);
 
@@ -2017,7 +2017,7 @@ Variant HHVM_FUNCTION(mb_language,
 
 String HHVM_FUNCTION(mb_output_handler,
                      const String& contents,
-                     int status) {
+                     int64_t status) {
   mbfl_string string, result;
   int last_feed;
 
@@ -2379,7 +2379,7 @@ static Variant php_mb_substr(const String& str, int from,
 
 Variant HHVM_FUNCTION(mb_substr,
                       const String& str,
-                      int start,
+                      int64_t start,
                       const Variant& length /*= uninit_null() */,
                       const Variant& opt_encoding) {
   const String encoding = convertArg(opt_encoding);
@@ -2388,7 +2388,7 @@ Variant HHVM_FUNCTION(mb_substr,
 
 Variant HHVM_FUNCTION(mb_strcut,
                       const String& str,
-                      int start,
+                      int64_t start,
                       const Variant& length /*= uninit_null() */,
                       const Variant& opt_encoding) {
   const String encoding = convertArg(opt_encoding);
@@ -2397,8 +2397,8 @@ Variant HHVM_FUNCTION(mb_strcut,
 
 Variant HHVM_FUNCTION(mb_strimwidth,
                       const String& str,
-                      int start,
-                      int width,
+                      int64_t start,
+                      int64_t width,
                       const Variant& opt_trimmarker,
                       const Variant& opt_encoding) {
   const String trimmarker = convertArg(opt_trimmarker);
@@ -2450,7 +2450,7 @@ Variant HHVM_FUNCTION(mb_strimwidth,
 Variant HHVM_FUNCTION(mb_stripos,
                       const String& haystack,
                       const String& needle,
-                      int offset /* = 0 */,
+                      int64_t offset /* = 0 */,
                       const Variant& opt_encoding) {
   const String encoding = convertArg(opt_encoding);
 
@@ -2477,7 +2477,7 @@ Variant HHVM_FUNCTION(mb_stripos,
 Variant HHVM_FUNCTION(mb_strripos,
                       const String& haystack,
                       const String& needle,
-                      int offset /* = 0 */,
+                      int64_t offset /* = 0 */,
                       const Variant& opt_encoding) {
   const String encoding = convertArg(opt_encoding);
 
@@ -2587,7 +2587,7 @@ Variant HHVM_FUNCTION(mb_strlen,
 Variant HHVM_FUNCTION(mb_strpos,
                       const String& haystack,
                       const String& needle,
-                      int offset /* = 0 */,
+                      int64_t offset /* = 0 */,
                       const Variant& opt_encoding) {
   const String encoding = convertArg(opt_encoding);
 
@@ -3687,7 +3687,7 @@ int64_t HHVM_FUNCTION(mb_ereg_search_getpos) {
 }
 
 bool HHVM_FUNCTION(mb_ereg_search_setpos,
-                   int position) {
+                   int64_t position) {
   if (position < 0 || position >= (int)MBSTRG(search_str).size()) {
     raise_warning("Position is out of range");
     MBSTRG(search_pos) = 0;
@@ -4016,7 +4016,7 @@ String HHVM_FUNCTION(mb_regex_set_options,
 Variant HHVM_FUNCTION(mb_split,
                       const String& pattern,
                       const String& str,
-                      int count /* = -1 */) {
+                      int64_t count /* = -1 */) {
   php_mb_regex_t *re;
   OnigRegion *regs = nullptr;
 

--- a/hphp/runtime/ext/mbstring/ext_mbstring.h
+++ b/hphp/runtime/ext/mbstring/ext_mbstring.h
@@ -32,7 +32,7 @@ bool HHVM_FUNCTION(mb_check_encoding,
                    const Variant& opt_encoding = uninit_variant);
 Variant HHVM_FUNCTION(mb_convert_case,
                       const String& str,
-                      int mode,
+                      int64_t mode,
                       const Variant& opt_encoding = uninit_variant);
 Variant HHVM_FUNCTION(mb_convert_encoding,
                       const String& str,
@@ -64,7 +64,7 @@ Variant HHVM_FUNCTION(mb_encode_mimeheader,
                       const Variant& opt_charset = uninit_variant,
                       const Variant& opt_transfer_encoding = uninit_variant,
                       const String& linefeed = "\r\n",
-                      int indent = 0);
+                      int64_t indent = 0);
 Variant HHVM_FUNCTION(mb_encode_numericentity,
                       const String& str,
                       const Variant& convmap,
@@ -94,7 +94,7 @@ Variant HHVM_FUNCTION(mb_ereg_search_regs,
                       const Variant& opt_pattern = uninit_variant,
                       const Variant& opt_option = uninit_variant);
 bool HHVM_FUNCTION(mb_ereg_search_setpos,
-                   int position);
+                   int64_t position);
 Variant HHVM_FUNCTION(mb_ereg_search,
                       const Variant& opt_pattern = uninit_variant,
                       const Variant& opt_option = uninit_variant);
@@ -123,7 +123,7 @@ Variant HHVM_FUNCTION(mb_language,
                       const Variant& opt_language = uninit_variant);
 String HHVM_FUNCTION(mb_output_handler,
                      const String& contents,
-                     int status);
+                     int64_t status);
 bool HHVM_FUNCTION(mb_parse_str,
                    const String& encoded_string,
                    Array& result);
@@ -142,22 +142,22 @@ bool HHVM_FUNCTION(mb_send_mail,
 Variant HHVM_FUNCTION(mb_split,
                       const String& pattern,
                       const String& str,
-                      int count = -1);
+                      int64_t count = -1);
 Variant HHVM_FUNCTION(mb_strcut,
                       const String& str,
-                      int start,
+                      int64_t start,
                       const Variant& length = uninit_null(),
                       const Variant& opt_encoding = uninit_variant);
 Variant HHVM_FUNCTION(mb_strimwidth,
                       const String& str,
-                      int start,
-                      int width,
+                      int64_t start,
+                      int64_t width,
                       const Variant& opt_trimmarker = uninit_variant,
                       const Variant& opt_encoding = uninit_variant);
 Variant HHVM_FUNCTION(mb_stripos,
                       const String& haystack,
                       const String& needle,
-                      int offset = 0,
+                      int64_t offset = 0,
                       const Variant& opt_encoding = uninit_variant);
 Variant HHVM_FUNCTION(mb_stristr,
                       const String& haystack,
@@ -170,7 +170,7 @@ Variant HHVM_FUNCTION(mb_strlen,
 Variant HHVM_FUNCTION(mb_strpos,
                       const String& haystack,
                       const String& needle,
-                      int offset = 0,
+                      int64_t offset = 0,
                       const Variant& opt_encoding = uninit_variant);
 Variant HHVM_FUNCTION(mb_strrchr,
                       const String& haystack,
@@ -185,7 +185,7 @@ Variant HHVM_FUNCTION(mb_strrichr,
 Variant HHVM_FUNCTION(mb_strripos,
                       const String& haystack,
                       const String& needle,
-                      int offset = 0,
+                      int64_t offset = 0,
                       const Variant& opt_encoding = uninit_variant);
 Variant HHVM_FUNCTION(mb_strrpos,
                       const String& haystack,
@@ -214,10 +214,9 @@ Variant HHVM_FUNCTION(mb_substr_count,
                       const Variant& opt_encoding = uninit_variant);
 Variant HHVM_FUNCTION(mb_substr,
                       const String& str,
-                      int start,
+                      int64_t start,
                       const Variant& length = uninit_null(),
                       const Variant& opt_encoding = uninit_variant);
 
 ///////////////////////////////////////////////////////////////////////////////
 }
-

--- a/hphp/runtime/ext/mcrypt/ext_mcrypt.cpp
+++ b/hphp/runtime/ext/mcrypt/ext_mcrypt.cpp
@@ -368,7 +368,7 @@ bool HHVM_FUNCTION(mcrypt_module_self_test, const String& algorithm,
                                  (char*)dir.data()) == 0;
 }
 
-Variant HHVM_FUNCTION(mcrypt_create_iv, int size, int source /* = 0 */) {
+Variant HHVM_FUNCTION(mcrypt_create_iv, int64_t size, int64_t source /* = 0 */) {
   if (size <= 0 || size >= INT_MAX) {
     raise_warning("Can not create an IV with a size of less than 1 or "
                     "greater than %d", INT_MAX);

--- a/hphp/runtime/ext/memcache/ext_memcache.cpp
+++ b/hphp/runtime/ext/memcache/ext_memcache.cpp
@@ -125,8 +125,8 @@ static bool isServerReachable(const String& host, int port /*= 0*/) {
 ///////////////////////////////////////////////////////////////////////////////
 // methods
 
-static bool HHVM_METHOD(Memcache, connect, const String& host, int port /*= 0*/,
-                        int /*timeout*/ /*= 0*/, int /*timeoutms*/ /*= 0*/) {
+static bool HHVM_METHOD(Memcache, connect, const String& host, int64_t port /*= 0*/,
+                        int64_t /*timeout*/ /*= 0*/, int64_t /*timeoutms*/ /*= 0*/) {
   auto data = Native::data<MemcacheData>(this_);
   memcached_return_t ret;
 
@@ -192,7 +192,7 @@ static void memcache_set_type_from_flag(Variant& var, uint32_t flags) {
 
 static std::vector<char> memcache_prepare_for_storage(const MemcacheData* data,
                                                       const Variant& var,
-                                                      int &flag) {
+                                                      int64_t &flag) {
   String v;
   if (var.isString()) {
     v = var.toString();
@@ -300,7 +300,7 @@ static Variant memcache_fetch_from_storage(const char *payload,
 }
 
 static bool HHVM_METHOD(Memcache, add, const String& key, const Variant& var,
-                                       int flag /*= 0*/, int expire /*= 0*/) {
+                                       int64_t flag /*= 0*/, int64_t expire /*= 0*/) {
   if (key.empty()) {
     raise_warning("Key cannot be empty");
     return false;
@@ -326,7 +326,7 @@ static bool HHVM_METHOD(Memcache, add, const String& key, const Variant& var,
 }
 
 static bool HHVM_METHOD(Memcache, set, const String& key, const Variant& var,
-                                       int flag /*= 0*/, int expire /*= 0*/) {
+                                       int64_t flag /*= 0*/, int64_t expire /*= 0*/) {
   if (key.empty()) {
     raise_warning("Key cannot be empty");
     return false;
@@ -356,8 +356,8 @@ static bool HHVM_METHOD(Memcache, set, const String& key, const Variant& var,
 }
 
 static bool HHVM_METHOD(Memcache, replace, const String& key,
-                                           const Variant& var, int flag /*= 0*/,
-                                           int expire /*= 0*/) {
+                                           const Variant& var, int64_t flag /*= 0*/,
+                                           int64_t expire /*= 0*/) {
   if (key.empty()) {
     raise_warning("Key cannot be empty");
     return false;
@@ -483,7 +483,7 @@ HHVM_METHOD(Memcache, get, const Variant& key) {
 }
 
 static bool HHVM_METHOD(Memcache, delete, const String& key,
-                                          int expire /*= 0*/) {
+                                          int64_t expire /*= 0*/) {
   if (key.empty()) {
     raise_warning("Key cannot be empty");
     return false;
@@ -504,7 +504,7 @@ static bool HHVM_METHOD(Memcache, delete, const String& key,
 }
 
 static Variant HHVM_METHOD(Memcache, increment, const String& key,
-                                                int offset /*= 1*/) {
+                                                int64_t offset /*= 1*/) {
   if (key.empty()) {
     raise_warning("Key cannot be empty");
     return false;
@@ -531,7 +531,7 @@ static Variant HHVM_METHOD(Memcache, increment, const String& key,
 }
 
 static Variant HHVM_METHOD(Memcache, decrement, const String& key,
-                                                int offset /*= 1*/) {
+                                                int64_t offset /*= 1*/) {
   if (key.empty()) {
     raise_warning("Key cannot be empty");
     return false;
@@ -593,12 +593,12 @@ static Variant HHVM_METHOD(Memcache, getversion) {
   return false;
 }
 
-static bool HHVM_METHOD(Memcache, flush, int expire /*= 0*/) {
+static bool HHVM_METHOD(Memcache, flush, int64_t expire /*= 0*/) {
   auto data = Native::data<MemcacheData>(this_);
   return memcached_flush(&data->m_memcache, expire) == MEMCACHED_SUCCESS;
 }
 
-static bool HHVM_METHOD(Memcache, setcompressthreshold, int threshold,
+static bool HHVM_METHOD(Memcache, setcompressthreshold, int64_t threshold,
                                         double min_savings /* = 0.2 */) {
   if (threshold < 0) {
     raise_warning("threshold must be a positive integer");
@@ -652,7 +652,7 @@ static Array memcache_build_stats(const memcached_st *ptr,
 
 static Array HHVM_METHOD(Memcache, getstats,
                          const String& type /* = null_string */,
-                         int slabid /* = 0 */, int limit /* = 100 */) {
+                         int64_t slabid /* = 0 */, int64_t limit /* = 100 */) {
   auto data = Native::data<MemcacheData>(this_);
   if (!memcached_server_count(&data->m_memcache)) {
     return Array();
@@ -661,7 +661,7 @@ static Array HHVM_METHOD(Memcache, getstats,
   char extra_args[30] = {0};
 
   if (slabid) {
-    snprintf(extra_args, sizeof(extra_args), "%s %d %d", type.c_str(),
+    snprintf(extra_args, sizeof(extra_args), "%s %ld %ld", type.c_str(),
              slabid, limit);
   } else if (!type.empty()) {
     snprintf(extra_args, sizeof(extra_args), "%s", type.c_str());
@@ -684,7 +684,7 @@ static Array HHVM_METHOD(Memcache, getstats,
 
 static Array HHVM_METHOD(Memcache, getextendedstats,
                          const String& /*type*/ /* = null_string */,
-                         int /*slabid*/ /* = 0 */, int /*limit*/ /* = 100 */) {
+                         int64_t /*slabid*/ /* = 0 */, int64_t /*limit*/ /* = 100 */) {
   auto data = Native::data<MemcacheData>(this_);
   memcached_return_t ret;
   memcached_stat_st *stats;
@@ -729,12 +729,12 @@ static Array HHVM_METHOD(Memcache, getextendedstats,
 }
 
 static bool
-HHVM_METHOD(Memcache, addserver, const String& host, int port /* = 11211 */,
-            bool /*persistent*/ /* = false */, int weight /* = 0 */,
-            int /*timeout*/ /* = 0 */, int /*retry_interval*/ /* = 0 */,
+HHVM_METHOD(Memcache, addserver, const String& host, int64_t port /* = 11211 */,
+            bool /*persistent*/ /* = false */, int64_t weight /* = 0 */,
+            int64_t /*timeout*/ /* = 0 */, int64_t /*retry_interval*/ /* = 0 */,
             bool /*status*/ /* = true */,
             const Variant& /*failure_callback*/ /* = uninit_variant */,
-            int /*timeoutms*/ /* = 0 */) {
+            int64_t /*timeoutms*/ /* = 0 */) {
   auto data = Native::data<MemcacheData>(this_);
   memcached_return_t ret;
 

--- a/hphp/runtime/ext/memcached/ext_memcached.cpp
+++ b/hphp/runtime/ext/memcached/ext_memcached.cpp
@@ -601,7 +601,7 @@ Variant HHVM_METHOD(Memcached, getbykeywithcastoken,
 
 Variant HHVM_METHOD(Memcached, getmultibykey, const String& server_key,
                                const Array& keys,
-                               int flags /*= 0*/) {
+                               int64_t flags /*= 0*/) {
   return getMultiByKeyImpl(this_, server_key, keys, nullptr, flags);
 }
 
@@ -609,7 +609,7 @@ Variant HHVM_METHOD(Memcached, getmultibykeywithcastokens,
                     const String& server_key,
                     const Array& keys,
                     Variant& cas_tokens,
-                    int flags /*= 0*/) {
+                    int64_t flags /*= 0*/) {
   return getMultiByKeyImpl(this_, server_key, keys, &cas_tokens, flags);
 }
 
@@ -658,7 +658,7 @@ Variant HHVM_METHOD(Memcached, fetchall) {
 
 bool HHVM_METHOD(Memcached, setbykey, const String& server_key,
                                       const String& key, const Variant& value,
-                                      int expiration /*= 0*/) {
+                                      int64_t expiration /*= 0*/) {
   auto data = Native::data<MemcachedData>(this_);
   return data->setOperationImpl(memcached_set_by_key, server_key, key, value,
                           expiration);
@@ -666,7 +666,7 @@ bool HHVM_METHOD(Memcached, setbykey, const String& server_key,
 
 bool HHVM_METHOD(Memcached, addbykey, const String& server_key,
                                       const String& key, const Variant& value,
-                                      int expiration /*= 0*/) {
+                                      int64_t expiration /*= 0*/) {
   auto data = Native::data<MemcachedData>(this_);
   return data->setOperationImpl(memcached_add_by_key, server_key, key, value,
                                                       expiration);
@@ -699,7 +699,7 @@ bool HHVM_METHOD(Memcached, prependbykey, const String& server_key,
 bool HHVM_METHOD(Memcached, replacebykey, const String& server_key,
                                           const String& key,
                                           const Variant& value,
-                                          int expiration /*= 0*/) {
+                                          int64_t expiration /*= 0*/) {
   auto data = Native::data<MemcachedData>(this_);
   return data->setOperationImpl(memcached_replace_by_key, server_key, key,
                                 value, expiration);
@@ -709,7 +709,7 @@ bool HHVM_METHOD(Memcached, casbykey, double cas_token,
                                       const String& server_key,
                                       const String& key,
                                       const Variant& value,
-                                      int expiration /*= 0*/) {
+                                      int64_t expiration /*= 0*/) {
   auto data = Native::data<MemcachedData>(this_);
   data->m_impl->rescode = MEMCACHED_SUCCESS;
   if (key.empty()) {
@@ -728,7 +728,7 @@ bool HHVM_METHOD(Memcached, casbykey, double cas_token,
 
 bool HHVM_METHOD(Memcached, deletebykey, const String& server_key,
                                          const String& key,
-                                         int time /*= 0*/) {
+                                         int64_t time /*= 0*/) {
   auto data = Native::data<MemcachedData>(this_);
   data->m_impl->rescode = MEMCACHED_SUCCESS;
   if (key.empty()) {
@@ -809,8 +809,8 @@ Variant HHVM_METHOD(Memcached, decrementbykey,
     false, server_key.get(), key.get(), offset, initial_value, expiry);
 }
 
-bool HHVM_METHOD(Memcached, addserver, const String& host, int port,
-                                       int weight /*= 0*/) {
+bool HHVM_METHOD(Memcached, addserver, const String& host, int64_t port,
+                                       int64_t weight /*= 0*/) {
   auto data = Native::data<MemcachedData>(this_);
   data->m_impl->rescode = MEMCACHED_SUCCESS;
   if (!host.empty() && host[0] == '/') {
@@ -1034,12 +1034,12 @@ Variant HHVM_METHOD(Memcached, getversion) {
   return returnValue;
 }
 
-bool HHVM_METHOD(Memcached, flush, int delay /*= 0*/) {
+bool HHVM_METHOD(Memcached, flush, int64_t delay /*= 0*/) {
   auto data = Native::data<MemcachedData>(this_);
   return data->handleError(memcached_flush(&data->m_impl->memcached, delay));
 }
 
-Variant HHVM_METHOD(Memcached, getoption, int option) {
+Variant HHVM_METHOD(Memcached, getoption, int64_t option) {
   auto data = Native::data<MemcachedData>(this_);
   switch (option) {
   case q_Memcached$$OPT_COMPRESSION:
@@ -1074,7 +1074,7 @@ Variant HHVM_METHOD(Memcached, getoption, int option) {
   }
 }
 
-bool HHVM_METHOD(Memcached, setoption, int option, const Variant& value) {
+bool HHVM_METHOD(Memcached, setoption, int64_t option, const Variant& value) {
   auto data = Native::data<MemcachedData>(this_);
   switch (option) {
   case q_Memcached$$OPT_COMPRESSION:
@@ -1181,7 +1181,7 @@ bool HHVM_METHOD(Memcached, ispristine) {
 bool HHVM_METHOD(Memcached, touchbykey,
                  ATTRIBUTE_UNUSED const String& server_key,
                  ATTRIBUTE_UNUSED const String& key,
-                 ATTRIBUTE_UNUSED int expiration /*= 0*/) {
+                 ATTRIBUTE_UNUSED int64_t expiration /*= 0*/) {
 
 #ifndef HAVE_MEMCACHED_TOUCH
   throw_not_supported(__func__, "Not Implemented in libmemcached versions below"

--- a/hphp/runtime/ext/mysql/ext_mysql.cpp
+++ b/hphp/runtime/ext/mysql/ext_mysql.cpp
@@ -37,8 +37,8 @@ using std::string;
 
 static Variant
 HHVM_FUNCTION(mysql_connect, const String& server, const String& username,
-              const String& password, bool /*new_link*/, int client_flags,
-              int connect_timeout_ms, int query_timeout_ms,
+              const String& password, bool /*new_link*/, int64_t client_flags,
+              int64_t connect_timeout_ms, int64_t query_timeout_ms,
               const Array& conn_attrs) {
   return Variant(php_mysql_do_connect(
       server,
@@ -58,9 +58,9 @@ static Variant HHVM_FUNCTION(
     const String& username,
     const String& password,
     const String& database,
-    int client_flags,
-    int connect_timeout_ms,
-    int query_timeout_ms,
+    int64_t client_flags,
+    int64_t connect_timeout_ms,
+    int64_t query_timeout_ms,
     const Variant& sslContextProvider, /* = null */
     const Array& conn_attrs) {
   return Variant(php_mysql_do_connect_with_ssl(
@@ -78,8 +78,8 @@ static Variant HHVM_FUNCTION(
 static Variant HHVM_FUNCTION(mysql_connect_with_db, const String& server,
                              const String& username, const String& password,
                              const String& database, bool /*new_link*/,
-                             int client_flags, int connect_timeout_ms,
-                             int query_timeout_ms, const Array& conn_attrs) {
+                             int64_t client_flags, int64_t connect_timeout_ms,
+                             int64_t query_timeout_ms, const Array& conn_attrs) {
   return Variant(php_mysql_do_connect(
       server,
       username,
@@ -96,9 +96,9 @@ static Variant HHVM_FUNCTION(mysql_pconnect,
   const String& server,
   const String& username,
   const String& password,
-  int client_flags,
-  int connect_timeout_ms,
-  int query_timeout_ms,
+  int64_t client_flags,
+  int64_t connect_timeout_ms,
+  int64_t query_timeout_ms,
   const Array& conn_attrs) {
   return php_mysql_do_connect(
     server,
@@ -118,9 +118,9 @@ static Variant HHVM_FUNCTION(mysql_pconnect_with_db,
   const String& username,
   const String& password,
   const String& database,
-  int client_flags,
-  int connect_timeout_ms,
-  int query_timeout_ms,
+  int64_t client_flags,
+  int64_t connect_timeout_ms,
+  int64_t query_timeout_ms,
   const Array& conn_attrs) {
   return php_mysql_do_connect(
     server,
@@ -135,7 +135,7 @@ static Variant HHVM_FUNCTION(mysql_pconnect_with_db,
   );
 }
 
-static bool HHVM_FUNCTION(mysql_set_timeout, int query_timeout_ms /* = -1 */,
+static bool HHVM_FUNCTION(mysql_set_timeout, int64_t query_timeout_ms /* = -1 */,
                           const Variant& /*link_identifier*/ /* = null */) {
   MySQL::SetDefaultReadTimeout(query_timeout_ms);
   return true;
@@ -431,7 +431,7 @@ static Variant HHVM_FUNCTION(mysql_list_processes,
 ///////////////////////////////////////////////////////////////////////////////
 // row operations
 
-static bool HHVM_FUNCTION(mysql_data_seek, const Resource& result, int row) {
+static bool HHVM_FUNCTION(mysql_data_seek, const Resource& result, int64_t row) {
   auto res = php_mysql_extract_result(result);
   if (res == nullptr) return false;
 
@@ -439,7 +439,7 @@ static bool HHVM_FUNCTION(mysql_data_seek, const Resource& result, int row) {
 }
 
 static Variant HHVM_FUNCTION(mysql_fetch_array, const Resource& result,
-                                         int result_type /* = 3 */) {
+                                         int64_t result_type /* = 3 */) {
   return php_mysql_fetch_hash(result, result_type);
 }
 
@@ -510,7 +510,7 @@ Variant HHVM_FUNCTION(mysql_fetch_lengths, const Resource& result) {
   return ret;
 }
 
-static Variant HHVM_FUNCTION(mysql_result, const Resource& result, int row,
+static Variant HHVM_FUNCTION(mysql_result, const Resource& result, int64_t row,
                                     const Variant& field /* = 0 */) {
   auto res = php_mysql_extract_result(result);
   if (res == nullptr) return false;
@@ -525,7 +525,7 @@ static Variant HHVM_FUNCTION(mysql_result, const Resource& result, int row,
   } else {
     mysql_result = res->get();
     if (row < 0 || row >= (int)mysql_num_rows(mysql_result)) {
-      raise_warning("Unable to jump to row %d on MySQL result index %d",
+      raise_warning("Unable to jump to row %ld on MySQL result index %d",
                       row, result->getId());
       return false;
     }
@@ -648,7 +648,7 @@ StaticString
 }
 
 static Variant HHVM_FUNCTION(mysql_fetch_field, const Resource& result,
-                                         int field /* = -1 */) {
+                                         int64_t field /* = -1 */) {
   auto res = php_mysql_extract_result(result);
   if (res == nullptr) return false;
 
@@ -675,30 +675,30 @@ static Variant HHVM_FUNCTION(mysql_fetch_field, const Resource& result,
   return ObjectData::FromArray(props.create());
 }
 
-static bool HHVM_FUNCTION(mysql_field_seek, const Resource& result, int field) {
+static bool HHVM_FUNCTION(mysql_field_seek, const Resource& result, int64_t field) {
   auto res = php_mysql_extract_result(result);
   if (res == nullptr) return false;
   return res->seekField(field);
 }
 
 static Variant HHVM_FUNCTION(mysql_field_name, const Resource& result,
-                                               int field) {
+                                               int64_t field) {
   return php_mysql_field_info(result, field, PHP_MYSQL_FIELD_NAME);
 }
 static Variant HHVM_FUNCTION(mysql_field_table, const Resource& result,
-                                                int field) {
+                                                int64_t field) {
   return php_mysql_field_info(result, field, PHP_MYSQL_FIELD_TABLE);
 }
 static Variant HHVM_FUNCTION(mysql_field_len, const Resource& result,
-                                              int field) {
+                                              int64_t field) {
   return php_mysql_field_info(result, field, PHP_MYSQL_FIELD_LEN);
 }
 static Variant HHVM_FUNCTION(mysql_field_type, const Resource& result,
-                                               int field) {
+                                               int64_t field) {
   return php_mysql_field_info(result, field, PHP_MYSQL_FIELD_TYPE);
 }
 static Variant HHVM_FUNCTION(mysql_field_flags, const Resource& result,
-                                                int field) {
+                                                int64_t field) {
   return php_mysql_field_info(result, field, PHP_MYSQL_FIELD_FLAGS);
 }
 

--- a/hphp/runtime/ext/objprof/ext_objprof.cpp
+++ b/hphp/runtime/ext/objprof/ext_objprof.cpp
@@ -920,7 +920,7 @@ void getObjStrings(
 ///////////////////////////////////////////////////////////////////////////////
 // Function that traverses objects and counts metrics per strings
 
-Array HHVM_FUNCTION(objprof_get_strings, int min_dup) {
+Array HHVM_FUNCTION(objprof_get_strings, int64_t min_dup) {
   ObjprofStrings metrics;
 
   std::unordered_set<void*> pointers;
@@ -953,7 +953,7 @@ Array HHVM_FUNCTION(objprof_get_strings, int min_dup) {
 // Function that inits the scan of the memory and count of class pointers
 
 Array HHVM_FUNCTION(objprof_get_data,
-  int flags = ObjprofFlags::DEFAULT,
+  int64_t flags = ObjprofFlags::DEFAULT,
   const Array& exclude_list = Array()
 ) {
   std::unordered_map<ClassProp, ObjprofMetrics> histogram;
@@ -1024,7 +1024,7 @@ Array HHVM_FUNCTION(objprof_get_data,
 }
 
 Array HHVM_FUNCTION(objprof_get_paths,
-  int flags = ObjprofFlags::DEFAULT,
+  int64_t flags = ObjprofFlags::DEFAULT,
   const Array& exclude_list = Array()
 ) {
   std::unordered_map<ClassProp, ObjprofMetrics> histogram;

--- a/hphp/runtime/ext/openssl/ext_openssl.cpp
+++ b/hphp/runtime/ext/openssl/ext_openssl.cpp
@@ -1095,9 +1095,9 @@ Variant HHVM_FUNCTION(openssl_csr_new,
 
 Variant HHVM_FUNCTION(openssl_csr_sign, const Variant& csr,
                                         const Variant& cacert,
-                                        const Variant& priv_key, int days,
+                                        const Variant& priv_key, int64_t days,
                                         const Variant& configargs /* = null */,
-                                        int serial /* = 0 */) {
+                                        int64_t serial /* = 0 */) {
   auto pcsr = CSRequest::Get(csr);
   if (!pcsr) return false;
 
@@ -1524,8 +1524,8 @@ bool HHVM_FUNCTION(openssl_pkcs7_encrypt, const String& infilename,
                                           const String& outfilename,
                                           const Variant& recipcerts,
                                           const Array& headers,
-                                          int flags /* = 0 */,
-                                int cipherid /* = k_OPENSSL_CIPHER_RC2_40 */) {
+                                          int64_t flags /* = 0 */,
+                                int64_t cipherid /* = k_OPENSSL_CIPHER_RC2_40 */) {
   bool ret = false;
   BIO *infile = nullptr, *outfile = nullptr;
   STACK_OF(X509) *precipcerts = nullptr;
@@ -1557,7 +1557,7 @@ bool HHVM_FUNCTION(openssl_pkcs7_encrypt, const String& infilename,
   case PHP_OPENSSL_CIPHER_3DES:    cipher = EVP_des_ede3_cbc(); break;
 #endif
   default:
-    raise_warning("Invalid cipher type `%d'", cipherid);
+    raise_warning("Invalid cipher type `%ld'", cipherid);
     goto clean_exit;
   }
   if (cipher == nullptr) {
@@ -1586,7 +1586,7 @@ bool HHVM_FUNCTION(openssl_pkcs7_sign, const String& infilename,
                                        const Variant& signcert,
                                        const Variant& privkey,
                                        const Variant& headers,
-                                       int flags /* = k_PKCS7_DETACHED */,
+                                       int64_t flags /* = k_PKCS7_DETACHED */,
                                 const String& extracerts /* = null_string */) {
   bool ret = false;
   STACK_OF(X509) *others = nullptr;
@@ -1771,7 +1771,7 @@ Variant openssl_pkcs7_verify_core(
   return ret;
 }
 
-Variant HHVM_FUNCTION(openssl_pkcs7_verify, const String& filename, int flags,
+Variant HHVM_FUNCTION(openssl_pkcs7_verify, const String& filename, int64_t flags,
                                const Variant& voutfilename /* = null_string */,
                                const Variant& vcainfo /* = null_array */,
                                const Variant& vextracerts /* = null_string */,
@@ -2045,7 +2045,7 @@ Variant HHVM_FUNCTION(openssl_pkey_new,
 bool HHVM_FUNCTION(openssl_private_decrypt, const String& data,
                                             Variant& decrypted,
                                             const Variant& key,
-                                  int padding /* = k_OPENSSL_PKCS1_PADDING */) {
+                                  int64_t padding /* = k_OPENSSL_PKCS1_PADDING */) {
   auto okey = Key::Get(key, false);
   if (!okey) {
     raise_warning("key parameter is not a valid private key");
@@ -2085,7 +2085,7 @@ bool HHVM_FUNCTION(openssl_private_decrypt, const String& data,
 bool HHVM_FUNCTION(openssl_private_encrypt, const String& data,
                                             Variant& crypted,
                                             const Variant& key,
-                                  int padding /* = k_OPENSSL_PKCS1_PADDING */) {
+                                  int64_t padding /* = k_OPENSSL_PKCS1_PADDING */) {
   auto okey = Key::Get(key, false);
   if (!okey) {
     raise_warning("key param is not a valid private key");
@@ -2121,7 +2121,7 @@ bool HHVM_FUNCTION(openssl_private_encrypt, const String& data,
 bool HHVM_FUNCTION(openssl_public_decrypt, const String& data,
                                            Variant& decrypted,
                                            const Variant& key,
-                                  int padding /* = k_OPENSSL_PKCS1_PADDING */) {
+                                  int64_t padding /* = k_OPENSSL_PKCS1_PADDING */) {
   auto okey = Key::Get(key, true);
   if (!okey) {
     raise_warning("key parameter is not a valid public key");
@@ -2161,7 +2161,7 @@ bool HHVM_FUNCTION(openssl_public_decrypt, const String& data,
 bool HHVM_FUNCTION(openssl_public_encrypt, const String& data,
                                            Variant& crypted,
                                            const Variant& key,
-                                  int padding /* = k_OPENSSL_PKCS1_PADDING */) {
+                                  int64_t padding /* = k_OPENSSL_PKCS1_PADDING */) {
   auto okey = Key::Get(key, true);
   if (!okey) {
     raise_warning("key parameter is not a valid public key");
@@ -2441,7 +2441,7 @@ static int check_cert(X509_STORE *ctx, X509 *x, STACK_OF(X509) *untrustedchain,
 }
 
 Variant HHVM_FUNCTION(openssl_x509_checkpurpose, const Variant& x509cert,
-                      int purpose,
+                      int64_t purpose,
                       const Array& cainfo /* = null_array */,
                       const String& untrustedfile /* = null_string */) {
   int ret = -1;
@@ -2804,7 +2804,7 @@ Variant HHVM_FUNCTION(openssl_x509_read, const Variant& x509certdata) {
   return Variant(ocert);
 }
 
-Variant HHVM_FUNCTION(openssl_random_pseudo_bytes, int length,
+Variant HHVM_FUNCTION(openssl_random_pseudo_bytes, int64_t length,
                       bool& crypto_strong) {
   if (length <= 0) {
     return false;
@@ -3103,10 +3103,10 @@ Variant HHVM_FUNCTION(openssl_encrypt,
                       const String& data,
                       const String& method,
                       const String& password,
-                      int options /* = 0 */,
+                      int64_t options /* = 0 */,
                       const String& iv /* = null_string */,
                       const String& aad /* = null_string */,
-                      int tag_length /* = 16 */) {
+                      int64_t tag_length /* = 16 */) {
   return openssl_encrypt_impl(data, method, password, options, iv,
                               nullptr, aad, tag_length);
 }
@@ -3115,18 +3115,18 @@ Variant HHVM_FUNCTION(openssl_encrypt_with_tag,
                       const String& data,
                       const String& method,
                       const String& password,
-                      int options,
+                      int64_t options,
                       const String& iv,
                       Variant& tag_out,
                       const String& aad /* = null_string */,
-                      int tag_length /* = 16 */) {
+                      int64_t tag_length /* = 16 */) {
   return openssl_encrypt_impl(data, method, password, options, iv,
                               &tag_out, aad, tag_length);
 }
 
 Variant HHVM_FUNCTION(openssl_decrypt, const String& data, const String& method,
                                        const String& password,
-                                       int options /* = 0 */,
+                                       int64_t options /* = 0 */,
                                        const String& iv /* = null_string */,
                                        const String& tag /* = null_string */,
                                        const String& aad /* = null_string */) {

--- a/hphp/runtime/ext/openssl/ext_openssl.h
+++ b/hphp/runtime/ext/openssl/ext_openssl.h
@@ -91,9 +91,9 @@ Variant HHVM_FUNCTION(openssl_csr_new,
 Variant HHVM_FUNCTION(openssl_csr_sign,
                       const Variant& csr,
                       const Variant& cacert,
-                      const Variant& priv_key, int days,
+                      const Variant& priv_key, int64_t days,
                       const Variant& configargs = uninit_variant,
-                      int serial = 0);
+                      int64_t serial = 0);
 Variant HHVM_FUNCTION(openssl_error_string);
 bool HHVM_FUNCTION(openssl_open, const String& sealed_data, Variant& open_data,
                                  const String& env_key,
@@ -119,14 +119,14 @@ bool HHVM_FUNCTION(openssl_pkcs7_encrypt, const String& infilename,
                                           const String& outfilename,
                                           const Variant& recipcerts,
                                           const Array& headers,
-                                          int flags = 0,
-                                int cipherid = PHP_OPENSSL_CIPHER_RC2_40);
+                                          int64_t flags = 0,
+                                int64_t cipherid = PHP_OPENSSL_CIPHER_RC2_40);
 bool HHVM_FUNCTION(openssl_pkcs7_sign, const String& infilename,
                                        const String& outfilename,
                                        const Variant& signcert,
                                        const Variant& privkey,
                                        const Variant& headers,
-                                       int flags = PKCS7_DETACHED,
+                                       int64_t flags = PKCS7_DETACHED,
                                 const String& extracerts = null_string);
 Variant openssl_pkcs7_verify_core(const String& filename, int flags,
                                 const Variant& voutfilename /* = null_string */,
@@ -134,13 +134,13 @@ Variant openssl_pkcs7_verify_core(const String& filename, int flags,
                                 const Variant& vextracerts /* = null_string */,
                                 const Variant& vcontent /* = null_string */,
                                 bool ignore_cert_expiration);
-Variant HHVM_FUNCTION(openssl_pkcs7_verify, const String& filename, int flags,
+Variant HHVM_FUNCTION(openssl_pkcs7_verify, const String& filename, int64_t flags,
                                const Variant& outfilename = null_string,
                                const Variant& cainfo = null_array,
                                const Variant& extracerts = null_string,
                                const Variant& content = null_string);
 Variant HHVM_FUNCTION(fb_unsafe_openssl_pkcs7_verify_ignore_cert_expiration,
-                               const String& filename, int flags,
+                               const String& filename, int64_t flags,
                                const Variant& outfilename = null_string,
                                const Variant& cainfo = null_array,
                                const Variant& extracerts = null_string,
@@ -161,19 +161,19 @@ Variant HHVM_FUNCTION(openssl_pkey_new,
 bool HHVM_FUNCTION(openssl_private_decrypt, const String& data,
                                             Variant& decrypted,
                                             const Variant& key,
-                                  int padding = k_OPENSSL_PKCS1_PADDING);
+                                  int64_t padding = k_OPENSSL_PKCS1_PADDING);
 bool HHVM_FUNCTION(openssl_private_encrypt, const String& data,
                                             Variant& crypted,
                                             const Variant& key,
-                                  int padding = k_OPENSSL_PKCS1_PADDING);
+                                  int64_t padding = k_OPENSSL_PKCS1_PADDING);
 bool HHVM_FUNCTION(openssl_public_decrypt, const String& data,
                                            Variant& decrypted,
                                            const Variant& key,
-                                  int padding = k_OPENSSL_PKCS1_PADDING);
+                                  int64_t padding = k_OPENSSL_PKCS1_PADDING);
 bool HHVM_FUNCTION(openssl_public_encrypt, const String& data,
                                            Variant& crypted,
                                            const Variant& key,
-                                  int padding = k_OPENSSL_PKCS1_PADDING);
+                                  int64_t padding = k_OPENSSL_PKCS1_PADDING);
 Variant HHVM_FUNCTION(openssl_seal, const String& data, Variant& sealed_data,
                                     Variant& env_keys,
                                     const Array& pub_key_ids,
@@ -189,7 +189,7 @@ Variant HHVM_FUNCTION(openssl_verify, const String& data,
 bool HHVM_FUNCTION(openssl_x509_check_private_key, const Variant& cert,
                                                    const Variant& key);
 Variant HHVM_FUNCTION(openssl_x509_checkpurpose, const Variant& x509cert,
-                      int purpose,
+                      int64_t purpose,
                       const Array& cainfo = null_array,
                       const String& untrustedfile = null_string);
 bool HHVM_FUNCTION(openssl_x509_export_to_file, const Variant& x509,
@@ -200,18 +200,18 @@ bool HHVM_FUNCTION(openssl_x509_export, const Variant& x509, Variant& output,
 Variant HHVM_FUNCTION(openssl_x509_parse, const Variant& x509cert,
                                           bool shortnames = true);
 Variant HHVM_FUNCTION(openssl_x509_read, const Variant& x509certdata);
-Variant HHVM_FUNCTION(openssl_random_pseudo_bytes, int length,
+Variant HHVM_FUNCTION(openssl_random_pseudo_bytes, int64_t length,
                                         bool& crypto_strong);
 Variant HHVM_FUNCTION(openssl_cipher_iv_length, const String& method);
 Variant HHVM_FUNCTION(openssl_encrypt, const String& data, const String& method,
                                        const String& password,
-                                       int options = 0,
+                                       int64_t options = 0,
                                        const String& iv = null_string,
                                        const String& aad = null_string,
-                                       int tag_length = 16);
+                                       int64_t tag_length = 16);
 Variant HHVM_FUNCTION(openssl_decrypt, const String& data, const String& method,
                                        const String& password,
-                                       int options = 0,
+                                       int64_t options = 0,
                                        const String& iv = null_string,
                                        const String& tag = null_string,
                                        const String& aad = null_string);
@@ -223,4 +223,3 @@ Array HHVM_FUNCTION(openssl_get_md_methods, bool aliases = false);
 
 ///////////////////////////////////////////////////////////////////////////////
 }
-

--- a/hphp/runtime/ext/pcre/ext_pcre.cpp
+++ b/hphp/runtime/ext/pcre/ext_pcre.cpp
@@ -36,7 +36,7 @@ namespace HPHP {
 static int s_pcre_has_jit = 0;
 
 Variant HHVM_FUNCTION(preg_grep, const String& pattern, const Variant& input,
-                      int flags /* = 0 */) {
+                      int64_t flags /* = 0 */) {
   if (!isContainer(input)) {
     raise_warning("input to preg_grep must be an array or collection");
     return init_null();
@@ -45,7 +45,7 @@ Variant HHVM_FUNCTION(preg_grep, const String& pattern, const Variant& input,
 }
 
 Variant HHVM_FUNCTION(preg_grep_with_error, const String& pattern,
-                      const Variant& input, Variant& error, int flags /* = 0 */) {
+                      const Variant& input, Variant& error, int64_t flags /* = 0 */) {
   PregWithErrorGuard guard(error);
   return HHVM_FN(preg_grep)(pattern, input, flags);
 }
@@ -54,14 +54,14 @@ Variant HHVM_FUNCTION(preg_grep_with_error, const String& pattern,
 
 TypedValue HHVM_FUNCTION(preg_match,
                          StringArg pattern, StringArg subject,
-                         int flags /* = 0 */, int offset /* = 0 */) {
+                         int64_t flags /* = 0 */, int64_t offset /* = 0 */) {
   return tvReturn(preg_match(pattern.get(), subject.get(),
                              nullptr, flags, offset));
 }
 
 TypedValue HHVM_FUNCTION(preg_match_with_error, StringArg pattern,
                          StringArg subject, Variant& error,
-                         int flags /* = 0 */, int offset /* = 0 */) {
+                         int64_t flags /* = 0 */, int64_t offset /* = 0 */) {
   PregWithErrorGuard guard(error);
   return tvReturn(preg_match(pattern.get(), subject.get(),
                              nullptr, flags, offset));
@@ -70,7 +70,7 @@ TypedValue HHVM_FUNCTION(preg_match_with_error, StringArg pattern,
 TypedValue HHVM_FUNCTION(preg_match_with_matches,
                          StringArg pattern, StringArg subject,
                          Variant& matches,
-                         int flags /* = 0 */, int offset /* = 0 */) {
+                         int64_t flags /* = 0 */, int64_t offset /* = 0 */) {
   return tvReturn(preg_match(pattern.get(), subject.get(),
                              &matches, flags, offset));
 }
@@ -78,7 +78,7 @@ TypedValue HHVM_FUNCTION(preg_match_with_matches,
 TypedValue HHVM_FUNCTION(preg_match_with_matches_and_error,
                          StringArg pattern, StringArg subject,
                          Variant& matches, Variant& error,
-                         int flags /* = 0 */, int offset /* = 0 */) {
+                         int64_t flags /* = 0 */, int64_t offset /* = 0 */) {
   PregWithErrorGuard guard(error);
   return tvReturn(preg_match(pattern.get(), subject.get(),
                              &matches, flags, offset));
@@ -87,8 +87,8 @@ TypedValue HHVM_FUNCTION(preg_match_with_matches_and_error,
 TypedValue HHVM_FUNCTION(preg_match_all,
                          StringArg pattern,
                          StringArg subject,
-                         int flags /* = 0 */,
-                         int offset /* = 0 */) {
+                         int64_t flags /* = 0 */,
+                         int64_t offset /* = 0 */) {
   return tvReturn(preg_match_all(pattern.get(), subject.get(),
                                  nullptr, flags, offset));
 }
@@ -97,8 +97,8 @@ TypedValue HHVM_FUNCTION(preg_match_all_with_error,
                          StringArg pattern,
                          StringArg subject,
                          Variant& error,
-                         int flags /* = 0 */,
-                         int offset /* = 0 */) {
+                         int64_t flags /* = 0 */,
+                         int64_t offset /* = 0 */) {
   PregWithErrorGuard guard(error);
   return tvReturn(preg_match_all(pattern.get(), subject.get(),
                                  nullptr, flags, offset));
@@ -108,8 +108,8 @@ TypedValue HHVM_FUNCTION(preg_match_all_with_matches,
                          StringArg pattern,
                          StringArg subject,
                          Variant& matches,
-                         int flags /* = 0 */,
-                         int offset /* = 0 */) {
+                         int64_t flags /* = 0 */,
+                         int64_t offset /* = 0 */) {
   return tvReturn(preg_match_all(pattern.get(), subject.get(),
                                  &matches, flags, offset));
 }
@@ -119,8 +119,8 @@ TypedValue HHVM_FUNCTION(preg_match_all_with_matches_and_error,
                          StringArg subject,
                          Variant& matches,
                          Variant& error,
-                         int flags /* = 0 */,
-                         int offset /* = 0 */) {
+                         int64_t flags /* = 0 */,
+                         int64_t offset /* = 0 */) {
   PregWithErrorGuard guard(error);
   return tvReturn(preg_match_all(pattern.get(), subject.get(),
                                  &matches, flags, offset));
@@ -130,14 +130,14 @@ TypedValue HHVM_FUNCTION(preg_match_all_with_matches_and_error,
 
 
 Variant HHVM_FUNCTION(preg_replace, const Variant& pattern, const Variant& replacement,
-                                    const Variant& subject, int limit /* = -1 */) {
+                                    const Variant& subject, int64_t limit /* = -1 */) {
   return preg_replace_impl(pattern, replacement, subject,
                            limit, nullptr, false, false);
 }
 
 Variant HHVM_FUNCTION(preg_replace_with_error, const Variant& pattern,
                       const Variant& replacement, const Variant& subject,
-                      Variant& error, int limit /* = -1 */) {
+                      Variant& error, int64_t limit /* = -1 */) {
   PregWithErrorGuard guard(error);
   return preg_replace_impl(pattern, replacement, subject,
                            limit, nullptr, false, false);
@@ -147,7 +147,7 @@ Variant HHVM_FUNCTION(preg_replace_with_count,
                       const Variant& pattern,
                       const Variant& replacement,
                       const Variant& subject,
-                      int limit,
+                      int64_t limit,
                       int64_t& count) {
   return preg_replace_impl(pattern, replacement, subject,
                            limit, &count, false, false);
@@ -157,7 +157,7 @@ Variant HHVM_FUNCTION(preg_replace_with_count_and_error,
                       const Variant& pattern,
                       const Variant& replacement,
                       const Variant& subject,
-                      int limit,
+                      int64_t limit,
                       int64_t& count,
                       Variant& error) {
   PregWithErrorGuard guard(error);
@@ -169,7 +169,7 @@ Variant HHVM_FUNCTION(preg_replace_callback,
                       const Variant& pattern,
                       const Variant& callback,
                       const Variant& subject,
-                      int limit,
+                      int64_t limit,
                       int64_t& count) {
   if (!is_callable(callback)) {
     raise_warning("Not a valid callback function %s",
@@ -184,7 +184,7 @@ Variant HHVM_FUNCTION(preg_replace_callback_with_error,
                       const Variant& pattern,
                       const Variant& callback,
                       const Variant& subject,
-                      int limit,
+                      int64_t limit,
                       int64_t& count,
                       Variant& error) {
   PregWithErrorGuard guard(error);
@@ -233,7 +233,7 @@ static Variant preg_replace_callback_array_impl(
 Variant HHVM_FUNCTION(preg_replace_callback_array,
                       const Variant& patterns_and_callbacks,
                       const Variant& subject,
-                      int limit,
+                      int64_t limit,
                       int64_t& count) {
   if (!patterns_and_callbacks.isArray()) {
     raise_warning(
@@ -276,7 +276,7 @@ Variant HHVM_FUNCTION(preg_replace_callback_array,
 Variant HHVM_FUNCTION(preg_replace_callback_array_with_error,
                       const Variant& patterns_and_callbacks,
                       const Variant& subject,
-                      int limit,
+                      int64_t limit,
                       int64_t& count,
                       Variant& error) {
   PregWithErrorGuard guard(error);
@@ -285,7 +285,7 @@ Variant HHVM_FUNCTION(preg_replace_callback_array_with_error,
 }
 
 Variant HHVM_FUNCTION(preg_filter, const Variant& pattern, const Variant& callback,
-                                   const Variant& subject, int limit,
+                                   const Variant& subject, int64_t limit,
                                    int64_t& count) {
   return preg_replace_impl(pattern, callback, subject,
                            limit, &count, false, true);
@@ -294,14 +294,14 @@ Variant HHVM_FUNCTION(preg_filter, const Variant& pattern, const Variant& callba
 ///////////////////////////////////////////////////////////////////////////////
 
 Variant HHVM_FUNCTION(preg_split, const String& pattern, const String& subject,
-                                  const Variant& limit, int flags /* = 0 */) {
+                                  const Variant& limit, int64_t flags /* = 0 */) {
   //NOTE: .toInt64() returns 0 for null
   return preg_split(pattern, subject, limit.toInt64(), flags);
 }
 
 Variant HHVM_FUNCTION(preg_split_with_error, const String& pattern,
                       const String& subject, Variant& error,
-                      const Variant& limit /* = null */, int flags /* = 0 */) {
+                      const Variant& limit /* = null */, int64_t flags /* = 0 */) {
   PregWithErrorGuard guard(error);
   //NOTE: .toInt64() returns 0 for null
   return preg_split(pattern, subject, limit.toInt64(), flags);
@@ -337,12 +337,12 @@ String HHVM_FUNCTION(eregi_replace, const String& pattern,
 // regexec
 
 Variant HHVM_FUNCTION(split, const String& pattern, const String& str,
-                             int limit /* = -1 */) {
+                             int64_t limit /* = -1 */) {
   return php_split(pattern, str, limit, false);
 }
 
 Variant HHVM_FUNCTION(spliti, const String& pattern, const String& str,
-                              int limit /* = -1 */) {
+                              int64_t limit /* = -1 */) {
   return php_split(pattern, str, limit, true);
 }
 

--- a/hphp/runtime/ext/pcre/ext_pcre.h
+++ b/hphp/runtime/ext/pcre/ext_pcre.h
@@ -26,23 +26,23 @@ namespace HPHP {
 Variant HHVM_FUNCTION(preg_filter, const Variant& pattern,
                                    const Variant& replacement,
                                    const Variant& subject,
-                                   int limit,
+                                   int64_t limit,
                                    int64_t& count);
 Variant HHVM_FUNCTION(preg_grep, const String& pattern, const Variant& input,
-                                 int flags = 0);
+                                 int64_t flags = 0);
 Variant HHVM_FUNCTION(preg_replace, const Variant& pattern, const Variant& replacement,
-                                    const Variant& subject, int limit = -1);
+                                    const Variant& subject, int64_t limit = -1);
 Variant HHVM_FUNCTION(preg_replace_callback, const Variant& pattern,
                                              const Variant& callback,
                                              const Variant& subject,
-                                             int limit,
+                                             int64_t limit,
                                              int64_t& count);
 Variant HHVM_FUNCTION(
     preg_replace_callback_array, const Variant& patterns_and_callbacks,
-                                 const Variant& subject, int limit,
+                                 const Variant& subject, int64_t limit,
                                  int64_t& count);
 Variant HHVM_FUNCTION(preg_split, const String& pattern, const String& subject,
-                                  const Variant& limit, int flags = 0);
+                                  const Variant& limit, int64_t flags = 0);
 String HHVM_FUNCTION(preg_quote, const String& str,
                                  const Variant& = null_string);
 
@@ -54,9 +54,9 @@ String HHVM_FUNCTION(ereg_replace, const String& pattern,
 String HHVM_FUNCTION(eregi_replace, const String& pattern,
                                 const String& replacement, const String& str);
 Variant HHVM_FUNCTION(split, const String& pattern, const String& str,
-                             int limit = -1);
+                             int64_t limit = -1);
 Variant HHVM_FUNCTION(spliti, const String& pattern, const String& str,
-                              int limit = -1);
+                              int64_t limit = -1);
 String HHVM_FUNCTION(sql_regcase, const String& str);
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/hphp/runtime/ext/pgsql/pgsql.cpp
+++ b/hphp/runtime/ext/pgsql/pgsql.cpp
@@ -608,7 +608,7 @@ std::vector<PGSQLConnectionPool*>& PGSQLConnectionPoolContainer::GetPools() {
 //////////////////// Connection functions /////////////////////////
 
 static Variant HHVM_FUNCTION(pg_connect,
-  const String& connection_string, int connect_type /* = 0 */
+  const String& connection_string, int64_t connect_type /* = 0 */
 ) {
   auto pgsql = req::make<PGSQL>(connection_string);
 
@@ -620,7 +620,7 @@ static Variant HHVM_FUNCTION(pg_connect,
 
 
 static Variant HHVM_FUNCTION(pg_pconnect,
-  const String& connection_string, int connect_type /* = 0 */
+  const String& connection_string, int64_t connect_type /* = 0 */
 ) {
   PGSQLConnectionPool& pool =
     s_connectionPoolContainer.GetPool(connection_string.toCppString());
@@ -821,7 +821,7 @@ static Variant HHVM_FUNCTION(pg_client_encoding, const Resource& connection) {
   return ret;
 }
 
-static int HHVM_FUNCTION(pg_set_client_encoding,
+static int64_t HHVM_FUNCTION(pg_set_client_encoding,
   const Resource& connection, const String& enc) {
   auto pgsql = PGSQL::Get(connection);
 

--- a/hphp/runtime/ext/posix/ext_posix.cpp
+++ b/hphp/runtime/ext/posix/ext_posix.cpp
@@ -125,7 +125,7 @@ static struct POSIXExtension final : Extension {
 
 bool HHVM_FUNCTION(posix_access,
                    const String& file,
-                   int mode /* = 0 */) {
+                   int64_t mode /* = 0 */) {
   if (!FileUtil::checkPathAndWarn(file, __FUNCTION__ + 2, 1)) {
     return false;
   }
@@ -209,7 +209,7 @@ static Variant php_posix_group_to_array(group* gr) {
 }
 
 Variant HHVM_FUNCTION(posix_getgrgid,
-                      int gid) {
+                      int64_t gid) {
   if (gid < 0) return false;
 
   auto buf = GroupBuffer{};
@@ -261,7 +261,7 @@ Variant HHVM_FUNCTION(posix_getlogin) {
 }
 
 Variant HHVM_FUNCTION(posix_getpgid,
-                      int pid) {
+                      int64_t pid) {
   int ret = getpgid(pid);
   if (ret < 0) return false;
   return ret;
@@ -308,7 +308,7 @@ Variant HHVM_FUNCTION(posix_getpwnam,
 }
 
 Variant HHVM_FUNCTION(posix_getpwuid,
-                      int uid) {
+                      int64_t uid) {
   if (uid < 0) return false;
 
   auto buf = PasswdBuffer{};
@@ -386,7 +386,7 @@ Variant HHVM_FUNCTION(posix_getrlimit) {
 }
 
 Variant HHVM_FUNCTION(posix_getsid,
-                      int pid) {
+                      int64_t pid) {
   int ret = getsid(pid);
   if (ret < 0) return false;
   return ret;
@@ -400,7 +400,7 @@ int64_t HHVM_FUNCTION(posix_getuid) {
 
 bool HHVM_FUNCTION(posix_initgroups,
                    const String& name,
-                   int base_group_id) {
+                   int64_t base_group_id) {
   if (name.empty()) return false;
   return !initgroups(name.data(), base_group_id);
 }
@@ -425,8 +425,8 @@ bool HHVM_FUNCTION(posix_isatty,
 }
 
 bool HHVM_FUNCTION(posix_kill,
-                   int pid,
-                   int sig) {
+                   int64_t pid,
+                   int64_t sig) {
   if (pid == 0 || pid == getpid()) {
     if (is_sync_signal(sig)) {
       // Only send to the current thread, and invoke signal handlers in PHP, if
@@ -440,7 +440,7 @@ bool HHVM_FUNCTION(posix_kill,
 
 bool HHVM_FUNCTION(posix_mkfifo,
                    const String& pathname,
-                   int mode) {
+                   int64_t mode) {
   if (!FileUtil::checkPathAndWarn(pathname, __FUNCTION__ + 2, 1)) {
     return false;
   }
@@ -450,9 +450,9 @@ bool HHVM_FUNCTION(posix_mkfifo,
 
 bool HHVM_FUNCTION(posix_mknod,
                    const String& pathname,
-                   int mode,
-                   int major /* = 0 */,
-                   int minor /* = 0 */) {
+                   int64_t mode,
+                   int64_t major /* = 0 */,
+                   int64_t minor /* = 0 */) {
   if (!FileUtil::checkPathAndWarn(pathname, __FUNCTION__ + 2, 1)) {
     return false;
   }
@@ -476,23 +476,23 @@ bool HHVM_FUNCTION(posix_mknod,
 }
 
 bool HHVM_FUNCTION(posix_setegid,
-                   int gid) {
+                   int64_t gid) {
   return setegid(gid);
 }
 
 bool HHVM_FUNCTION(posix_seteuid,
-                   int uid) {
+                   int64_t uid) {
   return seteuid(uid);
 }
 
 bool HHVM_FUNCTION(posix_setgid,
-                   int gid) {
+                   int64_t gid) {
   return setgid(gid);
 }
 
 bool HHVM_FUNCTION(posix_setpgid,
-                   int pid,
-                   int pgid) {
+                   int64_t pid,
+                   int64_t pgid) {
   return setpgid(pid, pgid) >= 0;
 }
 
@@ -501,12 +501,12 @@ int64_t HHVM_FUNCTION(posix_setsid) {
 }
 
 bool HHVM_FUNCTION(posix_setuid,
-                   int uid) {
+                   int64_t uid) {
   return setuid(uid);
 }
 
 String HHVM_FUNCTION(posix_strerror,
-                     int errnum) {
+                     int64_t errnum) {
   return String(folly::errnoStr(errnum));
 }
 

--- a/hphp/runtime/ext/posix/ext_posix.h
+++ b/hphp/runtime/ext/posix/ext_posix.h
@@ -27,7 +27,7 @@ namespace HPHP {
 
 bool HHVM_FUNCTION(posix_access,
                    const String& file,
-                   int mode = 0);
+                   int64_t mode = 0);
 
 String HHVM_FUNCTION(posix_ctermid);
 
@@ -44,7 +44,7 @@ int64_t HHVM_FUNCTION(posix_geteuid);
 int64_t HHVM_FUNCTION(posix_getgid);
 
 Variant HHVM_FUNCTION(posix_getgrgid,
-                      int gid);
+                      int64_t gid);
 
 Variant HHVM_FUNCTION(posix_getgrnam,
                       const String& name);
@@ -54,7 +54,7 @@ Variant HHVM_FUNCTION(posix_getgroups);
 Variant HHVM_FUNCTION(posix_getlogin);
 
 Variant HHVM_FUNCTION(posix_getpgid,
-                      int pid);
+                      int64_t pid);
 
 int64_t HHVM_FUNCTION(posix_getpgrp);
 
@@ -66,56 +66,56 @@ Variant HHVM_FUNCTION(posix_getpwnam,
                       const String& username);
 
 Variant HHVM_FUNCTION(posix_getpwuid,
-                      int uid);
+                      int64_t uid);
 
 Variant HHVM_FUNCTION(posix_getrlimit);
 
 Variant HHVM_FUNCTION(posix_getsid,
-                      int pid);
+                      int64_t pid);
 
 int64_t HHVM_FUNCTION(posix_getuid);
 
 bool HHVM_FUNCTION(posix_initgroups,
                    const String& name,
-                   int base_group_id);
+                   int64_t base_group_id);
 
 bool HHVM_FUNCTION(posix_isatty,
                    const Variant& fd);
 
 bool HHVM_FUNCTION(posix_kill,
-                   int pid,
-                   int sig);
+                   int64_t pid,
+                   int64_t sig);
 
 bool HHVM_FUNCTION(posix_mkfifo,
                    const String& pathname,
-                   int mode);
+                   int64_t mode);
 
 bool HHVM_FUNCTION(posix_mknod,
                    const String& pathname,
-                   int mode,
-                   int major = 0,
-                   int minor = 0);
+                   int64_t mode,
+                   int64_t major = 0,
+                   int64_t minor = 0);
 
 bool HHVM_FUNCTION(posix_setegid,
-                   int gid);
+                   int64_t gid);
 
 bool HHVM_FUNCTION(posix_seteuid,
-                   int uid);
+                   int64_t uid);
 
 bool HHVM_FUNCTION(posix_setgid,
-                   int gid);
+                   int64_t gid);
 
 bool HHVM_FUNCTION(posix_setpgid,
-                   int pid,
-                   int pgid);
+                   int64_t pid,
+                   int64_t pgid);
 
 int64_t HHVM_FUNCTION(posix_setsid);
 
 bool HHVM_FUNCTION(posix_setuid,
-                   int uid);
+                   int64_t uid);
 
 String HHVM_FUNCTION(posix_strerror,
-                     int errnum);
+                     int64_t errnum);
 
 Variant HHVM_FUNCTION(posix_times);
 
@@ -126,4 +126,3 @@ Variant HHVM_FUNCTION(posix_uname);
 
 ///////////////////////////////////////////////////////////////////////////////
 }
-

--- a/hphp/runtime/ext/process/ext_process.cpp
+++ b/hphp/runtime/ext/process/ext_process.cpp
@@ -155,7 +155,7 @@ static struct ProcessExtension final : Extension {
 } s_process_extension;
 
 int64_t HHVM_FUNCTION(pcntl_alarm,
-                      int seconds) {
+                      int64_t seconds) {
   return alarm(seconds);
 }
 
@@ -255,8 +255,8 @@ int64_t HHVM_FUNCTION(pcntl_fork) {
 }
 
 Variant HHVM_FUNCTION(pcntl_getpriority,
-                      int pid /* = 0 */,
-                      int process_identifier /* = 0 */) {
+                      int64_t pid /* = 0 */,
+                      int64_t process_identifier /* = 0 */) {
   if (pid == 0) {
     pid = getpid();
   }
@@ -286,9 +286,9 @@ Variant HHVM_FUNCTION(pcntl_getpriority,
 }
 
 bool HHVM_FUNCTION(pcntl_setpriority,
-                   int priority,
-                   int pid /* = 0 */,
-                   int process_identifier /* = 0 */) {
+                   int64_t priority,
+                   int64_t pid /* = 0 */,
+                   int64_t process_identifier /* = 0 */) {
   if (pid == 0) {
     pid = getpid();
   }
@@ -444,7 +444,7 @@ bool HHVM_FUNCTION(pcntl_signal_dispatch) {
 }
 
 bool HHVM_FUNCTION(pcntl_signal,
-                   int signo,
+                   int64_t signo,
                    const Variant& handler,
                    bool restart_syscalls /* = true */) {
   /* Special long value case for SIG_DFL and SIG_IGN */
@@ -482,7 +482,7 @@ bool HHVM_FUNCTION(pcntl_signal,
 }
 
 bool HHVM_FUNCTION(pcntl_sigprocmask,
-                   int how,
+                   int64_t how,
                    const Array& set,
                    Array& oldset) {
   auto const invalid_argument = [&] {
@@ -531,7 +531,7 @@ bool HHVM_FUNCTION(pcntl_sigprocmask,
 
 int64_t HHVM_FUNCTION(pcntl_wait,
                       int64_t& status,
-                      int options /* = 0 */) {
+                      int64_t options /* = 0 */) {
   int nstatus = -1;
   auto const child_id = LightProcess::waitpid(-1, &nstatus, options);
 /*  if (options) {
@@ -544,9 +544,9 @@ int64_t HHVM_FUNCTION(pcntl_wait,
 }
 
 int64_t HHVM_FUNCTION(pcntl_waitpid,
-                      int pid,
+                      int64_t pid,
                       int64_t& status,
-                      int options /* = 0 */) {
+                      int64_t options /* = 0 */) {
   int nstatus = -1;
   auto const child_id = LightProcess::waitpid(
     (pid_t)pid,
@@ -558,32 +558,32 @@ int64_t HHVM_FUNCTION(pcntl_waitpid,
 }
 
 int64_t HHVM_FUNCTION(pcntl_wexitstatus,
-                      int status) {
+                      int64_t status) {
   return WEXITSTATUS(status);
 }
 
 bool HHVM_FUNCTION(pcntl_wifexited,
-                   int status) {
+                   int64_t status) {
   return WIFEXITED(status);
 }
 
 bool HHVM_FUNCTION(pcntl_wifsignaled,
-                   int status) {
+                   int64_t status) {
   return WIFSIGNALED(status);
 }
 
 bool HHVM_FUNCTION(pcntl_wifstopped,
-                   int status) {
+                   int64_t status) {
   return WIFSTOPPED(status);
 }
 
 int64_t HHVM_FUNCTION(pcntl_wstopsig,
-                      int status) {
+                      int64_t status) {
   return WSTOPSIG(status);
 }
 
 int64_t HHVM_FUNCTION(pcntl_wtermsig,
-                      int status) {
+                      int64_t status) {
   return WTERMSIG(status);
 }
 

--- a/hphp/runtime/ext/process/ext_process.h
+++ b/hphp/runtime/ext/process/ext_process.h
@@ -24,7 +24,7 @@ namespace HPHP {
 ///////////////////////////////////////////////////////////////////////////////
 
 int64_t HHVM_FUNCTION(pcntl_alarm,
-                      int seconds);
+                      int64_t seconds);
 void HHVM_FUNCTION(pcntl_exec,
                    const String& path,
                    const Array& args = null_array,
@@ -32,31 +32,31 @@ void HHVM_FUNCTION(pcntl_exec,
 
 int64_t HHVM_FUNCTION(pcntl_fork);
 Variant HHVM_FUNCTION(pcntl_getpriority,
-                      int pid = 0,
-                      int process_identifier = 0);
+                      int64_t pid = 0,
+                      int64_t process_identifier = 0);
 bool HHVM_FUNCTION(pcntl_setpriority,
-                   int priority,
-                   int pid = 0,
-                   int process_identifier = 0);
+                   int64_t priority,
+                   int64_t pid = 0,
+                   int64_t process_identifier = 0);
 
 bool HHVM_FUNCTION(pcntl_signal,
-                   int signo,
+                   int64_t signo,
                    const Variant& handler,
                    bool restart_syscalls = true);
 bool HHVM_FUNCTION(pcntl_sigprocmask,
-                   int how,
+                   int64_t how,
                    const Array& set,
                    Array& oldset);
 int64_t HHVM_FUNCTION(pcntl_wait,
                       int64_t& status,
-                      int options = 0);
+                      int64_t options = 0);
 int64_t HHVM_FUNCTION(pcntl_waitpid,
-                      int pid,
+                      int64_t pid,
                       int64_t& status,
-                      int options = 0);
+                      int64_t options = 0);
 
 int64_t HHVM_FUNCTION(pcntl_wexitstatus,
-                      int status);
+                      int64_t status);
 
 /**
  * Process pending signals flagged earlier.
@@ -65,16 +65,15 @@ bool HHVM_FUNCTION(pcntl_signal_dispatch);
 
 // status querying
 bool HHVM_FUNCTION(pcntl_wifexited,
-                   int status);
+                   int64_t status);
 bool HHVM_FUNCTION(pcntl_wifsignaled,
-                   int status);
+                   int64_t status);
 bool HHVM_FUNCTION(pcntl_wifstopped,
-                   int status);
+                   int64_t status);
 int64_t HHVM_FUNCTION(pcntl_wstopsig,
-                      int status);
+                      int64_t status);
 int64_t HHVM_FUNCTION(pcntl_wtermsig,
-                      int status);
+                      int64_t status);
 
 ///////////////////////////////////////////////////////////////////////////////
 }
-

--- a/hphp/runtime/ext/reflection/ext_reflection.cpp
+++ b/hphp/runtime/ext/reflection/ext_reflection.cpp
@@ -1021,7 +1021,7 @@ static bool HHVM_METHOD(ReflectionMethod, isReadonly) {
   return func->attrs() & AttrReadonlyThis;
 }
 
-static int HHVM_METHOD(ReflectionMethod, getModifiers) {
+static int64_t HHVM_METHOD(ReflectionMethod, getModifiers) {
   auto const func = ReflectionFuncHandle::GetFuncFor(this_);
   return get_modifiers(func->attrs(), false, false);
 }
@@ -1224,7 +1224,7 @@ static String HHVM_METHOD(ReflectionClass, getEnumUnderlyingType) {
   return StrNR(cls->preClass()->enumBaseTy().typeName());
 }
 
-static int HHVM_METHOD(ReflectionClass, getModifiers) {
+static int64_t HHVM_METHOD(ReflectionClass, getModifiers) {
   auto const cls = ReflectionClassHandle::GetClassFor(this_);
   return get_modifiers(cls->attrs(), true, false);
 }
@@ -1987,7 +1987,7 @@ static bool HHVM_METHOD(ReflectionProperty, isDefault) {
   }
 }
 
-static int HHVM_METHOD(ReflectionProperty, getModifiers) {
+static int64_t HHVM_METHOD(ReflectionProperty, getModifiers) {
   auto const data = Native::data<ReflectionPropHandle>(this_);
   switch (data->getType()) {
     case ReflectionPropHandle::Type::Instance:

--- a/hphp/runtime/ext/sockets/ext_sockets.cpp
+++ b/hphp/runtime/ext/sockets/ext_sockets.cpp
@@ -53,15 +53,15 @@ namespace HPHP {
 ///////////////////////////////////////////////////////////////////////////////
 // helpers
 
-static void check_socket_parameters(int &domain, int &type) {
+static void check_socket_parameters(int64_t &domain, int64_t &type) {
   if (domain != AF_UNIX && domain != AF_INET6 && domain != AF_INET) {
-    raise_warning("invalid socket domain [%d] specified for argument 1, "
+    raise_warning("invalid socket domain [%ld] specified for argument 1, "
                     "assuming AF_INET", domain);
     domain = AF_INET;
   }
 
   if (type > 10) {
-    raise_warning("invalid socket type [%d] specified for argument 2, "
+    raise_warning("invalid socket type [%ld] specified for argument 2, "
                     "assuming SOCK_STREAM", type);
     type = SOCK_STREAM;
   }
@@ -630,9 +630,9 @@ static Variant new_socket_connect(const HostURL &hosturl, double timeout,
 ///////////////////////////////////////////////////////////////////////////////
 
 Variant HHVM_FUNCTION(socket_create,
-                      int domain,
-                      int type,
-                      int protocol) {
+                      int64_t domain,
+                      int64_t type,
+                      int64_t protocol) {
   check_socket_parameters(domain, type);
   int socketId = socket(domain, type, protocol);
   if (socketId == -1) {
@@ -645,8 +645,8 @@ Variant HHVM_FUNCTION(socket_create,
 }
 
 Variant HHVM_FUNCTION(socket_create_listen,
-                      int port,
-                      int backlog /* = 128 */) {
+                      int64_t port,
+                      int64_t backlog /* = 128 */) {
   HostEnt result;
   if (!safe_gethostbyname("0.0.0.0", result)) {
     return false;
@@ -682,7 +682,7 @@ Variant HHVM_FUNCTION(socket_create_listen,
 const StaticString
   s_socktype_generic("generic_socket");
 
-bool socket_create_pair_impl(int domain, int type, int protocol, Variant& fd,
+bool socket_create_pair_impl(int64_t domain, int64_t type, int64_t protocol, Variant& fd,
                              bool asStream) {
   check_socket_parameters(domain, type);
 
@@ -713,9 +713,9 @@ bool socket_create_pair_impl(int domain, int type, int protocol, Variant& fd,
 }
 
 bool HHVM_FUNCTION(socket_create_pair,
-                   int domain,
-                   int type,
-                   int protocol,
+                   int64_t domain,
+                   int64_t type,
+                   int64_t protocol,
                    Variant& fd) {
   return socket_create_pair_impl(domain, type, protocol, fd, false);
 }
@@ -728,8 +728,8 @@ const StaticString
 
 Variant HHVM_FUNCTION(socket_get_option,
                       const Resource& socket,
-                      int level,
-                      int optname) {
+                      int64_t level,
+                      int64_t optname) {
   auto sock = cast<Socket>(socket);
   socklen_t optlen;
 
@@ -833,8 +833,8 @@ bool HHVM_FUNCTION(socket_set_nonblock,
 
 bool HHVM_FUNCTION(socket_set_option,
                    const Resource& socket,
-                   int level,
-                   int optname,
+                   int64_t level,
+                   int64_t optname,
                    const Variant& optval) {
   auto sock = cast<Socket>(socket);
 
@@ -910,7 +910,7 @@ bool HHVM_FUNCTION(socket_set_option,
 bool HHVM_FUNCTION(socket_connect,
                    const Resource& socket,
                    const String& address,
-                   int port /* = 0 */) {
+                   int64_t port /* = 0 */) {
   auto sock = cast<Socket>(socket);
 
   switch (sock->getType()) {
@@ -949,7 +949,7 @@ bool HHVM_FUNCTION(socket_connect,
 bool HHVM_FUNCTION(socket_bind,
                    const Resource& socket,
                    const String& address,
-                   int port /* = 0 */) {
+                   int64_t port /* = 0 */) {
   auto sock = cast<Socket>(socket);
 
   sockaddr_storage sa_storage;
@@ -974,7 +974,7 @@ bool HHVM_FUNCTION(socket_bind,
 
 bool HHVM_FUNCTION(socket_listen,
                    const Resource& socket,
-                   int backlog /* = 0 */) {
+                   int64_t backlog /* = 0 */) {
   auto sock = cast<Socket>(socket);
   if (listen(sock->fd(), backlog) != 0) {
     SOCKET_ERROR(sock, "unable to listen on socket", errno);
@@ -988,7 +988,7 @@ Variant HHVM_FUNCTION(socket_select,
                       Variant& write,
                       Variant& except,
                       const Variant& vtv_sec,
-                      int tv_usec /* = 0 */) {
+                      int64_t tv_usec /* = 0 */) {
   int count = 0;
   if (!read.isNull()) {
     if (!read.isArray()) {
@@ -1086,7 +1086,7 @@ Variant HHVM_FUNCTION(socket_select,
 
 Variant HHVM_FUNCTION(socket_server,
                       const String& hostname,
-                      int port,
+                      int64_t port,
                       Variant& errnum,
                       Variant& errstr) {
   HostURL hosturl(static_cast<const std::string>(hostname), port);
@@ -1097,7 +1097,7 @@ Variant HHVM_FUNCTION(socket_server,
 
 Variant socket_server_impl(
   const HostURL &hosturl,
-  int flags,
+  int64_t flags,
   Variant& errnum,
   Variant& errstr,
   const Variant& context /* = uninit_variant */
@@ -1148,7 +1148,7 @@ Variant HHVM_FUNCTION(socket_accept,
 Variant HHVM_FUNCTION(socket_read,
                       const Resource& socket,
                       int64_t length,
-                      int type /* = 0 */) {
+                      int64_t type /* = 0 */) {
   if (length <= 0) {
     return false;
   }
@@ -1200,7 +1200,7 @@ Variant HHVM_FUNCTION(socket_send,
                       const Resource& socket,
                       const String& buf,
                       int64_t len,
-                      int flags) {
+                      int64_t flags) {
   auto sock = cast<Socket>(socket);
   if (len < 0) return false;
   if (len > buf.size()) {
@@ -1218,9 +1218,9 @@ Variant HHVM_FUNCTION(socket_sendto,
                       const Resource& socket,
                       const String& buf,
                       int64_t len,
-                      int flags,
+                      int64_t flags,
                       const String& addr,
-                      int port /* = -1 */) {
+                      int64_t port /* = -1 */) {
   auto sock = cast<Socket>(socket);
   if (len < 0) return false;
   if (len > buf.size()) {
@@ -1301,7 +1301,7 @@ Variant HHVM_FUNCTION(socket_recv,
                       const Resource& socket,
                       Variant& buf,
                       int64_t len,
-                      int flags) {
+                      int64_t flags) {
   if (len <= 0) {
     return false;
   }
@@ -1328,7 +1328,7 @@ Variant HHVM_FUNCTION(socket_recvfrom,
                       const Resource& socket,
                       Variant& buf,
                       int64_t len,
-                      int flags,
+                      int64_t flags,
                       Variant& name,
                       Variant& port) {
   if (len <= 0) {
@@ -1438,7 +1438,7 @@ Variant HHVM_FUNCTION(socket_recvfrom,
 
 bool HHVM_FUNCTION(socket_shutdown,
                    const Resource& socket,
-                   int how /* = 0 */) {
+                   int64_t how /* = 0 */) {
   /* For some operations that are conceptually a socket operation
    * (eg fopen('http://...)) we actually complete it and store the result in
    * a memfile. As the fact that it's not really a socket is an implementation
@@ -1461,7 +1461,7 @@ void HHVM_FUNCTION(socket_close,
 }
 
 String HHVM_FUNCTION(socket_strerror,
-                     int errnum) {
+                     int64_t errnum) {
   /*
    * PHP5 encodes both the h_errno and errno values into a single int:
    * < -10000: transformed h_errno value
@@ -1559,7 +1559,7 @@ Variant sockopen_impl(const HostURL &hosturl, Variant& errnum,
 
 Variant HHVM_FUNCTION(fsockopen,
                       const String& hostname,
-                      int port,
+                      int64_t port,
                       Variant& errnum,
                       Variant& errstr,
                       double timeout /* = -1.0 */) {
@@ -1569,7 +1569,7 @@ Variant HHVM_FUNCTION(fsockopen,
 
 Variant HHVM_FUNCTION(pfsockopen,
                       const String& hostname,
-                      int port,
+                      int64_t port,
                       Variant& errnum,
                       Variant& errstr,
                       double timeout /* = -1.0 */) {
@@ -1601,10 +1601,10 @@ const StaticString
 Variant HHVM_FUNCTION(getaddrinfo,
                       const String& host,
                       const String& port,
-                      int family /* = 0 */,
-                      int socktype /* = 0 */,
-                      int protocol /* = 0 */,
-                      int flags /* = 0 */) {
+                      int64_t family /* = 0 */,
+                      int64_t socktype /* = 0 */,
+                      int64_t protocol /* = 0 */,
+                      int64_t flags /* = 0 */) {
   const char *hptr = NULL, *pptr = NULL;
   if (!host.empty()) {
     hptr = host.c_str();

--- a/hphp/runtime/ext/sockets/ext_sockets.h
+++ b/hphp/runtime/ext/sockets/ext_sockets.h
@@ -24,25 +24,25 @@
 namespace HPHP {
 ///////////////////////////////////////////////////////////////////////////////
 
-bool socket_create_pair_impl(int domain, int type, int protocol, Variant& fd,
+bool socket_create_pair_impl(int64_t domain, int64_t type, int64_t protocol, Variant& fd,
                              bool asStream);
 
 Variant HHVM_FUNCTION(socket_create,
-                      int domain,
-                      int type,
-                      int protocol);
+                      int64_t domain,
+                      int64_t type,
+                      int64_t protocol);
 Variant HHVM_FUNCTION(socket_create_listen,
-                      int port,
-                      int backlog = 128);
+                      int64_t port,
+                      int64_t backlog = 128);
 bool HHVM_FUNCTION(socket_create_pair,
-                   int domain,
-                   int type,
-                   int protocol,
+                   int64_t domain,
+                   int64_t type,
+                   int64_t protocol,
                    Variant& fd);
 Variant HHVM_FUNCTION(socket_get_option,
                       const Resource& socket,
-                      int level,
-                      int optname);
+                      int64_t level,
+                      int64_t optname);
 bool HHVM_FUNCTION(socket_getpeername,
                    const Resource& socket,
                    Variant& address,
@@ -57,29 +57,29 @@ bool HHVM_FUNCTION(socket_set_nonblock,
                    const Resource& socket);
 bool HHVM_FUNCTION(socket_set_option,
                    const Resource& socket,
-                   int level,
-                   int optname,
+                   int64_t level,
+                   int64_t optname,
                    const Variant& optval);
 bool HHVM_FUNCTION(socket_connect,
                    const Resource& socket,
                    const String& address,
-                   int port = 0);
+                   int64_t port = 0);
 bool HHVM_FUNCTION(socket_bind,
                    const Resource& socket,
                    const String& address,
-                   int port = 0);
+                   int64_t port = 0);
 bool HHVM_FUNCTION(socket_listen,
                    const Resource& socket,
-                   int backlog = 0);
+                   int64_t backlog = 0);
 Variant HHVM_FUNCTION(socket_select,
                       Variant& read,
                       Variant& write,
                       Variant& except,
                       const Variant& vtv_sec,
-                      int tv_usec = 0);
+                      int64_t tv_usec = 0);
 Variant HHVM_FUNCTION(socket_server,
                       const String& hostname,
-                      int port,
+                      int64_t port,
                       Variant& errnum,
                       Variant& errstr);
 Variant HHVM_FUNCTION(socket_accept,
@@ -87,7 +87,7 @@ Variant HHVM_FUNCTION(socket_accept,
 Variant HHVM_FUNCTION(socket_read,
                       const Resource& socket,
                       int64_t length,
-                      int type = 0);
+                      int64_t type = 0);
 Variant HHVM_FUNCTION(socket_write,
                       const Resource& socket,
                       const String& buffer,
@@ -96,33 +96,33 @@ Variant HHVM_FUNCTION(socket_send,
                       const Resource& socket,
                       const String& buf,
                       int64_t len,
-                      int flags);
+                      int64_t flags);
 Variant HHVM_FUNCTION(socket_sendto,
                       const Resource& socket,
                       const String& buf,
                       int64_t  len,
-                      int flags,
+                      int64_t flags,
                       const String& addr,
-                      int port = -1);
+                      int64_t port = -1);
 Variant HHVM_FUNCTION(socket_recv,
                       const Resource& socket,
                       Variant& buf,
                       int64_t len,
-                      int flags);
+                      int64_t flags);
 Variant HHVM_FUNCTION(socket_recvfrom,
                       const Resource& socket,
                       Variant& buf,
                       int64_t len,
-                      int flags,
+                      int64_t flags,
                       Variant& name,
                       Variant& port);
 bool HHVM_FUNCTION(socket_shutdown,
                    const Resource& socket,
-                   int how = 0);
+                   int64_t how = 0);
 void HHVM_FUNCTION(socket_close,
                    const Resource& socket);
 String HHVM_FUNCTION(socket_strerror,
-                     int errnum);
+                     int64_t errnum);
 int64_t HHVM_FUNCTION(socket_last_error,
                       const Variant& socket = uninit_variant);
 void HHVM_FUNCTION(socket_clear_error,
@@ -130,10 +130,10 @@ void HHVM_FUNCTION(socket_clear_error,
 Variant HHVM_FUNCTION(getaddrinfo,
                       const String& host,
                       const String& port,
-                      int family = 0,
-                      int socktype = 0,
-                      int protocol = 0,
-                      int flags = 0);
+                      int64_t family = 0,
+                      int64_t socktype = 0,
+                      int64_t protocol = 0,
+                      int64_t flags = 0);
 
 ///////////////////////////////////////////////////////////////////////////////
 // Zend defines the following in network, so these are not part of the
@@ -141,13 +141,13 @@ Variant HHVM_FUNCTION(getaddrinfo,
 
 Variant HHVM_FUNCTION(fsockopen,
                       const String& hostname,
-                      int port,
+                      int64_t port,
                       Variant& errnum,
                       Variant& errstr,
                       double timeout = -1.0);
 Variant HHVM_FUNCTION(pfsockopen,
                       const String& hostname,
-                      int port,
+                      int64_t port,
                       Variant& errnum,
                       Variant& errstr,
                       double timeout = -1.0);
@@ -155,7 +155,7 @@ Variant HHVM_FUNCTION(pfsockopen,
 ///////////////////////////////////////////////////////////////////////////////
 
 Variant socket_server_impl(const HostURL &hosturl,
-                           int flags,
+                           int64_t flags,
                            Variant& errnum,
                            Variant& errstr,
                            const Variant& context = uninit_variant);
@@ -165,4 +165,3 @@ Variant sockopen_impl(const HostURL &hosturl, Variant& errnum,
 
 ///////////////////////////////////////////////////////////////////////////////
 }
-

--- a/hphp/runtime/ext/sodium/ext_sodium.cpp
+++ b/hphp/runtime/ext/sodium/ext_sodium.cpp
@@ -1990,7 +1990,7 @@ String HHVM_FUNCTION(sodium_crypto_secretstream_xchacha20poly1305_push,
                      Variant& state_inout,
                      const String& plaintext,
                      const String& ad,
-                     int tag) {
+                     int64_t tag) {
   // parse state string into the struct
   if (!state_inout.isString()) {
     throwSodiumException(s_crypto_secretstream_xchacha20poly130_state_string_required);

--- a/hphp/runtime/ext/std/ext_std_errorfunc.cpp
+++ b/hphp/runtime/ext/std/ext_std_errorfunc.cpp
@@ -223,7 +223,7 @@ Array HHVM_FUNCTION(error_get_last) {
   );
 }
 
-bool HHVM_FUNCTION(error_log, const String& message, int message_type /* = 0 */,
+bool HHVM_FUNCTION(error_log, const String& message, int64_t message_type /* = 0 */,
                    const Variant& destination /* = null */,
                    const Variant& /*extra_headers*/ /* = null */) {
   // error_log() should not invoke the user error handler,
@@ -251,7 +251,7 @@ bool HHVM_FUNCTION(error_log, const String& message, int message_type /* = 0 */,
   }
   case 2: // not used per PHP
   default:
-    Logger::Error("error_log does not support message_type %d!", message_type);
+    Logger::Error("error_log does not support message_type %ld!", message_type);
     break;
   }
   return false;
@@ -277,7 +277,7 @@ bool HHVM_FUNCTION(restore_exception_handler) {
 }
 
 Variant HHVM_FUNCTION(set_error_handler, const Variant& error_handler,
-                      int error_types /* = ErrorMode::PHP_ALL | STRICT */) {
+                      int64_t error_types /* = ErrorMode::PHP_ALL | STRICT */) {
   if (!is_null(error_handler.asTypedValue())) {
     return g_context->pushUserErrorHandler(error_handler, error_types);
   } else {
@@ -306,7 +306,7 @@ void HHVM_FUNCTION(hphp_clear_unflushed) {
 }
 
 bool HHVM_FUNCTION(trigger_error, const String& error_msg,
-                   int error_type /* = ErrorMode::USER_NOTICE */) {
+                   int64_t error_type /* = ErrorMode::USER_NOTICE */) {
   std::string msg = error_msg.data(); // not toCppString()
   if (UNLIKELY(g_context->getThrowAllErrors())) {
     throw Exception(folly::sformat("throwAllErrors: {}", error_type));
@@ -373,8 +373,8 @@ bool HHVM_FUNCTION(trigger_error, const String& error_msg,
 }
 
 bool HHVM_FUNCTION(trigger_sampled_error, const String& error_msg,
-                   int sample_rate,
-                   int error_type /* = (int)ErrorMode::USER_NOTICE */) {
+                   int64_t sample_rate,
+                   int64_t error_type /* = (int)ErrorMode::USER_NOTICE */) {
   if (!folly::Random::oneIn(sample_rate)) {
     return true;
   }
@@ -382,7 +382,7 @@ bool HHVM_FUNCTION(trigger_sampled_error, const String& error_msg,
 }
 
 bool HHVM_FUNCTION(user_error, const String& error_msg,
-                   int error_type /* = (int)ErrorMode::USER_NOTICE */) {
+                   int64_t error_type /* = (int)ErrorMode::USER_NOTICE */) {
   return HHVM_FN(trigger_error)(error_msg, error_type);
 }
 

--- a/hphp/runtime/ext/std/ext_std_errorfunc.h
+++ b/hphp/runtime/ext/std/ext_std_errorfunc.h
@@ -42,26 +42,26 @@ int64_t HHVM_FUNCTION(hphp_debug_backtrace_hash, int64_t options = 0);
 void HHVM_FUNCTION(debug_print_backtrace, int64_t options = 0,
                                           int64_t limit = 0);
 Array HHVM_FUNCTION(error_get_last);
-bool HHVM_FUNCTION(error_log, const String& message, int message_type = 0,
+bool HHVM_FUNCTION(error_log, const String& message, int64_t message_type = 0,
                               const Variant& destination = uninit_variant,
                               const Variant& extra_headers = uninit_variant);
 int64_t HHVM_FUNCTION(error_reporting, const Variant& level = uninit_variant);
 bool HHVM_FUNCTION(restore_error_handler);
 bool HHVM_FUNCTION(restore_exception_handler);
 Variant HHVM_FUNCTION(set_error_handler, const Variant& error_handler,
-                      int error_types = ((int)ErrorMode::PHP_ALL |
+                      int64_t error_types = ((int)ErrorMode::PHP_ALL |
                                          (int)ErrorMode::STRICT));
 Variant HHVM_FUNCTION(set_exception_handler, const Variant& exception_handler);
 void HHVM_FUNCTION(hphp_set_error_page, const String& page);
 void HHVM_FUNCTION(hphp_throw_fatal_error, const String& error_msg);
 void HHVM_FUNCTION(hphp_clear_unflushed);
 bool HHVM_FUNCTION(trigger_error, const String& error_msg,
-                                  int error_type = (int)ErrorMode::USER_NOTICE);
+                                  int64_t error_type = (int)ErrorMode::USER_NOTICE);
 bool HHVM_FUNCTION(trigger_sampled_error, const String& error_msg,
-                   int sample_rate,
-                   int error_type = (int)ErrorMode::USER_NOTICE);
+                   int64_t sample_rate,
+                   int64_t error_type = (int)ErrorMode::USER_NOTICE);
 bool HHVM_FUNCTION(user_error, const String& error_msg,
-                               int error_type = (int)ErrorMode::USER_NOTICE);
+                               int64_t error_type = (int)ErrorMode::USER_NOTICE);
 
 ArrayData* debug_backtrace_jit(int64_t options);
 String debug_string_backtrace(bool skip, bool ignore_args = false,
@@ -70,4 +70,3 @@ String stringify_backtrace(const Array& bt, bool ignore_args);
 
 ///////////////////////////////////////////////////////////////////////////////
 }
-

--- a/hphp/runtime/ext/std/ext_std_file.cpp
+++ b/hphp/runtime/ext/std/ext_std_file.cpp
@@ -519,7 +519,7 @@ static int flock_values[] = { LOCK_SH, LOCK_EX, LOCK_UN };
 
 bool HHVM_FUNCTION(flock,
                    const Resource& handle,
-                   int operation,
+                   int64_t operation,
                    bool& wouldblock) {
   CHECK_HANDLE(handle, f);
   int act;
@@ -527,7 +527,7 @@ bool HHVM_FUNCTION(flock,
 
   act = operation & 3;
   if (act < 1 || act > 3) {
-    raise_invalid_argument_warning("operation: %d", operation);
+    raise_invalid_argument_warning("operation: %ld", operation);
     return false;
   }
   act = flock_values[act - 1] | (operation & 4 ? LOCK_NB : 0);
@@ -599,7 +599,7 @@ Variant HHVM_FUNCTION(file_get_contents,
 Variant HHVM_FUNCTION(file_put_contents,
                       const String& filename,
                       const Variant& data,
-                      int flags /* = 0 */,
+                      int64_t flags /* = 0 */,
                       const Variant& context /* = null */) {
   CHECK_PATH(filename, 1);
 
@@ -730,7 +730,7 @@ Variant HHVM_FUNCTION(file_put_contents,
 
 Variant HHVM_FUNCTION(file,
                       const String& filename,
-                      int flags /* = 0 */,
+                      int64_t flags /* = 0 */,
                       const Variant& context /* = null */) {
   CHECK_PATH(filename, 1);
   Variant contents = HHVM_FN(file_get_contents)(filename,
@@ -869,7 +869,7 @@ String resolve_parse_ini_filename(const String& filename) {
 Variant HHVM_FUNCTION(parse_ini_file,
                       const String& filename,
                       bool process_sections /* = false */,
-                      int scanner_mode /* = k_INI_SCANNER_NORMAL */) {
+                      int64_t scanner_mode /* = k_INI_SCANNER_NORMAL */) {
   CHECK_PATH_FALSE(filename, 1);
   if (filename.empty()) {
     raise_invalid_argument_warning("Filename cannot be empty!");
@@ -907,7 +907,7 @@ Variant HHVM_FUNCTION(parse_ini_file,
 Variant HHVM_FUNCTION(parse_ini_string,
                       const String& ini,
                       bool process_sections /* = false */,
-                      int scanner_mode /* = k_INI_SCANNER_NORMAL */) {
+                      int64_t scanner_mode /* = k_INI_SCANNER_NORMAL */) {
   return IniSetting::FromString(ini, "", process_sections, scanner_mode);
 }
 
@@ -1322,7 +1322,7 @@ const StaticString
 
 Variant HHVM_FUNCTION(pathinfo,
                       const String& path,
-                      int opt /* = 15 */) {
+                      int64_t opt /* = 15 */) {
   DictInit ret{4};
 
   if (opt == 0) {
@@ -1750,7 +1750,7 @@ String HHVM_FUNCTION(basename,
 
 bool HHVM_FUNCTION(fnmatch,
                    const String& pattern,
-                   const String& filename, int flags /* = 0 */) {
+                   const String& filename, int64_t flags /* = 0 */) {
   CHECK_PATH_FALSE(pattern, 1);
   CHECK_PATH_FALSE(filename, 2);
   if (filename.size() >= PATH_MAX) {
@@ -1770,7 +1770,7 @@ bool HHVM_FUNCTION(fnmatch,
 
 Variant HHVM_FUNCTION(glob,
                       const String& pattern,
-                      int flags /* = 0 */) {
+                      int64_t flags /* = 0 */) {
   CHECK_PATH(pattern, 1);
   glob_t globbuf;
   int cwd_skip = 0;

--- a/hphp/runtime/ext/std/ext_std_file.h
+++ b/hphp/runtime/ext/std/ext_std_file.h
@@ -134,7 +134,7 @@ bool HHVM_FUNCTION(ftruncate,
                    int64_t size);
 bool HHVM_FUNCTION(flock,
                    const Resource& handle,
-                   int operation,
+                   int64_t operation,
                    bool& wouldblock);
 Variant HHVM_FUNCTION(fputcsv,
                       const Resource& handle,
@@ -161,11 +161,11 @@ Variant HHVM_FUNCTION(file_get_contents,
 Variant HHVM_FUNCTION(file_put_contents,
                       const String& filename,
                       const Variant& data,
-                      int flags = 0,
+                      int64_t flags = 0,
                       const Variant& context = uninit_null());
 Variant HHVM_FUNCTION(file,
                       const String& filename,
-                      int flags = 0,
+                      int64_t flags = 0,
                       const Variant& context = uninit_null());
 Variant HHVM_FUNCTION(readfile,
                       const String& filename,
@@ -177,11 +177,11 @@ bool HHVM_FUNCTION(move_uploaded_file,
 Variant HHVM_FUNCTION(parse_ini_file,
                       const String& filename,
                       bool process_sections = false,
-                      int scanner_mode = k_INI_SCANNER_NORMAL);
+                      int64_t scanner_mode = k_INI_SCANNER_NORMAL);
 Variant HHVM_FUNCTION(parse_ini_string,
                       const String& ini,
                       bool process_sections = false,
-                      int scanner_mode = k_INI_SCANNER_NORMAL);
+                      int64_t scanner_mode = k_INI_SCANNER_NORMAL);
 Variant HHVM_FUNCTION(md5_file,
                       const String& filename,
                       bool raw_output = false);
@@ -236,10 +236,10 @@ String HHVM_FUNCTION(basename,
 bool HHVM_FUNCTION(fnmatch,
                    const String& pattern,
                    const String& filename,
-                   int flags = 0);
+                   int64_t flags = 0);
 Variant HHVM_FUNCTION(glob,
                       const String& pattern,
-                      int flags = 0);
+                      int64_t flags = 0);
 Variant HHVM_FUNCTION(tempnam,
                       const String& dir,
                       const String& prefix);
@@ -302,7 +302,7 @@ Variant HHVM_FUNCTION(realpath,
                       const String& path);
 Variant HHVM_FUNCTION(pathinfo,
                       const String& path,
-                      int opt = 15);
+                      int64_t opt = 15);
 Variant HHVM_FUNCTION(disk_free_space,
                       const String& directory);
 Variant HHVM_FUNCTION(diskfreespace,
@@ -346,4 +346,3 @@ void HHVM_FUNCTION(closedir,
 
 ///////////////////////////////////////////////////////////////////////////////
 }
-

--- a/hphp/runtime/ext/std/ext_std_intrinsics.cpp
+++ b/hphp/runtime/ext/std/ext_std_intrinsics.cpp
@@ -261,7 +261,7 @@ void HHVM_FUNCTION(hhbbc_fail_verification) {
  *   string $s,
  *   inout string $str,
  *   inout int $num,
- *   int $i,
+ *   int64_t $i,
  *   inout object $obj
  *   object $o,
  *   mixed $m,
@@ -277,7 +277,7 @@ Array HHVM_FUNCTION(
   StringArg s,
   String& str,
   int64_t& num,
-  int i,
+  int64_t i,
   Object& obj,
   ObjectArg o,
   const Variant& m,

--- a/hphp/runtime/ext/std/ext_std_misc.cpp
+++ b/hphp/runtime/ext/std/ext_std_misc.cpp
@@ -423,7 +423,7 @@ Variant HHVM_FUNCTION(pack, const String& format, const Array& argv) {
   return ZendPack().pack(format, argv);
 }
 
-int64_t HHVM_FUNCTION(sleep, int seconds) {
+int64_t HHVM_FUNCTION(sleep, int64_t seconds) {
   IOStatusHelper io("sleep");
   Transport *transport = g_context->getTransport();
   if (transport) {
@@ -433,7 +433,7 @@ int64_t HHVM_FUNCTION(sleep, int seconds) {
   return 0;
 }
 
-void HHVM_FUNCTION(usleep, int micro_seconds) {
+void HHVM_FUNCTION(usleep, int64_t micro_seconds) {
   IOStatusHelper io("usleep");
   Transport *transport = g_context->getTransport();
   if (transport) {
@@ -473,7 +473,7 @@ const StaticString
   s_seconds("seconds"),
   s_nanoseconds("nanoseconds");
 
-Variant HHVM_FUNCTION(time_nanosleep, int seconds, int nanoseconds) {
+Variant HHVM_FUNCTION(time_nanosleep, int64_t seconds, int64_t nanoseconds) {
   if (seconds < 0) {
     raise_invalid_argument_warning("seconds: cannot be negative");
     return false;

--- a/hphp/runtime/ext/std/ext_std_misc.h
+++ b/hphp/runtime/ext/std/ext_std_misc.h
@@ -37,9 +37,9 @@ bool HHVM_FUNCTION(define, const String& name, const Variant& value,
 bool HHVM_FUNCTION(defined, const String& name, bool autoload = true);
 int64_t HHVM_FUNCTION(ignore_user_abort, bool setting = false);
 Variant HHVM_FUNCTION(pack, const String& format, const Array& argv);
-int64_t HHVM_FUNCTION(sleep, int seconds);
-void HHVM_FUNCTION(usleep, int micro_seconds);
-Variant HHVM_FUNCTION(time_nanosleep, int seconds, int nanoseconds);
+int64_t HHVM_FUNCTION(sleep, int64_t seconds);
+void HHVM_FUNCTION(usleep, int64_t micro_seconds);
+Variant HHVM_FUNCTION(time_nanosleep, int64_t seconds, int64_t nanoseconds);
 bool HHVM_FUNCTION(time_sleep_until, double timestamp);
 String HHVM_FUNCTION(uniqid, const String& prefix = null_string,
                      bool more_entropy = false);
@@ -58,4 +58,3 @@ extern const double k_NAN;
 
 ///////////////////////////////////////////////////////////////////////////////
 }
-

--- a/hphp/runtime/ext/std/ext_std_network-posix.cpp
+++ b/hphp/runtime/ext/std/ext_std_network-posix.cpp
@@ -484,13 +484,13 @@ static unsigned char *php_parserr(unsigned char *cp, unsigned char* end,
   return cp;
 }
 
-Variant HHVM_FUNCTION(dns_get_record, const String& hostname, int type,
+Variant HHVM_FUNCTION(dns_get_record, const String& hostname, int64_t type,
                       Variant& authnsRef,
                       Variant& addtlRef) {
   IOStatusHelper io("dns_get_record", hostname.data(), type);
   if (type < 0) type = PHP_DNS_ALL;
   if (type & ~PHP_DNS_ALL && type != PHP_DNS_ANY) {
-    raise_warning("Type '%d' not supported", type);
+    raise_warning("Type '%ld' not supported", type);
     return false;
   }
 

--- a/hphp/runtime/ext/std/ext_std_network-win.cpp
+++ b/hphp/runtime/ext/std/ext_std_network-win.cpp
@@ -273,7 +273,7 @@ static void php_parserr(PDNS_RECORD pRec, int type_to_fetch, int store,
 
 }
 
-Variant HHVM_FUNCTION(dns_get_record, const String& hostname, int type,
+Variant HHVM_FUNCTION(dns_get_record, const String& hostname, int64_t type,
                       Variant& authnsRef,
                       Variant& addtlRef) {
   IOStatusHelper io("dns_get_record", hostname.data(), type);

--- a/hphp/runtime/ext/std/ext_std_network.cpp
+++ b/hphp/runtime/ext/std/ext_std_network.cpp
@@ -247,7 +247,7 @@ String HHVM_FUNCTION(long2ip, const String& proper_address) {
 // http
 
 void HHVM_FUNCTION(header, const String& str, bool replace /* = true */,
-                   int http_response_code /* = 0 */) {
+                   int64_t http_response_code /* = 0 */) {
   if (HHVM_FN(headers_sent)()) {
     raise_warning("Cannot modify header information - headers already sent");
   }
@@ -315,7 +315,7 @@ void HHVM_FUNCTION(header, const String& str, bool replace /* = true */,
 
 static RDS_LOCAL(int, s_response_code);
 
-Variant HHVM_FUNCTION(http_response_code, int response_code /* = 0 */) {
+Variant HHVM_FUNCTION(http_response_code, int64_t response_code /* = 0 */) {
   Transport *transport = g_context->getTransport();
   if (transport) {
     *s_response_code = transport->getResponseCode();
@@ -441,7 +441,7 @@ bool HHVM_FUNCTION(setrawcookie, const String& name,
 
 ///////////////////////////////////////////////////////////////////////////////
 
-bool HHVM_FUNCTION(openlog, const String& ident, int option, int facility) {
+bool HHVM_FUNCTION(openlog, const String& ident, int64_t option, int64_t facility) {
   openlog(ident.data(), option, facility);
   return true;
 }
@@ -451,7 +451,7 @@ bool HHVM_FUNCTION(closelog) {
   return true;
 }
 
-bool HHVM_FUNCTION(syslog, int priority, const String& message) {
+bool HHVM_FUNCTION(syslog, int64_t priority, const String& message) {
   syslog(priority, "%s", message.data());
   return true;
 }

--- a/hphp/runtime/ext/std/ext_std_network.h
+++ b/hphp/runtime/ext/std/ext_std_network.h
@@ -42,15 +42,15 @@ Variant HHVM_FUNCTION(ip2long, const String& ip_address);
 String HHVM_FUNCTION(long2ip, const String& proper_address);
 bool HHVM_FUNCTION(checkdnsrr, const String& host,
                                const String& type = null_string);
-Variant HHVM_FUNCTION(dns_get_record, const String& hostname, int type,
+Variant HHVM_FUNCTION(dns_get_record, const String& hostname, int64_t type,
                                       Variant& authnsRef,
                                       Variant& addtlRef);
 bool HHVM_FUNCTION(getmxrr, const String& hostname,
                             Variant& mxhostsRef,
                             Variant& weightsRef);
 void HHVM_FUNCTION(header, const String& str, bool replace = true,
-                   int http_response_code = 0);
-Variant HHVM_FUNCTION(http_response_code, int response_code = 0);
+                   int64_t http_response_code = 0);
+Variant HHVM_FUNCTION(http_response_code, int64_t response_code = 0);
 Array HHVM_FUNCTION(headers_list);
 bool HHVM_FUNCTION(headers_sent);
 Variant HHVM_FUNCTION(header_register_callback, const Variant& callback);
@@ -70,11 +70,10 @@ bool HHVM_FUNCTION(setrawcookie, const String& name,
                                  const String& domain = null_string,
                                  bool secure = false,
                                  bool httponly = false);
-bool HHVM_FUNCTION(openlog, const String& ident, int option, int facility);
+bool HHVM_FUNCTION(openlog, const String& ident, int64_t option, int64_t facility);
 bool HHVM_FUNCTION(closelog);
-bool HHVM_FUNCTION(syslog, int priority, const String& message);
+bool HHVM_FUNCTION(syslog, int64_t priority, const String& message);
 
 bool validate_dns_arguments(const String& host, const String& type,
                             int& ntype);
 }
-

--- a/hphp/runtime/ext/std/ext_std_output.cpp
+++ b/hphp/runtime/ext/std/ext_std_output.cpp
@@ -52,8 +52,8 @@ const int64_t k_PHP_OUTPUT_HANDLER_STDFLAGS =
   k_PHP_OUTPUT_HANDLER_REMOVABLE;
 
 bool HHVM_FUNCTION(ob_start, const Variant& callback /* = null */,
-                             int chunk_size /* = 0 */,
-                             int flags /* = k_PHP_OUTPUT_HANDLER_STDFLAGS */) {
+                             int64_t chunk_size /* = 0 */,
+                             int64_t flags /* = k_PHP_OUTPUT_HANDLER_STDFLAGS */) {
   // Note: the only flag which is implemented is FLUSHABLE
 
   if (!callback.isNull()) {

--- a/hphp/runtime/ext/std/ext_std_output.h
+++ b/hphp/runtime/ext/std/ext_std_output.h
@@ -35,8 +35,8 @@ extern const int64_t k_PHP_OUTPUT_HANDLER_REMOVABLE;
 extern const int64_t k_PHP_OUTPUT_HANDLER_STDFLAGS;
 
 bool HHVM_FUNCTION(ob_start, const Variant& output_callback = uninit_null(),
-                             int chunk_size = 0,
-                             int flags = k_PHP_OUTPUT_HANDLER_STDFLAGS);
+                             int64_t chunk_size = 0,
+                             int64_t flags = k_PHP_OUTPUT_HANDLER_STDFLAGS);
 void HHVM_FUNCTION(ob_clean);
 bool HHVM_FUNCTION(ob_flush);
 bool HHVM_FUNCTION(ob_end_clean);
@@ -67,4 +67,3 @@ void HHVM_FUNCTION(hphp_clear_hardware_events, void);
 
 ///////////////////////////////////////////////////////////////////////////////
 }
-

--- a/hphp/runtime/ext/std/ext_std_process.cpp
+++ b/hphp/runtime/ext/std/ext_std_process.cpp
@@ -919,7 +919,7 @@ HHVM_FUNCTION(proc_open, const String& cmd, const Array& descriptorspec,
 
 bool HHVM_FUNCTION(proc_terminate,
                    const Resource& process,
-                   int signal /* = SIGTERM */) {
+                   int64_t signal /* = SIGTERM */) {
 #ifdef _WIN32
   // 255 is what PHP sends, so we do the same.
   return TerminateProcess(cast<ChildProcess>(process)->childHandle, 255);
@@ -994,7 +994,7 @@ Array HHVM_FUNCTION(proc_get_status,
 
 #ifndef _WIN32
 bool HHVM_FUNCTION(proc_nice,
-                   int increment) {
+                   int64_t increment) {
   errno = 0;
   if (nice(increment) == -1 && errno) {
     raise_warning("Only a super user may attempt to increase the "

--- a/hphp/runtime/ext/std/ext_std_process.h
+++ b/hphp/runtime/ext/std/ext_std_process.h
@@ -47,13 +47,13 @@ Variant HHVM_FUNCTION(proc_open,
                       const Variant& other_options = uninit_variant);
 bool HHVM_FUNCTION(proc_terminate,
                    const Resource& process,
-                   int signal = SIGTERM);
+                   int64_t signal = SIGTERM);
 int64_t HHVM_FUNCTION(proc_close,
                       const Resource& process);
 Array HHVM_FUNCTION(proc_get_status,
                     const Resource& process);
 bool HHVM_FUNCTION(proc_nice,
-                   int increment);
+                   int64_t increment);
 
 ///////////////////////////////////////////////////////////////////////////////
 
@@ -64,4 +64,3 @@ String HHVM_FUNCTION(escapeshellcmd,
 
 ///////////////////////////////////////////////////////////////////////////////
 }
-

--- a/hphp/runtime/ext/stream/ext_stream.cpp
+++ b/hphp/runtime/ext/stream/ext_stream.cpp
@@ -430,7 +430,7 @@ Variant HHVM_FUNCTION(stream_select,
                       Variant& write,
                       Variant& except,
                       const Variant& vtv_sec,
-                      int tv_usec /* = 0 */) {
+                      int64_t tv_usec /* = 0 */) {
   return HHVM_FN(socket_select)(read, write, except,
                                 vtv_sec, tv_usec);
 }
@@ -497,8 +497,8 @@ const StaticString
 
 bool HHVM_FUNCTION(stream_set_timeout,
                    const Resource& stream,
-                   int seconds,
-                   int microseconds /* = 0 */) {
+                   int64_t seconds,
+                   int64_t microseconds /* = 0 */) {
   if (isa<Socket>(stream)) {
     return HHVM_FN(socket_set_option)
       (stream, SOL_SOCKET, SO_RCVTIMEO,
@@ -688,7 +688,7 @@ Variant HHVM_FUNCTION(stream_socket_server,
                       const String& local_socket,
                       Variant& errnum,
                       Variant& errstr,
-                      int flags /* = 0 */,
+                      int64_t flags /* = 0 */,
                       const Variant& context /* = uninit_variant */) {
   HostURL hosturl(static_cast<const std::string>(local_socket));
   return socket_server_impl(hosturl, flags, errnum, errstr, context);
@@ -699,7 +699,7 @@ Variant HHVM_FUNCTION(stream_socket_client,
                       Variant& errnum,
                       Variant& errstr,
                       double timeout /* = -1.0 */,
-                      int flags /* = 0 */,
+                      int64_t flags /* = 0 */,
                       const Variant& context /* = uninit_variant */) {
   HostURL hosturl(static_cast<const std::string>(remote_socket));
   bool persistent = (flags & k_STREAM_CLIENT_PERSISTENT) ==
@@ -711,7 +711,7 @@ Variant HHVM_FUNCTION(stream_socket_client,
 bool HHVM_FUNCTION(stream_socket_enable_crypto,
                    const Resource& socket,
                    bool enable,
-                   int cryptotype,
+                   int64_t cryptotype,
                    const Variant& sessionstream) {
   auto sock = cast<SSLSocket>(socket);
   if (!enable) {
@@ -788,9 +788,9 @@ Variant HHVM_FUNCTION(stream_socket_get_name,
 }
 
 Variant HHVM_FUNCTION(stream_socket_pair,
-                      int domain,
-                      int type,
-                      int protocol) {
+                      int64_t domain,
+                      int64_t type,
+                      int64_t protocol) {
   Variant fd;
   if (!socket_create_pair_impl(domain, type, protocol, fd, true)) {
     return false;
@@ -801,7 +801,7 @@ Variant HHVM_FUNCTION(stream_socket_pair,
 Variant HHVM_FUNCTION(stream_socket_recvfrom,
                       const Resource& socket,
                       int64_t length,
-                      int flags,
+                      int64_t flags,
                       Variant& address) {
   Variant ret, host, port;
   Variant retval = HHVM_FN(socket_recvfrom)(socket, ret, length, flags,
@@ -821,7 +821,7 @@ Variant HHVM_FUNCTION(stream_socket_recvfrom,
 Variant HHVM_FUNCTION(stream_socket_sendto,
                       const Resource& socket,
                       const String& data,
-                      int flags /* = 0 */,
+                      int64_t flags /* = 0 */,
                       const Variant& address /* = uninit_variant */) {
   String host; int port;
   const String& strAddress = address.isNull()
@@ -843,7 +843,7 @@ Variant HHVM_FUNCTION(stream_socket_sendto,
 
 bool HHVM_FUNCTION(stream_socket_shutdown,
                    const Resource& stream,
-                   int how) {
+                   int64_t how) {
   return HHVM_FN(socket_shutdown)(stream, how);
 }
 

--- a/hphp/runtime/ext/stream/ext_stream.h
+++ b/hphp/runtime/ext/stream/ext_stream.h
@@ -188,7 +188,7 @@ Variant HHVM_FUNCTION(stream_select,
                       Variant& write,
                       Variant& except,
                       const Variant& vtv_sec,
-                      int tv_usec = 0);
+                      int64_t tv_usec = 0);
 
 Object HHVM_FUNCTION(stream_await,
                      const Resource& stream,
@@ -209,8 +209,8 @@ Variant HHVM_FUNCTION(stream_set_chunk_size,
 
 bool HHVM_FUNCTION(stream_set_timeout,
                    const Resource& stream,
-                   int seconds,
-                   int microseconds = 0);
+                   int64_t seconds,
+                   int64_t microseconds = 0);
 
 int64_t HHVM_FUNCTION(stream_set_write_buffer,
                       const Resource& stream,
@@ -232,7 +232,7 @@ Variant HHVM_FUNCTION(stream_socket_server,
                       const String& local_socket,
                       Variant& errnum,
                       Variant& errstr,
-                      int flags = k_STREAM_SERVER_BIND|k_STREAM_SERVER_LISTEN,
+                      int64_t flags = k_STREAM_SERVER_BIND|k_STREAM_SERVER_LISTEN,
                       const Variant& context = uninit_variant);
 
 Variant HHVM_FUNCTION(stream_socket_client,
@@ -240,13 +240,13 @@ Variant HHVM_FUNCTION(stream_socket_client,
                       Variant& errnum,
                       Variant& errstr,
                       double timeout = -1.0,
-                      int flags = 0,
+                      int64_t flags = 0,
                       const Variant& context = uninit_variant);
 
 bool HHVM_FUNCTION(stream_socket_enable_crypto,
                    const Resource& socket,
                    bool enable,
-                   int cryptotype,
+                   int64_t cryptotype,
                    const Variant& sessionstream);
 
 Variant HHVM_FUNCTION(stream_socket_get_name,
@@ -254,26 +254,25 @@ Variant HHVM_FUNCTION(stream_socket_get_name,
                       bool want_peer);
 
 Variant HHVM_FUNCTION(stream_socket_pair,
-                      int domain,
-                      int type,
-                      int protocol);
+                      int64_t domain,
+                      int64_t type,
+                      int64_t protocol);
 
 Variant HHVM_FUNCTION(stream_socket_recvfrom,
                       const Resource& socket,
                       int64_t length,
-                      int flags,
+                      int64_t flags,
                       Variant& address);
 
 Variant HHVM_FUNCTION(stream_socket_sendto,
                       const Resource& socket,
                       const String& data,
-                      int flags = 0,
+                      int64_t flags = 0,
                       const Variant& address = uninit_variant);
 
 bool HHVM_FUNCTION(stream_socket_shutdown,
                    const Resource& stream,
-                   int how);
+                   int64_t how);
 
 ///////////////////////////////////////////////////////////////////////////////
 }
-

--- a/hphp/runtime/ext/string/ext_string.cpp
+++ b/hphp/runtime/ext/string/ext_string.cpp
@@ -522,7 +522,7 @@ TypedValue HHVM_FUNCTION(str_split, const String& str, int64_t split_length) {
 }
 
 TypedValue HHVM_FUNCTION(chunk_split, const String& body,
-                      int chunklen, const String& end) {
+                      int64_t chunklen, const String& end) {
   return tvReturn(StringUtil::ChunkSplit(body, chunklen, end));
 }
 
@@ -827,7 +827,7 @@ TypedValue HHVM_FUNCTION(substr_replace,
  * This function determines how those two parameters are interpreted in
  * f_substr.
  */
-static bool string_substr_check(int len, int& f, int& l) {
+static bool string_substr_check(int len, int64_t& f, int64_t& l) {
   assertx(len >= 0);
 
   if (l < 0 && -l > len) {
@@ -871,7 +871,7 @@ static bool string_substr_check(int len, int& f, int& l) {
   return true;
 }
 
-TypedValue HHVM_FUNCTION(substr, StringArg str, int start, int length) {
+TypedValue HHVM_FUNCTION(substr, StringArg str, int64_t start, int64_t length) {
   auto const size = str.get()->size();
   if (!string_substr_check(size, start, length)) {
     if (RuntimeOption::PHP7_Substr && size == start) {
@@ -885,9 +885,9 @@ TypedValue HHVM_FUNCTION(substr, StringArg str, int start, int length) {
 
 String HHVM_FUNCTION(str_pad,
                      const String& input,
-                     int pad_length,
+                     int64_t pad_length,
                      const String& pad_string /* = " " */,
-                     int pad_type /* = k_STR_PAD_RIGHT */) {
+                     int64_t pad_type /* = k_STR_PAD_RIGHT */) {
   return StringUtil::Pad(input, pad_length, pad_string,
                          (StringUtil::PadType)pad_type);
 }
@@ -987,7 +987,7 @@ Variant HHVM_FUNCTION(money_format,
 
 String HHVM_FUNCTION(number_format,
                      double number,
-                     int decimals /* = 0 */,
+                     int64_t decimals /* = 0 */,
                      const Variant& dec_point_in /* = "." */,
                      const Variant& thousands_sep_in /* = "," */) {
 
@@ -1012,7 +1012,7 @@ int64_t HHVM_FUNCTION(strcmp,
 TypedValue HHVM_FUNCTION(strncmp,
                          const String& str1,
                          const String& str2,
-                         int len) {
+                         int64_t len) {
   if (len < 0) {
     raise_warning("Length must be greater than or equal to 0");
     return make_tv<KindOfBoolean>(false);
@@ -1039,7 +1039,7 @@ int64_t HHVM_FUNCTION(strcasecmp,
 TypedValue HHVM_FUNCTION(strncasecmp,
                          const String& str1,
                          const String& str2,
-                         int len) {
+                         int64_t len) {
   if (len < 0) {
     raise_warning("Length must be greater than or equal to 0");
     return make_tv<KindOfBoolean>(false);
@@ -1066,8 +1066,8 @@ int64_t HHVM_FUNCTION(strcoll,
 TypedValue HHVM_FUNCTION(substr_compare,
                          const String& main_str,
                          const String& str,
-                         int offset,
-                         int length /* = INT_MAX */,
+                         int64_t offset,
+                         int64_t length /* = INT_MAX */,
                          bool case_insensitivity /* = false */) {
   int s1_len = main_str.size();
   int s2_len = str.size();
@@ -1087,7 +1087,7 @@ TypedValue HHVM_FUNCTION(substr_compare,
     return make_tv<KindOfBoolean>(false);
   }
 
-  auto const cmp_len = std::min(s1_len - offset, std::min(s2_len, length));
+  auto const cmp_len = std::min(s1_len - offset, std::min<int64_t>(s2_len, length));
 
   auto const ret = [&] {
     const char *s1 = main_str.data();
@@ -1098,7 +1098,7 @@ TypedValue HHVM_FUNCTION(substr_compare,
   }();
   if (ret == 0) {
     auto const m1 = std::min(s1_len - offset, length);
-    auto const m2 = std::min(s2_len, length);
+    auto const m2 = std::min<int64_t>(s2_len, length);
     if (m1 > m2) return tvReturn(1);
     if (m1 < m2) return tvReturn(-1);
     return tvReturn(0);
@@ -1249,7 +1249,7 @@ TypedValue HHVM_FUNCTION(strpbrk,
 TypedValue HHVM_FUNCTION(strpos,
                          const String& haystack,
                          const Variant& needle,
-                         int offset /* = 0 */) {
+                         int64_t offset /* = 0 */) {
   if (offset < 0 || offset > haystack.size()) {
     raise_warning("Offset not contained in string");
     return make_tv<KindOfBoolean>(false);
@@ -1272,7 +1272,7 @@ TypedValue HHVM_FUNCTION(strpos,
 TypedValue HHVM_FUNCTION(stripos,
                          const String& haystack,
                          const Variant& needle,
-                         int offset /* = 0 */) {
+                         int64_t offset /* = 0 */) {
   if (offset < 0 || offset > haystack.size()) {
     raise_warning("Offset not contained in string");
     return make_tv<KindOfBoolean>(false);
@@ -1330,7 +1330,7 @@ TypedValue HHVM_FUNCTION(strrchr,
 TypedValue HHVM_FUNCTION(strrpos,
                          const String& haystack,
                          const Variant& needle,
-                         int offset /* = 0 */) {
+                         int64_t offset /* = 0 */) {
   if (!is_valid_strrpos_args(haystack, needle, offset)) {
     return make_tv<KindOfBoolean>(false);
   }
@@ -1347,7 +1347,7 @@ TypedValue HHVM_FUNCTION(strrpos,
 TypedValue HHVM_FUNCTION(strripos,
                          const String& haystack,
                          const Variant& needle,
-                         int offset /* = 0 */) {
+                         int64_t offset /* = 0 */) {
   if (!is_valid_strrpos_args(haystack, needle, offset)) {
     return make_tv<KindOfBoolean>(false);
   }
@@ -1364,8 +1364,8 @@ TypedValue HHVM_FUNCTION(strripos,
 TypedValue HHVM_FUNCTION(substr_count,
                          const String& haystack,
                          const String& needle,
-                         int offset /* = 0 */,
-                         int length /* = 0x7FFFFFFF */) {
+                         int64_t offset /* = 0 */,
+                         int64_t length /* = 0x7FFFFFFF */) {
   int lenNeedle = needle.size();
   if (lenNeedle == 0) {
     raise_invalid_argument_warning("needle: (empty)");
@@ -1394,7 +1394,7 @@ TypedValue HHVM_FUNCTION(substr_count,
 }
 
 namespace {
-  bool string_strspn_check(int inputLength, int &start, int &scanLength) {
+  bool string_strspn_check(int inputLength, int64_t &start, int64_t &scanLength) {
     if (start < 0) {
       start += inputLength;
       if (start < 0) {
@@ -1420,8 +1420,8 @@ namespace {
 TypedValue HHVM_FUNCTION(strspn,
                          const String& str1,
                          const String& str2,
-                         int start /* = 0 */,
-                         int length /* = 0x7FFFFFFF */) {
+                         int64_t start /* = 0 */,
+                         int64_t length /* = 0x7FFFFFFF */) {
   const char *s1 = str1.data();
   const char *s2 = str2.data();
   int s1_len = str1.size();
@@ -1444,8 +1444,8 @@ TypedValue HHVM_FUNCTION(strspn,
 TypedValue HHVM_FUNCTION(strcspn,
                          const String& str1,
                          const String& str2,
-                         int start /* = 0 */,
-                         int length /* = 0x7FFFFFFF */) {
+                         int64_t start /* = 0 */,
+                         int64_t length /* = 0x7FFFFFFF */) {
   const char *s1 = str1.data();
   const char *s2 = str2.data();
   int s1_len = str1.size();
@@ -1634,9 +1634,9 @@ Variant HHVM_FUNCTION(str_word_count,
 int64_t HHVM_FUNCTION(levenshtein,
                       const String& str1,
                       const String& str2,
-                      int cost_ins /* = 1 */,
-                      int cost_rep /* = 1 */,
-                      int cost_del /* = 1 */) {
+                      int64_t cost_ins /* = 1 */,
+                      int64_t cost_rep /* = 1 */,
+                      int64_t cost_del /* = 1 */) {
   return string_levenshtein(str1.data(), str1.size(), str2.data(), str2.size(),
                             cost_ins, cost_rep, cost_del);
 }
@@ -1656,13 +1656,13 @@ Variant HHVM_FUNCTION(soundex,
   return string_soundex(str);
 }
 
-Variant HHVM_FUNCTION(metaphone, const String& str, int /*phones*/ /* = 0 */) {
+Variant HHVM_FUNCTION(metaphone, const String& str, int64_t /*phones*/ /* = 0 */) {
   return string_metaphone(str.data(), str.size(), 0, 1);
 }
 
 String HHVM_FUNCTION(html_entity_decode,
                      const String& str,
-                     int flags /* = k_ENT_HTML_QUOTE_DOUBLE */,
+                     int64_t flags /* = k_ENT_HTML_QUOTE_DOUBLE */,
                      const String& charset /* = "UTF-8" */) {
   const char *scharset = charset.data();
   if (!*scharset) scharset = "ISO-8859-1";
@@ -1672,7 +1672,7 @@ String HHVM_FUNCTION(html_entity_decode,
 
 String HHVM_FUNCTION(htmlentities,
                      const String& str,
-                     int flags /* = k_ENT_HTML_QUOTE_DOUBLE */,
+                     int64_t flags /* = k_ENT_HTML_QUOTE_DOUBLE */,
                      const String& charset /* = "UTF-8" */,
                      bool double_encode /* = true */) {
   // dropping double_encode parameters and see runtime/base/zend-html.h
@@ -1684,14 +1684,14 @@ String HHVM_FUNCTION(htmlentities,
 
 String HHVM_FUNCTION(htmlspecialchars_decode,
                      const String& str,
-                     int flags /* = k_ENT_HTML_QUOTE_DOUBLE */) {
+                     int64_t flags /* = k_ENT_HTML_QUOTE_DOUBLE */) {
   return StringUtil::HtmlDecode(str, StringUtil::toQuoteStyle(flags),
                                 "UTF-8", false);
 }
 
 String HHVM_FUNCTION(htmlspecialchars,
                      const String& str,
-                     int flags /* = k_ENT_HTML_QUOTE_DOUBLE */,
+                     int64_t flags /* = k_ENT_HTML_QUOTE_DOUBLE */,
                      const String& charset /* = "UTF-8" */,
                      bool double_encode /* = true */) {
   // dropping double_encode parameters and see runtime/base/zend-html.h
@@ -1703,7 +1703,7 @@ String HHVM_FUNCTION(htmlspecialchars,
 
 String HHVM_FUNCTION(fb_htmlspecialchars,
                      const String& str,
-                     int flags /* = k_ENT_HTML_QUOTE_DOUBLE */,
+                     int64_t flags /* = k_ENT_HTML_QUOTE_DOUBLE */,
                      const String& charset /* = "ISO-8859-1" */,
                      const Variant& extra /* = varray[] */) {
   if (!extra.isNull() && !extra.isArray()) {
@@ -2121,7 +2121,7 @@ Variant HHVM_FUNCTION(strtr,
 }
 
 Variant HHVM_FUNCTION(setlocale,
-                      int category,
+                      int64_t category,
                       const Variant& locale,
                       const Array& _argv /* = null_array */) {
   Array argv = _argv;
@@ -2225,7 +2225,7 @@ Array HHVM_FUNCTION(localeconv) {
   return ret;
 }
 
-Variant HHVM_FUNCTION(nl_langinfo, int item) {
+Variant HHVM_FUNCTION(nl_langinfo, int64_t item) {
 #ifdef _MSC_VER
   raise_warning("nl_langinfo is not yet implemented on Windows!");
   return empty_string();
@@ -2391,7 +2391,7 @@ Variant HHVM_FUNCTION(nl_langinfo, int item) {
 #endif
       break;
     default:
-      raise_warning("Item '%d' is not valid", item);
+      raise_warning("Item '%ld' is not valid", item);
       return false;
   }
 
@@ -2471,8 +2471,8 @@ String encode_as_utf8(int code_point) {
 }
 
 Array HHVM_FUNCTION(get_html_translation_table,
-                    int table /* = 0 */,
-                    int flags /* = k_ENT_HTML_QUOTE_DOUBLE */,
+                    int64_t table /* = 0 */,
+                    int64_t flags /* = k_ENT_HTML_QUOTE_DOUBLE */,
                     const String& encoding /* = "UTF-8" */) {
   using namespace entity_charset_enum;
   auto charset = determine_charset(encoding.data());
@@ -2547,14 +2547,14 @@ Array HHVM_FUNCTION(get_html_translation_table,
 
 String HHVM_FUNCTION(hebrev,
                      const String& hebrew_text,
-                     int max_chars_per_line /* = 0 */) {
+                     int64_t max_chars_per_line /* = 0 */) {
   if (hebrew_text.empty()) return hebrew_text;
   return string_convert_hebrew_string(hebrew_text, max_chars_per_line, false);
 }
 
 String HHVM_FUNCTION(hebrevc,
                      const String& hebrew_text,
-                     int max_chars_per_line /* = 0 */) {
+                     int64_t max_chars_per_line /* = 0 */) {
   if (hebrew_text.empty()) return hebrew_text;
   return string_convert_hebrew_string(hebrew_text, max_chars_per_line, true);
 }

--- a/hphp/runtime/ext/string/ext_string.h
+++ b/hphp/runtime/ext/string/ext_string.h
@@ -121,7 +121,7 @@ TypedValue HHVM_FUNCTION(str_split,
                          int64_t split_length = 1);
 TypedValue HHVM_FUNCTION(chunk_split,
                          const String& body,
-                         int chunklen = 76,
+                         int64_t chunklen = 76,
                          const String& end = "\r\n");
 TypedValue HHVM_FUNCTION(strtok,
                          const String& str,
@@ -141,9 +141,9 @@ TypedValue HHVM_FUNCTION(substr_replace,
                          const Variant& length = 0x7FFFFFFF);
 String HHVM_FUNCTION(str_pad,
                      const String& input,
-                     int pad_length,
+                     int64_t pad_length,
                      const String& pad_string = " ",
-                     int pad_type = k_STR_PAD_RIGHT);
+                     int64_t pad_type = k_STR_PAD_RIGHT);
 String HHVM_FUNCTION(str_repeat,
                      const String& input,
                      int64_t multiplier);
@@ -153,24 +153,24 @@ String HHVM_FUNCTION(str_repeat,
 
 String HHVM_FUNCTION(html_entity_decode,
                      const String& str,
-                     int quote_style = k_ENT_HTML_QUOTE_DOUBLE,
+                     int64_t quote_style = k_ENT_HTML_QUOTE_DOUBLE,
                      const String& charset = "UTF-8");
 String HHVM_FUNCTION(htmlentities,
                      const String& str,
-                     int quote_style = k_ENT_HTML_QUOTE_DOUBLE,
+                     int64_t quote_style = k_ENT_HTML_QUOTE_DOUBLE,
                      const String& charset = "UTF-8",
                      bool double_encode = true);
 String HHVM_FUNCTION(htmlspecialchars_decode,
                      const String& str,
-                     int quote_style = k_ENT_HTML_QUOTE_DOUBLE);
+                     int64_t quote_style = k_ENT_HTML_QUOTE_DOUBLE);
 String HHVM_FUNCTION(htmlspecialchars,
                      const String& str,
-                     int quote_style = k_ENT_HTML_QUOTE_DOUBLE,
+                     int64_t quote_style = k_ENT_HTML_QUOTE_DOUBLE,
                      const String& charset = "UTF-8",
                      bool double_encode = true);
 String HHVM_FUNCTION(fb_htmlspecialchars,
                      const String& str,
-                     int quote_style,
+                     int64_t quote_style,
                      const String& charset,
                      const Variant& extra);
 String HHVM_FUNCTION(quoted_printable_encode,
@@ -201,31 +201,31 @@ String HHVM_FUNCTION(convert_cyr_string,
                      const String& from,
                      const String& to);
 Array HHVM_FUNCTION(get_html_translation_table,
-                    int table = 0,
-                    int quote_style = k_ENT_HTML_QUOTE_DOUBLE,
+                    int64_t table = 0,
+                    int64_t quote_style = k_ENT_HTML_QUOTE_DOUBLE,
                     const String& encoding = "UTF-8");
 String HHVM_FUNCTION(hebrev,
                      const String& hebrew_text,
-                     int max_chars_per_line = 0);
+                     int64_t max_chars_per_line = 0);
 String HHVM_FUNCTION(hebrevc,
                      const String& hebrew_text,
-                     int max_chars_per_line = 0);
+                     int64_t max_chars_per_line = 0);
 Variant HHVM_FUNCTION(setlocale,
-                      int category,
+                      int64_t category,
                       const Variant& locale,
                       const Array& _argv = null_array);
 Array HHVM_FUNCTION(localeconv);
-Variant HHVM_FUNCTION(nl_langinfo, int item);
+Variant HHVM_FUNCTION(nl_langinfo, int64_t item);
 
 ///////////////////////////////////////////////////////////////////////////////
 // input/output
 
-Variant f_printf(int _argc,
+Variant f_printf(int64_t _argc,
                  const String& format,
                  const Array& _argv = null_array);
 Variant f_vprintf(const String& format,
                   const Array& args);
-Variant f_sprintf(int _argc,
+Variant f_sprintf(int64_t _argc,
                   const String& format,
                   const Array& _argv = null_array);
 Variant f_vsprintf(const String& format,
@@ -243,7 +243,7 @@ Variant HHVM_FUNCTION(money_format,
                       double number);
 String HHVM_FUNCTION(number_format,
                      double number,
-                     int decimals = 0,
+                     int64_t decimals = 0,
                      const Variant& dec_point = ".",
                      const Variant& thousands_sep = ",");
 
@@ -258,7 +258,7 @@ int64_t HHVM_FUNCTION(strcmp,
 TypedValue HHVM_FUNCTION(strncmp,
                          const String& str1,
                          const String& str2,
-                         int len);
+                         int64_t len);
 int64_t HHVM_FUNCTION(strnatcmp,
                       const String& str1,
                       const String& str2);
@@ -268,7 +268,7 @@ int64_t HHVM_FUNCTION(strcasecmp,
 TypedValue HHVM_FUNCTION(strncasecmp,
                          const String& str1,
                          const String& str2,
-                         int len);
+                         int64_t len);
 int64_t HHVM_FUNCTION(strnatcasecmp,
                       const String& str1,
                       const String& str2);
@@ -278,8 +278,8 @@ int64_t HHVM_FUNCTION(strcoll,
 TypedValue HHVM_FUNCTION(substr_compare,
                          const String& main_str,
                          const String& str,
-                         int offset,
-                         int length = INT_MAX,
+                         int64_t offset,
+                         int64_t length = INT_MAX,
                          bool case_insensitivity = false);
 TypedValue HHVM_FUNCTION(strchr,
                          const String& haystack,
@@ -301,34 +301,34 @@ TypedValue HHVM_FUNCTION(strpbrk,
 TypedValue HHVM_FUNCTION(strpos,
                          const String& haystack,
                          const Variant& needle,
-                         int offset = 0);
+                         int64_t offset = 0);
 TypedValue HHVM_FUNCTION(stripos,
                          const String& haystack,
                          const Variant& needle,
-                         int offset = 0);
+                         int64_t offset = 0);
 TypedValue HHVM_FUNCTION(strrpos,
                         const String& haystack,
                         const Variant& needle,
-                        int offset = 0);
+                        int64_t offset = 0);
 TypedValue HHVM_FUNCTION(strripos,
                         const String& haystack,
                         const Variant& needle,
-                        int offset = 0);
+                        int64_t offset = 0);
 TypedValue HHVM_FUNCTION(substr_count,
                          const String& haystack,
                          const String& needle,
-                         int offset = 0,
-                         int length = 0x7FFFFFFF);
+                         int64_t offset = 0,
+                         int64_t length = 0x7FFFFFFF);
 TypedValue HHVM_FUNCTION(strspn,
                          const String& str1,
                          const String& str2,
-                         int start = 0,
-                         int length = 0x7FFFFFFF);
+                         int64_t start = 0,
+                         int64_t length = 0x7FFFFFFF);
 TypedValue HHVM_FUNCTION(strcspn,
                          const String& str1,
                          const String& str2,
-                         int start = 0,
-                         int length = 0x7FFFFFFF);
+                         int64_t start = 0,
+                         int64_t length = 0x7FFFFFFF);
 Array HHVM_FUNCTION(str_getcsv,
                     const String& str,
                     const String& delimiter = ",",
@@ -344,9 +344,9 @@ Variant HHVM_FUNCTION(str_word_count,
 int64_t HHVM_FUNCTION(levenshtein,
                       const String& str1,
                       const String& str2,
-                      int cost_ins = 1,
-                      int cost_rep = 1,
-                      int cost_del = 1);
+                      int64_t cost_ins = 1,
+                      int64_t cost_rep = 1,
+                      int64_t cost_del = 1);
 int64_t HHVM_FUNCTION(similar_text,
                       const String& first,
                       const String& second,
@@ -355,7 +355,7 @@ Variant HHVM_FUNCTION(soundex,
                       const String& str);
 Variant HHVM_FUNCTION(metaphone,
                       const String& str,
-                      int phones = 0);
+                      int64_t phones = 0);
 bool HHVM_FUNCTION(HH_str_number_coercible,
                    const String& str);
 Variant HHVM_FUNCTION(HH_str_to_numeric,

--- a/hphp/runtime/ext/thrift/binary.cpp
+++ b/hphp/runtime/ext/thrift/binary.cpp
@@ -669,7 +669,7 @@ void HHVM_FUNCTION(thrift_protocol_write_binary,
                    const String& method_name,
                    int64_t msgtype,
                    const Object& request_struct,
-                   int seqid,
+                   int64_t seqid,
                    bool strict_write,
                    bool oneway) {
   CoeffectsAutoGuard _;
@@ -705,7 +705,7 @@ Object HHVM_FUNCTION(thrift_protocol_read_binary,
                      const Object& transportobj,
                      const String& obj_typename,
                      bool strict_read,
-                     int options) {
+                     int64_t options) {
   CoeffectsAutoGuard _;
   // Suppress class-to-string conversion warnings that occur during
   // serialization and deserialization.
@@ -756,7 +756,7 @@ Object HHVM_FUNCTION(thrift_protocol_read_binary,
 Variant HHVM_FUNCTION(thrift_protocol_read_binary_struct,
                       const Object& transportobj,
                       const String& obj_typename,
-                      int options) {
+                      int64_t options) {
   // Suppress class-to-string conversion warnings that occur during
   // serialization and deserialization.
   SuppressClassConversionWarning suppressor;

--- a/hphp/runtime/ext/thrift/compact.cpp
+++ b/hphp/runtime/ext/thrift/compact.cpp
@@ -1204,7 +1204,7 @@ struct CompactReader {
 };
 
 int64_t HHVM_FUNCTION(thrift_protocol_set_compact_version,
-                      int version) {
+                      int64_t version) {
   int result = s_compact_request_data->version;
   s_compact_request_data->version = (uint8_t)version;
   return result;
@@ -1215,7 +1215,7 @@ void HHVM_FUNCTION(thrift_protocol_write_compact,
                    const String& method_name,
                    int64_t msgtype,
                    const Object& request_struct,
-                   int seqid,
+                   int64_t seqid,
                    bool oneway) {
   CoeffectsAutoGuard _;
   // Suppress class-to-string conversion warnings that occur during
@@ -1239,7 +1239,7 @@ void HHVM_FUNCTION(thrift_protocol_write_compact,
 Variant HHVM_FUNCTION(thrift_protocol_read_compact,
                       const Object& transportobj,
                       const String& obj_typename,
-                      int options) {
+                      int64_t options) {
   CoeffectsAutoGuard _;
   // Suppress class-to-string conversion warnings that occur during
   // serialization and deserialization.
@@ -1253,7 +1253,7 @@ Variant HHVM_FUNCTION(thrift_protocol_read_compact,
 Object HHVM_FUNCTION(thrift_protocol_read_compact_struct,
                      const Object& transportobj,
                      const String& obj_typename,
-                     int options) {
+                     int64_t options) {
   // Suppress class-to-string conversion warnings that occur during
   // serialization and deserialization.
   SuppressClassConversionWarning suppressor;

--- a/hphp/runtime/ext/thrift/ext_thrift.h
+++ b/hphp/runtime/ext/thrift/ext_thrift.h
@@ -47,7 +47,7 @@ void HHVM_FUNCTION(
     const String& method_name,
     int64_t msgtype,
     const Object& request_struct,
-    int seqid,
+    int64_t seqid,
     bool strict_write,
     bool oneway = false);
 
@@ -56,15 +56,15 @@ Object HHVM_FUNCTION(
     const Object& transportobj,
     const String& obj_typename,
     bool strict_read,
-    int options);
+    int64_t options);
 
 Variant HHVM_FUNCTION(
     thrift_protocol_read_binary_struct,
     const Object& transportobj,
     const String& obj_typename,
-    int options);
+    int64_t options);
 
-int64_t HHVM_FUNCTION(thrift_protocol_set_compact_version, int version);
+int64_t HHVM_FUNCTION(thrift_protocol_set_compact_version, int64_t version);
 
 void HHVM_FUNCTION(
     thrift_protocol_write_compact,
@@ -72,20 +72,20 @@ void HHVM_FUNCTION(
     const String& method_name,
     int64_t msgtype,
     const Object& request_struct,
-    int seqid,
+    int64_t seqid,
     bool oneway = false);
 
 Variant HHVM_FUNCTION(
     thrift_protocol_read_compact,
     const Object& transportobj,
     const String& obj_typename,
-    int options);
+    int64_t options);
 
 Object HHVM_FUNCTION(
     thrift_protocol_read_compact_struct,
     const Object& transportobj,
     const String& obj_typename,
-    int options);
+    int64_t options);
 
 ///////////////////////////////////////////////////////////////////////////////
 

--- a/hphp/runtime/ext/url/ext_url.cpp
+++ b/hphp/runtime/ext/url/ext_url.cpp
@@ -58,7 +58,7 @@ String HHVM_FUNCTION(base64_encode, const String& data) {
   return StringUtil::Base64Encode(data);
 }
 
-Variant HHVM_FUNCTION(get_headers, const String& url, int format /* = 0 */) {
+Variant HHVM_FUNCTION(get_headers, const String& url, int64_t format /* = 0 */) {
   Variant c = HHVM_FN(curl_init)();
   HHVM_FN(curl_setopt)(c.toResource(), CURLOPT_URL, url);
   HHVM_FN(curl_setopt)(c.toResource(), CURLOPT_RETURNTRANSFER, true);
@@ -204,7 +204,7 @@ const StaticString s_arg_separator_output("arg_separator.output");
 Variant HHVM_FUNCTION(http_build_query, const Variant& formdata,
                            const Variant& numeric_prefix /* = null_string */,
                            const String& arg_separator /* = null_string */,
-                           int enc_type /* = k_PHP_QUERY_RFC1738 */) {
+                           int64_t enc_type /* = k_PHP_QUERY_RFC1738 */) {
   if (!formdata.isArray() && !formdata.is(KindOfObject)) {
     raise_invalid_argument_warning("formdata: (need Array or Object)");
     return false;

--- a/hphp/runtime/ext/url/ext_url.h
+++ b/hphp/runtime/ext/url/ext_url.h
@@ -37,14 +37,14 @@ Variant HHVM_FUNCTION(base64_decode, const String& data,
                                      bool strict /* = false */);
 String HHVM_FUNCTION(base64_encode, const String& data);
 
-Variant HHVM_FUNCTION(get_headers, const String& url, int format /* = 0 */);
+Variant HHVM_FUNCTION(get_headers, const String& url, int64_t format /* = 0 */);
 Array HHVM_FUNCTION(get_meta_tags, const String& filename,
                                    bool use_include_path /* = false */);
 
 Variant HHVM_FUNCTION(http_build_query, const Variant& formdata,
                            const Variant& numeric_prefix /* = null_string */,
                            const String& arg_separator /* = null_string */,
-                           int enc_type = k_PHP_QUERY_RFC1738);
+                           int64_t enc_type = k_PHP_QUERY_RFC1738);
 Variant HHVM_FUNCTION(parse_url, const String& url,
                                  int64_t component /* = -1 */);
 
@@ -55,4 +55,3 @@ String HHVM_FUNCTION(urlencode, const String& str);
 
 ///////////////////////////////////////////////////////////////////////////////
 }
-

--- a/hphp/runtime/ext/watchman/ext_watchman.cpp
+++ b/hphp/runtime/ext/watchman/ext_watchman.cpp
@@ -731,7 +731,7 @@ bool HHVM_FUNCTION(HH_watchman_check_sub, const String& _name) {
 // (PHP entry-point)
 Object HHVM_FUNCTION(HH_watchman_sync_sub,
   const String& _name,
-  int timeout_ms)
+  int64_t timeout_ms)
 {
   std::lock_guard<std::mutex> g(s_sharedDataMutex);
 

--- a/hphp/runtime/ext/xml/ext_xml.cpp
+++ b/hphp/runtime/ext/xml/ext_xml.cpp
@@ -835,7 +835,7 @@ int64_t HHVM_FUNCTION(xml_parse_into_struct,
 
 Variant HHVM_FUNCTION(xml_parser_get_option,
                       const Resource& parser,
-                      int option) {
+                      int64_t option) {
   auto p = cast<XmlParser>(parser);
   switch (option) {
   case PHP_XML_OPTION_CASE_FOLDING:
@@ -851,7 +851,7 @@ Variant HHVM_FUNCTION(xml_parser_get_option,
 
 bool HHVM_FUNCTION(xml_parser_set_option,
                    const Resource& parser,
-                   int option,
+                   int64_t option,
                    const Variant& value) {
   auto p = cast<XmlParser>(parser);
   switch (option) {
@@ -1000,7 +1000,7 @@ int64_t HHVM_FUNCTION(xml_get_error_code,
 }
 
 String HHVM_FUNCTION(xml_error_string,
-                     int code) {
+                     int64_t code) {
   char * str = (char *)XML_ErrorString((XML_Error)/*(int)*/code);
   return String(str, CopyString);
 }

--- a/hphp/runtime/ext/xml/ext_xml.h
+++ b/hphp/runtime/ext/xml/ext_xml.h
@@ -40,10 +40,10 @@ Resource HHVM_FUNCTION(xml_parser_create_ns,
                        const Variant& separator = uninit_variant);
 Variant HHVM_FUNCTION(xml_parser_get_option,
                       const Resource& parser,
-                      int option);
+                      int64_t option);
 bool HHVM_FUNCTION(xml_parser_set_option,
                    const Resource& parser,
-                   int option,
+                   int64_t option,
                    const Variant& value);
 bool HHVM_FUNCTION(xml_set_character_data_handler,
                    const Resource& parser,
@@ -85,7 +85,7 @@ int64_t HHVM_FUNCTION(xml_get_current_line_number,
 int64_t HHVM_FUNCTION(xml_get_error_code,
                       const Resource& parser);
 String HHVM_FUNCTION(xml_error_string,
-                     int code);
+                     int64_t code);
 String HHVM_FUNCTION(utf8_decode,
                      const String& data);
 String HHVM_FUNCTION(utf8_encode,
@@ -93,4 +93,3 @@ String HHVM_FUNCTION(utf8_encode,
 
 ///////////////////////////////////////////////////////////////////////////////
 }
-

--- a/hphp/runtime/ext/zlib/ext_zlib.cpp
+++ b/hphp/runtime/ext/zlib/ext_zlib.cpp
@@ -192,11 +192,11 @@ Variant HHVM_FUNCTION(gzcompress, const String& data,
                                   int64_t level) {
   return hhvm_zlib_encode(data, level, k_ZLIB_ENCODING_DEFLATE);
 }
-Variant HHVM_FUNCTION(gzdeflate, const String& data, int level) {
+Variant HHVM_FUNCTION(gzdeflate, const String& data, int64_t level) {
   return hhvm_zlib_encode(data, level, k_ZLIB_ENCODING_RAW);
 }
-Variant HHVM_FUNCTION(gzencode, const String& data, int level,
-                                int encoding_mode) {
+Variant HHVM_FUNCTION(gzencode, const String& data, int64_t level,
+                                int64_t encoding_mode) {
   return hhvm_zlib_encode(data, level, encoding_mode);
 }
 
@@ -303,13 +303,13 @@ Variant HHVM_FUNCTION(zlib_decode, const String& data,
   return hhvm_zlib_decode(data, limit, k_ZLIB_ENCODING_ANY);
 }
 Variant HHVM_FUNCTION(gzuncompress, const String& data,
-                                    int limit) {
+                                    int64_t limit) {
   return hhvm_zlib_decode(data, limit, k_ZLIB_ENCODING_DEFLATE);
 }
-Variant HHVM_FUNCTION(gzinflate, const String& data, int limit) {
+Variant HHVM_FUNCTION(gzinflate, const String& data, int64_t limit) {
   return hhvm_zlib_decode(data, limit, k_ZLIB_ENCODING_RAW);
 }
-Variant HHVM_FUNCTION(gzdecode, const String& data, int limit) {
+Variant HHVM_FUNCTION(gzdecode, const String& data, int64_t limit) {
   return hhvm_zlib_decode(data, limit, k_ZLIB_ENCODING_GZIP);
 }
 
@@ -579,7 +579,7 @@ void HHVM_METHOD(ChunkedInflator, close) {
   return data->close();
 }
 
-int HHVM_METHOD(ChunkedInflator, getUndecompressedByteCount) {
+int64_t HHVM_METHOD(ChunkedInflator, getUndecompressedByteCount) {
   FETCH_CHUNKED_INFLATOR(data, this_);
   assertx(data);
   return data->getUndecompressedByteCount();
@@ -608,7 +608,7 @@ void HHVM_METHOD(ChunkedGunzipper, close) {
   return data->close();
 }
 
-int HHVM_METHOD(ChunkedGunzipper, getUndecompressedByteCount) {
+int64_t HHVM_METHOD(ChunkedGunzipper, getUndecompressedByteCount) {
   FETCH_CHUNKED_GUNZIPPER(data, this_);
   assertx(data);
   return data->getUndecompressedByteCount();

--- a/hphp/runtime/ext/zlib/ext_zlib.h
+++ b/hphp/runtime/ext/zlib/ext_zlib.h
@@ -40,16 +40,16 @@ Variant HHVM_FUNCTION(zlib_decode, const String& data,
 Variant HHVM_FUNCTION(gzcompress, const String& data,
                                   int64_t level = -1);
 Variant HHVM_FUNCTION(gzuncompress, const String& data,
-                                    int limit = 0);
-Variant HHVM_FUNCTION(gzdeflate, const String& data, int level = -1);
-Variant HHVM_FUNCTION(gzinflate, const String& data, int limit = 0);
-Variant HHVM_FUNCTION(gzencode, const String& data, int level = -1,
-                                int encoding_mode = k_FORCE_GZIP);
-Variant HHVM_FUNCTION(gzdecode, const String& data, int limit = 0);
+                                    int64_t limit = 0);
+Variant HHVM_FUNCTION(gzdeflate, const String& data, int64_t level = -1);
+Variant HHVM_FUNCTION(gzinflate, const String& data, int64_t limit = 0);
+Variant HHVM_FUNCTION(gzencode, const String& data, int64_t level = -1,
+                                int64_t encoding_mode = k_FORCE_GZIP);
+Variant HHVM_FUNCTION(gzdecode, const String& data, int64_t limit = 0);
 String HHVM_FUNCTION(zlib_get_coding_type);
 #ifdef HAVE_QUICKLZ
-Variant HHVM_FUNCTION(qlzcompress, const String& data, int level = 1);
-Variant HHVM_FUNCTION(qlzuncompress, const String& data, int level = 1);
+Variant HHVM_FUNCTION(qlzcompress, const String& data, int64_t level = 1);
+Variant HHVM_FUNCTION(qlzuncompress, const String& data, int64_t level = 1);
 #endif
 Variant HHVM_FUNCTION(nzcompress, const String& uncompressed);
 Variant HHVM_FUNCTION(nzuncompress, const String& compressed);
@@ -77,4 +77,3 @@ Variant HHVM_FUNCTION(gzwrite, const Resource& zp, const String& str,
 ///////////////////////////////////////////////////////////////////////////////
 
 }
-

--- a/hphp/runtime/vm/native.cpp
+++ b/hphp/runtime/vm/native.cpp
@@ -606,7 +606,7 @@ static bool tcCheckNative(const TypeConstraint& tc, const NativeSig::Type ty) {
     case KindOfResource:     return ty == T::Resource || ty == T::ResourceArg;
     case KindOfUninit:
     case KindOfNull:         return ty == T::Void;
-    case KindOfInt64:        return ty == T::Int64    || ty == T::Int32;
+    case KindOfInt64:        return ty == T::Int64;
     case KindOfRFunc:        return false; // TODO(T66903859)
     case KindOfFunc:         return ty == T::Func;
     case KindOfClass:        return ty == T::Class;
@@ -786,7 +786,6 @@ void FuncTable::dump() const {
 static std::string nativeTypeString(NativeSig::Type ty) {
   using T = NativeSig::Type;
   switch (ty) {
-  case T::Int32:
   case T::Int64:      return "int";
   case T::Double:     return "double";
   case T::Bool:       return "bool";

--- a/hphp/runtime/vm/native.h
+++ b/hphp/runtime/vm/native.h
@@ -225,7 +225,6 @@ void coerceFCallArgsFromLocals(const ActRec* fp,
 
 #define NATIVE_TYPES                                  \
   /* kind       arg type              return type */  \
-  X(Int32,      int32_t,              int32_t)        \
   X(Int64,      int64_t,              int64_t)        \
   X(Double,     double,               double)         \
   X(Bool,       bool,                 bool)           \
@@ -651,4 +650,3 @@ const ConstantMap* getClassConstants(const StringData* clsName) {
 
 //////////////////////////////////////////////////////////////////////////////
 }} // namespace HPHP::Native
-

--- a/hphp/test/slow/ext_array/array_fill_large.php
+++ b/hphp/test/slow/ext_array/array_fill_large.php
@@ -1,0 +1,6 @@
+<?hh
+
+<<__EntryPoint>>
+function main() {
+  array_fill(1, 2000000000, "2");
+}

--- a/hphp/test/slow/ext_array/array_fill_large.php.expectf
+++ b/hphp/test/slow/ext_array/array_fill_large.php.expectf
@@ -1,0 +1,1 @@
+Fatal error: request has exceeded memory limit in %s/array_fill_large.php on line %d

--- a/hphp/test/slow/ext_array/array_fill_negative.php
+++ b/hphp/test/slow/ext_array/array_fill_negative.php
@@ -1,0 +1,6 @@
+<?hh
+
+<<__EntryPoint>>
+function main() {
+  array_fill(1, -2147483649, "2");
+}

--- a/hphp/test/slow/ext_array/array_fill_negative.php.expectf
+++ b/hphp/test/slow/ext_array/array_fill_negative.php.expectf
@@ -1,0 +1,1 @@
+Warning: Invalid argument: Number of elements can't be negative in %s/array_fill_negative.php on line %d

--- a/hphp/test/slow/ext_gd/t114251150.php
+++ b/hphp/test/slow/ext_gd/t114251150.php
@@ -1,0 +1,7 @@
+<?hh
+
+<<__EntryPoint>>
+function main(): void {
+  $s = "data://text/plain;base64,/9jhAGFFeGlmAABJSSoAIgAAAIYA/QAAAAACSSANRRCSAAAqYgQAO4i2ACphBAAliLb/IgAAAAQAAACth/vX/////////z0BAgYAAQAAAO/HxcoXAQj3AQAAABY1/5IiAAAAiA==";
+  var_dump(exif_read_data($s, "", false, true));
+}

--- a/hphp/test/slow/ext_gd/t114251150.php.expectf
+++ b/hphp/test/slow/ext_gd/t114251150.php.expectf
@@ -1,0 +1,41 @@
+
+Warning: Process tag(x8825=GPS_IFD_Poi): Illegal format code 0xFFB6, suppose BYTE in %s on line 6
+
+Warning: Process tag(x8825=UndefinedTa): Illegal format code 0xFFB6, suppose BYTE in %s on line 6
+
+Warning: Process tag(x87AD=UndefinedTa): Illegal format code 0xD7FB, suppose BYTE in %s on line 6
+
+Warning: Process tag(x87AD=UndefinedTa): Illegal components(-1) in %s on line 6
+
+Warning: Process tag(x0117=UndefinedTa): Illegal format code 0xF708, suppose BYTE in %s on line 6
+
+Warning: Process tag(x8825=GPS_IFD_Poi): Illegal format code 0xFFB6, suppose BYTE in %s on line 6
+
+Warning: Process tag(x87AD=UndefinedTa): Illegal format code 0xD7FB, suppose BYTE in %s on line 6
+
+Warning: Process tag(x87AD=UndefinedTa): Illegal components(-1) in %s on line 6
+
+Warning: Process tag(x0117=StripByteCo): Illegal format code 0xF708, suppose BYTE in %s on line 6
+
+Warning: Thumbnail goes IFD boundary or end of file reached in %s on line 6
+
+Warning: Process tag(x87AD=UndefinedTa): Illegal format code 0xD7FB, suppose BYTE in %s on line 6
+
+Warning: Process tag(x87AD=UndefinedTa): Illegal components(-1) in %s on line 6
+
+Warning: Process tag(x0117=StripByteCo): Illegal format code 0xF708, suppose BYTE in %s on line 6
+
+Warning: Process tag(x8825=GPS_IFD_Poi): Illegal format code 0xFFB6, suppose BYTE in %s on line 6
+
+Warning: Process tag(x87AD=UndefinedTa): Illegal format code 0xD7FB, suppose BYTE in %s on line 6
+
+Warning: Process tag(x87AD=UndefinedTa): Illegal components(-1) in %s on line 6
+
+Warning: Process tag(x0117=StripByteCo): Illegal format code 0xF708, suppose BYTE in %s on line 6
+
+Warning: Thumbnail goes IFD boundary or end of file reached in %s on line 6
+
+Warning: File structure corrupted in %s on line 6
+
+Warning: Invalid JPEG file in %s on line 6
+bool(false)


### PR DESCRIPTION
Builtins are allowed to take 32 or 64-bit integers
(int/int32_t versus int64_t). It's not clear why we allow this, as
integers from Hack are always 64-bit. A builtin taking an int will
just have the upper 32-bits truncated. Depending on the value, this
might change a negative number to a positive one, defeating various
input validity checks.
Remove support for 32-bit integers. Change all of the builtins which
took or returned an int to use int64_t instead. This required a few
fixups here and there, mainly around format strings. If the builtin
uses 32-bits ints internally, I left them. At least the truncation is
now obvious.

Test Plan:
New unit test. Beforehand this large negative input would
be turned into a large positive number, bypassing the "input cannot be
negative" check. Now that it takes int64_t, it is correctly recognized
as a negative number.

---
Initializes m_arr in ArrayInitBase

ArrayInitBase's protected constructor does not initialize
m_arr (presumably because a derived class is meant to do so). However
if a derived class' constructor throws, we'll run the ArrayInitBase
destructor, which will try to release m_arr. If m_arr hasn't been
initialized yet, it can contain garbage and we'll try to release
random memory. The protected constructor should initialize m_arr to
nullptr.

Test Plan:
New unit test which previously failed with ASAN builds

Co-authored-by: Rick Lavoie <rlavoie@fb.com>