### PR TITLE
Add continue-on-error to "Assume the AWS role" GitHub Action step

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -52,14 +52,16 @@ jobs:
       if: runner.os == 'Linux'
       run: rpm --query --list --package bundle.rpm
     - name: Assume the AWS role
+      continue-on-error: true
+      id: configure-aws-credentials
       if: github.event_name != 'pull_request'
       uses: aws-actions/configure-aws-credentials@v1
       with:
         role-to-assume: arn:aws:iam::223121549624:role/hhvm-github-actions
         aws-region: us-west-2
     - name: Sign Nix binaries with a private key downloaded from AWS Secrets Manager
-      if: github.event_name != 'pull_request'
+      if: steps.configure-aws-credentials.outcome == 'success'
       run: nix store sign --recursive --key-file <(aws secretsmanager get-secret-value --secret-id hhvm-nix-cache-1 --query SecretString --output text) --print-build-logs --no-sandbox "git+file://$(pwd)?submodules=1&shallow=1"
     - name: Upload Nix binaries to the binary cache server on S3
-      if: github.event_name != 'pull_request'
+      if: steps.configure-aws-credentials.outcome == 'success'
       run: nix copy --to 's3://hhvm-nix-cache?region=us-west-2&endpoint=hhvm-nix-cache.s3-accelerate.amazonaws.com' --print-build-logs --no-sandbox "git+file://$(pwd)?submodules=1&shallow=1"


### PR DESCRIPTION
This commit prevents the GitHub Action job from failing when running from a forked repository, where they don't have the permission to assume the AWS role.

Fixes #9117.