### PR TITLE
Update Exception::__construct($previous)

### DIFF
--- a/hphp/hack/hhi/exceptions.hhi
+++ b/hphp/hack/hhi/exceptions.hhi
@@ -94,8 +94,8 @@ class Exception implements Throwable {
    * This method isn't pure. Consider using IExceptionWithPureGetMessage
    */
   public function getMessage()[defaults]: string;
-  final public function getPrevious()[]: ?Exception;
-  public final function setPrevious(Exception $previous)[write_props]: void;
+  final public function getPrevious()[]: ?Throwable;
+  public final function setPrevious(Throwable $previous)[write_props]: void;
   public function getCode()[]: int;
   final public function getFile()[]: string;
   final public function getLine()[]: int;

--- a/hphp/hack/hhi/exceptions.hhi
+++ b/hphp/hack/hhi/exceptions.hhi
@@ -87,7 +87,7 @@ class Exception implements Throwable {
   public function __construct (
     protected string $message = '',
     int $code = 0,
-    protected ?Exception $previous = null,
+    protected ?Throwable $previous = null,
   )[];
 
   /**


### PR DESCRIPTION
The type should be nullable Throwable since 4.162.0. There may have been good reasons for leaving it though...