### PR TITLE
Fix hhvm-mac errors

### DIFF
--- a/hphp/hack/.cargo/Cargo.toml.ocaml_build
+++ b/hphp/hack/.cargo/Cargo.toml.ocaml_build
@@ -71,6 +71,7 @@ members = [
     "src/hackc/emitter/cargo/instruction_sequence",
     "src/hackc/emitter/cargo/label_rewriter",
     "src/hackc/emitter/cargo/statement_state",
+    "src/hackc/hhbc/cargo/dump-opcodes",
     "src/hackc/hhbc/cargo/hhbc",
     "src/hackc/ffi_bridge",
     "src/hackc/emitter/cargo/adata_state",

--- a/hphp/hack/CMakeLists.txt
+++ b/hphp/hack/CMakeLists.txt
@@ -119,7 +119,7 @@ invoke_dune(hack_dune_debug debug)
 invoke_dune(hack_dune_test test)
 invoke_dune(hack_dune all)
 
-set(CARGO_BUILD "${CMAKE_SOURCE_DIR}/hphp/hack/scripts/build_rust_to_ocaml.sh")
+set(INVOKE_CARGO "${CMAKE_SOURCE_DIR}/hphp/hack/scripts/build_rust_to_ocaml.sh")
 
 set(OPCODE_DATA "${CMAKE_BINARY_DIR}/hphp/tools/opcodes.rs")
 
@@ -180,7 +180,8 @@ add_custom_command(
   OUTPUT ${RUST_OPCODES}
   COMMAND
     . "${CMAKE_CURRENT_BINARY_DIR}/dev_env_rust_only.sh" &&
-     ${CARGO_BUILD} dump-opcodes dump-opcodes --exe
+     ${INVOKE_CARGO} dump-opcodes dump-opcodes &&
+     ${INVOKE_CARGO} dump-opcodes dump_opcodes --run
       --output "${RUST_OPCODES}"
 )
 
@@ -196,13 +197,14 @@ add_custom_command(
   OUTPUT ${HHBC_AST_HEADER}
   COMMAND
    . "${CMAKE_CURRENT_BINARY_DIR}/dev_env_rust_only.sh" &&
-    ${CARGO_BUILD} ffi_cbindgen ffi_cbindgen --exe
+    ${INVOKE_CARGO} ffi_cbindgen ffi_cbindgen &&
+    ${INVOKE_CARGO} ffi_cbindgen ffi_cbindgen --run
       --header "${FFI_HEADER}" --namespaces "HPHP,hackc"
       ${FFI_SRCS} &&
-    ${CARGO_BUILD} ffi_cbindgen ffi_cbindgen --exe
+    ${INVOKE_CARGO} ffi_cbindgen ffi_cbindgen --run
       --header "${NAMING_SPECIAL_NAMES_HEADER}" --namespaces "HPHP,hackc,hhbc"
       ${NAMING_SPECIAL_NAMES_SRCS} &&
-    ${CARGO_BUILD} ffi_cbindgen ffi_cbindgen --exe
+    ${INVOKE_CARGO} ffi_cbindgen ffi_cbindgen --run
       --header "${HHBC_AST_HEADER}" --namespaces "HPHP,hackc,hhbc"
       --includes "${FFI_HEADER},${NAMING_SPECIAL_NAMES_HEADER},${TYPE_CONSTRAINT_HEADER},${ATTR_HEADER},${FCALL_HEADER},${HHBC_HEADER}"
       ${HHBC_AST_SRCS}
@@ -260,7 +262,7 @@ function(build_cxx_bridge NAME)
       COMMAND
         ${CMAKE_COMMAND} -E make_directory "${FFI_BRIDGE_BIN}" &&
         . "${CMAKE_CURRENT_BINARY_DIR}/dev_env_rust_only.sh" &&
-        ${CARGO_BUILD} "${NAME}" "${NAME}" --cxx "${FFI_BRIDGE_BIN}" &&
+        ${INVOKE_CARGO} "${NAME}" "${NAME}" --target-dir "${FFI_BRIDGE_BIN}" &&
         ${CMAKE_COMMAND} -E copy "${GENERATED}.rs.cc" "${RUST_PART_CXX}" &&
         ${CMAKE_COMMAND} -E copy "${GENERATED}.rs.h" "${RUST_PART_HEADER}"
       WORKING_DIRECTORY ${FFI_BRIDGE_SRC}

--- a/hphp/hack/CMakeLists.txt
+++ b/hphp/hack/CMakeLists.txt
@@ -121,13 +121,13 @@ invoke_dune(hack_dune all)
 
 set(CARGO_BUILD "${CMAKE_SOURCE_DIR}/hphp/hack/scripts/build_rust_to_ocaml.sh")
 
-set(OPCODES "${CMAKE_BINARY_DIR}/hphp/tools/opcodes.rs")
+set(OPCODE_DATA "${CMAKE_BINARY_DIR}/hphp/tools/opcodes.rs")
 
 add_executable(gen-rust1 "${CMAKE_SOURCE_DIR}/hphp/tools/hhbc-gen/gen-rust.cpp")
 add_custom_command(
-  OUTPUT "${OPCODES}"
-  COMMAND gen-rust1 > "${OPCODES}"
-  COMMENT "Generating opcodes.rs"
+  OUTPUT "${OPCODE_DATA}"
+  COMMAND gen-rust1 > "${OPCODE_DATA}"
+  COMMENT "Generating opcode data"
 )
 
 if(DEFINED ENV{HACKDEBUG})
@@ -135,6 +135,8 @@ if(DEFINED ENV{HACKDEBUG})
 else()
   set(PROFILE "release")
 endif()
+
+set(RUST_OPCODES "${CMAKE_BINARY_DIR}/hphp/hack/src/hackc/opcodes.rs")
 
 set(HHBC_PREFIX "${CMAKE_CURRENT_SOURCE_DIR}/src/hackc")
 set(HHBC_AST_SRCS
@@ -158,8 +160,8 @@ set(HHBC_AST_SRCS
   "${HHBC_PREFIX}/hhbc/hhbc_ast.rs"
   "${HHBC_PREFIX}/hhbc/hhbc_ast_ffi_cbindgen.rs"  # Not in a crate.
   "${HHBC_PREFIX}/hhbc/hhbc_id.rs"
-  "${HHBC_PREFIX}/hhbc/opcodes.rs"
   "${HHBC_PREFIX}/hhbc/typed_value.rs"
+  "${RUST_OPCODES}"
 )
 
 set(NAMING_SPECIAL_NAMES_PREFIX "${CMAKE_CURRENT_SOURCE_DIR}/src/naming")
@@ -172,6 +174,14 @@ set(FFI_PREFIX "${CMAKE_CURRENT_SOURCE_DIR}/src/utils/ffi")
 set(FFI_SRCS
    "${FFI_PREFIX}/ffi.rs"
    "${FFI_PREFIX}/ffi_ffi_cbindgen.rs"
+)
+
+add_custom_command(
+  OUTPUT ${RUST_OPCODES}
+  COMMAND
+    . "${CMAKE_CURRENT_BINARY_DIR}/dev_env_rust_only.sh" &&
+     ${CARGO_BUILD} dump-opcodes dump-opcodes --exe
+      --output "${RUST_OPCODES}"
 )
 
 set(HHBC_AST_HEADER "${RUST_FFI_BUILD_ROOT}/hphp/hack/src/hackc/hhbc-ast.h")
@@ -196,7 +206,7 @@ add_custom_command(
       --header "${HHBC_AST_HEADER}" --namespaces "HPHP,hackc,hhbc"
       --includes "${FFI_HEADER},${NAMING_SPECIAL_NAMES_HEADER},${TYPE_CONSTRAINT_HEADER},${ATTR_HEADER},${FCALL_HEADER},${HHBC_HEADER}"
       ${HHBC_AST_SRCS}
-  DEPENDS rustc cargo "${OPCODES}"
+  DEPENDS rustc cargo "${OPCODE_DATA}" "${RUST_OPCODES}"
   COMMENT "Generating hhbc-ast.h"
 )
 
@@ -254,7 +264,7 @@ function(build_cxx_bridge NAME)
         ${CMAKE_COMMAND} -E copy "${GENERATED}.rs.cc" "${RUST_PART_CXX}" &&
         ${CMAKE_COMMAND} -E copy "${GENERATED}.rs.h" "${RUST_PART_HEADER}"
       WORKING_DIRECTORY ${FFI_BRIDGE_SRC}
-      DEPENDS rustc cargo "${OPCODES}"
+      DEPENDS rustc cargo "${OPCODED_DATA}"
   )
   add_custom_target(
     "${NAME}_cxx"
@@ -302,8 +312,8 @@ endif()
 # you're working with Hack, but means that e.g. hhvm can't find
 # `hh_single_compile` in the source tree. Keep it around, but require it to be
 # explicitly used
-add_custom_target(hack ALL DEPENDS hack_dune "${OPCODES}")
-add_custom_target(hack_test DEPENDS hack_dune_test "${OPCODES}")
+add_custom_target(hack ALL DEPENDS hack_dune "${OPCODE_DATA}")
+add_custom_target(hack_test DEPENDS hack_dune_test "${OPCODE_DATA}")
 
 configure_file(dev_env.sh.in dev_env.sh ESCAPE_QUOTES @ONLY)
 configure_file(dev_env_common.sh.in dev_env_common.sh ESCAPE_QUOTES @ONLY)

--- a/hphp/hack/CMakeLists.txt
+++ b/hphp/hack/CMakeLists.txt
@@ -1,5 +1,7 @@
 option(BUILD_HACK "True if we should build the Hack typechecker." ON)
 
+include(CMakeParseArguments)
+
 if (NOT BUILD_HACK)
   message(STATUS "Skipping hack")
   return()
@@ -209,14 +211,38 @@ add_dependencies("hhbc_ast_header" "hhbc_ast_cbindgen")
 add_custom_target(hack_rust_ffi_bridge_targets)
 
 # Compiling cxx entrypoints for hhvm
-function(build_cxx_bridge NAME FFI_BRIDGE_DIR)
-  set(FFI_BRIDGE_SRC "${CMAKE_CURRENT_SOURCE_DIR}/${FFI_BRIDGE_DIR}")
-  set(FFI_BRIDGE_BIN "${RUST_FFI_BUILD_ROOT}/hphp/hack/${FFI_BRIDGE_DIR}")
+#
+# Usage:
+#     build_cxx_bridge(
+#       name
+#       DIR directory
+#       [EXTRA_SRCS src [src ...]]
+#       [LINK_LIBS lib [lib ...]]
+#     )
+#
+# Where:
+#   `name` is the target name of the cxx_bridge.
+#   `directory` is the required directory of the cxx_bridge sources.
+#   `src` are extra source files to include in the bridge.
+#   `lib` are extra link libraries to include in the bridge.
+#
+function(build_cxx_bridge NAME)
+  cmake_parse_arguments(CXX_BRIDGE "" "DIR" "EXTRA_SRCS;LINK_LIBS" ${ARGN})
 
-  set(RUST_PART_LIB "${FFI_BRIDGE_BIN}/${PROFILE}/${CMAKE_STATIC_LIBRARY_PREFIX}${NAME}_ffi${CMAKE_STATIC_LIBRARY_SUFFIX}")
-  set(RUST_PART_CXX "${FFI_BRIDGE_BIN}/${NAME}_ffi.cpp")
-  set(RUST_PART_HEADER "${FFI_BRIDGE_BIN}/${NAME}_ffi.rs")
-  set(GENERATED "${FFI_BRIDGE_BIN}/cxxbridge/${NAME}_ffi/${NAME}_ffi")
+  if ("${CXX_BRIDGE_DIR}" STREQUAL "")
+    message(FATAL_ERROR "Missing DIR parameter")
+  endif()
+  if (NOT "${CXX_BRIDGE_UNPARSED_ARGUMENTS}" STREQUAL "")
+    message(FATAL_ERROR "Unexpected parameters: ${CXX_BRIDGE_UNPARSED_ARGUMENTS}")
+  endif()
+
+  set(FFI_BRIDGE_SRC "${CMAKE_CURRENT_SOURCE_DIR}/${CXX_BRIDGE_DIR}")
+  set(FFI_BRIDGE_BIN "${RUST_FFI_BUILD_ROOT}/hphp/hack/${CXX_BRIDGE_DIR}")
+
+  set(RUST_PART_LIB "${FFI_BRIDGE_BIN}/${PROFILE}/${CMAKE_STATIC_LIBRARY_PREFIX}${NAME}${CMAKE_STATIC_LIBRARY_SUFFIX}")
+  set(RUST_PART_CXX "${FFI_BRIDGE_BIN}/${NAME}.cpp")
+  set(RUST_PART_HEADER "${FFI_BRIDGE_BIN}/${NAME}.rs")
+  set(GENERATED "${FFI_BRIDGE_BIN}/cxxbridge/${NAME}/${NAME}")
   set(GENERATED_CXXBRIDGE "${FFI_BRIDGE_BIN}/cxxbridge")
 
   add_custom_command(
@@ -224,7 +250,7 @@ function(build_cxx_bridge NAME FFI_BRIDGE_DIR)
       COMMAND
         ${CMAKE_COMMAND} -E make_directory "${FFI_BRIDGE_BIN}" &&
         . "${CMAKE_CURRENT_BINARY_DIR}/dev_env_rust_only.sh" &&
-        ${CARGO_BUILD} "${NAME}_ffi" "${NAME}_ffi" --cxx "${FFI_BRIDGE_BIN}" &&
+        ${CARGO_BUILD} "${NAME}" "${NAME}" --cxx "${FFI_BRIDGE_BIN}" &&
         ${CMAKE_COMMAND} -E copy "${GENERATED}.rs.cc" "${RUST_PART_CXX}" &&
         ${CMAKE_COMMAND} -E copy "${GENERATED}.rs.h" "${RUST_PART_HEADER}"
       WORKING_DIRECTORY ${FFI_BRIDGE_SRC}
@@ -235,21 +261,35 @@ function(build_cxx_bridge NAME FFI_BRIDGE_DIR)
     DEPENDS ${RUST_PART_CXX}
   )
 
-  add_library("${NAME}_ffi" STATIC ${RUST_PART_CXX} ${ARGN})
-  add_dependencies("${NAME}_ffi" rustc cargo "${NAME}_cxx")
-  add_dependencies(hack_rust_ffi_bridge_targets "${NAME}_ffi")
-  target_link_libraries("${NAME}_ffi" PUBLIC ${RUST_PART_LIB})
+  add_library("${NAME}" STATIC ${RUST_PART_CXX} ${CXX_BRIDGE_EXTRA_SRCS} )
+  add_dependencies("${NAME}" rustc cargo "${NAME}_cxx")
+  add_dependencies(hack_rust_ffi_bridge_targets "${NAME}")
+  target_link_libraries("${NAME}" PUBLIC ${RUST_PART_LIB} ${CXX_BRIDGE_LINK_LIBS})
   # `-iquote` is like `-I` (or target_include_directories()`), except:
   # - it takes precedence over `-I`
   # - it only applies to `#include "foo"`, not `#include <foo>`
-  target_compile_options("${NAME}_ffi" INTERFACE "-iquote" "${RUST_FFI_BUILD_ROOT}")
-  target_compile_options("${NAME}_ffi" PUBLIC "-iquote" "${GENERATED_CXXBRIDGE}")
+  target_compile_options("${NAME}" INTERFACE "-iquote" "${RUST_FFI_BUILD_ROOT}")
+  target_compile_options("${NAME}" PRIVATE "-iquote" "${GENERATED_CXXBRIDGE}")
 endfunction()
 
-build_cxx_bridge(parser "src/parser/ffi_bridge")
-build_cxx_bridge(compiler "src/hackc/ffi_bridge")
-build_cxx_bridge(hhvm_types "src/hackc/hhvm_cxx/hhvm_types" "${CMAKE_CURRENT_SOURCE_DIR}/src/hackc/hhvm_cxx/hhvm_types/as-base-ffi.cpp")
-build_cxx_bridge(hhvm_hhbc_defs "src/hackc/hhvm_cxx/hhvm_hhbc_defs" "${CMAKE_CURRENT_SOURCE_DIR}/src/hackc/hhvm_cxx/hhvm_hhbc_defs/as-hhbc-ffi.cpp")
+build_cxx_bridge(parser_ffi DIR "src/parser/ffi_bridge")
+build_cxx_bridge(compiler_ffi DIR "src/hackc/ffi_bridge" LINK_LIBS hdf)
+build_cxx_bridge(
+  hdf
+  DIR "src/utils/hdf"
+  EXTRA_SRCS "${CMAKE_CURRENT_SOURCE_DIR}/src/utils/hdf/hdf-wrap.cpp"
+  LINK_LIBS folly
+)
+build_cxx_bridge(
+  hhvm_types_ffi
+  DIR "src/hackc/hhvm_cxx/hhvm_types"
+  EXTRA_SRCS "${CMAKE_CURRENT_SOURCE_DIR}/src/hackc/hhvm_cxx/hhvm_types/as-base-ffi.cpp"
+)
+build_cxx_bridge(
+ hhvm_hhbc_defs_ffi
+ DIR "src/hackc/hhvm_cxx/hhvm_hhbc_defs"
+ EXTRA_SRCS "${CMAKE_CURRENT_SOURCE_DIR}/src/hackc/hhvm_cxx/hhvm_hhbc_defs/as-hhbc-ffi.cpp"
+)
 
 if (NOT LZ4_FOUND)
   add_dependencies(hack_dune lz4)

--- a/hphp/hack/Cargo.lock
+++ b/hphp/hack/Cargo.lock
@@ -446,6 +446,7 @@ dependencies = [
  "env",
  "error",
  "hhbc",
+ "hhvm_options",
  "ocamlrep",
  "ocamlrep_derive",
  "options",
@@ -1702,6 +1703,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hdf"
+version = "0.0.0"
+dependencies = [
+ "cxx",
+ "cxx-build",
+ "thiserror",
+]
+
+[[package]]
 name = "hdrhistogram"
 version = "6.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1896,6 +1906,26 @@ dependencies = [
  "cxx",
  "cxx-build",
  "oxidized",
+]
+
+[[package]]
+name = "hhvm_options"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "clap 3.1.8",
+ "hdf",
+ "hhvm_runtime_options",
+]
+
+[[package]]
+name = "hhvm_runtime_options"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "cxx",
+ "hdf",
+ "log",
 ]
 
 [[package]]

--- a/hphp/hack/Cargo.lock
+++ b/hphp/hack/Cargo.lock
@@ -918,6 +918,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "dump-opcodes"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "emit_opcodes",
+ "hhbc-gen",
+ "quote",
+ "structopt",
+]
+
+[[package]]
 name = "dump_saved_state_depgraph"
 version = "0.0.0"
 dependencies = [

--- a/hphp/hack/scripts/build_rust_to_ocaml.sh
+++ b/hphp/hack/scripts/build_rust_to_ocaml.sh
@@ -24,6 +24,9 @@ while :; do
         --exe) exe=$1
           shift 1
         ;;
+        --output) output=$2
+          shift 2
+        ;;
         --header) header=$2
           shift 2
         ;;
@@ -67,9 +70,15 @@ fi
     $profile_flags
 if [ -n "$exe" ]
 then
-  cargo run --bin ffi_cbindgen -- --header "$header" \
-  --includes "$includes" --namespaces "$namespaces" \
-    "$@"
+  if [[ "$pkg" == "ffi_cbindgen" ]]
+  then
+    cargo run --bin ffi_cbindgen -- --header "$header" \
+    --includes "$includes" --namespaces "$namespaces" \
+      "$@"
+  elif [[ "$pkg" == "dump-opcodes" ]]
+  then
+    cargo run --bin dump_opcodes -- -o "$output"
+  fi
 fi) &&
 if [ -z "$exe" ]
 then

--- a/hphp/hack/scripts/build_rust_to_ocaml.sh
+++ b/hphp/hack/scripts/build_rust_to_ocaml.sh
@@ -64,8 +64,7 @@ fi
     --quiet \
     --target-dir "${TARGET_DIR}" \
     --package "$pkg" \
-    $profile_flags \
-    "$@";
+    $profile_flags
 if [ -n "$exe" ]
 then
   cargo run --bin ffi_cbindgen -- --header "$header" \

--- a/hphp/hack/src/hackc/bytecode_printer/print_opcode.rs
+++ b/hphp/hack/src/hackc/bytecode_printer/print_opcode.rs
@@ -84,6 +84,7 @@ impl<'a, 'b> PrintOpcode<'a, 'b> {
         w: &mut dyn Write,
         cases: &[Str<'_>],
         targets: &[Label],
+        _dummy_imm: &u8,
     ) -> Result<()> {
         if cases.len() != targets.len() {
             return Err(Error::new(

--- a/hphp/hack/src/hackc/bytecode_printer/print_opcode/print_opcode_impl.rs
+++ b/hphp/hack/src/hackc/bytecode_printer/print_opcode/print_opcode_impl.rs
@@ -204,6 +204,7 @@ fn convert_immediate(name: &str, imm: &ImmType) -> TokenStream {
         ImmType::BA2 => quote!(self.print_label2(w, #name)?;),
         ImmType::BLA => quote!(self.print_branch_labels(w, #name.as_ref())?;),
         ImmType::DA => quote!(print_double(w, *#name)?;),
+        ImmType::DUMMY => TokenStream::new(),
         ImmType::FCA => quote!(self.print_fcall_args(w, #name)?;),
         ImmType::I64A => quote!(write!(w, "{}", #name)?;),
         ImmType::IA => quote!(print_iterator_id(w, #name)?;),
@@ -237,6 +238,7 @@ fn convert_call_arg(name: &str, imm: &ImmType) -> TokenStream {
         | ImmType::BA
         | ImmType::BA2
         | ImmType::DA
+        | ImmType::DUMMY
         | ImmType::FCA
         | ImmType::I64A
         | ImmType::IA

--- a/hphp/hack/src/hackc/compile/cargo/compile/Cargo.toml
+++ b/hphp/hack/src/hackc/compile/cargo/compile/Cargo.toml
@@ -19,6 +19,7 @@ emit_unit = { path = "../../../emitter/cargo/emit_unit" }
 env = { path = "../../../emitter/cargo/env" }
 error = { path = "../../../error/cargo/error" }
 hhbc = { path = "../../../hhbc/cargo/hhbc" }
+hhvm_options = { path = "../../../../utils/hhvm_options" }
 ocamlrep = { path = "../../../../ocamlrep" }
 ocamlrep_derive = { path = "../../../../ocamlrep_derive" }
 options = { path = "../options" }

--- a/hphp/hack/src/hackc/emitter/instruction_sequence.rs
+++ b/hphp/hack/src/hackc/emitter/instruction_sequence.rs
@@ -331,6 +331,9 @@ pub mod instr {
     pub fn memo_get_eager<'a>(label1: Label, label2: Label, range: LocalRange) -> InstrSeq<'a> {
         instr(Instruct::Opcode(Opcode::MemoGetEager(
             [label1, label2],
+            // Need dummy immediate here to satisfy opcodes translator expectation of immediate
+            // with name _0.
+            u8::MAX,
             range,
         )))
     }
@@ -368,7 +371,11 @@ pub mod instr {
             alloc,
             alloc.alloc_slice_fill_iter(cases.into_iter().map(|(s, _)| Str::from(s))),
         );
-        instr(Instruct::Opcode(Opcode::SSwitch { cases, targets }))
+        instr(Instruct::Opcode(Opcode::SSwitch {
+            cases,
+            targets,
+            _0: u8::MAX,
+        }))
     }
 
     pub fn string<'a>(alloc: &'a bumpalo::Bump, litstr: impl Into<String>) -> InstrSeq<'a> {

--- a/hphp/hack/src/hackc/hhbc/emit_opcodes.rs
+++ b/hphp/hack/src/hackc/hhbc/emit_opcodes.rs
@@ -85,6 +85,7 @@ pub fn emit_impl_targets(input: TokenStream, opcodes: &[OpcodeData]) -> Result<T
                 ImmType::ARR(subty) => is_label_type(subty),
                 ImmType::AA
                 | ImmType::DA
+                | ImmType::DUMMY
                 | ImmType::I64A
                 | ImmType::IA
                 | ImmType::ILA
@@ -217,6 +218,7 @@ fn convert_imm_type(imm: &ImmType, lifetime: &Lifetime) -> TokenStream {
         ImmType::BA2 => quote!([Label; 2]),
         ImmType::BLA => quote!(BumpSliceMut<#lifetime, Label>),
         ImmType::DA => quote!(f64),
+        ImmType::DUMMY => quote!(u8),
         ImmType::FCA => quote!(FCallArgs<#lifetime>),
         ImmType::I64A => quote!(i64),
         ImmType::IA => quote!(IterId),

--- a/hphp/hack/src/utils/hdf/build.rs
+++ b/hphp/hack/src/utils/hdf/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    let _build = cxx_build::bridge("hdf.rs");
+}

--- a/hphp/hack/src/utils/hdf/hdf-wrap.cpp
+++ b/hphp/hack/src/utils/hdf/hdf-wrap.cpp
@@ -1,10 +1,8 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the "hack" directory of this source tree.
-#pragma once
-#include "hphp/util/hdf.h"
-#include "rust/cxx.h"
-#include <memory>
+
+#include "hphp/hack/src/utils/hdf/hdf-wrap.h"
 
 namespace HPHP {
 

--- a/hphp/hack/src/utils/hdf/hdf-wrap.h
+++ b/hphp/hack/src/utils/hdf/hdf-wrap.h
@@ -1,0 +1,17 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the "hack" directory of this source tree.
+#pragma once
+#include "hphp/util/hdf.h"
+#include "rust/cxx.h"
+#include <memory>
+
+namespace HPHP {
+
+std::unique_ptr<Hdf> hdf_new();
+std::unique_ptr<Hdf> hdf_new_child(const Hdf& hdf, const std::string& name);
+std::unique_ptr<Hdf> hdf_first_child(const Hdf& hdf);
+std::unique_ptr<Hdf> hdf_next(const Hdf& hdf);
+rust::String hdf_name(const Hdf& hdf);
+
+}

--- a/hphp/hack/src/utils/hdf/hdf.rs
+++ b/hphp/hack/src/utils/hdf/hdf.rs
@@ -5,7 +5,7 @@
 #[cxx::bridge(namespace = "HPHP")]
 pub(crate) mod ffi {
     unsafe extern "C++" {
-        include!("hphp/hack/src/utils/hdf/bridge.h");
+        include!("hphp/hack/src/utils/hdf/hdf-wrap.h");
         type Hdf;
         fn hdf_new() -> UniquePtr<Hdf>;
         fn hdf_new_child(parent: &Hdf, name: &CxxString) -> UniquePtr<Hdf>;

--- a/hphp/hack/src/utils/hdf/lib.rs
+++ b/hphp/hack/src/utils/hdf/lib.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the "hack" directory of this source tree.
-mod bridge;
+mod hdf;
 mod value;
 
 pub use value::*;

--- a/hphp/hack/src/utils/hdf/value.rs
+++ b/hphp/hack/src/utils/hdf/value.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the "hack" directory of this source tree.
-use crate::bridge::ffi;
+use crate::hdf::ffi;
 use cxx::{let_cxx_string, UniquePtr};
 use std::{borrow::Cow, ffi::CStr, os::unix::ffi::OsStrExt, path::Path};
 use thiserror::Error;

--- a/hphp/tools/hhbc-gen/hhbc.rs
+++ b/hphp/tools/hhbc-gen/hhbc.rs
@@ -30,6 +30,7 @@ pub enum ImmType {
     BA,
     BLA,
     DA,
+    DUMMY,
     FCA,
     I64A,
     IA,
@@ -283,7 +284,7 @@ mod fixups {
             ],
             "MemoGetEager" => vec![
                 replace_imm("target1", ImmType::BA, ImmType::BA2),
-                remove_imm("target2"),
+                replace_imm("target2", ImmType::BA, ImmType::DUMMY),
             ],
             "NewObjD" => vec![
                 replace_imm("str1", ImmType::SA, ImmType::OAL("ClassName")),
@@ -341,8 +342,11 @@ mod fixups {
             "SSwitch" => vec![
                 // Instead of using a single [(String, Label)] field in HHAS we
                 // split the cases and targets.
+                // One of the immediates needs to be "_0" to satisfy opcodes
+                // translator macro in the HackC Translator.
                 add_flag(InstrFlags::AS_STRUCT),
                 insert_imm(0, "cases", ImmType::ARR(Box::new(ImmType::SA))),
+                insert_imm(2, "_0", ImmType::DUMMY),
                 replace_imm("targets", ImmType::SLA, ImmType::BLA),
             ],
             "UnsetM" => vec![


### PR DESCRIPTION
Summary: I've noticed a bunch of intermittent hhvm-mac errors like https://fburl.com/sandcastle/2wvtlpyf that stem from passing `$@` to `cargo build`. I believe this change was made in D35618274 (https://github.com/facebook/hhvm/commit/64292c74d69140f71c2b91669ea3e80fab1309bd)

Differential Revision: D35979151

