### PR TITLE
Use nightly Rust from nixpkgs-mozilla in Nix build

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -45,11 +45,27 @@
         "type": "indirect"
       }
     },
+    "nixpkgs-mozilla": {
+      "locked": {
+        "lastModified": 1657214286,
+        "narHash": "sha256-rO/4oymKXU09wG2bcTt4uthPCp1XsBZjxuCJo3yVXNs=",
+        "owner": "mozilla",
+        "repo": "nixpkgs-mozilla",
+        "rev": "0508a66e28a5792fdfb126bbf4dec1029c2509e0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "mozilla",
+        "repo": "nixpkgs-mozilla",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "flake-compat": "flake-compat",
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-mozilla": "nixpkgs-mozilla"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -3,9 +3,10 @@
     flake-utils.url = "github:numtide/flake-utils";
     flake-compat.url = "github:edolstra/flake-compat";
     flake-compat.flake = false;
+    nixpkgs-mozilla.url = "github:mozilla/nixpkgs-mozilla";
   };
   outputs =
-    { self, nixpkgs, flake-utils, flake-compat }:
+    { self, nixpkgs, flake-utils, flake-compat, nixpkgs-mozilla }:
     flake-utils.lib.eachSystem [
       "x86_64-darwin"
       "x86_64-linux"
@@ -13,7 +14,12 @@
       (
         system:
         let
-          pkgs = nixpkgs.legacyPackages.${system};
+          pkgs = import nixpkgs {
+            inherit system;
+            overlays = [
+              nixpkgs-mozilla.overlays.rust
+            ];
+          };
         in
         rec {
           packages.hhvm = pkgs.callPackage ./hhvm.nix {

--- a/hhvm.nix
+++ b/hhvm.nix
@@ -56,6 +56,7 @@
 , python3
 , re2
 , re2c
+, rustChannelOf
 , stdenv
 , sqlite
 , tbb
@@ -84,6 +85,7 @@ let
     if suffix == "-dev" then "hhvm_nightly" else "hhvm";
   makeVersion = major: minor: patch: suffix:
     if suffix == "-dev" then "${major}.${minor}.${patch}-${lastModifiedDate}" else "${major}.${minor}.${patch}";
+  rustNightly = rustChannelOf { date = "2022-02-24"; channel = "nightly"; };
 in
 stdenv.mkDerivation rec {
   pname = builtins.foldl' lib.trivial.id makePName versionParts;
@@ -183,6 +185,8 @@ stdenv.mkDerivation rec {
           set(HAVE_SYSTEM_TZDATA_PREFIX "${tzdata}/share/zoneinfo" CACHE STRING "The zoneinfo directory" FORCE)
           set(HAVE_SYSTEM_TZDATA ON CACHE BOOL "Use system zoneinfo" FORCE)
           set(MYSQL_UNIX_SOCK_ADDR "/run/mysqld/mysqld.sock" CACHE STRING "The MySQL unix socket" FORCE)
+          set(CARGO_EXECUTABLE "${rustNightly.cargo}/bin/cargo" CACHE FILEPATH "The nightly cargo" FORCE)
+          set(RUSTC_EXECUTABLE "${rustNightly.rust}/bin/rustc" CACHE FILEPATH "The nightly rustc" FORCE)
           ${
             lib.optionalString hostPlatform.isMacOS ''
               set(CMAKE_OSX_DEPLOYMENT_TARGET "10.15" CACHE STRING "Targeting macOS version" FORCE)
@@ -206,34 +210,6 @@ stdenv.mkDerivation rec {
         third-party/proxygen/bundled_proxygen-prefix/src/bundled_proxygen-stamp/bundled_proxygen-patch
       patchShebangs \
         third-party/proxygen/bundled_proxygen-prefix/src/bundled_proxygen
-
-      make \
-        -f third-party/rustc/CMakeFiles/bundled_rust.dir/build.make \
-        third-party/rustc/bundled_rust-prefix/src/bundled_rust-stamp/bundled_rust-patch
-      patchShebangs \
-        third-party/rustc/bundled_rust-prefix/src/bundled_rust
-    ''
-    # Prebuilt rustc and cargo needs patch if HHVM is built either
-    # on NixOS or in a Nix sandbox
-    + lib.optionalString hostPlatform.isLinux ''
-      make \
-        -f third-party/rustc/CMakeFiles/bundled_rust.dir/build.make \
-        third-party/rustc/bundled_rust-prefix/src/bundled_rust-stamp/bundled_rust-install
-      patchelf \
-        --set-interpreter ${stdenv.cc.bintools.dynamicLinker} \
-        --add-needed ${zlib}/lib/libz.so.1 \
-        --add-rpath "${lib.makeLibraryPath [zlib stdenv.cc.cc.lib]}" \
-        third-party/rustc/bundled_rust-prefix/bin/rustc
-      patchelf \
-        --set-interpreter ${stdenv.cc.bintools.dynamicLinker} \
-        --add-needed ${zlib}/lib/libz.so.1 \
-        --add-rpath "${lib.makeLibraryPath [zlib stdenv.cc.cc.lib]}" \
-        third-party/rustc/bundled_rust-prefix/bin/cargo
-      patchelf \
-        --set-interpreter ${stdenv.cc.bintools.dynamicLinker} \
-        --add-needed ${zlib}/lib/libz.so.1 \
-        --add-rpath "${lib.makeLibraryPath [zlib stdenv.cc.cc.lib]}" \
-        third-party/rustc/bundled_rust-prefix/bin/rustfmt
     '';
 
   meta = {

--- a/third-party/rustc/CMakeLists.txt
+++ b/third-party/rustc/CMakeLists.txt
@@ -11,39 +11,55 @@
 
 include(HPHPFunctions)
 
-set(RUST_NIGHTLY_VERSION "2022-02-24")
-
-SET_HHVM_THIRD_PARTY_SOURCE_ARGS(
-  RUST_DOWNLOAD_ARGS
-  Linux_URL
-  "https://static.rust-lang.org/dist/${RUST_NIGHTLY_VERSION}/rust-nightly-x86_64-unknown-linux-gnu.tar.gz"
-  Darwin_URL
-  "https://static.rust-lang.org/dist/${RUST_NIGHTLY_VERSION}/rust-nightly-x86_64-apple-darwin.tar.gz"
-  Linux_HASH
-  "SHA512=79e4f5a81b668fe5718b5491eb9acfd363067ab0d1220af27b3aef7b6490f291a05bd29ed761f19786e87d4ff6a63b07194f2de2f81d2631c13ba4848ab7df43"
-  Darwin_HASH
-  "SHA512=d44aa4da10736dd43eac32794a46cd50b8aff06b2c66cb756fdccfa828773de755a11892b27a8256ec89fe65393948abfda55880c62aa3b5225ed0d5f56f7935"
-  # The original filename doesn't contain any version information, so add the version information as a prefix to avoid cache collisions when updating later
-  FILENAME_PREFIX "rustc-${RUST_NIGHTLY_VERSION}-"
-)
-
-include(ExternalProject)
-ExternalProject_Add(
-  bundled_rust
-  ${RUST_DOWNLOAD_ARGS}
-  CONFIGURE_COMMAND ""
-  BUILD_COMMAND ""
-  INSTALL_COMMAND
-  # rust-docs aren't needed, and installing them takes more time than installing
-  # everything else and building the rust parts of hack combined
-  "<SOURCE_DIR>/install.sh" "--prefix=<INSTALL_DIR>" --without=rust-docs
-)
+option(RUSTC_EXECUTABLE "The full path of rustc executable")
+option(CARGO_EXECUTABLE "The full path of cargo executable")
 
 add_executable(rustc IMPORTED GLOBAL)
 add_executable(cargo IMPORTED GLOBAL)
-add_dependencies(rustc bundled_rust)
-add_dependencies(cargo bundled_rust)
 
-ExternalProject_Get_Property(bundled_rust INSTALL_DIR)
-set_property(TARGET rustc PROPERTY IMPORTED_LOCATION "${INSTALL_DIR}/bin/rustc")
-set_property(TARGET cargo PROPERTY IMPORTED_LOCATION "${INSTALL_DIR}/bin/cargo")
+if(RUSTC_EXECUTABLE)
+  if(CARGO_EXECUTABLE)
+    message(STATUS "Using specified Rust")
+    set_property(TARGET rustc PROPERTY IMPORTED_LOCATION "${RUSTC_EXECUTABLE}")
+    set_property(TARGET cargo PROPERTY IMPORTED_LOCATION "${CARGO_EXECUTABLE}")
+  else()
+    message(FATAL_ERROR "CARGO_EXECUTABLE must be defined if RUSTC_EXECUTABLE is defined")
+  endif()
+else()
+  message(STATUS "Using bundled Rust")
+
+  set(RUST_NIGHTLY_VERSION "2022-02-24")
+
+  SET_HHVM_THIRD_PARTY_SOURCE_ARGS(
+    RUST_DOWNLOAD_ARGS
+    Linux_URL
+    "https://static.rust-lang.org/dist/${RUST_NIGHTLY_VERSION}/rust-nightly-x86_64-unknown-linux-gnu.tar.gz"
+    Darwin_URL
+    "https://static.rust-lang.org/dist/${RUST_NIGHTLY_VERSION}/rust-nightly-x86_64-apple-darwin.tar.gz"
+    Linux_HASH
+    "SHA512=79e4f5a81b668fe5718b5491eb9acfd363067ab0d1220af27b3aef7b6490f291a05bd29ed761f19786e87d4ff6a63b07194f2de2f81d2631c13ba4848ab7df43"
+    Darwin_HASH
+    "SHA512=d44aa4da10736dd43eac32794a46cd50b8aff06b2c66cb756fdccfa828773de755a11892b27a8256ec89fe65393948abfda55880c62aa3b5225ed0d5f56f7935"
+    # The original filename doesn't contain any version information, so add the version information as a prefix to avoid cache collisions when updating later
+    FILENAME_PREFIX "rustc-${RUST_NIGHTLY_VERSION}-"
+  )
+
+  include(ExternalProject)
+  ExternalProject_Add(
+    bundled_rust
+    ${RUST_DOWNLOAD_ARGS}
+    CONFIGURE_COMMAND ""
+    BUILD_COMMAND ""
+    INSTALL_COMMAND
+    # rust-docs aren't needed, and installing them takes more time than installing
+    # everything else and building the rust parts of hack combined
+    "<SOURCE_DIR>/install.sh" "--prefix=<INSTALL_DIR>" --without=rust-docs
+  )
+
+  add_dependencies(rustc bundled_rust)
+  add_dependencies(cargo bundled_rust)
+
+  ExternalProject_Get_Property(bundled_rust INSTALL_DIR)
+  set_property(TARGET rustc PROPERTY IMPORTED_LOCATION "${INSTALL_DIR}/bin/rustc")
+  set_property(TARGET cargo PROPERTY IMPORTED_LOCATION "${INSTALL_DIR}/bin/cargo")
+endif()


### PR DESCRIPTION
The Rust binary downloaded from rust-lang.org needs patch to work with Nix. Use the nightly Rust from nixpkgs-mozilla instead