### PR TITLE
Use the system default compiler for Nix build

### DIFF
--- a/hhvm.nix
+++ b/hhvm.nix
@@ -13,7 +13,6 @@
 , fmt
 , freetype
 , fribidi
-, gcc10Stdenv
 , gd
 , gdb
 , gettext
@@ -70,12 +69,7 @@
 , zstd
 }:
 let
-  # Use gcc10 in Linux because fbthrift is not compatible with gcc 11+.
-  # For macOS, use the the default compiler, which should be clang.
-  hhvmStdenv =
-    if hostPlatform.isLinux
-    then gcc10Stdenv
-    else stdenv;
+  hhvmStdenv = stdenv;
   versionParts =
     builtins.match
       ''


### PR DESCRIPTION
We previously used gcc 10 on Ubuntu because a [bug](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=104008) in gcc 11.2 prevented folly and fbthrift from being compiled. Since the bug has been fixed in 11.3 and gcc 11.3 becomes Nix's default compiler on Linux, we can now just use the system default compiler.