### PR TITLE
Set up version number for deb and rpm

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -81,7 +81,10 @@
                     --input-type dir \
                     --output-type ${outputType} \
                     --name ${pkgs.lib.strings.escapeShellArg pkg.pname} \
-                    --version ${pkgs.lib.strings.escapeShellArg pkg.version} \
+                    --version ${
+                      pkgs.lib.strings.escapeShellArg
+                        (builtins.replaceStrings ["-"] ["~"] pkg.version)
+                    } \
                     --description ${pkgs.lib.strings.escapeShellArg pkg.meta.description} \
                     --url ${pkgs.lib.strings.escapeShellArg pkg.meta.homepage} \
                     --maintainer ${pkgs.lib.strings.escapeShellArg (pkgs.lib.strings.concatStringsSep ", " (map ({name, email, ...}: "\"${name}\" <${email}>") pkg.meta.maintainers))} \

--- a/hhvm.nix
+++ b/hhvm.nix
@@ -80,10 +80,8 @@ let
         .*
       ''
       (builtins.readFile ./hphp/runtime/version.h);
-  makePName = major: minor: patch: suffix:
-    if suffix == "-dev" then "hhvm_nightly" else "hhvm";
   makeVersion = major: minor: patch: suffix:
-    if suffix == "-dev" then "${major}.${minor}.${patch}-${lastModifiedDate}" else "${major}.${minor}.${patch}";
+    if suffix == "-dev" then "${major}.${minor}.${patch}-dev${lastModifiedDate}" else "${major}.${minor}.${patch}";
   rustNightly = rustChannelOf {
     sha256 = "TpJKRroEs7V2BTo2GFPJlEScYVArFY2MnGpYTxbnSo8=";
     date = "2022-02-24";
@@ -91,7 +89,7 @@ let
   };
 in
 stdenv.mkDerivation rec {
-  pname = builtins.foldl' lib.trivial.id makePName versionParts;
+  pname = "hhvm";
   version = builtins.foldl' lib.trivial.id makeVersion versionParts;
   src = ./.;
   nativeBuildInputs =


### PR DESCRIPTION
See https://github.com/hhvm/packaging/issues/311 for version schema

Test Plan:
---
Check "Show the rpm package's information" "Show the deb package's information" steps in GitHub Actions output. The version number should be like `4.165.0~dev20220714183154`