### PR TITLE
Spelling runtime base

### DIFF
--- a/hphp/runtime/base/annot-type.h
+++ b/hphp/runtime/base/annot-type.h
@@ -125,7 +125,7 @@ enum class AnnotAction {
 
 /*
  * annotCompat() takes a DataType (`dt') and tries to determine if a value
- * with DataType `dt' could be compatiable with a given AnnotType (`at')
+ * with DataType `dt' could be compatible with a given AnnotType (`at')
  * and class name (`annotClsName').  Note that this function does not have
  * access to the actual value, nor does it do any run time resolution on
  * the annotation's class name.  Here are the possible values that can be

--- a/hphp/runtime/base/apc-stats.cpp
+++ b/hphp/runtime/base/apc-stats.cpp
@@ -410,7 +410,7 @@ const StaticString s_replacedValueCount("replaced_values_count");
 const StaticString s_expiredValueCount("expired_values_count");
 
 std::string APCDetailedStats::getStatsInfo() const {
-  return "\nPrimitve and static strings count: " +
+  return "\nPrimitive and static strings count: " +
          std::to_string(m_uncounted->getValue()) +
          "\nAPC strings count: " +
          std::to_string(m_apcString->getValue()) +

--- a/hphp/runtime/base/array-util.h
+++ b/hphp/runtime/base/array-util.h
@@ -72,7 +72,7 @@ struct ArrayUtil final {
   // modifying input, although names of these functions sound like mutating.
 
   /**
-   * Retuns an array with all string keys lowercased [or uppercased].
+   * Returns an array with all string keys lowercased [or uppercased].
    */
   static Variant ChangeKeyCase(const Array& input, bool lower);
 

--- a/hphp/runtime/base/bespoke-array.h
+++ b/hphp/runtime/base/bespoke-array.h
@@ -84,7 +84,7 @@ void waitOnExportProfiles();
 }
 
 /*
- * A bespoke array is an array satisfing the ArrayData interface but backed by
+ * A bespoke array is an array satisfying the ArrayData interface but backed by
  * a variety of possible memory layouts. Eventually, our goal is to generate
  * these layouts at runtime, based on profiling information.
  *

--- a/hphp/runtime/base/collections.h
+++ b/hphp/runtime/base/collections.h
@@ -84,7 +84,7 @@ ObjectData* alloc(CollectionType ctype, ArrayData* arr);
 ObjectData* allocPair(TypedValue c1, TypedValue c2);
 
 /////////////////////////////////////////////////////////////////////////////
-// Casting and Cloing
+// Casting and Cloning
 
 bool isType(const Class* cls, CollectionType type);
 template<typename ...Args>

--- a/hphp/runtime/base/concurrent-shared-store.cpp
+++ b/hphp/runtime/base/concurrent-shared-store.cpp
@@ -683,7 +683,7 @@ bool ConcurrentTableSharedStore::get(const String& keyStr, Variant& value) {
   if (needsToLocal) {
     SCOPE_EXIT { svar->unreferenceNonRoot(); };
 
-    l.unlock(); // toLocal() may reenter the autolaoder
+    l.unlock(); // toLocal() may reenter the autoloader
     value = svar->toLocal();
     if (promoteObj) handlePromoteObj(keyStr, svar, value);
   }

--- a/hphp/runtime/base/extended-logger.cpp
+++ b/hphp/runtime/base/extended-logger.cpp
@@ -73,7 +73,7 @@ void ExtendedLogger::LogImpl(LogLevelType level, const std::string &msg) {
   for (auto& l : s_loggers) {
     auto& logger = l.second;
     if (logger) {
-      // we can only get here if ther's no extended loggers (see assertion)
+      // we can only get here if there's no extended loggers (see assertion)
       // if this isn't enough of assurance we could check type at runtime,
       // but probably good enough for now
       Array bt;

--- a/hphp/runtime/base/heap-collect.cpp
+++ b/hphp/runtime/base/heap-collect.cpp
@@ -247,7 +247,7 @@ void Collector::exactEnqueue(const void* p) {
   }
 }
 
-// mark ambigous pointers in the range [start,start+len). If the start or
+// mark ambiguous pointers in the range [start,start+len). If the start or
 // end is a partial word, don't scan that word.
 void FOLLY_DISABLE_ADDRESS_SANITIZER
 Collector::conservativeScan(const void* start, size_t len) {

--- a/hphp/runtime/base/heap-collect.cpp
+++ b/hphp/runtime/base/heap-collect.cpp
@@ -476,7 +476,7 @@ NEVER_INLINE void Collector::sweep() {
     if (type == KindOfObject) {
       auto h = find(wr_data->pointee.m_data.pobj);
       if (!marked(h)) {
-        // Its important we invalidate the pointer stored in the weakref, and
+        // It's important we invalidate the pointer stored in the weakref, and
         // not the start of the allocation.  In the case of objects with
         // native data, the start of allocation may not be the start of the
         // ObjectData*.

--- a/hphp/runtime/base/heap-collect.cpp
+++ b/hphp/runtime/base/heap-collect.cpp
@@ -478,7 +478,7 @@ NEVER_INLINE void Collector::sweep() {
       if (!marked(h)) {
         // Its important we invalidate the pointer stored in the weakref, and
         // not the start of the allocation.  In the case of objects with
-        // native datas, the start of allocation may not be the start of the
+        // native data, the start of allocation may not be the start of the
         // ObjectData*.
         WeakRefData::invalidateWeakRef(uintptr_t(wr_data->pointee.m_data.pobj));
         mm.reinitFree();

--- a/hphp/runtime/base/locale.h
+++ b/hphp/runtime/base/locale.h
@@ -30,7 +30,7 @@ namespace HPHP {
 
 /* Act on exactly 1 category, e.g. LC_CTYPE
  *
- * This is useful for interoperatbility with `setlocale()`.
+ * This is useful for interoperability with `setlocale()`.
  */
 enum LocaleCategoryMode { LocaleCategory };
 /* Act on multiple categories, e.g. LC_CTYPE_MASK | LC_TIME_MASK

--- a/hphp/runtime/base/memory-manager-defs.h
+++ b/hphp/runtime/base/memory-manager-defs.h
@@ -137,7 +137,7 @@ private:
   // Start-bit state:
   // 1 = a HeapObject starts at corresponding address AND it has had its header
   //     kind initialized at least once (not necessarily currently accurate but
-  //     definetly does not contain never initialized data)
+  //     definitely does not contain never initialized data)
   // 0 = in the middle of an object OR free space OR a heap object with
   //     uninitialized headers OR a heap object not created through split tail
   uint64_t startsCache_[kNumStarts];

--- a/hphp/runtime/base/memory-manager.h
+++ b/hphp/runtime/base/memory-manager.h
@@ -842,7 +842,7 @@ struct MemoryManager {
   int64_t currentUsage() const;
 
   /*
-   * Reset all stats that are synchronzied externally from the memory manager.
+   * Reset all stats that are synchronized externally from the memory manager.
    *
    * Used between sessions and to signal that external sync is now safe to
    * begin (after shared structure initialization that should not be counted is

--- a/hphp/runtime/base/object-data-inl.h
+++ b/hphp/runtime/base/object-data-inl.h
@@ -261,7 +261,7 @@ inline void ObjectData::verifyPropTypeHintImpl(tv_lval val,
   tc.verifyProperty(val, m_cls, prop.cls, prop.name);
 
   if (debug && RuntimeOption::RepoAuthoritative) {
-    // The fact that uninitialized LateInit props are uninint isn't
+    // The fact that uninitialized LateInit props are uninit isn't
     // reflected in the repo-auth-type.
     if (type(val) != KindOfUninit || !(prop.attrs & AttrLateInit)) {
       always_assert(tvMatchesRepoAuthType(val.tv(), prop.repoAuthType));

--- a/hphp/runtime/base/object-data.cpp
+++ b/hphp/runtime/base/object-data.cpp
@@ -118,7 +118,7 @@ bool ObjectData::assertTypeHint(tv_rval prop, Slot slot) const {
   }
 
   if (debug && RuntimeOption::RepoAuthoritative) {
-    // The fact that uninitialized LateInit props are uninint isn't
+    // The fact that uninitialized LateInit props are uninit isn't
     // reflected in the repo-auth-type.
     if (prop.type() != KindOfUninit || !(propDecl.attrs & AttrLateInit)) {
       always_assert(tvMatchesRepoAuthType(*prop, propDecl.repoAuthType));

--- a/hphp/runtime/base/plain-file.cpp
+++ b/hphp/runtime/base/plain-file.cpp
@@ -103,7 +103,7 @@ bool PlainFile::open(const String& filename, const String& mode) {
   assertx(m_stream == nullptr);
   assertx(getFd() == -1);
 
-  // For these definded in php fopen but C stream have different modes
+  // For these defined in php fopen but C stream have different modes
   switch (mode[0]) {
     case 'x':
       if (mode.find('+') == -1) {

--- a/hphp/runtime/base/program-functions.cpp
+++ b/hphp/runtime/base/program-functions.cpp
@@ -1847,7 +1847,7 @@ static int execute_program_impl(int argc, char** argv) {
   RuntimeOption::BuildId = po.buildId;
   RuntimeOption::InstanceId = po.instanceId;
 
-  // Do this as early as possible to avoid creating temp files and spawing
+  // Do this as early as possible to avoid creating temp files and spawning
   // light processes. Correct compilation still requires loading all of the
   // ini/hdf/cli options.
   if (po.mode == "dumphhas" || po.mode == "verify" ||

--- a/hphp/runtime/base/program-functions.cpp
+++ b/hphp/runtime/base/program-functions.cpp
@@ -136,7 +136,7 @@
 #endif
 
 #include <oniguruma.h>
-// Onigurama defines UChar to unsigned char, but ICU4C defines it to signed
+// Oniguruma defines UChar to unsigned char, but ICU4C defines it to signed
 // 16-bit int. This is supposed to be resolved by ONIG_ESCAPE_UCHAR_COLLISION,
 // however this isn't fully supported in 6.8.0 or 6.8.1.
 //

--- a/hphp/runtime/base/runtime-option.cpp
+++ b/hphp/runtime/base/runtime-option.cpp
@@ -2700,7 +2700,7 @@ void RuntimeOption::Load(
     if (CoreDumpReport) {
       install_crash_reporter();
     }
-    // Binding default dependenant on whether we are using an OSS build or
+    // Binding default dependent on whether we are using an OSS build or
     // not, and that is set at initialization time of CoreDumpReportDirectory.
     Config::Bind(CoreDumpReportDirectory, ini, config,
                  "Debug.CoreDumpReportDirectory", CoreDumpReportDirectory);
@@ -2825,7 +2825,7 @@ void RuntimeOption::Load(
 
   Config::Bind(CustomSettings, ini, config, "CustomSettings");
 
-  // Run initializers depedent on options, e.g., resizing atomic maps/vectors.
+  // Run initializers dependent on options, e.g., resizing atomic maps/vectors.
   refineStaticStringTableSize();
   InitFiniNode::ProcessPostRuntimeOptions();
 

--- a/hphp/runtime/base/runtime-option.h
+++ b/hphp/runtime/base/runtime-option.h
@@ -1374,7 +1374,7 @@ struct RuntimeOption {
   F(bool, UseXedAssembler, false)                                       \
   /* Record the first N units loaded via StructuredLog::log()        */ \
   F(uint64_t, RecordFirstUnits, 0)                                      \
-  /* More aggresively reuse already compiled units based on SHA1     */ \
+  /* More aggressively reuse already compiled units based on SHA1    */ \
   F(bool, CheckUnitSHA1, true)                                          \
   F(bool, ReuseUnitsByHash, false)                                      \
   F(bool, UseEdenFS, true)                                              \

--- a/hphp/runtime/base/string-data.cpp
+++ b/hphp/runtime/base/string-data.cpp
@@ -134,7 +134,7 @@ void StringData::setColor(uint16_t color) {
 //////////////////////////////////////////////////////////////////////
 
 // Create either a static or an uncounted string.
-// Diffrence between static and uncounted is in the lifetime
+// Difference between static and uncounted is in the lifetime
 // of the string. Static are alive for the lifetime of the process.
 // Uncounted are not ref counted but will be deleted at some point.
 template <bool trueStatic> ALWAYS_INLINE

--- a/hphp/runtime/base/string-data.h
+++ b/hphp/runtime/base/string-data.h
@@ -322,7 +322,7 @@ struct StringData final : MaybeCountable,
    * undocumented.
    *
    * If overflow is set its value is initialized to either zero to
-   * indicate that no overflow occurred or 1/-1 to inidicate the direction
+   * indicate that no overflow occurred or 1/-1 to indicate the direction
    * of overflow.
    *
    * Returns: KindOfNull, KindOfInt64 or KindOfDouble.  The int64_t or

--- a/hphp/runtime/base/strings.h
+++ b/hphp/runtime/base/strings.h
@@ -85,7 +85,7 @@ constexpr char HACKARR_COMPAT_ARR_HACK_ARR_CMP[] =
 constexpr char HACKARR_COMPAT_VARR_IS_VEC[] = "is_vec() called on varray";
 constexpr char HACKARR_COMPAT_DARR_IS_DICT[] = "is_dict() called on darray";
 constexpr char DATATYPE_SPECIALIZED_DVARR[] =
-  "Dataype-specialized array currently unsupported";
+  "Datatype-specialized array currently unsupported";
 constexpr char FUNCTION_CALLED_DYNAMICALLY_WITHOUT_ATTRIBUTE[] =
   "'%s' called dynamically but is not __DynamicallyCallable";
 constexpr char FUNCTION_CALLED_DYNAMICALLY_WITH_ATTRIBUTE[] =

--- a/hphp/runtime/base/surprise-flags.h
+++ b/hphp/runtime/base/surprise-flags.h
@@ -105,7 +105,7 @@ enum SurpriseFlag : size_t {
 /*
  * Code within this scope must never handle any of the specified flags, and is
  * furthermore not even allowed to check for them using, e.g. `getSurpriseFlag',
- * regardess of whether they actually are set.
+ * regardless of whether they actually are set.
  */
 struct NoHandleSurpriseScope {
 #ifndef NDEBUG

--- a/hphp/runtime/base/tracing.h
+++ b/hphp/runtime/base/tracing.h
@@ -29,7 +29,7 @@
  * Request tracing facility
  *
  * This provides a facility for logging detailed traces to a pluggable
- * backend, as well as aggregrate statistics via StructuredLog. It is
+ * backend, as well as aggregate statistics via StructuredLog. It is
  * enabled by a configerable coin-flip and is designed to add almost
  * no overhead when tracing is disabled.
  *

--- a/hphp/runtime/base/tracing.h
+++ b/hphp/runtime/base/tracing.h
@@ -30,7 +30,7 @@
  *
  * This provides a facility for logging detailed traces to a pluggable
  * backend, as well as aggregate statistics via StructuredLog. It is
- * enabled by a configerable coin-flip and is designed to add almost
+ * enabled by a configurable coin-flip and is designed to add almost
  * no overhead when tracing is disabled.
  *
  * Data-model:

--- a/hphp/runtime/base/tv-val.h
+++ b/hphp/runtime/base/tv-val.h
@@ -156,7 +156,7 @@ private:
 
   /*
    * Wide storage type: separate pointers for the type and the value. m_type is
-   * only meangingful is m_val != nullptr.
+   * only meaningful is m_val != nullptr.
    */
   struct wide_storage {
     INLINE_FLATTEN wide_storage()

--- a/hphp/runtime/base/unit-cache.cpp
+++ b/hphp/runtime/base/unit-cache.cpp
@@ -1945,7 +1945,7 @@ private:
     // Nothing is expired. We're done.
     if (expired.empty()) return;
 
-    // As mentioed above, we might have visited an entry more than
+    // As mentioned above, we might have visited an entry more than
     // once. Remove any duplicates.
     std::sort(
       expired.begin(), expired.end(),

--- a/hphp/runtime/base/unit-cache.cpp
+++ b/hphp/runtime/base/unit-cache.cpp
@@ -1832,7 +1832,7 @@ namespace {
  * Unit Reaper
  *
  * This thread is responsible for removing "expired" Units from caches
- * (after which they will get deleted by the treadmil). This helps
+ * (after which they will get deleted by the treadmill). This helps
  * long running server processes avoid wasting memory on old Units
  * which will never be used any longer. This is especially useful when
  * using symlinks and every change is considered a "new" Unit.

--- a/hphp/runtime/base/vanilla-dict.cpp
+++ b/hphp/runtime/base/vanilla-dict.cpp
@@ -950,8 +950,8 @@ void VanillaDict::AppendTombstoneInPlace(ArrayData* ad) {
 ArrayData* VanillaDict::SetIntMove(ArrayData* ad, int64_t k, TypedValue v) {
   assertx(v.m_type != KindOfUninit);
   assertx(ad->cowCheck() || ad->notCyclic(v));
-  auto const preped = as(ad)->prepareForInsert(ad->cowCheck());
-  auto const result = preped->update(k, v);
+  auto const prepped = as(ad)->prepareForInsert(ad->cowCheck());
+  auto const result = prepped->update(k, v);
   if (ad != result && ad->decReleaseCheck()) VanillaDict::Release(ad);
   return result;
 }
@@ -967,8 +967,8 @@ ArrayData* VanillaDict::SetIntInPlace(ArrayData* ad, int64_t k, TypedValue v) {
 ArrayData* VanillaDict::SetStrMoveSkipConflict(ArrayData* ad, StringData* k, TypedValue v) {
   assertx(v.m_type != KindOfUninit);
   assertx(ad->cowCheck() || ad->notCyclic(v));
-  auto const preped = as(ad)->prepareForInsert(ad->cowCheck());
-  auto const result = preped->updateSkipConflict(k, v);
+  auto const prepped = as(ad)->prepareForInsert(ad->cowCheck());
+  auto const result = prepped->updateSkipConflict(k, v);
   if (ad != result && ad->decReleaseCheck()) VanillaDict::Release(ad);
   return result;
 }
@@ -976,8 +976,8 @@ ArrayData* VanillaDict::SetStrMoveSkipConflict(ArrayData* ad, StringData* k, Typ
 ArrayData* VanillaDict::SetIntMoveSkipConflict(ArrayData* ad, int64_t k, TypedValue v) {
   assertx(v.m_type != KindOfUninit);
   assertx(ad->cowCheck() || ad->notCyclic(v));
-  auto const preped = as(ad)->prepareForInsert(ad->cowCheck());
-  auto const result = preped->updateSkipConflict(k, v);
+  auto const prepped = as(ad)->prepareForInsert(ad->cowCheck());
+  auto const result = prepped->updateSkipConflict(k, v);
   if (ad != result && ad->decReleaseCheck()) VanillaDict::Release(ad);
   return result;
 }
@@ -985,8 +985,8 @@ ArrayData* VanillaDict::SetIntMoveSkipConflict(ArrayData* ad, int64_t k, TypedVa
 ArrayData* VanillaDict::SetStrMove(ArrayData* ad, StringData* k, TypedValue v) {
   assertx(v.m_type != KindOfUninit);
   assertx(ad->cowCheck() || ad->notCyclic(v));
-  auto const preped = as(ad)->prepareForInsert(ad->cowCheck());
-  auto const result = preped->update(k, v);
+  auto const prepped = as(ad)->prepareForInsert(ad->cowCheck());
+  auto const result = prepped->update(k, v);
   if (ad != result && ad->decReleaseCheck()) VanillaDict::Release(ad);
   return result;
 }

--- a/hphp/runtime/base/vanilla-dict.h
+++ b/hphp/runtime/base/vanilla-dict.h
@@ -44,7 +44,7 @@ struct VanillaDictElm {
   // We store values here, but also some information local to this array:
   // data.m_aux.u_hash contains either a negative number (for an int key) or
   // a string hashcode (31-bit and thus non-negative); the high bit is the
-  // int/string key descriminator. data.m_type == kInvalidDataType if this is
+  // int/string key discriminator. data.m_type == kInvalidDataType if this is
   // an empty slot in the array (e.g. after a key is deleted).  It is
   // critical that when we return &data to clients, that they not read or
   // write the m_aux field!

--- a/hphp/runtime/base/vanilla-keyset.cpp
+++ b/hphp/runtime/base/vanilla-keyset.cpp
@@ -435,7 +435,7 @@ void VanillaKeyset::compact() {
  */
 bool VanillaKeyset::checkInvariants() const {
   static_assert(sizeof(VanillaKeyset) % 16 == 0, "Some memcpy16 can fail.");
-  static_assert(sizeof(Elm) <= 16, "Don't loose the precious memory gainz!");
+  static_assert(sizeof(Elm) <= 16, "Don't lose the precious memory gainz!");
 
   // All arrays:
   assertx(checkCount());

--- a/hphp/runtime/base/variable-serializer.h
+++ b/hphp/runtime/base/variable-serializer.h
@@ -295,7 +295,7 @@ private:
   int m_maxCount;                // for max recursive levels
   int m_levelDebugger{0};        // keep track of levels for DebuggerSerialize
   int m_maxLevelDebugger{0};     // for max level of DebuggerSerialize
-  size_t m_currentDepth{0};      // current depth (nasted objects/arrays)
+  size_t m_currentDepth{0};      // current depth (nested objects/arrays)
   size_t m_maxDepth{0};          // max depth limit before an error (0 -> none)
   bool m_keyPrinted{false};
 

--- a/hphp/runtime/base/zend-collator.cpp
+++ b/hphp/runtime/base/zend-collator.cpp
@@ -241,7 +241,7 @@ static DataType collator_is_numeric(UChar *str, int length, int64_t *lval,
   }
 
   if (conv_base == 16) { /* hex string, under UNIX strtod() messes it up */
-    /* UTODO: keep compatibility with is_numeric_string() here? */
+    /* TODO: keep compatibility with is_numeric_string() here? */
     return KindOfNull;
   }
 

--- a/hphp/runtime/base/zend-scanf.cpp
+++ b/hphp/runtime/base/zend-scanf.cpp
@@ -75,7 +75,7 @@
 #define SCAN_ERROR_INTERNAL           (SCAN_ERROR_WRONG_PARAM_COUNT - 1)
 
 /*
- * Flag values used internally by [f|s]canf.
+ * Flag values used internally by (f|s)scanf.
  */
 #define SCAN_NOSKIP     0x1       /* Don't skip blanks. */
 #define SCAN_SUPPRESS   0x2       /* Suppress assignment. */

--- a/hphp/runtime/base/zend-string.cpp
+++ b/hphp/runtime/base/zend-string.cpp
@@ -1887,7 +1887,7 @@ char _codes[26] = { 1,16,4,16,9,2,4,16,9,2,0,2,2,2,1,4,0,2,4,4,1,0,0,0,8,0};
 /*----------------------------- */
 
 /* I suppose I could have been using a character pointer instead of
- * accesssing the array directly... */
+ * accessing the array directly... */
 
 /* Look at the next letter in the word */
 #define Next_Letter ((char)toupper(word[w_idx+1]))

--- a/hphp/runtime/base/zend-string.cpp
+++ b/hphp/runtime/base/zend-string.cpp
@@ -2033,7 +2033,7 @@ String string_metaphone(const char *input, int word_len, long max_phonemes,
 
     /* THOUGHT:  It would be nice if, rather than having things like...
      * well, SCI.  For SCI you encode the S, then have to remember
-     * to skip the C.  So the phonome SCI invades both S and C.  It would
+     * to skip the C.  So the phoneme SCI invades both S and C.  It would
      * be better, IMHO, to skip the C from the S part of the encoding.
      * Hell, I'm trying it.
      */


### PR DESCRIPTION
This is a subset of #9005, it should be easier to review/test/clear

Note: while the top level item is `hphp/runtime/base`, if a commit overlaps other directories, I'm dropping the commit. By excluding spanning commits, I reduce the risk of missing a related change (these tend to result in build/test failures which are painful) at the slight increase in additional commits for my general series.