### PR TITLE
Ignore failures in macOS CI

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -18,6 +18,7 @@ jobs:
         - ubuntu-latest
         - macos-latest
     runs-on: ${{matrix.os}}
+    continue-on-error: ${{ matrix.os == 'macos-latest' }}
     steps:
     - uses: actions/checkout@v2.4.0
     - uses: cachix/install-nix-action@v15


### PR DESCRIPTION
Since we have dropped Homebrew macOS support, we expect the Nix CI on macOS would be also be broken and we are not committed to fix it. 