### PR TITLE
Pass C compiler to opam_setup.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,10 @@ hphp.log
 hphp/hack/_build/
 hphp/hack/cargo_home/
 /deps
+/obj-x86_64-linux-gnu
+/debian
+*.buildinfo
+*.changes
 
 /hphp/test/test
 /hphp/test/test_fast.inc

--- a/hphp/hack/CMakeLists.txt
+++ b/hphp/hack/CMakeLists.txt
@@ -48,10 +48,19 @@ set(HACK_BUILD_ROOT "${DUNE_BUILD_DIR}/default")
 
 get_target_property(OPAM_EXECUTABLE opam IMPORTED_LOCATION)
 
+string(REGEX REPLACE "^/usr/bin/?(.+)$" "\\1" OPAM_CC ${CMAKE_C_COMPILER})
+if (CMAKE_OSX_SYSROOT)
+  set(ISYSROOT_FLAG -isysroot${CMAKE_OSX_SYSROOT})
+endif ()
+
 add_custom_command(
   OUTPUT "${OPAM_STAMP_FILE}"
   DEPENDS opam opam_setup.sh
   COMMAND
+    CC=${OPAM_CC}
+    CXX=${CMAKE_CXX_COMPILER}
+    CFLAGS=${ISYSROOT_FLAG}
+    CXXFLAGS=${ISYSROOT_FLAG}
     ${CMAKE_CURRENT_SOURCE_DIR}/opam_setup.sh
     "${OPAM_EXECUTABLE}"
     "${DUNE_BUILD_DIR}"


### PR DESCRIPTION
As discussed in https://github.com/hhvm/packaging/pull/287 , there is a bug in g++ 11.2 preventing folly and thrift from being compiled. We will compile hhvm on 21.10 with gcc 10 instead. Therefore, this PR is used to pass the compiler to subprojects.

In https://github.com/facebook/hhvm/issues/9048 and https://github.com/facebook/hhvm/pull/9052, we have added the C and C++ compiler to all third-party libraries. This diff in addition passes the compiler setting to opam as well.


`ocamlmklib` internally uses a hard-coded constant to find the C compiler and linker. As a result, the only way to specify the C compiler is to compile `ocamlmklib` with the specific C compiler.

Test Plan:

From [hhvm/packaging](https://github.com/hhvm/packaging) checkout:
```
bin/make-source-tarball && bin/make-package-in-throwaway-container
```