### PR TITLE
Remove disposability from doc comment

### DIFF
--- a/hphp/hsl/src/network/Server.php
+++ b/hphp/hsl/src/network/Server.php
@@ -23,11 +23,9 @@ interface Server<TSock as Socket> {
    */
   abstract const type TAddress;
 
-  /** Retrieve the next pending connection as a disposable.
+  /** Retrieve the next pending connection.
    *
    * Will wait for new connections if none are pending.
-   *
-   * @see `nextConnectionNDAsync()` for non-disposables.
    */
   public function nextConnectionAsync(): Awaitable<TSock>;
 


### PR DESCRIPTION
This note survived the removal of disposable handles.
The nextConnectionAsync method is the only method (no non-disposable variant exists).