### PR TITLE
Move option logic to hackc/compiler

### DIFF
--- a/hphp/hack/CMakeLists.txt
+++ b/hphp/hack/CMakeLists.txt
@@ -213,10 +213,10 @@ function(build_cxx_bridge NAME FFI_BRIDGE_DIR)
   set(FFI_BRIDGE_SRC "${CMAKE_CURRENT_SOURCE_DIR}/${FFI_BRIDGE_DIR}")
   set(FFI_BRIDGE_BIN "${RUST_FFI_BUILD_ROOT}/hphp/hack/${FFI_BRIDGE_DIR}")
 
-  set(RUST_PART_LIB "${FFI_BRIDGE_BIN}/${PROFILE}/${CMAKE_STATIC_LIBRARY_PREFIX}${NAME}_ffi${CMAKE_STATIC_LIBRARY_SUFFIX}")
-  set(RUST_PART_CXX "${FFI_BRIDGE_BIN}/${NAME}_ffi.cpp")
-  set(RUST_PART_HEADER "${FFI_BRIDGE_BIN}/${NAME}_ffi.rs")
-  set(GENERATED "${FFI_BRIDGE_BIN}/cxxbridge/${NAME}_ffi/${NAME}_ffi")
+  set(RUST_PART_LIB "${FFI_BRIDGE_BIN}/${PROFILE}/${CMAKE_STATIC_LIBRARY_PREFIX}${NAME}${CMAKE_STATIC_LIBRARY_SUFFIX}")
+  set(RUST_PART_CXX "${FFI_BRIDGE_BIN}/${NAME}.cpp")
+  set(RUST_PART_HEADER "${FFI_BRIDGE_BIN}/${NAME}.rs")
+  set(GENERATED "${FFI_BRIDGE_BIN}/cxxbridge/${NAME}/${NAME}")
   set(GENERATED_CXXBRIDGE "${FFI_BRIDGE_BIN}/cxxbridge")
 
   add_custom_command(
@@ -224,7 +224,7 @@ function(build_cxx_bridge NAME FFI_BRIDGE_DIR)
       COMMAND
         ${CMAKE_COMMAND} -E make_directory "${FFI_BRIDGE_BIN}" &&
         . "${CMAKE_CURRENT_BINARY_DIR}/dev_env_rust_only.sh" &&
-        ${CARGO_BUILD} "${NAME}_ffi" "${NAME}_ffi" --cxx "${FFI_BRIDGE_BIN}" &&
+        ${CARGO_BUILD} "${NAME}" "${NAME}" --cxx "${FFI_BRIDGE_BIN}" &&
         ${CMAKE_COMMAND} -E copy "${GENERATED}.rs.cc" "${RUST_PART_CXX}" &&
         ${CMAKE_COMMAND} -E copy "${GENERATED}.rs.h" "${RUST_PART_HEADER}"
       WORKING_DIRECTORY ${FFI_BRIDGE_SRC}
@@ -235,21 +235,34 @@ function(build_cxx_bridge NAME FFI_BRIDGE_DIR)
     DEPENDS ${RUST_PART_CXX}
   )
 
-  add_library("${NAME}_ffi" STATIC ${RUST_PART_CXX} ${ARGN})
-  add_dependencies("${NAME}_ffi" rustc cargo "${NAME}_cxx")
-  add_dependencies(hack_rust_ffi_bridge_targets "${NAME}_ffi")
-  target_link_libraries("${NAME}_ffi" PUBLIC ${RUST_PART_LIB})
+  add_library("${NAME}" STATIC ${RUST_PART_CXX} ${ARGN})
+  add_dependencies("${NAME}" rustc cargo "${NAME}_cxx")
+  add_dependencies(hack_rust_ffi_bridge_targets "${NAME}")
+  target_link_libraries("${NAME}" PUBLIC ${RUST_PART_LIB})
   # `-iquote` is like `-I` (or target_include_directories()`), except:
   # - it takes precedence over `-I`
   # - it only applies to `#include "foo"`, not `#include <foo>`
-  target_compile_options("${NAME}_ffi" INTERFACE "-iquote" "${RUST_FFI_BUILD_ROOT}")
-  target_compile_options("${NAME}_ffi" PUBLIC "-iquote" "${GENERATED_CXXBRIDGE}")
+  target_compile_options("${NAME}" INTERFACE "-iquote" "${RUST_FFI_BUILD_ROOT}")
+  target_compile_options("${NAME}" PUBLIC "-iquote" "${GENERATED_CXXBRIDGE}")
 endfunction()
 
-build_cxx_bridge(parser "src/parser/ffi_bridge")
-build_cxx_bridge(compiler "src/hackc/ffi_bridge")
-build_cxx_bridge(hhvm_types "src/hackc/hhvm_cxx/hhvm_types" "${CMAKE_CURRENT_SOURCE_DIR}/src/hackc/hhvm_cxx/hhvm_types/as-base-ffi.cpp")
-build_cxx_bridge(hhvm_hhbc_defs "src/hackc/hhvm_cxx/hhvm_hhbc_defs" "${CMAKE_CURRENT_SOURCE_DIR}/src/hackc/hhvm_cxx/hhvm_hhbc_defs/as-hhbc-ffi.cpp")
+build_cxx_bridge(parser_ffi "src/parser/ffi_bridge")
+build_cxx_bridge(compiler_ffi "src/hackc/ffi_bridge")
+build_cxx_bridge(
+  hdf
+  "src/utils/hdf"
+  "${CMAKE_CURRENT_SOURCE_DIR}/src/utils/hdf/hdf-wrap.cpp"
+)
+build_cxx_bridge(
+  hhvm_types_ffi
+  "src/hackc/hhvm_cxx/hhvm_types"
+  "${CMAKE_CURRENT_SOURCE_DIR}/src/hackc/hhvm_cxx/hhvm_types/as-base-ffi.cpp"
+)
+build_cxx_bridge(
+ hhvm_hhbc_defs_ffi
+ "src/hackc/hhvm_cxx/hhvm_hhbc_defs"
+ "${CMAKE_CURRENT_SOURCE_DIR}/src/hackc/hhvm_cxx/hhvm_hhbc_defs/as-hhbc-ffi.cpp"
+)
 
 if (NOT LZ4_FOUND)
   add_dependencies(hack_dune lz4)

--- a/hphp/hack/Cargo.lock
+++ b/hphp/hack/Cargo.lock
@@ -446,6 +446,7 @@ dependencies = [
  "env",
  "error",
  "hhbc",
+ "hhvm_options",
  "ocamlrep",
  "ocamlrep_derive",
  "options",
@@ -1702,6 +1703,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hdf"
+version = "0.0.0"
+dependencies = [
+ "cxx",
+ "cxx-build",
+ "thiserror",
+]
+
+[[package]]
 name = "hdrhistogram"
 version = "6.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1896,6 +1906,26 @@ dependencies = [
  "cxx",
  "cxx-build",
  "oxidized",
+]
+
+[[package]]
+name = "hhvm_options"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "clap 3.1.8",
+ "hdf",
+ "hhvm_runtime_options",
+]
+
+[[package]]
+name = "hhvm_runtime_options"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "cxx",
+ "hdf",
+ "log",
 ]
 
 [[package]]

--- a/hphp/hack/src/hackc/compile/cargo/compile/Cargo.toml
+++ b/hphp/hack/src/hackc/compile/cargo/compile/Cargo.toml
@@ -19,6 +19,7 @@ emit_unit = { path = "../../../emitter/cargo/emit_unit" }
 env = { path = "../../../emitter/cargo/env" }
 error = { path = "../../../error/cargo/error" }
 hhbc = { path = "../../../hhbc/cargo/hhbc" }
+hhvm_options = { path = "../../../../utils/hhvm_options" }
 ocamlrep = { path = "../../../../ocamlrep" }
 ocamlrep_derive = { path = "../../../../ocamlrep_derive" }
 options = { path = "../options" }

--- a/hphp/hack/src/utils/hdf/build.rs
+++ b/hphp/hack/src/utils/hdf/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    let _build = cxx_build::bridge("hdf.rs");
+}

--- a/hphp/hack/src/utils/hdf/hdf-wrap.cpp
+++ b/hphp/hack/src/utils/hdf/hdf-wrap.cpp
@@ -1,10 +1,8 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the "hack" directory of this source tree.
-#pragma once
-#include "hphp/util/hdf.h"
-#include "rust/cxx.h"
-#include <memory>
+
+#include "hphp/hack/src/utils/hdf/hdf-wrap.h"
 
 namespace HPHP {
 

--- a/hphp/hack/src/utils/hdf/hdf-wrap.h
+++ b/hphp/hack/src/utils/hdf/hdf-wrap.h
@@ -1,0 +1,17 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the "hack" directory of this source tree.
+#pragma once
+#include "hphp/util/hdf.h"
+#include "rust/cxx.h"
+#include <memory>
+
+namespace HPHP {
+
+std::unique_ptr<Hdf> hdf_new();
+std::unique_ptr<Hdf> hdf_new_child(const Hdf& hdf, const std::string& name);
+std::unique_ptr<Hdf> hdf_first_child(const Hdf& hdf);
+std::unique_ptr<Hdf> hdf_next(const Hdf& hdf);
+rust::String hdf_name(const Hdf& hdf);
+
+}

--- a/hphp/hack/src/utils/hdf/hdf.rs
+++ b/hphp/hack/src/utils/hdf/hdf.rs
@@ -5,7 +5,7 @@
 #[cxx::bridge(namespace = "HPHP")]
 pub(crate) mod ffi {
     unsafe extern "C++" {
-        include!("hphp/hack/src/utils/hdf/bridge.h");
+        include!("hphp/hack/src/utils/hdf/hdf-wrap.h");
         type Hdf;
         fn hdf_new() -> UniquePtr<Hdf>;
         fn hdf_new_child(parent: &Hdf, name: &CxxString) -> UniquePtr<Hdf>;

--- a/hphp/hack/src/utils/hdf/lib.rs
+++ b/hphp/hack/src/utils/hdf/lib.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the "hack" directory of this source tree.
-mod bridge;
+mod hdf;
 mod value;
 
 pub use value::*;

--- a/hphp/hack/src/utils/hdf/value.rs
+++ b/hphp/hack/src/utils/hdf/value.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the "hack" directory of this source tree.
-use crate::bridge::ffi;
+use crate::hdf::ffi;
 use cxx::{let_cxx_string, UniquePtr};
 use std::{borrow::Cow, ffi::CStr, os::unix::ffi::OsStrExt, path::Path};
 use thiserror::Error;


### PR DESCRIPTION
Summary:
This factors out options processing we'd like to call from Rust as well as C++,
and adds a dependency on cxx-generated code from utils/hdf.

Differential Revision: D35744830

