### PR TITLE
Opcode Translator macro outline

### DIFF
--- a/hphp/hack/src/hackc/bytecode_printer/print_opcode.rs
+++ b/hphp/hack/src/hackc/bytecode_printer/print_opcode.rs
@@ -84,6 +84,7 @@ impl<'a, 'b> PrintOpcode<'a, 'b> {
         w: &mut dyn Write,
         cases: &[Str<'_>],
         targets: &[Label],
+        _dummy_imm: &u8,
     ) -> Result<()> {
         if cases.len() != targets.len() {
             return Err(Error::new(

--- a/hphp/hack/src/hackc/bytecode_printer/print_opcode/print_opcode_impl.rs
+++ b/hphp/hack/src/hackc/bytecode_printer/print_opcode/print_opcode_impl.rs
@@ -204,6 +204,7 @@ fn convert_immediate(name: &str, imm: &ImmType) -> TokenStream {
         ImmType::BA2 => quote!(self.print_label2(w, #name)?;),
         ImmType::BLA => quote!(self.print_branch_labels(w, #name.as_ref())?;),
         ImmType::DA => quote!(print_double(w, *#name)?;),
+        ImmType::DUMMY => TokenStream::new(),
         ImmType::FCA => quote!(self.print_fcall_args(w, #name)?;),
         ImmType::I64A => quote!(write!(w, "{}", #name)?;),
         ImmType::IA => quote!(print_iterator_id(w, #name)?;),
@@ -237,6 +238,7 @@ fn convert_call_arg(name: &str, imm: &ImmType) -> TokenStream {
         | ImmType::BA
         | ImmType::BA2
         | ImmType::DA
+        | ImmType::DUMMY
         | ImmType::FCA
         | ImmType::I64A
         | ImmType::IA

--- a/hphp/hack/src/hackc/emitter/instruction_sequence.rs
+++ b/hphp/hack/src/hackc/emitter/instruction_sequence.rs
@@ -331,6 +331,9 @@ pub mod instr {
     pub fn memo_get_eager<'a>(label1: Label, label2: Label, range: LocalRange) -> InstrSeq<'a> {
         instr(Instruct::Opcode(Opcode::MemoGetEager(
             [label1, label2],
+            // Need dummy immediate here to satisfy opcodes translator expectation of immediate
+            // with name _0.
+            u8::MAX,
             range,
         )))
     }
@@ -368,7 +371,11 @@ pub mod instr {
             alloc,
             alloc.alloc_slice_fill_iter(cases.into_iter().map(|(s, _)| Str::from(s))),
         );
-        instr(Instruct::Opcode(Opcode::SSwitch { cases, targets }))
+        instr(Instruct::Opcode(Opcode::SSwitch {
+            cases,
+            targets,
+            _0: u8::MAX,
+        }))
     }
 
     pub fn string<'a>(alloc: &'a bumpalo::Bump, litstr: impl Into<String>) -> InstrSeq<'a> {

--- a/hphp/hack/src/hackc/hhbc/emit_opcodes.rs
+++ b/hphp/hack/src/hackc/hhbc/emit_opcodes.rs
@@ -85,6 +85,7 @@ pub fn emit_impl_targets(input: TokenStream, opcodes: &[OpcodeData]) -> Result<T
                 ImmType::ARR(subty) => is_label_type(subty),
                 ImmType::AA
                 | ImmType::DA
+                | ImmType::DUMMY
                 | ImmType::I64A
                 | ImmType::IA
                 | ImmType::ILA
@@ -217,6 +218,7 @@ fn convert_imm_type(imm: &ImmType, lifetime: &Lifetime) -> TokenStream {
         ImmType::BA2 => quote!([Label; 2]),
         ImmType::BLA => quote!(BumpSliceMut<#lifetime, Label>),
         ImmType::DA => quote!(f64),
+        ImmType::DUMMY => quote!(u8),
         ImmType::FCA => quote!(FCallArgs<#lifetime>),
         ImmType::I64A => quote!(i64),
         ImmType::IA => quote!(IterId),

--- a/hphp/tools/hhbc-gen/hhbc.rs
+++ b/hphp/tools/hhbc-gen/hhbc.rs
@@ -30,6 +30,7 @@ pub enum ImmType {
     BA,
     BLA,
     DA,
+    DUMMY,
     FCA,
     I64A,
     IA,
@@ -283,7 +284,7 @@ mod fixups {
             ],
             "MemoGetEager" => vec![
                 replace_imm("target1", ImmType::BA, ImmType::BA2),
-                remove_imm("target2"),
+                replace_imm("target2", ImmType::BA, ImmType::DUMMY),
             ],
             "NewObjD" => vec![
                 replace_imm("str1", ImmType::SA, ImmType::OAL("ClassName")),
@@ -341,8 +342,11 @@ mod fixups {
             "SSwitch" => vec![
                 // Instead of using a single [(String, Label)] field in HHAS we
                 // split the cases and targets.
+                // One of the immediates needs to be "_0" to satisfy opcodes
+                // translator macro in the HackC Translator.
                 add_flag(InstrFlags::AS_STRUCT),
                 insert_imm(0, "cases", ImmType::ARR(Box::new(ImmType::SA))),
+                insert_imm(2, "_0", ImmType::DUMMY),
                 replace_imm("targets", ImmType::SLA, ImmType::BLA),
             ],
             "UnsetM" => vec![


### PR DESCRIPTION
Summary:
Outline for how opcode translator will work.

Wanted to publish this first without all the ```IMM_XXX``` implementation in next diff to get any feedback, and to get it checked-in so it doesn't break as I continue working on it. (Can be tested by just building hhvm and ensuring macros are compatible with HackCUnit)

Differential Revision: D35841778

