### PR TITLE
Translate Coeffects

### DIFF
--- a/hphp/runtime/base/coeffects-config.cpp
+++ b/hphp/runtime/base/coeffects-config.cpp
@@ -14,6 +14,7 @@
    +----------------------------------------------------------------------+
 */
 
+#include "hphp/hack/src/hackc/hhbc-ast.h"
 #include "hphp/runtime/base/coeffects-config.h"
 #include "hphp/runtime/vm/coeffects.h"
 
@@ -398,6 +399,26 @@ StaticCoeffects CoeffectsConfig::combine(const StaticCoeffects a,
     result |= std::max(a.value() & mask, b.value() & mask);
   }
   return StaticCoeffects::fromValue(result);
+}
+
+std::string CoeffectsConfig::fromHackCCtx(const hackc::Ctx& ctx) {
+  switch (ctx) {
+    case hackc::Ctx::Defaults:       return C::s_defaults;
+    case hackc::Ctx::WriteThisProps: return C::s_write_this_props;
+    case hackc::Ctx::WriteProps:     return C::s_write_props;
+    case hackc::Ctx::RxLocal:        return C::s_rx_local;
+    case hackc::Ctx::RxShallow:      return C::s_rx_shallow;
+    case hackc::Ctx::Rx:             return C::s_rx;
+    case hackc::Ctx::ZonedWith:      return C::s_zoned_with;
+    case hackc::Ctx::ZonedLocal:     return C::s_zoned_local;
+    case hackc::Ctx::ZonedShallow:   return C::s_zoned_shallow;
+    case hackc::Ctx::Zoned:          return C::s_zoned;
+    case hackc::Ctx::LeakSafe:       return C::s_leak_safe;
+    case hackc::Ctx::ReadGlobals:    return C::s_read_globals;
+    case hackc::Ctx::Globals:        return C::s_globals;
+    case hackc::Ctx::Pure:           return C::s_pure;
+  }
+  not_reached();
 }
 
 std::vector<std::string>

--- a/hphp/runtime/base/coeffects-config.h
+++ b/hphp/runtime/base/coeffects-config.h
@@ -24,6 +24,10 @@
 #include <memory>
 
 namespace HPHP {
+
+namespace hackc {
+  enum class Ctx;
+}
 ///////////////////////////////////////////////////////////////////////////////
 
 struct CoeffectsConfig {
@@ -68,6 +72,7 @@ struct CoeffectsConfig {
   static bool isAnyRx(const StringData*);
   static StaticCoeffects fromName(const std::string&);
   static StaticCoeffects combine(const StaticCoeffects, const StaticCoeffects);
+  static std::string fromHackCCtx(const hackc::Ctx& ctx);
   static RuntimeCoeffects escapesTo(const std::string&);
   static std::vector<std::string> toStringList(const StaticCoeffects data);
   static std::string mangle();

--- a/hphp/runtime/vm/disas.cpp
+++ b/hphp/runtime/vm/disas.cpp
@@ -404,7 +404,6 @@ void print_instr(Output& out, const FuncInfo& finfo, PC pc) {
   out.nl();
 }
 
-template<bool isTest=false>
 void print_func_directives(Output& out, const FuncInfo& finfo) {
   const Func* func = finfo.func;
   if (RuntimeOption::EvalDisassemblerDocComments) {
@@ -437,8 +436,6 @@ void print_func_directives(Output& out, const FuncInfo& finfo) {
     out.fmtln(".declvars {};", folly::join(" ", locals));
   }
 
-  // TODO(voork): handle coeffects in HackCTranslator
-  if (isTest) return;
   auto const coeffects = func->staticCoeffectNames();
   if (!coeffects.empty()) {
     std::vector<std::string> names;
@@ -662,7 +659,7 @@ void print_func(Output& out, const Func* func) {
     func_param_list<isTest>(finfo),
     func_flag_list(finfo));
   indented(out, [&] {
-    print_func_directives<isTest>(out, finfo);
+    print_func_directives(out, finfo);
     print_func_body(out, finfo);
   });
   out.fmtln("}}");
@@ -749,7 +746,7 @@ void print_method(Output& out, const Func* func) {
     func_param_list<isTest>(finfo),
     func_flag_list(finfo));
   indented(out, [&] {
-    print_func_directives<isTest>(out, finfo);
+    print_func_directives(out, finfo);
     print_func_body(out, finfo);
   });
   out.fmtln("}}");


### PR DESCRIPTION
Summary:
Translate Coeffects in HackC Translator.

I believe there may be a better way to share the static coeffects definition between HHVM and HackC using cxx. I tried first looking at the HHVM definition, but in HHVM, we represent Coeffects as a set of static strings. I'm not sure cxx supports sharing static strings. In HackC, I tried exposing a `to_string()` method for the `Ctx` enum. This was difficult because cxx requires custom types to be declared in the same module as the cxx_bridge, resulting in a more disorganized coeffects module in Rust.

I decided this approach of just adding a case-switch in c++ was the simplest approach for now.

Differential Revision: D36816360

