### PR TITLE
Find TBB on Ubuntu 22.04

### DIFF
--- a/CMake/FindTBB.cmake
+++ b/CMake/FindTBB.cmake
@@ -27,7 +27,7 @@
 
 # lets try in the obvious places first
 find_path(TEST_TBB_INCLUDE_DIR
-    tbb/task_scheduler_init.h
+    tbb/tbb.h
 )
 find_library(TEST_TBB_LIBRARY tbb)
 
@@ -151,7 +151,7 @@ else (TBB_OBVIOUS_PLACE)
   #-- Look for include directory and set ${TBB_INCLUDE_DIR}
   set (TBB_INC_SEARCH_DIR ${_TBB_INSTALL_DIR}/include)
   find_path(TBB_INCLUDE_DIR
-    tbb/task_scheduler_init.h
+    tbb/tbb.h
     PATHS ${TBB_INC_SEARCH_DIR}
   )
   mark_as_advanced(TBB_INCLUDE_DIR)
@@ -207,7 +207,11 @@ endif (TBB_OBVIOUS_PLACE)
 if (TBB_FOUND)
   set(TBB_INTERFACE_VERSION 0)
 
-  FILE(READ "${TBB_INCLUDE_DIRS}/tbb/tbb_stddef.h" _TBB_VERSION_CONTENTS)
+  if (EXISTS "${TBB_INCLUDE_DIRS}/tbb/tbb_stddef.h")
+    FILE(READ "${TBB_INCLUDE_DIRS}/tbb/tbb_stddef.h" _TBB_VERSION_CONTENTS)
+  else()
+    FILE(READ "${TBB_INCLUDE_DIRS}/oneapi/tbb/version.h" _TBB_VERSION_CONTENTS)
+  endif()
   STRING(REGEX REPLACE ".*#define TBB_INTERFACE_VERSION ([0-9]+).*" "\\1" TBB_INTERFACE_VERSION "${_TBB_VERSION_CONTENTS}")
 
   set(TBB_INTERFACE_VERSION "${TBB_INTERFACE_VERSION}")


### PR DESCRIPTION
This commit use `tbb/tbb.h` and `oneapi/tbb/version.h` to detect TBB version, because `tbb/tbb_stddef.h` and `tbb/task_scheduler_init.h` does not exist on Ubuntu 22.04, according to https://packages.ubuntu.com/jammy/amd64/libtbb-dev/filelist