### PR TITLE
Remove patchelf

### DIFF
--- a/hhvm.nix
+++ b/hhvm.nix
@@ -49,7 +49,6 @@
 , oniguruma
 , openldap
 , openssl
-, patchelf
 , pcre
 , perl
 , pkg-config
@@ -101,7 +100,6 @@ stdenv.mkDerivation rec {
       cacert
       cmake
       flex
-      patchelf
       pkg-config
       python3
       unixtools.getconf


### PR DESCRIPTION
`patchelf` is not used since 1878930ad037545a2d00f9b113c5bd5561d8cf39