### PR TITLE
Delete C++ register keyword

### DIFF
--- a/hphp/runtime/base/ini-parser/zend-ini.ll
+++ b/hphp/runtime/base/ini-parser/zend-ini.ll
@@ -70,7 +70,7 @@ static ZendINIGlobals s_zend_ini;
 
 static void zend_ini_escape_string(std::string &lval, char *str, int len,
                                    char quote_type) {
-  register char *s, *t;
+  char *s, *t;
   char *end;
 
   lval = std::string(str, len);

--- a/hphp/runtime/base/ini-parser/zend-ini.ll.cpp
+++ b/hphp/runtime/base/ini-parser/zend-ini.ll.cpp
@@ -1,7 +1,3 @@
-// @generated
-#line 2 "buck-out/dbg/gen/hphp/runtime/base/ini-parser/ini-parser=zend-ini.ll/zend-ini.ll.d/zend-ini.ll.cc"
-
-#line 4 "buck-out/dbg/gen/hphp/runtime/base/ini-parser/ini-parser=zend-ini.ll/zend-ini.ll.d/zend-ini.ll.cc"
 
 #define  YY_INT_ALIGNED short int
 
@@ -9,11 +5,17 @@
 
 #define yy_create_buffer zend_ini_yy_create_buffer
 #define yy_delete_buffer zend_ini_yy_delete_buffer
-#define yy_flex_debug zend_ini_yy_flex_debug
+#define yy_scan_buffer zend_ini_yy_scan_buffer
+#define yy_scan_string zend_ini_yy_scan_string
+#define yy_scan_bytes zend_ini_yy_scan_bytes
 #define yy_init_buffer zend_ini_yy_init_buffer
 #define yy_flush_buffer zend_ini_yy_flush_buffer
 #define yy_load_buffer_state zend_ini_yy_load_buffer_state
 #define yy_switch_to_buffer zend_ini_yy_switch_to_buffer
+#define yypush_buffer_state zend_ini_yypush_buffer_state
+#define yypop_buffer_state zend_ini_yypop_buffer_state
+#define yyensure_buffer_stack zend_ini_yyensure_buffer_stack
+#define yy_flex_debug zend_ini_yy_flex_debug
 #define yyin zend_ini_yyin
 #define yyleng zend_ini_yyleng
 #define yylex zend_ini_yylex
@@ -28,10 +30,244 @@
 
 #define FLEX_SCANNER
 #define YY_FLEX_MAJOR_VERSION 2
-#define YY_FLEX_MINOR_VERSION 5
-#define YY_FLEX_SUBMINOR_VERSION 39
+#define YY_FLEX_MINOR_VERSION 6
+#define YY_FLEX_SUBMINOR_VERSION 4
 #if YY_FLEX_SUBMINOR_VERSION > 0
 #define FLEX_BETA
+#endif
+
+#ifdef yy_create_buffer
+#define zend_ini_yy_create_buffer_ALREADY_DEFINED
+#else
+#define yy_create_buffer zend_ini_yy_create_buffer
+#endif
+
+#ifdef yy_delete_buffer
+#define zend_ini_yy_delete_buffer_ALREADY_DEFINED
+#else
+#define yy_delete_buffer zend_ini_yy_delete_buffer
+#endif
+
+#ifdef yy_scan_buffer
+#define zend_ini_yy_scan_buffer_ALREADY_DEFINED
+#else
+#define yy_scan_buffer zend_ini_yy_scan_buffer
+#endif
+
+#ifdef yy_scan_string
+#define zend_ini_yy_scan_string_ALREADY_DEFINED
+#else
+#define yy_scan_string zend_ini_yy_scan_string
+#endif
+
+#ifdef yy_scan_bytes
+#define zend_ini_yy_scan_bytes_ALREADY_DEFINED
+#else
+#define yy_scan_bytes zend_ini_yy_scan_bytes
+#endif
+
+#ifdef yy_init_buffer
+#define zend_ini_yy_init_buffer_ALREADY_DEFINED
+#else
+#define yy_init_buffer zend_ini_yy_init_buffer
+#endif
+
+#ifdef yy_flush_buffer
+#define zend_ini_yy_flush_buffer_ALREADY_DEFINED
+#else
+#define yy_flush_buffer zend_ini_yy_flush_buffer
+#endif
+
+#ifdef yy_load_buffer_state
+#define zend_ini_yy_load_buffer_state_ALREADY_DEFINED
+#else
+#define yy_load_buffer_state zend_ini_yy_load_buffer_state
+#endif
+
+#ifdef yy_switch_to_buffer
+#define zend_ini_yy_switch_to_buffer_ALREADY_DEFINED
+#else
+#define yy_switch_to_buffer zend_ini_yy_switch_to_buffer
+#endif
+
+#ifdef yypush_buffer_state
+#define zend_ini_yypush_buffer_state_ALREADY_DEFINED
+#else
+#define yypush_buffer_state zend_ini_yypush_buffer_state
+#endif
+
+#ifdef yypop_buffer_state
+#define zend_ini_yypop_buffer_state_ALREADY_DEFINED
+#else
+#define yypop_buffer_state zend_ini_yypop_buffer_state
+#endif
+
+#ifdef yyensure_buffer_stack
+#define zend_ini_yyensure_buffer_stack_ALREADY_DEFINED
+#else
+#define yyensure_buffer_stack zend_ini_yyensure_buffer_stack
+#endif
+
+#ifdef yylex
+#define zend_ini_yylex_ALREADY_DEFINED
+#else
+#define yylex zend_ini_yylex
+#endif
+
+#ifdef yyrestart
+#define zend_ini_yyrestart_ALREADY_DEFINED
+#else
+#define yyrestart zend_ini_yyrestart
+#endif
+
+#ifdef yylex_init
+#define zend_ini_yylex_init_ALREADY_DEFINED
+#else
+#define yylex_init zend_ini_yylex_init
+#endif
+
+#ifdef yylex_init_extra
+#define zend_ini_yylex_init_extra_ALREADY_DEFINED
+#else
+#define yylex_init_extra zend_ini_yylex_init_extra
+#endif
+
+#ifdef yylex_destroy
+#define zend_ini_yylex_destroy_ALREADY_DEFINED
+#else
+#define yylex_destroy zend_ini_yylex_destroy
+#endif
+
+#ifdef yyget_debug
+#define zend_ini_yyget_debug_ALREADY_DEFINED
+#else
+#define yyget_debug zend_ini_yyget_debug
+#endif
+
+#ifdef yyset_debug
+#define zend_ini_yyset_debug_ALREADY_DEFINED
+#else
+#define yyset_debug zend_ini_yyset_debug
+#endif
+
+#ifdef yyget_extra
+#define zend_ini_yyget_extra_ALREADY_DEFINED
+#else
+#define yyget_extra zend_ini_yyget_extra
+#endif
+
+#ifdef yyset_extra
+#define zend_ini_yyset_extra_ALREADY_DEFINED
+#else
+#define yyset_extra zend_ini_yyset_extra
+#endif
+
+#ifdef yyget_in
+#define zend_ini_yyget_in_ALREADY_DEFINED
+#else
+#define yyget_in zend_ini_yyget_in
+#endif
+
+#ifdef yyset_in
+#define zend_ini_yyset_in_ALREADY_DEFINED
+#else
+#define yyset_in zend_ini_yyset_in
+#endif
+
+#ifdef yyget_out
+#define zend_ini_yyget_out_ALREADY_DEFINED
+#else
+#define yyget_out zend_ini_yyget_out
+#endif
+
+#ifdef yyset_out
+#define zend_ini_yyset_out_ALREADY_DEFINED
+#else
+#define yyset_out zend_ini_yyset_out
+#endif
+
+#ifdef yyget_leng
+#define zend_ini_yyget_leng_ALREADY_DEFINED
+#else
+#define yyget_leng zend_ini_yyget_leng
+#endif
+
+#ifdef yyget_text
+#define zend_ini_yyget_text_ALREADY_DEFINED
+#else
+#define yyget_text zend_ini_yyget_text
+#endif
+
+#ifdef yyget_lineno
+#define zend_ini_yyget_lineno_ALREADY_DEFINED
+#else
+#define yyget_lineno zend_ini_yyget_lineno
+#endif
+
+#ifdef yyset_lineno
+#define zend_ini_yyset_lineno_ALREADY_DEFINED
+#else
+#define yyset_lineno zend_ini_yyset_lineno
+#endif
+
+#ifdef yywrap
+#define zend_ini_yywrap_ALREADY_DEFINED
+#else
+#define yywrap zend_ini_yywrap
+#endif
+
+#ifdef yyalloc
+#define zend_ini_yyalloc_ALREADY_DEFINED
+#else
+#define yyalloc zend_ini_yyalloc
+#endif
+
+#ifdef yyrealloc
+#define zend_ini_yyrealloc_ALREADY_DEFINED
+#else
+#define yyrealloc zend_ini_yyrealloc
+#endif
+
+#ifdef yyfree
+#define zend_ini_yyfree_ALREADY_DEFINED
+#else
+#define yyfree zend_ini_yyfree
+#endif
+
+#ifdef yytext
+#define zend_ini_yytext_ALREADY_DEFINED
+#else
+#define yytext zend_ini_yytext
+#endif
+
+#ifdef yyleng
+#define zend_ini_yyleng_ALREADY_DEFINED
+#else
+#define yyleng zend_ini_yyleng
+#endif
+
+#ifdef yyin
+#define zend_ini_yyin_ALREADY_DEFINED
+#else
+#define yyin zend_ini_yyin
+#endif
+
+#ifdef yyout
+#define zend_ini_yyout_ALREADY_DEFINED
+#else
+#define yyout zend_ini_yyout
+#endif
+
+#ifdef yy_flex_debug
+#define zend_ini_yy_flex_debug_ALREADY_DEFINED
+#else
+#define yy_flex_debug zend_ini_yy_flex_debug
+#endif
+
+#ifdef yylineno
+#define zend_ini_yylineno_ALREADY_DEFINED
+#else
+#define yylineno zend_ini_yylineno
 #endif
 
 /* First, we deal with  platform-specific or compiler-specific issues. */
@@ -54,7 +290,7 @@
 #if defined (__STDC_VERSION__) && __STDC_VERSION__ >= 199901L
 
 /* C99 says to define __STDC_LIMIT_MACROS before including stdint.h,
- * if you want the limit (max/min) macros for int types.
+ * if you want the limit (max/min) macros for int types. 
  */
 #ifndef __STDC_LIMIT_MACROS
 #define __STDC_LIMIT_MACROS 1
@@ -71,7 +307,7 @@ typedef uint32_t flex_uint32_t;
 typedef signed char flex_int8_t;
 typedef short int flex_int16_t;
 typedef int flex_int32_t;
-typedef unsigned char flex_uint8_t;
+typedef unsigned char flex_uint8_t; 
 typedef unsigned short int flex_uint16_t;
 typedef unsigned int flex_uint32_t;
 
@@ -104,65 +340,61 @@ typedef unsigned int flex_uint32_t;
 #define UINT32_MAX             (4294967295U)
 #endif
 
+#ifndef SIZE_MAX
+#define SIZE_MAX               (~(size_t)0)
+#endif
+
 #endif /* ! C99 */
 
 #endif /* ! FLEXINT_H */
 
-#ifdef __cplusplus
+/* begin standard C++ headers. */
 
-/* The "const" storage-class-modifier is valid. */
-#define YY_USE_CONST
-
-#else	/* ! __cplusplus */
-
-/* C99 requires __STDC__ to be defined as 1. */
-#if defined (__STDC__)
-
-#define YY_USE_CONST
-
-#endif	/* defined (__STDC__) */
-#endif	/* ! __cplusplus */
-
-#ifdef YY_USE_CONST
+/* TODO: this is always defined, so inline it */
 #define yyconst const
+
+#if defined(__GNUC__) && __GNUC__ >= 3
+#define yynoreturn __attribute__((__noreturn__))
 #else
-#define yyconst
+#define yynoreturn
 #endif
 
 /* Returned upon end-of-file. */
 #define YY_NULL 0
 
-/* Promotes a possibly negative, possibly signed char to an unsigned
- * integer for use as an array index.  If the signed char is negative,
- * we want to instead treat it as an 8-bit unsigned char, hence the
- * double cast.
+/* Promotes a possibly negative, possibly signed char to an
+ *   integer in range [0..255] for use as an array index.
  */
-#define YY_SC_TO_UI(c) ((unsigned int) (unsigned char) c)
+#define YY_SC_TO_UI(c) ((YY_CHAR) (c))
 
 /* Enter a start condition.  This macro really ought to take a parameter,
  * but we do it the disgusting crufty way forced on us by the ()-less
  * definition of BEGIN.
  */
 #define BEGIN (yy_start) = 1 + 2 *
-
 /* Translate the current start state into a value that can be later handed
  * to BEGIN to return to the state.  The YYSTATE alias is for lex
  * compatibility.
  */
 #define YY_START (((yy_start) - 1) / 2)
 #define YYSTATE YY_START
-
 /* Action number for EOF rule of a given start state. */
 #define YY_STATE_EOF(state) (YY_END_OF_BUFFER + state + 1)
-
 /* Special action meaning "start processing a new file". */
-#define YY_NEW_FILE zend_ini_yyrestart(zend_ini_yyin  )
-
+#define YY_NEW_FILE yyrestart( yyin  )
 #define YY_END_OF_BUFFER_CHAR 0
 
 /* Size of default input buffer. */
 #ifndef YY_BUF_SIZE
+#ifdef __ia64__
+/* On IA-64, the buffer size is 16k, not 8k.
+ * Moreover, YY_BUF_SIZE is 2*YY_READ_BUF_SIZE in the general case.
+ * Ditto for the __ia64__ case accordingly.
+ */
+#define YY_BUF_SIZE 32768
+#else
 #define YY_BUF_SIZE 16384
+#endif /* __ia64__ */
 #endif
 
 /* The state buf must be large enough to hold one state per character in the main buffer.
@@ -179,31 +411,30 @@ typedef struct yy_buffer_state *YY_BUFFER_STATE;
 typedef size_t yy_size_t;
 #endif
 
-extern yy_size_t zend_ini_yyleng;
+extern int yyleng;
 
-extern FILE *zend_ini_yyin, *zend_ini_yyout;
+extern FILE *yyin, *yyout;
 
 #define EOB_ACT_CONTINUE_SCAN 0
 #define EOB_ACT_END_OF_FILE 1
 #define EOB_ACT_LAST_MATCH 2
-
+    
     #define YY_LESS_LINENO(n)
     #define YY_LINENO_REWIND_TO(ptr)
-
+    
 /* Return all but the first "n" matched characters back to the input stream. */
 #define yyless(n) \
 	do \
 		{ \
-		/* Undo effects of setting up zend_ini_yytext. */ \
+		/* Undo effects of setting up yytext. */ \
         int yyless_macro_arg = (n); \
         YY_LESS_LINENO(yyless_macro_arg);\
 		*yy_cp = (yy_hold_char); \
 		YY_RESTORE_YY_MORE_OFFSET \
 		(yy_c_buf_p) = yy_cp = yy_bp + yyless_macro_arg - YY_MORE_ADJ; \
-		YY_DO_BEFORE_ACTION; /* set up zend_ini_yytext again */ \
+		YY_DO_BEFORE_ACTION; /* set up yytext again */ \
 		} \
 	while ( 0 )
-
 #define unput(c) yyunput( c, (yytext_ptr)  )
 
 #ifndef YY_STRUCT_YY_BUFFER_STATE
@@ -218,12 +449,12 @@ struct yy_buffer_state
 	/* Size of input buffer in bytes, not including room for EOB
 	 * characters.
 	 */
-	yy_size_t yy_buf_size;
+	int yy_buf_size;
 
 	/* Number of characters read into yy_ch_buf, not including EOB
 	 * characters.
 	 */
-	yy_size_t yy_n_chars;
+	int yy_n_chars;
 
 	/* Whether we "own" the buffer - i.e., we know we created it,
 	 * and can realloc() it to grow it, and should free() it to
@@ -263,8 +494,8 @@ struct yy_buffer_state
 	 * possible backing-up.
 	 *
 	 * When we actually see the EOF, we change the status to "new"
-	 * (via zend_ini_yyrestart()), so that the user can continue scanning by
-	 * just pointing zend_ini_yyin at a new input file.
+	 * (via yyrestart()), so that the user can continue scanning by
+	 * just pointing yyin at a new input file.
 	 */
 #define YY_BUFFER_EOF_PENDING 2
 
@@ -274,7 +505,7 @@ struct yy_buffer_state
 /* Stack of input buffers. */
 static size_t yy_buffer_stack_top = 0; /**< index of top of stack. */
 static size_t yy_buffer_stack_max = 0; /**< capacity of stack. */
-static YY_BUFFER_STATE * yy_buffer_stack = 0; /**< Stack as an array. */
+static YY_BUFFER_STATE * yy_buffer_stack = NULL; /**< Stack as an array. */
 
 /* We provide macros for accessing buffer states in case in the
  * future we want to put the buffer states in a more general
@@ -285,106 +516,101 @@ static YY_BUFFER_STATE * yy_buffer_stack = 0; /**< Stack as an array. */
 #define YY_CURRENT_BUFFER ( (yy_buffer_stack) \
                           ? (yy_buffer_stack)[(yy_buffer_stack_top)] \
                           : NULL)
-
 /* Same as previous macro, but useful when we know that the buffer stack is not
  * NULL or when we need an lvalue. For internal use only.
  */
 #define YY_CURRENT_BUFFER_LVALUE (yy_buffer_stack)[(yy_buffer_stack_top)]
 
-/* yy_hold_char holds the character lost when zend_ini_yytext is formed. */
+/* yy_hold_char holds the character lost when yytext is formed. */
 static char yy_hold_char;
-static yy_size_t yy_n_chars;		/* number of characters read into yy_ch_buf */
-yy_size_t zend_ini_yyleng;
+static int yy_n_chars;		/* number of characters read into yy_ch_buf */
+int yyleng;
 
 /* Points to current character in buffer. */
-static char *yy_c_buf_p = (char *) 0;
+static char *yy_c_buf_p = NULL;
 static int yy_init = 0;		/* whether we need to initialize */
 static int yy_start = 0;	/* start state number */
 
-/* Flag which is used to allow zend_ini_yywrap()'s to do buffer switches
- * instead of setting up a fresh zend_ini_yyin.  A bit of a hack ...
+/* Flag which is used to allow yywrap()'s to do buffer switches
+ * instead of setting up a fresh yyin.  A bit of a hack ...
  */
 static int yy_did_buffer_switch_on_eof;
 
-void zend_ini_yyrestart (FILE *input_file  );
-void zend_ini_yy_switch_to_buffer (YY_BUFFER_STATE new_buffer  );
-YY_BUFFER_STATE zend_ini_yy_create_buffer (FILE *file,int size  );
-void zend_ini_yy_delete_buffer (YY_BUFFER_STATE b  );
-void zend_ini_yy_flush_buffer (YY_BUFFER_STATE b  );
-void zend_ini_yypush_buffer_state (YY_BUFFER_STATE new_buffer  );
-void zend_ini_yypop_buffer_state (void );
+void yyrestart ( FILE *input_file  );
+void yy_switch_to_buffer ( YY_BUFFER_STATE new_buffer  );
+YY_BUFFER_STATE yy_create_buffer ( FILE *file, int size  );
+void yy_delete_buffer ( YY_BUFFER_STATE b  );
+void yy_flush_buffer ( YY_BUFFER_STATE b  );
+void yypush_buffer_state ( YY_BUFFER_STATE new_buffer  );
+void yypop_buffer_state ( void );
 
-static void zend_ini_yyensure_buffer_stack (void );
-static void zend_ini_yy_load_buffer_state (void );
-static void zend_ini_yy_init_buffer (YY_BUFFER_STATE b,FILE *file  );
+static void yyensure_buffer_stack ( void );
+static void yy_load_buffer_state ( void );
+static void yy_init_buffer ( YY_BUFFER_STATE b, FILE *file  );
+#define YY_FLUSH_BUFFER yy_flush_buffer( YY_CURRENT_BUFFER )
 
-#define YY_FLUSH_BUFFER zend_ini_yy_flush_buffer(YY_CURRENT_BUFFER )
+YY_BUFFER_STATE yy_scan_buffer ( char *base, yy_size_t size  );
+YY_BUFFER_STATE yy_scan_string ( const char *yy_str  );
+YY_BUFFER_STATE yy_scan_bytes ( const char *bytes, int len  );
 
-YY_BUFFER_STATE zend_ini_yy_scan_buffer (char *base,yy_size_t size  );
-YY_BUFFER_STATE zend_ini_yy_scan_string (yyconst char *yy_str  );
-YY_BUFFER_STATE zend_ini_yy_scan_bytes (yyconst char *bytes,yy_size_t len  );
+void *yyalloc ( yy_size_t  );
+void *yyrealloc ( void *, yy_size_t  );
+void yyfree ( void *  );
 
-void *zend_ini_yyalloc (yy_size_t  );
-void *zend_ini_yyrealloc (void *,yy_size_t  );
-void zend_ini_yyfree (void *  );
-
-#define yy_new_buffer zend_ini_yy_create_buffer
-
+#define yy_new_buffer yy_create_buffer
 #define yy_set_interactive(is_interactive) \
 	{ \
-	if (YY_CURRENT_BUFFER == NULL){ \
-        zend_ini_yyensure_buffer_stack (); \
+	if ( ! YY_CURRENT_BUFFER ){ \
+        yyensure_buffer_stack (); \
 		YY_CURRENT_BUFFER_LVALUE =    \
-            zend_ini_yy_create_buffer(zend_ini_yyin,YY_BUF_SIZE ); \
+            yy_create_buffer( yyin, YY_BUF_SIZE ); \
 	} \
 	YY_CURRENT_BUFFER_LVALUE->yy_is_interactive = is_interactive; \
 	}
-
 #define yy_set_bol(at_bol) \
 	{ \
-	if (YY_CURRENT_BUFFER == NULL){\
-        zend_ini_yyensure_buffer_stack (); \
+	if ( ! YY_CURRENT_BUFFER ){\
+        yyensure_buffer_stack (); \
 		YY_CURRENT_BUFFER_LVALUE =    \
-            zend_ini_yy_create_buffer(zend_ini_yyin,YY_BUF_SIZE ); \
+            yy_create_buffer( yyin, YY_BUF_SIZE ); \
 	} \
 	YY_CURRENT_BUFFER_LVALUE->yy_at_bol = at_bol; \
 	}
-
 #define YY_AT_BOL() (YY_CURRENT_BUFFER_LVALUE->yy_at_bol)
 
 /* Begin user sect3 */
 
-#define zend_ini_yywrap() 1
+#define zend_ini_yywrap() (/*CONSTCOND*/1)
 #define YY_SKIP_YYWRAP
+typedef flex_uint8_t YY_CHAR;
 
-typedef unsigned char YY_CHAR;
-
-FILE *zend_ini_yyin = (FILE *) 0, *zend_ini_yyout = (FILE *) 0;
+FILE *yyin = NULL, *yyout = NULL;
 
 typedef int yy_state_type;
 
-extern int zend_ini_yylineno;
+extern int yylineno;
+int yylineno = 1;
 
-int zend_ini_yylineno = 1;
+extern char *yytext;
+#ifdef yytext_ptr
+#undef yytext_ptr
+#endif
+#define yytext_ptr yytext
 
-extern char *zend_ini_yytext;
-#define yytext_ptr zend_ini_yytext
-
-static yy_state_type yy_get_previous_state (void );
-static yy_state_type yy_try_NUL_trans (yy_state_type current_state  );
-static int yy_get_next_buffer (void );
-static void yy_fatal_error (yyconst char msg[]  );
+static yy_state_type yy_get_previous_state ( void );
+static yy_state_type yy_try_NUL_trans ( yy_state_type current_state  );
+static int yy_get_next_buffer ( void );
+static void yynoreturn yy_fatal_error ( const char* msg  );
 
 /* Done after the current pattern has been matched and before the
- * corresponding action - sets up zend_ini_yytext.
+ * corresponding action - sets up yytext.
  */
 #define YY_DO_BEFORE_ACTION \
 	(yytext_ptr) = yy_bp; \
-	zend_ini_yyleng = (size_t) (yy_cp - yy_bp); \
+	yyleng = (int) (yy_cp - yy_bp); \
 	(yy_hold_char) = *yy_cp; \
 	*yy_cp = '\0'; \
 	(yy_c_buf_p) = yy_cp;
-
 #define YY_NUM_RULES 33
 #define YY_END_OF_BUFFER 34
 /* This struct is not used in this scanner,
@@ -394,7 +620,7 @@ struct yy_trans_info
 	flex_int32_t yy_verify;
 	flex_int32_t yy_nxt;
 	};
-static yyconst flex_int16_t yy_accept[199] =
+static const flex_int16_t yy_accept[199] =
     {   0,
         0,    0,    0,    0,    0,    0,    0,    0,    0,    0,
         0,    0,    0,    0,    0,    0,    0,    0,   34,   10,
@@ -420,7 +646,7 @@ static yyconst flex_int16_t yy_accept[199] =
 
     } ;
 
-static yyconst flex_int32_t yy_ec[256] =
+static const YY_CHAR yy_ec[256] =
     {   0,
         1,    1,    1,    1,    1,    1,    1,    1,    2,    3,
         1,    1,    4,    1,    1,    1,    1,    1,    1,    1,
@@ -452,7 +678,7 @@ static yyconst flex_int32_t yy_ec[256] =
         1,    1,    1,    1,    1
     } ;
 
-static yyconst flex_int32_t yy_meta[48] =
+static const YY_CHAR yy_meta[48] =
     {   0,
         1,    2,    3,    3,    4,    2,    5,    1,    6,    1,
         7,    1,    1,    1,    8,    2,    1,    1,    1,    1,
@@ -461,7 +687,7 @@ static yyconst flex_int32_t yy_meta[48] =
         1,    1,    1,    1,    6,    6,   10
     } ;
 
-static yyconst flex_int16_t yy_base[223] =
+static const flex_int16_t yy_base[223] =
     {   0,
         0,    0,   47,    0,   93,   94,   98,  102,  131,    0,
       176,  178,  176,  180,  209,  254,  188,  224,  607,    0,
@@ -490,7 +716,7 @@ static yyconst flex_int16_t yy_base[223] =
      1018, 1028
     } ;
 
-static yyconst flex_int16_t yy_def[223] =
+static const flex_int16_t yy_def[223] =
     {   0,
       198,    1,  198,    3,    3,    3,  199,  199,  198,    9,
       200,  200,  201,  201,  202,  202,  203,  203,  198,  204,
@@ -519,7 +745,7 @@ static yyconst flex_int16_t yy_def[223] =
       198,  198
     } ;
 
-static yyconst flex_int16_t yy_nxt[1087] =
+static const flex_int16_t yy_nxt[1087] =
     {   0,
        20,   21,   22,   23,   24,   25,   25,   26,   25,   27,
        27,   27,   27,   20,   28,   25,   20,   20,   20,   29,
@@ -642,7 +868,7 @@ static yyconst flex_int16_t yy_nxt[1087] =
       198,  198,  198,  198,  198,  198
     } ;
 
-static yyconst flex_int16_t yy_chk[1087] =
+static const flex_int16_t yy_chk[1087] =
     {   0,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
@@ -768,8 +994,8 @@ static yyconst flex_int16_t yy_chk[1087] =
 static yy_state_type yy_last_accepting_state;
 static char *yy_last_accepting_cpos;
 
-extern int zend_ini_yy_flex_debug;
-int zend_ini_yy_flex_debug = 0;
+extern int yy_flex_debug;
+int yy_flex_debug = 0;
 
 /* The intent behind this definition is that it'll catch
  * any uses of REJECT which flex missed.
@@ -778,9 +1004,7 @@ int zend_ini_yy_flex_debug = 0;
 #define yymore() yymore_used_but_not_detected
 #define YY_MORE_ADJ 0
 #define YY_RESTORE_YY_MORE_OFFSET
-char *zend_ini_yytext;
-#line 1 "hphp/runtime/base/ini-parser/zend-ini.ll"
-#line 2 "hphp/runtime/base/ini-parser/zend-ini.ll"
+char *yytext;
 /*
    +----------------------------------------------------------------------+
    | HipHop for PHP                                                       |
@@ -825,10 +1049,10 @@ static ZendINIGlobals s_zend_ini;
 
 /* Eat leading whitespace */
 #define EAT_LEADING_WHITESPACE() \
-  while (zend_ini_yytext[0]) {                             \
-    if (zend_ini_yytext[0] == ' ' || zend_ini_yytext[0] == '\t') {  \
-      zend_ini_yytext++;                                   \
-      zend_ini_yyleng--;                                   \
+  while (yytext[0]) {                             \
+    if (yytext[0] == ' ' || yytext[0] == '\t') {  \
+      yytext++;                                   \
+      yyleng--;                                   \
     } else {                                      \
       break;                                      \
     }                                             \
@@ -836,13 +1060,13 @@ static ZendINIGlobals s_zend_ini;
 
 /* Eat trailing whitespace */
 #define EAT_TRAILING_WHITESPACE()                 \
-  while (zend_ini_yyleng > 0 && (                          \
-    zend_ini_yytext[zend_ini_yyleng - 1] == '\n' ||                 \
-    zend_ini_yytext[zend_ini_yyleng - 1] == '\r' ||                 \
-    zend_ini_yytext[zend_ini_yyleng - 1] == '\t' ||                 \
-    zend_ini_yytext[zend_ini_yyleng - 1] == ' ')                    \
+  while (yyleng > 0 && (                          \
+    yytext[yyleng - 1] == '\n' ||                 \
+    yytext[yyleng - 1] == '\r' ||                 \
+    yytext[yyleng - 1] == '\t' ||                 \
+    yytext[yyleng - 1] == ' ')                    \
   ) {                                             \
-    zend_ini_yyleng--;                                     \
+    yyleng--;                                     \
   }
 
 #define RETURN_TOKEN(type, str, len) {            \
@@ -852,7 +1076,7 @@ static ZendINIGlobals s_zend_ini;
 
 static void zend_ini_escape_string(std::string &lval, char *str, int len,
                                    char quote_type) {
-  register char *s, *t;
+  char *s, *t;
   char *end;
 
   lval = std::string(str, len);
@@ -916,16 +1140,6 @@ restart:
   return ret;
 }
 
-
-
-
-
-
-
-
-
-#line 927 "buck-out/dbg/gen/hphp/runtime/base/ini-parser/ini-parser=zend-ini.ll/zend-ini.ll.d/zend-ini.ll.cc"
-
 #define INITIAL 0
 #define ST_OFFSET 1
 #define ST_SECTION_VALUE 2
@@ -948,36 +1162,36 @@ restart:
 #define YY_EXTRA_TYPE void *
 #endif
 
-static int yy_init_globals (void );
+static int yy_init_globals ( void );
 
 /* Accessor methods to globals.
    These are made visible to non-reentrant scanners for convenience. */
 
-int zend_ini_yylex_destroy (void );
+int yylex_destroy ( void );
 
-int zend_ini_yyget_debug (void );
+int yyget_debug ( void );
 
-void zend_ini_yyset_debug (int debug_flag  );
+void yyset_debug ( int debug_flag  );
 
-YY_EXTRA_TYPE zend_ini_yyget_extra (void );
+YY_EXTRA_TYPE yyget_extra ( void );
 
-void zend_ini_yyset_extra (YY_EXTRA_TYPE user_defined  );
+void yyset_extra ( YY_EXTRA_TYPE user_defined  );
 
-FILE *zend_ini_yyget_in (void );
+FILE *yyget_in ( void );
 
-void zend_ini_yyset_in  (FILE * in_str  );
+void yyset_in  ( FILE * _in_str  );
 
-FILE *zend_ini_yyget_out (void );
+FILE *yyget_out ( void );
 
-void zend_ini_yyset_out  (FILE * out_str  );
+void yyset_out  ( FILE * _out_str  );
 
-yy_size_t zend_ini_yyget_leng (void );
+			int yyget_leng ( void );
 
-char *zend_ini_yyget_text (void );
+char *yyget_text ( void );
 
-int zend_ini_yyget_lineno (void );
+int yyget_lineno ( void );
 
-void zend_ini_yyset_lineno (int line_number  );
+void yyset_lineno ( int _line_number  );
 
 /* Macros after this point can all be overridden by user definitions in
  * section 1.
@@ -985,28 +1199,31 @@ void zend_ini_yyset_lineno (int line_number  );
 
 #ifndef YY_SKIP_YYWRAP
 #ifdef __cplusplus
-extern "C" int zend_ini_yywrap (void );
+extern "C" int yywrap ( void );
 #else
-extern int zend_ini_yywrap (void );
+extern int yywrap ( void );
 #endif
 #endif
 
-    static void yyunput (int c,char *buf_ptr  );
+#ifndef YY_NO_UNPUT
+    
+    static void yyunput ( int c, char *buf_ptr  );
+    
+#endif
 
 #ifndef yytext_ptr
-static void yy_flex_strncpy (char *,yyconst char *,int );
+static void yy_flex_strncpy ( char *, const char *, int );
 #endif
 
 #ifdef YY_NEED_STRLEN
-static int yy_flex_strlen (yyconst char * );
+static int yy_flex_strlen ( const char * );
 #endif
 
 #ifndef YY_NO_INPUT
-
 #ifdef __cplusplus
-static int yyinput (void );
+static int yyinput ( void );
 #else
-static int input (void );
+static int input ( void );
 #endif
 
 #endif
@@ -1014,16 +1231,21 @@ static int input (void );
         static int yy_start_stack_ptr = 0;
         static int yy_start_stack_depth = 0;
         static int *yy_start_stack = NULL;
-
-    static void yy_push_state (int new_state );
-
-    static void yy_pop_state (void );
-
-    static int yy_top_state (void );
-
+    
+    static void yy_push_state ( int _new_state );
+    
+    static void yy_pop_state ( void );
+    
+    static int yy_top_state ( void );
+    
 /* Amount of stuff to slurp up with each read. */
 #ifndef YY_READ_BUF_SIZE
+#ifdef __ia64__
+/* On IA-64, the buffer size is 16k, not 8k */
+#define YY_READ_BUF_SIZE 16384
+#else
 #define YY_READ_BUF_SIZE 8192
+#endif /* __ia64__ */
 #endif
 
 /* Copy whatever the last rule matched to the standard output. */
@@ -1031,7 +1253,7 @@ static int input (void );
 /* This used to be an fputs(), but since the string might contain NUL's,
  * we now use fwrite().
  */
-#define ECHO do { if (fwrite( zend_ini_yytext, zend_ini_yyleng, 1, zend_ini_yyout )) {} } while (0)
+#define ECHO do { if (fwrite( yytext, (size_t) yyleng, 1, yyout )) {} } while (0)
 #endif
 
 /* Gets input and stuffs it into "buf".  number of characters read, or YY_NULL,
@@ -1042,20 +1264,20 @@ static int input (void );
 	if ( YY_CURRENT_BUFFER_LVALUE->yy_is_interactive ) \
 		{ \
 		int c = '*'; \
-		size_t n; \
+		int n; \
 		for ( n = 0; n < max_size && \
-			     (c = getc( zend_ini_yyin )) != EOF && c != '\n'; ++n ) \
+			     (c = getc( yyin )) != EOF && c != '\n'; ++n ) \
 			buf[n] = (char) c; \
 		if ( c == '\n' ) \
 			buf[n++] = (char) c; \
-		if ( c == EOF && ferror( zend_ini_yyin ) ) \
+		if ( c == EOF && ferror( yyin ) ) \
 			YY_FATAL_ERROR( "input in flex scanner failed" ); \
 		result = n; \
 		} \
 	else \
 		{ \
 		errno=0; \
-		while ( (result = fread(buf, 1, max_size, zend_ini_yyin))==0 && ferror(zend_ini_yyin)) \
+		while ( (result = (int) fread(buf, 1, (yy_size_t) max_size, yyin)) == 0 && ferror(yyin)) \
 			{ \
 			if( errno != EINTR) \
 				{ \
@@ -1063,7 +1285,7 @@ static int input (void );
 				break; \
 				} \
 			errno=0; \
-			clearerr(zend_ini_yyin); \
+			clearerr(yyin); \
 			} \
 		}\
 \
@@ -1096,12 +1318,12 @@ static int input (void );
 #ifndef YY_DECL
 #define YY_DECL_IS_OURS 1
 
-extern int zend_ini_yylex (void);
+extern int yylex (void);
 
-#define YY_DECL int zend_ini_yylex (void)
+#define YY_DECL int yylex (void)
 #endif /* !YY_DECL */
 
-/* Code executed at the beginning of each rule, after zend_ini_yytext and zend_ini_yyleng
+/* Code executed at the beginning of each rule, after yytext and yyleng
  * have been set up.
  */
 #ifndef YY_USER_ACTION
@@ -1110,7 +1332,7 @@ extern int zend_ini_yylex (void);
 
 /* Code executed at the end of each rule. */
 #ifndef YY_BREAK
-#define YY_BREAK break;
+#define YY_BREAK /*LINTED*/break;
 #endif
 
 #define YY_RULE_SETUP \
@@ -1120,10 +1342,10 @@ extern int zend_ini_yylex (void);
  */
 YY_DECL
 {
-	register yy_state_type yy_current_state;
-	register char *yy_cp, *yy_bp;
-	register int yy_act;
-
+	yy_state_type yy_current_state;
+	char *yy_cp, *yy_bp;
+	int yy_act;
+    
 	if ( !(yy_init) )
 		{
 		(yy_init) = 1;
@@ -1135,32 +1357,28 @@ YY_DECL
 		if ( ! (yy_start) )
 			(yy_start) = 1;	/* first start state */
 
-		if ( ! zend_ini_yyin )
-			zend_ini_yyin = stdin;
+		if ( ! yyin )
+			yyin = stdin;
 
-		if ( ! zend_ini_yyout )
-			zend_ini_yyout = stdout;
+		if ( ! yyout )
+			yyout = stdout;
 
-		if (YY_CURRENT_BUFFER == NULL) {
-			zend_ini_yyensure_buffer_stack ();
+		if ( ! YY_CURRENT_BUFFER ) {
+			yyensure_buffer_stack ();
 			YY_CURRENT_BUFFER_LVALUE =
-				zend_ini_yy_create_buffer(zend_ini_yyin,YY_BUF_SIZE );
+				yy_create_buffer( yyin, YY_BUF_SIZE );
 		}
 
-		zend_ini_yy_load_buffer_state( );
+		yy_load_buffer_state(  );
 		}
 
 	{
-#line 174 "hphp/runtime/base/ini-parser/zend-ini.ll"
 
-
-#line 1157 "buck-out/dbg/gen/hphp/runtime/base/ini-parser/ini-parser=zend-ini.ll/zend-ini.ll.d/zend-ini.ll.cc"
-
-	while ( 1 )		/* loops until end-of-file is reached */
+	while ( /*CONSTCOND*/1 )		/* loops until end-of-file is reached */
 		{
 		yy_cp = (yy_c_buf_p);
 
-		/* Support of zend_ini_yytext. */
+		/* Support of yytext. */
 		*yy_cp = (yy_hold_char);
 
 		/* yy_bp points to the position in yy_ch_buf of the start of
@@ -1172,7 +1390,7 @@ YY_DECL
 yy_match:
 		do
 			{
-			register YY_CHAR yy_c = yy_ec[YY_SC_TO_UI(*yy_cp)] ;
+			YY_CHAR yy_c = yy_ec[YY_SC_TO_UI(*yy_cp)] ;
 			if ( yy_accept[yy_current_state] )
 				{
 				(yy_last_accepting_state) = yy_current_state;
@@ -1182,9 +1400,9 @@ yy_match:
 				{
 				yy_current_state = (int) yy_def[yy_current_state];
 				if ( yy_current_state >= 199 )
-					yy_c = yy_meta[(unsigned int) yy_c];
+					yy_c = yy_meta[yy_c];
 				}
-			yy_current_state = yy_nxt[yy_base[yy_current_state] + (unsigned int) yy_c];
+			yy_current_state = yy_nxt[yy_base[yy_current_state] + yy_c];
 			++yy_cp;
 			}
 		while ( yy_base[yy_current_state] != 1039 );
@@ -1213,7 +1431,6 @@ do_action:	/* This label is used only to access EOF actions. */
 
 case 1:
 YY_RULE_SETUP
-#line 176 "hphp/runtime/base/ini-parser/zend-ini.ll"
 {
 /* Section start */
   /* Enter section data lookup state */
@@ -1228,7 +1445,6 @@ YY_RULE_SETUP
 case 2:
 /* rule 2 can match eol */
 YY_RULE_SETUP
-#line 187 "hphp/runtime/base/ini-parser/zend-ini.ll"
 {
 /* End of section */
   BEGIN(INITIAL);
@@ -1238,7 +1454,6 @@ YY_RULE_SETUP
 	YY_BREAK
 case 3:
 YY_RULE_SETUP
-#line 194 "hphp/runtime/base/ini-parser/zend-ini.ll"
 {
 /* Start of option with offset */
   /* Eat leading whitespace */
@@ -1255,7 +1470,6 @@ YY_RULE_SETUP
 	YY_BREAK
 case 4:
 YY_RULE_SETUP
-#line 208 "hphp/runtime/base/ini-parser/zend-ini.ll"
 {
 /* End of section or an option offset */
   yy_push_state(ST_LABEL);
@@ -1264,7 +1478,6 @@ YY_RULE_SETUP
 	YY_BREAK
 case 5:
 YY_RULE_SETUP
-#line 214 "hphp/runtime/base/ini-parser/zend-ini.ll"
 {
 /* Variable start */
   yy_push_state(ST_VARNAME);
@@ -1273,7 +1486,6 @@ YY_RULE_SETUP
 	YY_BREAK
 case 6:
 YY_RULE_SETUP
-#line 220 "hphp/runtime/base/ini-parser/zend-ini.ll"
 {
 /* Variable name */
   /* Eat leading whitespace */
@@ -1282,12 +1494,11 @@ YY_RULE_SETUP
   /* Eat trailing whitespace */
   EAT_TRAILING_WHITESPACE();
 
-  RETURN_TOKEN(TC_VARNAME, zend_ini_yytext, zend_ini_yyleng);
+  RETURN_TOKEN(TC_VARNAME, yytext, yyleng);
 }
 	YY_BREAK
 case 7:
 YY_RULE_SETUP
-#line 231 "hphp/runtime/base/ini-parser/zend-ini.ll"
 { /* Variable end */
   yy_pop_state();
   return '}';
@@ -1295,7 +1506,6 @@ YY_RULE_SETUP
 	YY_BREAK
 case 8:
 YY_RULE_SETUP
-#line 236 "hphp/runtime/base/ini-parser/zend-ini.ll"
 {
 /* TRUE value (when used outside option value/offset this causes error!) */
   RETURN_TOKEN(BOOL_TRUE, "1", 1);
@@ -1303,7 +1513,6 @@ YY_RULE_SETUP
 	YY_BREAK
 case 9:
 YY_RULE_SETUP
-#line 241 "hphp/runtime/base/ini-parser/zend-ini.ll"
 {
 /* FALSE value (when used outside option value/offset this causes error!)*/
   RETURN_TOKEN(BOOL_FALSE, "", (size_t) 0);
@@ -1311,7 +1520,6 @@ YY_RULE_SETUP
 	YY_BREAK
 case 10:
 YY_RULE_SETUP
-#line 246 "hphp/runtime/base/ini-parser/zend-ini.ll"
 {
 /* Get option name */
   /* Eat leading whitespace */
@@ -1322,12 +1530,11 @@ YY_RULE_SETUP
 
   yy_push_state(ST_LABEL);
 
-  RETURN_TOKEN(TC_LABEL, zend_ini_yytext, zend_ini_yyleng);
+  RETURN_TOKEN(TC_LABEL, yytext, yyleng);
 }
 	YY_BREAK
 case 11:
 YY_RULE_SETUP
-#line 259 "hphp/runtime/base/ini-parser/zend-ini.ll"
 {
 /* Start option value */
   if (SCNG(scanner_mode) == IniSetting::RawScanner) {
@@ -1340,35 +1547,31 @@ YY_RULE_SETUP
 	YY_BREAK
 case 12:
 YY_RULE_SETUP
-#line 269 "hphp/runtime/base/ini-parser/zend-ini.ll"
 {
 /* Raw value, only used when SCNG(scanner_mode) == IniSetting::RawScanner. */
   /* Eat leading and trailing double quotes */
-  zend_ini_yytext++;
-  zend_ini_yyleng = zend_ini_yyleng - 2;
-  RETURN_TOKEN(TC_RAW, zend_ini_yytext, zend_ini_yyleng);
+  yytext++;
+  yyleng = yyleng - 2;
+  RETURN_TOKEN(TC_RAW, yytext, yyleng);
 }
 	YY_BREAK
 case 13:
 YY_RULE_SETUP
-#line 277 "hphp/runtime/base/ini-parser/zend-ini.ll"
 {
 /* Raw value, only used when SCNG(scanner_mode) == IniSetting::RawScanner. */
-  RETURN_TOKEN(TC_RAW, zend_ini_yytext, zend_ini_yyleng);
+  RETURN_TOKEN(TC_RAW, yytext, yyleng);
 }
 	YY_BREAK
 case 14:
 YY_RULE_SETUP
-#line 282 "hphp/runtime/base/ini-parser/zend-ini.ll"
 {
 /* Raw value, only used when SCNG(scanner_mode) == IniSetting::RawScanner. */
-  RETURN_TOKEN(TC_RAW, zend_ini_yytext, zend_ini_yyleng);
+  RETURN_TOKEN(TC_RAW, yytext, yyleng);
 }
 	YY_BREAK
 case 15:
 /* rule 15 can match eol */
 YY_RULE_SETUP
-#line 287 "hphp/runtime/base/ini-parser/zend-ini.ll"
 {
 /* End of option value */
   BEGIN(INITIAL);
@@ -1378,39 +1581,34 @@ YY_RULE_SETUP
 	YY_BREAK
 case 16:
 YY_RULE_SETUP
-#line 294 "hphp/runtime/base/ini-parser/zend-ini.ll"
 {
 /* Get constant option value */
-  RETURN_TOKEN(TC_CONSTANT, zend_ini_yytext, zend_ini_yyleng);
+  RETURN_TOKEN(TC_CONSTANT, yytext, yyleng);
 }
 	YY_BREAK
 case 17:
 YY_RULE_SETUP
-#line 299 "hphp/runtime/base/ini-parser/zend-ini.ll"
 {
 /* Get number option value as string */
-  RETURN_TOKEN(TC_NUMBER, zend_ini_yytext, zend_ini_yyleng);
+  RETURN_TOKEN(TC_NUMBER, yytext, yyleng);
 }
 	YY_BREAK
 case 18:
 YY_RULE_SETUP
-#line 304 "hphp/runtime/base/ini-parser/zend-ini.ll"
 {
 /* Disallow these chars outside option values */
-  return zend_ini_yytext[0];
+  return yytext[0];
 }
 	YY_BREAK
 case 19:
 YY_RULE_SETUP
-#line 309 "hphp/runtime/base/ini-parser/zend-ini.ll"
 {
 /* Boolean operators */
-  return zend_ini_yytext[0];
+  return yytext[0];
 }
 	YY_BREAK
 case 20:
 YY_RULE_SETUP
-#line 314 "hphp/runtime/base/ini-parser/zend-ini.ll"
 {
 /* Make = used in option value to trigger error */
   yyless(0);
@@ -1421,38 +1619,34 @@ YY_RULE_SETUP
 case 21:
 /* rule 21 can match eol */
 YY_RULE_SETUP
-#line 321 "hphp/runtime/base/ini-parser/zend-ini.ll"
 {
 /* Get everything else as option/offset value */
-  RETURN_TOKEN(TC_STRING, zend_ini_yytext, zend_ini_yyleng);
+  RETURN_TOKEN(TC_STRING, yytext, yyleng);
 }
 	YY_BREAK
 case 22:
 /* rule 22 can match eol */
 YY_RULE_SETUP
-#line 326 "hphp/runtime/base/ini-parser/zend-ini.ll"
 {
 /* Get rest as section/offset value */
-  RETURN_TOKEN(TC_STRING, zend_ini_yytext, zend_ini_yyleng);
+  RETURN_TOKEN(TC_STRING, yytext, yyleng);
 }
 	YY_BREAK
 case 23:
 /* rule 23 can match eol */
 YY_RULE_SETUP
-#line 331 "hphp/runtime/base/ini-parser/zend-ini.ll"
 {
 /* Raw string */
   /* Eat leading and trailing single quotes */
-  if (zend_ini_yytext[0] == '\'' && zend_ini_yytext[zend_ini_yyleng - 1] == '\'') {
-    zend_ini_yytext++;
-    zend_ini_yyleng = zend_ini_yyleng - 2;
+  if (yytext[0] == '\'' && yytext[yyleng - 1] == '\'') {
+    yytext++;
+    yyleng = yyleng - 2;
   }
-  RETURN_TOKEN(TC_RAW, zend_ini_yytext, zend_ini_yyleng);
+  RETURN_TOKEN(TC_RAW, yytext, yyleng);
 }
 	YY_BREAK
 case 24:
 YY_RULE_SETUP
-#line 341 "hphp/runtime/base/ini-parser/zend-ini.ll"
 {
 /* Double quoted '"' string start */
   yy_push_state(ST_DOUBLE_QUOTES);
@@ -1461,7 +1655,6 @@ YY_RULE_SETUP
 	YY_BREAK
 case 25:
 YY_RULE_SETUP
-#line 347 "hphp/runtime/base/ini-parser/zend-ini.ll"
 {
 /* Double quoted '"' string ends */
   yy_pop_state();
@@ -1471,23 +1664,20 @@ YY_RULE_SETUP
 case 26:
 /* rule 26 can match eol */
 YY_RULE_SETUP
-#line 353 "hphp/runtime/base/ini-parser/zend-ini.ll"
 {
 /* Escape double quoted string contents */
-  zend_ini_escape_string(*ini_lval, zend_ini_yytext, zend_ini_yyleng, '"');
+  zend_ini_escape_string(*ini_lval, yytext, yyleng, '"');
   return TC_QUOTED_STRING;
 }
 	YY_BREAK
 case 27:
 YY_RULE_SETUP
-#line 359 "hphp/runtime/base/ini-parser/zend-ini.ll"
 {
-  RETURN_TOKEN(TC_WHITESPACE, zend_ini_yytext, zend_ini_yyleng);
+  RETURN_TOKEN(TC_WHITESPACE, yytext, yyleng);
 }
 	YY_BREAK
 case 28:
 YY_RULE_SETUP
-#line 363 "hphp/runtime/base/ini-parser/zend-ini.ll"
 {
   /* eat whitespace */
   return GOTO_RESTART;
@@ -1496,7 +1686,6 @@ YY_RULE_SETUP
 case 29:
 /* rule 29 can match eol */
 YY_RULE_SETUP
-#line 368 "hphp/runtime/base/ini-parser/zend-ini.ll"
 {
   SCNG(lineno)++;
   BEGIN(INITIAL);
@@ -1506,7 +1695,6 @@ YY_RULE_SETUP
 case 30:
 /* rule 30 can match eol */
 YY_RULE_SETUP
-#line 374 "hphp/runtime/base/ini-parser/zend-ini.ll"
 {
 /* Comment */
   BEGIN(INITIAL);
@@ -1517,7 +1705,6 @@ YY_RULE_SETUP
 case 31:
 /* rule 31 can match eol */
 YY_RULE_SETUP
-#line 381 "hphp/runtime/base/ini-parser/zend-ini.ll"
 {
 /* #Comment */
   Logger::Error("Comments starting with '#' are deprecated in %s on line %d",
@@ -1530,7 +1717,6 @@ YY_RULE_SETUP
 case YY_STATE_EOF(ST_VALUE):
 case YY_STATE_EOF(ST_RAW):
 case YY_STATE_EOF(ST_LABEL):
-#line 390 "hphp/runtime/base/ini-parser/zend-ini.ll"
 {
 /* End of option value (if EOF is reached before EOL) */
   BEGIN(INITIAL);
@@ -1540,17 +1726,14 @@ case YY_STATE_EOF(ST_LABEL):
 case 32:
 /* rule 32 can match eol */
 YY_RULE_SETUP
-#line 396 "hphp/runtime/base/ini-parser/zend-ini.ll"
 {
   return JUNK;
 }
 	YY_BREAK
 case 33:
 YY_RULE_SETUP
-#line 400 "hphp/runtime/base/ini-parser/zend-ini.ll"
 YY_FATAL_ERROR( "flex scanner jammed" );
 	YY_BREAK
-#line 1553 "buck-out/dbg/gen/hphp/runtime/base/ini-parser/ini-parser=zend-ini.ll/zend-ini.ll.d/zend-ini.ll.cc"
 case YY_STATE_EOF(INITIAL):
 case YY_STATE_EOF(ST_OFFSET):
 case YY_STATE_EOF(ST_SECTION_VALUE):
@@ -1572,15 +1755,15 @@ case YY_STATE_EOF(ST_VARNAME):
 			{
 			/* We're scanning a new file or input source.  It's
 			 * possible that this happened because the user
-			 * just pointed zend_ini_yyin at a new source and called
-			 * zend_ini_yylex().  If so, then we have to assure
+			 * just pointed yyin at a new source and called
+			 * yylex().  If so, then we have to assure
 			 * consistency between YY_CURRENT_BUFFER and our
 			 * globals.  Here is the right place to do so, because
 			 * this is the first action (other than possibly a
 			 * back-up) that will match for the new input source.
 			 */
 			(yy_n_chars) = YY_CURRENT_BUFFER_LVALUE->yy_n_chars;
-			YY_CURRENT_BUFFER_LVALUE->yy_input_file = zend_ini_yyin;
+			YY_CURRENT_BUFFER_LVALUE->yy_input_file = yyin;
 			YY_CURRENT_BUFFER_LVALUE->yy_buffer_status = YY_BUFFER_NORMAL;
 			}
 
@@ -1633,11 +1816,11 @@ case YY_STATE_EOF(ST_VARNAME):
 				{
 				(yy_did_buffer_switch_on_eof) = 0;
 
-				if ( zend_ini_yywrap( ) )
+				if ( yywrap(  ) )
 					{
 					/* Note: because we've taken care in
 					 * yy_get_next_buffer() to have set up
-					 * zend_ini_yytext, we can now set up
+					 * yytext, we can now set up
 					 * yy_c_buf_p so that if some total
 					 * hoser (like flex itself) wants to
 					 * call the scanner after we return the
@@ -1687,7 +1870,7 @@ case YY_STATE_EOF(ST_VARNAME):
 	} /* end of action switch */
 		} /* end of scanning one token */
 	} /* end of user's declarations */
-} /* end of zend_ini_yylex */
+} /* end of yylex */
 
 /* yy_get_next_buffer - try to read in a new buffer
  *
@@ -1698,9 +1881,9 @@ case YY_STATE_EOF(ST_VARNAME):
  */
 static int yy_get_next_buffer (void)
 {
-    	register char *dest = YY_CURRENT_BUFFER_LVALUE->yy_ch_buf;
-	register char *source = (yytext_ptr);
-	register int number_to_move, i;
+    	char *dest = YY_CURRENT_BUFFER_LVALUE->yy_ch_buf;
+	char *source = (yytext_ptr);
+	int number_to_move, i;
 	int ret_val;
 
 	if ( (yy_c_buf_p) > &YY_CURRENT_BUFFER_LVALUE->yy_ch_buf[(yy_n_chars) + 1] )
@@ -1729,7 +1912,7 @@ static int yy_get_next_buffer (void)
 	/* Try to read more data. */
 
 	/* First move last chars to start of buffer. */
-	number_to_move = (int) ((yy_c_buf_p) - (yytext_ptr)) - 1;
+	number_to_move = (int) ((yy_c_buf_p) - (yytext_ptr) - 1);
 
 	for ( i = 0; i < number_to_move; ++i )
 		*(dest++) = *(source++);
@@ -1742,7 +1925,7 @@ static int yy_get_next_buffer (void)
 
 	else
 		{
-			yy_size_t num_to_read =
+			int num_to_read =
 			YY_CURRENT_BUFFER_LVALUE->yy_buf_size - number_to_move - 1;
 
 		while ( num_to_read <= 0 )
@@ -1756,7 +1939,7 @@ static int yy_get_next_buffer (void)
 
 			if ( b->yy_is_our_buffer )
 				{
-				yy_size_t new_size = b->yy_buf_size * 2;
+				int new_size = b->yy_buf_size * 2;
 
 				if ( new_size <= 0 )
 					b->yy_buf_size += b->yy_buf_size / 8;
@@ -1765,11 +1948,12 @@ static int yy_get_next_buffer (void)
 
 				b->yy_ch_buf = (char *)
 					/* Include room in for 2 EOB chars. */
-					zend_ini_yyrealloc((void *) b->yy_ch_buf,b->yy_buf_size + 2  );
+					yyrealloc( (void *) b->yy_ch_buf,
+							 (yy_size_t) (b->yy_buf_size + 2)  );
 				}
 			else
 				/* Can't grow it, we don't own it. */
-				b->yy_ch_buf = 0;
+				b->yy_ch_buf = NULL;
 
 			if ( ! b->yy_ch_buf )
 				YY_FATAL_ERROR(
@@ -1797,7 +1981,7 @@ static int yy_get_next_buffer (void)
 		if ( number_to_move == YY_MORE_ADJ )
 			{
 			ret_val = EOB_ACT_END_OF_FILE;
-			zend_ini_yyrestart(zend_ini_yyin  );
+			yyrestart( yyin  );
 			}
 
 		else
@@ -1811,12 +1995,15 @@ static int yy_get_next_buffer (void)
 	else
 		ret_val = EOB_ACT_CONTINUE_SCAN;
 
-	if ((yy_size_t) ((yy_n_chars) + number_to_move) > YY_CURRENT_BUFFER_LVALUE->yy_buf_size) {
+	if (((yy_n_chars) + number_to_move) > YY_CURRENT_BUFFER_LVALUE->yy_buf_size) {
 		/* Extend the array by 50%, plus the number we really need. */
-		yy_size_t new_size = (yy_n_chars) + number_to_move + ((yy_n_chars) >> 1);
-		YY_CURRENT_BUFFER_LVALUE->yy_ch_buf = (char *) zend_ini_yyrealloc((void *) YY_CURRENT_BUFFER_LVALUE->yy_ch_buf,new_size  );
+		int new_size = (yy_n_chars) + number_to_move + ((yy_n_chars) >> 1);
+		YY_CURRENT_BUFFER_LVALUE->yy_ch_buf = (char *) yyrealloc(
+			(void *) YY_CURRENT_BUFFER_LVALUE->yy_ch_buf, (yy_size_t) new_size  );
 		if ( ! YY_CURRENT_BUFFER_LVALUE->yy_ch_buf )
 			YY_FATAL_ERROR( "out of dynamic memory in yy_get_next_buffer()" );
+		/* "- 2" to take care of EOB's */
+		YY_CURRENT_BUFFER_LVALUE->yy_buf_size = (int) (new_size - 2);
 	}
 
 	(yy_n_chars) += number_to_move;
@@ -1832,14 +2019,14 @@ static int yy_get_next_buffer (void)
 
     static yy_state_type yy_get_previous_state (void)
 {
-	register yy_state_type yy_current_state;
-	register char *yy_cp;
-
+	yy_state_type yy_current_state;
+	char *yy_cp;
+    
 	yy_current_state = (yy_start);
 
 	for ( yy_cp = (yytext_ptr) + YY_MORE_ADJ; yy_cp < (yy_c_buf_p); ++yy_cp )
 		{
-		register YY_CHAR yy_c = (*yy_cp ? yy_ec[YY_SC_TO_UI(*yy_cp)] : 47);
+		YY_CHAR yy_c = (*yy_cp ? yy_ec[YY_SC_TO_UI(*yy_cp)] : 47);
 		if ( yy_accept[yy_current_state] )
 			{
 			(yy_last_accepting_state) = yy_current_state;
@@ -1849,9 +2036,9 @@ static int yy_get_next_buffer (void)
 			{
 			yy_current_state = (int) yy_def[yy_current_state];
 			if ( yy_current_state >= 199 )
-				yy_c = yy_meta[(unsigned int) yy_c];
+				yy_c = yy_meta[yy_c];
 			}
-		yy_current_state = yy_nxt[yy_base[yy_current_state] + (unsigned int) yy_c];
+		yy_current_state = yy_nxt[yy_base[yy_current_state] + yy_c];
 		}
 
 	return yy_current_state;
@@ -1864,10 +2051,10 @@ static int yy_get_next_buffer (void)
  */
     static yy_state_type yy_try_NUL_trans  (yy_state_type yy_current_state )
 {
-	register int yy_is_jam;
-    	register char *yy_cp = (yy_c_buf_p);
+	int yy_is_jam;
+    	char *yy_cp = (yy_c_buf_p);
 
-	register YY_CHAR yy_c = 47;
+	YY_CHAR yy_c = 47;
 	if ( yy_accept[yy_current_state] )
 		{
 		(yy_last_accepting_state) = yy_current_state;
@@ -1877,30 +2064,32 @@ static int yy_get_next_buffer (void)
 		{
 		yy_current_state = (int) yy_def[yy_current_state];
 		if ( yy_current_state >= 199 )
-			yy_c = yy_meta[(unsigned int) yy_c];
+			yy_c = yy_meta[yy_c];
 		}
-	yy_current_state = yy_nxt[yy_base[yy_current_state] + (unsigned int) yy_c];
+	yy_current_state = yy_nxt[yy_base[yy_current_state] + yy_c];
 	yy_is_jam = (yy_current_state == 198);
 
 		return yy_is_jam ? 0 : yy_current_state;
 }
 
-    static void yyunput (int c, register char * yy_bp )
-{
-	register char *yy_cp;
+#ifndef YY_NO_UNPUT
 
+    static void yyunput (int c, char * yy_bp )
+{
+	char *yy_cp;
+    
     yy_cp = (yy_c_buf_p);
 
-	/* undo effects of setting up zend_ini_yytext */
+	/* undo effects of setting up yytext */
 	*yy_cp = (yy_hold_char);
 
 	if ( yy_cp < YY_CURRENT_BUFFER_LVALUE->yy_ch_buf + 2 )
 		{ /* need to shift things up to make room */
 		/* +2 for EOB chars. */
-		register yy_size_t number_to_move = (yy_n_chars) + 2;
-		register char *dest = &YY_CURRENT_BUFFER_LVALUE->yy_ch_buf[
+		int number_to_move = (yy_n_chars) + 2;
+		char *dest = &YY_CURRENT_BUFFER_LVALUE->yy_ch_buf[
 					YY_CURRENT_BUFFER_LVALUE->yy_buf_size + 2];
-		register char *source =
+		char *source =
 				&YY_CURRENT_BUFFER_LVALUE->yy_ch_buf[number_to_move];
 
 		while ( source > YY_CURRENT_BUFFER_LVALUE->yy_ch_buf )
@@ -1909,7 +2098,7 @@ static int yy_get_next_buffer (void)
 		yy_cp += (int) (dest - source);
 		yy_bp += (int) (dest - source);
 		YY_CURRENT_BUFFER_LVALUE->yy_n_chars =
-			(yy_n_chars) = YY_CURRENT_BUFFER_LVALUE->yy_buf_size;
+			(yy_n_chars) = (int) YY_CURRENT_BUFFER_LVALUE->yy_buf_size;
 
 		if ( yy_cp < YY_CURRENT_BUFFER_LVALUE->yy_ch_buf + 2 )
 			YY_FATAL_ERROR( "flex scanner push-back overflow" );
@@ -1922,6 +2111,8 @@ static int yy_get_next_buffer (void)
 	(yy_c_buf_p) = yy_cp;
 }
 
+#endif
+
 #ifndef YY_NO_INPUT
 #ifdef __cplusplus
     static int yyinput (void)
@@ -1931,7 +2122,7 @@ static int yy_get_next_buffer (void)
 
 {
 	int c;
-
+    
 	*(yy_c_buf_p) = (yy_hold_char);
 
 	if ( *(yy_c_buf_p) == YY_END_OF_BUFFER_CHAR )
@@ -1946,7 +2137,7 @@ static int yy_get_next_buffer (void)
 
 		else
 			{ /* need more input */
-			yy_size_t offset = (yy_c_buf_p) - (yytext_ptr);
+			int offset = (int) ((yy_c_buf_p) - (yytext_ptr));
 			++(yy_c_buf_p);
 
 			switch ( yy_get_next_buffer(  ) )
@@ -1963,14 +2154,14 @@ static int yy_get_next_buffer (void)
 					 */
 
 					/* Reset buffer status. */
-					zend_ini_yyrestart(zend_ini_yyin );
+					yyrestart( yyin );
 
 					/*FALLTHROUGH*/
 
 				case EOB_ACT_END_OF_FILE:
 					{
-					if ( zend_ini_yywrap( ) )
-						return EOF;
+					if ( yywrap(  ) )
+						return 0;
 
 					if ( ! (yy_did_buffer_switch_on_eof) )
 						YY_NEW_FILE;
@@ -1989,7 +2180,7 @@ static int yy_get_next_buffer (void)
 		}
 
 	c = *(unsigned char *) (yy_c_buf_p);	/* cast for 8-bit char's */
-	*(yy_c_buf_p) = '\0';	/* preserve zend_ini_yytext */
+	*(yy_c_buf_p) = '\0';	/* preserve yytext */
 	(yy_hold_char) = *++(yy_c_buf_p);
 
 	return c;
@@ -1998,39 +2189,39 @@ static int yy_get_next_buffer (void)
 
 /** Immediately switch to a different input stream.
  * @param input_file A readable stream.
- *
+ * 
  * @note This function does not reset the start condition to @c INITIAL .
  */
-    void zend_ini_yyrestart  (FILE * input_file )
+    void yyrestart  (FILE * input_file )
 {
-
-	if (YY_CURRENT_BUFFER == NULL){
-        zend_ini_yyensure_buffer_stack ();
+    
+	if ( ! YY_CURRENT_BUFFER ){
+        yyensure_buffer_stack ();
 		YY_CURRENT_BUFFER_LVALUE =
-            zend_ini_yy_create_buffer(zend_ini_yyin,YY_BUF_SIZE );
+            yy_create_buffer( yyin, YY_BUF_SIZE );
 	}
 
-	zend_ini_yy_init_buffer(YY_CURRENT_BUFFER,input_file );
-	zend_ini_yy_load_buffer_state( );
+	yy_init_buffer( YY_CURRENT_BUFFER, input_file );
+	yy_load_buffer_state(  );
 }
 
 /** Switch to a different input buffer.
  * @param new_buffer The new input buffer.
- *
+ * 
  */
-    void zend_ini_yy_switch_to_buffer  (YY_BUFFER_STATE  new_buffer )
+    void yy_switch_to_buffer  (YY_BUFFER_STATE  new_buffer )
 {
-
+    
 	/* TODO. We should be able to replace this entire function body
 	 * with
-	 *		zend_ini_yypop_buffer_state();
-	 *		zend_ini_yypush_buffer_state(new_buffer);
+	 *		yypop_buffer_state();
+	 *		yypush_buffer_state(new_buffer);
      */
-	zend_ini_yyensure_buffer_stack ();
+	yyensure_buffer_stack ();
 	if ( YY_CURRENT_BUFFER == new_buffer )
 		return;
 
-	if (YY_CURRENT_BUFFER != NULL)
+	if ( YY_CURRENT_BUFFER )
 		{
 		/* Flush out information for old buffer. */
 		*(yy_c_buf_p) = (yy_hold_char);
@@ -2039,61 +2230,61 @@ static int yy_get_next_buffer (void)
 		}
 
 	YY_CURRENT_BUFFER_LVALUE = new_buffer;
-	zend_ini_yy_load_buffer_state( );
+	yy_load_buffer_state(  );
 
 	/* We don't actually know whether we did this switch during
-	 * EOF (zend_ini_yywrap()) processing, but the only time this flag
-	 * is looked at is after zend_ini_yywrap() is called, so it's safe
+	 * EOF (yywrap()) processing, but the only time this flag
+	 * is looked at is after yywrap() is called, so it's safe
 	 * to go ahead and always set it.
 	 */
 	(yy_did_buffer_switch_on_eof) = 1;
 }
 
-static void zend_ini_yy_load_buffer_state  (void)
+static void yy_load_buffer_state  (void)
 {
     	(yy_n_chars) = YY_CURRENT_BUFFER_LVALUE->yy_n_chars;
 	(yytext_ptr) = (yy_c_buf_p) = YY_CURRENT_BUFFER_LVALUE->yy_buf_pos;
-	zend_ini_yyin = YY_CURRENT_BUFFER_LVALUE->yy_input_file;
+	yyin = YY_CURRENT_BUFFER_LVALUE->yy_input_file;
 	(yy_hold_char) = *(yy_c_buf_p);
 }
 
 /** Allocate and initialize an input buffer state.
  * @param file A readable stream.
  * @param size The character buffer size in bytes. When in doubt, use @c YY_BUF_SIZE.
- *
+ * 
  * @return the allocated buffer state.
  */
-    YY_BUFFER_STATE zend_ini_yy_create_buffer  (FILE * file, int  size )
+    YY_BUFFER_STATE yy_create_buffer  (FILE * file, int  size )
 {
 	YY_BUFFER_STATE b;
-
-	b = (YY_BUFFER_STATE) zend_ini_yyalloc(sizeof( struct yy_buffer_state )  );
+    
+	b = (YY_BUFFER_STATE) yyalloc( sizeof( struct yy_buffer_state )  );
 	if ( ! b )
-		YY_FATAL_ERROR( "out of dynamic memory in zend_ini_yy_create_buffer()" );
+		YY_FATAL_ERROR( "out of dynamic memory in yy_create_buffer()" );
 
 	b->yy_buf_size = size;
 
 	/* yy_ch_buf has to be 2 characters longer than the size given because
 	 * we need to put in 2 end-of-buffer characters.
 	 */
-	b->yy_ch_buf = (char *) zend_ini_yyalloc(b->yy_buf_size + 2  );
+	b->yy_ch_buf = (char *) yyalloc( (yy_size_t) (b->yy_buf_size + 2)  );
 	if ( ! b->yy_ch_buf )
-		YY_FATAL_ERROR( "out of dynamic memory in zend_ini_yy_create_buffer()" );
+		YY_FATAL_ERROR( "out of dynamic memory in yy_create_buffer()" );
 
 	b->yy_is_our_buffer = 1;
 
-	zend_ini_yy_init_buffer(b,file );
+	yy_init_buffer( b, file );
 
 	return b;
 }
 
 /** Destroy the buffer.
- * @param b a buffer created with zend_ini_yy_create_buffer()
- *
+ * @param b a buffer created with yy_create_buffer()
+ * 
  */
-    void zend_ini_yy_delete_buffer (YY_BUFFER_STATE  b )
+    void yy_delete_buffer (YY_BUFFER_STATE  b )
 {
-
+    
 	if ( ! b )
 		return;
 
@@ -2101,27 +2292,27 @@ static void zend_ini_yy_load_buffer_state  (void)
 		YY_CURRENT_BUFFER_LVALUE = (YY_BUFFER_STATE) 0;
 
 	if ( b->yy_is_our_buffer )
-		zend_ini_yyfree((void *) b->yy_ch_buf  );
+		yyfree( (void *) b->yy_ch_buf  );
 
-	zend_ini_yyfree((void *) b  );
+	yyfree( (void *) b  );
 }
 
 /* Initializes or reinitializes a buffer.
  * This function is sometimes called more than once on the same buffer,
- * such as during a zend_ini_yyrestart() or at EOF.
+ * such as during a yyrestart() or at EOF.
  */
-    static void zend_ini_yy_init_buffer  (YY_BUFFER_STATE  b, FILE * file )
+    static void yy_init_buffer  (YY_BUFFER_STATE  b, FILE * file )
 
 {
 	int oerrno = errno;
-
-	zend_ini_yy_flush_buffer(b );
+    
+	yy_flush_buffer( b );
 
 	b->yy_input_file = file;
 	b->yy_fill_buffer = 1;
 
-    /* If b is the current buffer, then zend_ini_yy_init_buffer was _probably_
-     * called from zend_ini_yyrestart() or through yy_get_next_buffer.
+    /* If b is the current buffer, then yy_init_buffer was _probably_
+     * called from yyrestart() or through yy_get_next_buffer.
      * In that case, we don't want to reset the lineno or column.
      */
     if (b != YY_CURRENT_BUFFER){
@@ -2130,15 +2321,15 @@ static void zend_ini_yy_load_buffer_state  (void)
     }
 
         b->yy_is_interactive = file ? (isatty( fileno(file) ) > 0) : 0;
-
+    
 	errno = oerrno;
 }
 
 /** Discard all buffered characters. On the next scan, YY_INPUT will be called.
  * @param b the buffer state to be flushed, usually @c YY_CURRENT_BUFFER.
- *
+ * 
  */
-    void zend_ini_yy_flush_buffer (YY_BUFFER_STATE  b )
+    void yy_flush_buffer (YY_BUFFER_STATE  b )
 {
     	if ( ! b )
 		return;
@@ -2158,24 +2349,24 @@ static void zend_ini_yy_load_buffer_state  (void)
 	b->yy_buffer_status = YY_BUFFER_NEW;
 
 	if ( b == YY_CURRENT_BUFFER )
-		zend_ini_yy_load_buffer_state( );
+		yy_load_buffer_state(  );
 }
 
 /** Pushes the new state onto the stack. The new state becomes
  *  the current state. This function will allocate the stack
  *  if necessary.
  *  @param new_buffer The new state.
- *
+ *  
  */
-void zend_ini_yypush_buffer_state (YY_BUFFER_STATE new_buffer )
+void yypush_buffer_state (YY_BUFFER_STATE new_buffer )
 {
     	if (new_buffer == NULL)
 		return;
 
-	zend_ini_yyensure_buffer_stack();
+	yyensure_buffer_stack();
 
-	/* This block is copied from zend_ini_yy_switch_to_buffer. */
-	if (YY_CURRENT_BUFFER != NULL)
+	/* This block is copied from yy_switch_to_buffer. */
+	if ( YY_CURRENT_BUFFER )
 		{
 		/* Flush out information for old buffer. */
 		*(yy_c_buf_p) = (yy_hold_char);
@@ -2184,31 +2375,31 @@ void zend_ini_yypush_buffer_state (YY_BUFFER_STATE new_buffer )
 		}
 
 	/* Only push if top exists. Otherwise, replace top. */
-	if (YY_CURRENT_BUFFER != NULL)
+	if (YY_CURRENT_BUFFER)
 		(yy_buffer_stack_top)++;
 	YY_CURRENT_BUFFER_LVALUE = new_buffer;
 
-	/* copied from zend_ini_yy_switch_to_buffer. */
-	zend_ini_yy_load_buffer_state( );
+	/* copied from yy_switch_to_buffer. */
+	yy_load_buffer_state(  );
 	(yy_did_buffer_switch_on_eof) = 1;
 }
 
 /** Removes and deletes the top of the stack, if present.
  *  The next element becomes the new top.
- *
+ *  
  */
-void zend_ini_yypop_buffer_state (void)
+void yypop_buffer_state (void)
 {
-    	if (YY_CURRENT_BUFFER == NULL)
+    	if (!YY_CURRENT_BUFFER)
 		return;
 
-	zend_ini_yy_delete_buffer(YY_CURRENT_BUFFER );
+	yy_delete_buffer(YY_CURRENT_BUFFER );
 	YY_CURRENT_BUFFER_LVALUE = NULL;
 	if ((yy_buffer_stack_top) > 0)
 		--(yy_buffer_stack_top);
 
-	if (YY_CURRENT_BUFFER != NULL) {
-		zend_ini_yy_load_buffer_state( );
+	if (YY_CURRENT_BUFFER) {
+		yy_load_buffer_state(  );
 		(yy_did_buffer_switch_on_eof) = 1;
 	}
 }
@@ -2216,22 +2407,22 @@ void zend_ini_yypop_buffer_state (void)
 /* Allocates the stack if it does not exist.
  *  Guarantees space for at least one push.
  */
-static void zend_ini_yyensure_buffer_stack (void)
+static void yyensure_buffer_stack (void)
 {
 	yy_size_t num_to_alloc;
-
-	if ((yy_buffer_stack) == NULL) {
+    
+	if (!(yy_buffer_stack)) {
 
 		/* First allocation is just for 2 elements, since we don't know if this
 		 * scanner will even need a stack. We use 2 instead of 1 to avoid an
 		 * immediate realloc on the next call.
          */
-		num_to_alloc = 1;
-		(yy_buffer_stack) = (struct yy_buffer_state**)zend_ini_yyalloc
+      num_to_alloc = 1; /* After all that talk, this was set to 1 anyways... */
+		(yy_buffer_stack) = (struct yy_buffer_state**)yyalloc
 								(num_to_alloc * sizeof(struct yy_buffer_state*)
 								);
-		if ( (yy_buffer_stack) == NULL )
-			YY_FATAL_ERROR( "out of dynamic memory in zend_ini_yyensure_buffer_stack()" );
+		if ( ! (yy_buffer_stack) )
+			YY_FATAL_ERROR( "out of dynamic memory in yyensure_buffer_stack()" );
 
 		memset((yy_buffer_stack), 0, num_to_alloc * sizeof(struct yy_buffer_state*));
 
@@ -2243,15 +2434,15 @@ static void zend_ini_yyensure_buffer_stack (void)
 	if ((yy_buffer_stack_top) >= ((yy_buffer_stack_max)) - 1){
 
 		/* Increase the buffer to prepare for a possible push. */
-		int grow_size = 8 /* arbitrary grow size */;
+		yy_size_t grow_size = 8 /* arbitrary grow size */;
 
 		num_to_alloc = (yy_buffer_stack_max) + grow_size;
-		(yy_buffer_stack) = (struct yy_buffer_state**)zend_ini_yyrealloc
+		(yy_buffer_stack) = (struct yy_buffer_state**)yyrealloc
 								((yy_buffer_stack),
 								num_to_alloc * sizeof(struct yy_buffer_state*)
 								);
-		if ( (yy_buffer_stack) == NULL )
-			YY_FATAL_ERROR( "out of dynamic memory in zend_ini_yyensure_buffer_stack()" );
+		if ( ! (yy_buffer_stack) )
+			YY_FATAL_ERROR( "out of dynamic memory in yyensure_buffer_stack()" );
 
 		/* zero only the new slots.*/
 		memset((yy_buffer_stack) + (yy_buffer_stack_max), 0, grow_size * sizeof(struct yy_buffer_state*));
@@ -2262,80 +2453,80 @@ static void zend_ini_yyensure_buffer_stack (void)
 /** Setup the input buffer state to scan directly from a user-specified character buffer.
  * @param base the character buffer
  * @param size the size in bytes of the character buffer
- *
+ * 
  * @return the newly allocated buffer state object.
  */
-YY_BUFFER_STATE zend_ini_yy_scan_buffer  (char * base, yy_size_t  size )
+YY_BUFFER_STATE yy_scan_buffer  (char * base, yy_size_t  size )
 {
 	YY_BUFFER_STATE b;
-
+    
 	if ( size < 2 ||
 	     base[size-2] != YY_END_OF_BUFFER_CHAR ||
 	     base[size-1] != YY_END_OF_BUFFER_CHAR )
 		/* They forgot to leave room for the EOB's. */
-		return 0;
+		return NULL;
 
-	b = (YY_BUFFER_STATE) zend_ini_yyalloc(sizeof( struct yy_buffer_state )  );
+	b = (YY_BUFFER_STATE) yyalloc( sizeof( struct yy_buffer_state )  );
 	if ( ! b )
-		YY_FATAL_ERROR( "out of dynamic memory in zend_ini_yy_scan_buffer()" );
+		YY_FATAL_ERROR( "out of dynamic memory in yy_scan_buffer()" );
 
-	b->yy_buf_size = size - 2;	/* "- 2" to take care of EOB's */
+	b->yy_buf_size = (int) (size - 2);	/* "- 2" to take care of EOB's */
 	b->yy_buf_pos = b->yy_ch_buf = base;
 	b->yy_is_our_buffer = 0;
-	b->yy_input_file = 0;
+	b->yy_input_file = NULL;
 	b->yy_n_chars = b->yy_buf_size;
 	b->yy_is_interactive = 0;
 	b->yy_at_bol = 1;
 	b->yy_fill_buffer = 0;
 	b->yy_buffer_status = YY_BUFFER_NEW;
 
-	zend_ini_yy_switch_to_buffer(b  );
+	yy_switch_to_buffer( b  );
 
 	return b;
 }
 
-/** Setup the input buffer state to scan a string. The next call to zend_ini_yylex() will
+/** Setup the input buffer state to scan a string. The next call to yylex() will
  * scan from a @e copy of @a str.
  * @param yystr a NUL-terminated string to scan
- *
+ * 
  * @return the newly allocated buffer state object.
  * @note If you want to scan bytes that may contain NUL values, then use
- *       zend_ini_yy_scan_bytes() instead.
+ *       yy_scan_bytes() instead.
  */
-YY_BUFFER_STATE zend_ini_yy_scan_string (yyconst char * yystr )
+YY_BUFFER_STATE yy_scan_string (const char * yystr )
 {
-
-	return zend_ini_yy_scan_bytes(yystr,strlen(yystr) );
+    
+	return yy_scan_bytes( yystr, (int) strlen(yystr) );
 }
 
-/** Setup the input buffer state to scan the given bytes. The next call to zend_ini_yylex() will
+/** Setup the input buffer state to scan the given bytes. The next call to yylex() will
  * scan from a @e copy of @a bytes.
  * @param yybytes the byte buffer to scan
  * @param _yybytes_len the number of bytes in the buffer pointed to by @a bytes.
- *
+ * 
  * @return the newly allocated buffer state object.
  */
-YY_BUFFER_STATE zend_ini_yy_scan_bytes  (yyconst char * yybytes, yy_size_t  _yybytes_len )
+YY_BUFFER_STATE yy_scan_bytes  (const char * yybytes, int  _yybytes_len )
 {
 	YY_BUFFER_STATE b;
 	char *buf;
 	yy_size_t n;
-	yy_size_t i;
-
+	int i;
+    
 	/* Get memory for full buffer, including space for trailing EOB's. */
-	n = _yybytes_len + 2;
-	buf = (char *) zend_ini_yyalloc(n  );
+	n = (yy_size_t) (_yybytes_len + 2);
+	buf = (char *) yyalloc( n  );
 	if ( ! buf )
-		YY_FATAL_ERROR( "out of dynamic memory in zend_ini_yy_scan_bytes()" );
+		YY_FATAL_ERROR( "out of dynamic memory in yy_scan_bytes()" );
 
 	for ( i = 0; i < _yybytes_len; ++i )
 		buf[i] = yybytes[i];
 
 	buf[_yybytes_len] = buf[_yybytes_len+1] = YY_END_OF_BUFFER_CHAR;
 
-	b = zend_ini_yy_scan_buffer(buf,n );
+	b = yy_scan_buffer( buf, n );
 	if ( ! b )
-		YY_FATAL_ERROR( "bad buffer in zend_ini_yy_scan_bytes()" );
+		YY_FATAL_ERROR( "bad buffer in yy_scan_bytes()" );
 
 	/* It's okay to grow etc. this buffer, and we should throw it
 	 * away when we're done.
@@ -2345,20 +2536,21 @@ YY_BUFFER_STATE zend_ini_yy_scan_bytes  (yyconst char * yybytes, yy_size_t  _yyb
 	return b;
 }
 
-    static void yy_push_state (int  new_state )
+    static void yy_push_state (int  _new_state )
 {
     	if ( (yy_start_stack_ptr) >= (yy_start_stack_depth) )
 		{
 		yy_size_t new_size;
 
 		(yy_start_stack_depth) += YY_START_STACK_INCR;
-		new_size = (yy_start_stack_depth) * sizeof( int );
+		new_size = (yy_size_t) (yy_start_stack_depth) * sizeof( int );
 
 		if ( ! (yy_start_stack) )
-			(yy_start_stack) = (int *) zend_ini_yyalloc(new_size  );
+			(yy_start_stack) = (int *) yyalloc( new_size  );
 
 		else
-			(yy_start_stack) = (int *) zend_ini_yyrealloc((void *) (yy_start_stack),new_size  );
+			(yy_start_stack) = (int *) yyrealloc(
+					(void *) (yy_start_stack), new_size  );
 
 		if ( ! (yy_start_stack) )
 			YY_FATAL_ERROR( "out of memory expanding start-condition stack" );
@@ -2366,7 +2558,7 @@ YY_BUFFER_STATE zend_ini_yy_scan_bytes  (yyconst char * yybytes, yy_size_t  _yyb
 
 	(yy_start_stack)[(yy_start_stack_ptr)++] = YY_START;
 
-	BEGIN(new_state);
+	BEGIN(_new_state);
 }
 
     static void yy_pop_state  (void)
@@ -2386,9 +2578,9 @@ YY_BUFFER_STATE zend_ini_yy_scan_bytes  (yyconst char * yybytes, yy_size_t  _yyb
 #define YY_EXIT_FAILURE 2
 #endif
 
-static void yy_fatal_error (yyconst char* msg )
+static void yynoreturn yy_fatal_error (const char* msg )
 {
-    	(void) fprintf( stderr, "%s\n", msg );
+			fprintf( stderr, "%s\n", msg );
 	exit( YY_EXIT_FAILURE );
 }
 
@@ -2398,107 +2590,107 @@ static void yy_fatal_error (yyconst char* msg )
 #define yyless(n) \
 	do \
 		{ \
-		/* Undo effects of setting up zend_ini_yytext. */ \
+		/* Undo effects of setting up yytext. */ \
         int yyless_macro_arg = (n); \
         YY_LESS_LINENO(yyless_macro_arg);\
-		zend_ini_yytext[zend_ini_yyleng] = (yy_hold_char); \
-		(yy_c_buf_p) = zend_ini_yytext + yyless_macro_arg; \
+		yytext[yyleng] = (yy_hold_char); \
+		(yy_c_buf_p) = yytext + yyless_macro_arg; \
 		(yy_hold_char) = *(yy_c_buf_p); \
 		*(yy_c_buf_p) = '\0'; \
-		zend_ini_yyleng = yyless_macro_arg; \
+		yyleng = yyless_macro_arg; \
 		} \
 	while ( 0 )
 
 /* Accessor  methods (get/set functions) to struct members. */
 
 /** Get the current line number.
- *
+ * 
  */
-int zend_ini_yyget_lineno  (void)
+int yyget_lineno  (void)
 {
-
-    return zend_ini_yylineno;
+    
+    return yylineno;
 }
 
 /** Get the input stream.
- *
+ * 
  */
-FILE *zend_ini_yyget_in  (void)
+FILE *yyget_in  (void)
 {
-        return zend_ini_yyin;
+        return yyin;
 }
 
 /** Get the output stream.
- *
+ * 
  */
-FILE *zend_ini_yyget_out  (void)
+FILE *yyget_out  (void)
 {
-        return zend_ini_yyout;
+        return yyout;
 }
 
 /** Get the length of the current token.
- *
+ * 
  */
-yy_size_t zend_ini_yyget_leng  (void)
+int yyget_leng  (void)
 {
-        return zend_ini_yyleng;
+        return yyleng;
 }
 
 /** Get the current token.
- *
+ * 
  */
 
-char *zend_ini_yyget_text  (void)
+char *yyget_text  (void)
 {
-        return zend_ini_yytext;
+        return yytext;
 }
 
 /** Set the current line number.
- * @param line_number
- *
+ * @param _line_number line number
+ * 
  */
-void zend_ini_yyset_lineno (int  line_number )
+void yyset_lineno (int  _line_number )
 {
-
-    zend_ini_yylineno = line_number;
+    
+    yylineno = _line_number;
 }
 
 /** Set the input stream. This does not discard the current
  * input buffer.
- * @param in_str A readable stream.
- *
- * @see zend_ini_yy_switch_to_buffer
+ * @param _in_str A readable stream.
+ * 
+ * @see yy_switch_to_buffer
  */
-void zend_ini_yyset_in (FILE *  in_str )
+void yyset_in (FILE *  _in_str )
 {
-        zend_ini_yyin = in_str ;
+        yyin = _in_str ;
 }
 
-void zend_ini_yyset_out (FILE *  out_str )
+void yyset_out (FILE *  _out_str )
 {
-        zend_ini_yyout = out_str ;
+        yyout = _out_str ;
 }
 
-int zend_ini_yyget_debug  (void)
+int yyget_debug  (void)
 {
-        return zend_ini_yy_flex_debug;
+        return yy_flex_debug;
 }
 
-void zend_ini_yyset_debug (int  bdebug )
+void yyset_debug (int  _bdebug )
 {
-        zend_ini_yy_flex_debug = bdebug ;
+        yy_flex_debug = _bdebug ;
 }
 
 static int yy_init_globals (void)
 {
         /* Initialization is the same as for the non-reentrant scanner.
-     * This function is called from zend_ini_yylex_destroy(), so don't allocate here.
+     * This function is called from yylex_destroy(), so don't allocate here.
      */
 
-    (yy_buffer_stack) = 0;
+    (yy_buffer_stack) = NULL;
     (yy_buffer_stack_top) = 0;
     (yy_buffer_stack_max) = 0;
-    (yy_c_buf_p) = (char *) 0;
+    (yy_c_buf_p) = NULL;
     (yy_init) = 0;
     (yy_start) = 0;
 
@@ -2508,40 +2700,40 @@ static int yy_init_globals (void)
 
 /* Defined in main.c */
 #ifdef YY_STDINIT
-    zend_ini_yyin = stdin;
-    zend_ini_yyout = stdout;
+    yyin = stdin;
+    yyout = stdout;
 #else
-    zend_ini_yyin = (FILE *) 0;
-    zend_ini_yyout = (FILE *) 0;
+    yyin = NULL;
+    yyout = NULL;
 #endif
 
     /* For future reference: Set errno on error, since we are called by
-     * zend_ini_yylex_init()
+     * yylex_init()
      */
     return 0;
 }
 
-/* zend_ini_yylex_destroy is for both reentrant and non-reentrant scanners. */
-int zend_ini_yylex_destroy  (void)
+/* yylex_destroy is for both reentrant and non-reentrant scanners. */
+int yylex_destroy  (void)
 {
-
+    
     /* Pop the buffer stack, destroying each element. */
-	while (YY_CURRENT_BUFFER != NULL){
-		zend_ini_yy_delete_buffer(YY_CURRENT_BUFFER  );
+	while(YY_CURRENT_BUFFER){
+		yy_delete_buffer( YY_CURRENT_BUFFER  );
 		YY_CURRENT_BUFFER_LVALUE = NULL;
-		zend_ini_yypop_buffer_state();
+		yypop_buffer_state();
 	}
 
 	/* Destroy the stack itself. */
-	zend_ini_yyfree((yy_buffer_stack) );
+	yyfree((yy_buffer_stack) );
 	(yy_buffer_stack) = NULL;
 
     /* Destroy the start condition stack. */
-        zend_ini_yyfree((yy_start_stack)  );
+        yyfree( (yy_start_stack)  );
         (yy_start_stack) = NULL;
 
     /* Reset the globals. This is important in a non-reentrant scanner so the next time
-     * zend_ini_yylex() is called, initialization will occur. */
+     * yylex() is called, initialization will occur. */
     yy_init_globals( );
 
     return 0;
@@ -2552,18 +2744,19 @@ int zend_ini_yylex_destroy  (void)
  */
 
 #ifndef yytext_ptr
-static void yy_flex_strncpy (char* s1, yyconst char * s2, int n )
+static void yy_flex_strncpy (char* s1, const char * s2, int n )
 {
-	register int i;
+		
+	int i;
 	for ( i = 0; i < n; ++i )
 		s1[i] = s2[i];
 }
 #endif
 
 #ifdef YY_NEED_STRLEN
-static int yy_flex_strlen (yyconst char * s )
+static int yy_flex_strlen (const char * s )
 {
-	register int n;
+	int n;
 	for ( n = 0; s[n]; ++n )
 		;
 
@@ -2571,13 +2764,14 @@ static int yy_flex_strlen (yyconst char * s )
 }
 #endif
 
-void *zend_ini_yyalloc (yy_size_t  size )
+void *yyalloc (yy_size_t  size )
 {
-	return (void *) malloc( size );
+			return malloc(size);
 }
 
-void *zend_ini_yyrealloc  (void * ptr, yy_size_t  size )
+void *yyrealloc  (void * ptr, yy_size_t  size )
 {
+		
 	/* The cast to (char *) in the following accommodates both
 	 * implementations that use char* generic pointers, and those
 	 * that use void* generic pointers.  It works with the latter
@@ -2585,19 +2779,15 @@ void *zend_ini_yyrealloc  (void * ptr, yy_size_t  size )
 	 * any pointer type to void*, and deal with argument conversions
 	 * as though doing an assignment.
 	 */
-	return (void *) realloc( (char *) ptr, size );
+	return realloc(ptr, size);
 }
 
-void zend_ini_yyfree (void * ptr )
+void yyfree (void * ptr )
 {
-	free( (char *) ptr );	/* see zend_ini_yyrealloc() for (char *) cast */
+			free( (char *) ptr );	/* see yyrealloc() for (char *) cast */
 }
 
 #define YYTABLES_NAME "yytables"
-
-#line 400 "hphp/runtime/base/ini-parser/zend-ini.ll"
-
-
 
 static void __attribute__((__unused__))
 suppress_defined_but_not_used_warnings() {
@@ -2617,16 +2807,16 @@ void zend_ini_scan(const std::string &str, int scanner_mode, const std::string &
 
   /* Eat any UTF-8 BOM we find in the first 3 bytes */
   if (str.size() > 3 && memcmp(str.data(), "\xef\xbb\xbf", 3) == 0) {
-    SCNG(state) = zend_ini_yy_scan_string(str.data() + 3);
+    SCNG(state) = yy_scan_string(str.data() + 3);
   } else {
-    SCNG(state) = zend_ini_yy_scan_string(str.data());
+    SCNG(state) = yy_scan_string(str.data());
   }
 }
 
 void zend_ini_scan_cleanup() {
-  zend_ini_yy_delete_buffer(SCNG(state));
+  yy_delete_buffer(SCNG(state));
   SCNG(state) = nullptr;
-  zend_ini_yylex_destroy();
+  yylex_destroy();
 }
 
 void zend_ini_on_section(const std::string &name) {
@@ -2661,3 +2851,4 @@ void ini_error(const char *msg) {
     Logger::Warning("Invalid configuration directive\n");
   }
 }
+

--- a/hphp/runtime/base/zend-printf.cpp
+++ b/hphp/runtime/base/zend-printf.cpp
@@ -63,7 +63,7 @@ inline static void appendstring(StringBuffer *buffer, const char *add,
                                 int min_width, int max_width, char padding,
                                 int alignment, int len, int neg, int expprec,
                                 int always_sign) {
-  register int npad;
+  int npad;
   int req_size;
   int copy_len;
 
@@ -100,8 +100,8 @@ inline static void appendint(StringBuffer *buffer, long number,
                              int width, char padding, int alignment,
                              int always_sign) {
   char numbuf[NUM_BUF_SIZE];
-  register unsigned long magn, nmagn;
-  register unsigned int i = NUM_BUF_SIZE - 1, neg = 0;
+  unsigned long magn, nmagn;
+  unsigned int i = NUM_BUF_SIZE - 1, neg = 0;
 
   if (number < 0) {
     neg = 1;
@@ -136,8 +136,8 @@ inline static void appenduint(StringBuffer *buffer,
                               unsigned long number,
                               int width, char padding, int alignment) {
   char numbuf[NUM_BUF_SIZE];
-  register unsigned long magn, nmagn;
-  register unsigned int i = NUM_BUF_SIZE - 1;
+  unsigned long magn, nmagn;
+  unsigned int i = NUM_BUF_SIZE - 1;
 
   magn = (unsigned long) number;
 
@@ -249,9 +249,9 @@ inline static void append2n(StringBuffer *buffer, long number,
                             int width, char padding, int alignment, int n,
                             char *chartable, int expprec) {
   char numbuf[NUM_BUF_SIZE];
-  register unsigned long num;
-  register unsigned int  i = NUM_BUF_SIZE - 1;
-  register int andbits = (1 << n) - 1;
+  unsigned long num;
+  unsigned int  i = NUM_BUF_SIZE - 1;
+  int andbits = (1 << n) - 1;
 
   num = (unsigned long) number;
   numbuf[i] = '\0';
@@ -269,8 +269,8 @@ inline static void append2n(StringBuffer *buffer, long number,
 
 inline static int getnumber(const char *buffer, int *pos) {
   char *endptr;
-  register long num = strtol(buffer + *pos, &endptr, 10);
-  register int i = 0;
+  long num = strtol(buffer + *pos, &endptr, 10);
+  int i = 0;
 
   if (endptr != nullptr) {
     i = (endptr - buffer - *pos);

--- a/hphp/runtime/base/zend-qsort.cpp
+++ b/hphp/runtime/base/zend-qsort.cpp
@@ -23,11 +23,11 @@ namespace HPHP {
 #define QSORT_STACK_SIZE (sizeof(size_t) * CHAR_BIT)
 
 void _zend_qsort_swap(void *a, void *b, size_t siz) {
-  register char  *tmp_a_char;
-  register char  *tmp_b_char;
-  register int   *tmp_a_int;
-  register int   *tmp_b_int;
-  register size_t i;
+  char  *tmp_a_char;
+  char  *tmp_b_char;
+  int   *tmp_a_int;
+  int   *tmp_b_int;
+  size_t i;
   int             t_i;
   char            t_c;
 
@@ -54,12 +54,12 @@ void zend_qsort(void *base, size_t nmemb, size_t siz,
                 compare_func_t compare, void *opaque) {
   void           *begin_stack[QSORT_STACK_SIZE];
   void           *end_stack[QSORT_STACK_SIZE];
-  register char  *begin;
-  register char  *end;
-  register char  *seg1;
-  register char  *seg2;
-  register char  *seg2p;
-  register int    loop;
+  char  *begin;
+  char  *end;
+  char  *seg1;
+  char  *seg2;
+  char  *seg2p;
+  int    loop;
   unsigned int    offset;
 
   begin_stack[0] = (char *) base;

--- a/hphp/runtime/base/zend-string.cpp
+++ b/hphp/runtime/base/zend-string.cpp
@@ -1409,7 +1409,7 @@ String string_escape_shell_arg(const char *str) {
 }
 
 String string_escape_shell_cmd(const char *str) {
-  register int x, y, l;
+  int x, y, l;
   char *cmd;
   char *p = nullptr;
 

--- a/hphp/runtime/ext/fileinfo/libmagic/strlcpy.cpp
+++ b/hphp/runtime/ext/fileinfo/libmagic/strlcpy.cpp
@@ -63,9 +63,9 @@ static char *rcsid = "$OpenBSD: strlcpy.c,v 1.4 1999/05/01 18:56:41 millert Exp 
  */
 size_t php_strlcpy(char *dst, const char *src, size_t siz)
 {
-  register char *d = dst;
-  register const char *s = src;
-  register size_t n = siz;
+  char *d = dst;
+  const char *s = src;
+  size_t n = siz;
 
   /* Copy as many bytes as will fit */
   if (n != 0 && --n != 0) {

--- a/hphp/runtime/ext/gd/libgd/gd_crop.cpp
+++ b/hphp/runtime/ext/gd/libgd/gd_crop.cpp
@@ -332,7 +332,7 @@ static int gdGuessBackgroundColorFromCorners(gdImagePtr im, int *color) {
     *color = bl;
     return 2;
   } else {
-    register int r,b,g,a;
+    int r,b,g,a;
 
     r = (int)(0.5f + (gdImageRed(im, tl) + gdImageRed(im, tr) +
               gdImageRed(im, bl) + gdImageRed(im, br)) / 4);

--- a/hphp/runtime/ext/gd/libgd/gd_gif_out.cpp
+++ b/hphp/runtime/ext/gd/libgd/gd_gif_out.cpp
@@ -93,7 +93,7 @@ static void GIFEncode (gdIOCtxPtr fp, int GWidth, int GHeight, int GInterlace, i
 static void compress (int init_bits, gdIOCtx *outfile, gdImagePtr im, GifCtx *ctx);
 static void output (code_int code, GifCtx *ctx);
 static void cl_block (GifCtx *ctx);
-static void cl_hash (register count_int chsize, GifCtx *ctx);
+static void cl_hash (count_int chsize, GifCtx *ctx);
 static void char_init (GifCtx *ctx);
 static void char_out (int c, GifCtx *ctx);
 static void flush_char (GifCtx *ctx);
@@ -490,13 +490,13 @@ output(code_int code, GifCtx *ctx);
 static void
 compress(int init_bits, gdIOCtxPtr outfile, gdImagePtr im, GifCtx *ctx)
 {
-    register long fcode;
-    register code_int i /* = 0 */;
-    register int c;
-    register code_int ent;
-    register code_int disp;
-    register code_int hsize_reg;
-    register int hshift;
+    long fcode;
+    code_int i /* = 0 */;
+    int c;
+    code_int ent;
+    code_int disp;
+    code_int hsize_reg;
+    int hshift;
 
     /*
      * Set up the globals:  g_init_bits - initial number of bits
@@ -685,14 +685,14 @@ cl_block (GifCtx *ctx)             /* table clear for block compress */
 }
 
 static void
-cl_hash(register count_int chsize, GifCtx *ctx)          /* reset code table */
+cl_hash(count_int chsize, GifCtx *ctx)          /* reset code table */
 
 {
 
-        register count_int *htab_p = ctx->htab+chsize;
+        count_int *htab_p = ctx->htab+chsize;
 
-        register long i;
-        register long m1 = -1;
+        long i;
+        long m1 = -1;
 
         i = chsize - 16;
         do {                            /* might use Sys V memset(3) here */

--- a/hphp/runtime/ext/gd/libgd/gd_interpolation.cpp
+++ b/hphp/runtime/ext/gd/libgd/gd_interpolation.cpp
@@ -178,7 +178,7 @@ static double KernelBessel_J1(const double x)
 {
   double p, q;
 
-  register long i;
+  long i;
 
   static const double
   Pone[] =
@@ -220,7 +220,7 @@ static double KernelBessel_P1(const double x)
 {
   double p, q;
 
-  register long i;
+  long i;
 
   static const double
   Pone[] =
@@ -256,7 +256,7 @@ static double KernelBessel_Q1(const double x)
 {
   double p, q;
 
-  register long i;
+  long i;
 
   static const double
   Pone[] =
@@ -521,7 +521,7 @@ static inline int _color_blend (const int dst, const int src)
     if( dst_alpha == gdAlphaTransparent ) {
       return src;
     } else {
-      register int alpha, red, green, blue;
+      int alpha, red, green, blue;
       const int src_weight = gdAlphaTransparent - src_alpha;
       const int dst_weight = (gdAlphaTransparent - dst_alpha) * src_alpha / gdAlphaMax;
       const int tot_weight = src_weight + dst_weight;
@@ -549,7 +549,7 @@ static inline int getPixelOverflowTC(gdImagePtr im, const int x, const int y, co
     }
     return c;
   } else {
-    register int border = 0;
+    int border = 0;
 
     if (y < im->cy1) {
       border = im->tpixels[0][im->cx1];
@@ -600,7 +600,7 @@ static inline int getPixelOverflowPalette(gdImagePtr im, const int x, const int 
     }
     return colorIndex2RGBA(c);
   } else {
-    register int border = 0;
+    int border = 0;
     if (y < im->cy1) {
       border = gdImageGetPixel(im, im->cx1, 0);
       goto processborder;
@@ -855,7 +855,7 @@ static inline LineContribType *_gdContributionsCalc(unsigned int line_size, unsi
     for (u = 0; u < line_size; u++) {
         const double dCenter = (double)u / scale_d;
         /* get the significant edge points affecting the pixel */
-        register int iLeft = MAX(0, (int)floor (dCenter - width_d));
+        int iLeft = MAX(0, (int)floor (dCenter - width_d));
         int iRight = MIN((int)ceil(dCenter + width_d), (int)src_size - 1);
         double dTotalWeight = 0.0;
     int iSrc;
@@ -898,7 +898,7 @@ static inline void _gdScaleRow(gdImagePtr pSrc, unsigned int /*src_width*/,
   unsigned int x;
 
     for (x = 0; x < dst_width - 1; x++) {
-    register unsigned char r = 0, g = 0, b = 0, a = 0;
+    unsigned char r = 0, g = 0, b = 0, a = 0;
         const int left = contrib->ContribRow[x].Left;
         const int right = contrib->ContribRow[x].Right;
     int i;
@@ -945,7 +945,7 @@ _gdScaleCol(gdImagePtr pSrc, unsigned int /*src_width*/, gdImagePtr pRes,
             unsigned int uCol, LineContribType* contrib) {
   unsigned int y;
   for (y = 0; y < dst_height - 1; y++) {
-    register unsigned char r = 0, g = 0, b = 0, a = 0;
+    unsigned char r = 0, g = 0, b = 0, a = 0;
     const int iLeft = contrib->ContribRow[y].Left;
     const int iRight = contrib->ContribRow[y].Right;
     int i;
@@ -1140,7 +1140,7 @@ static gdImagePtr gdImageScaleBilinearPalette(gdImagePtr im, const unsigned int 
     long j;
     const gdFixed f_i = gd_itofx(i);
     const gdFixed f_a = gd_mulfx(f_i, f_dy);
-    register long m = gd_fxtoi(f_a);
+    long m = gd_fxtoi(f_a);
 
     dst_offset_h = 0;
 
@@ -1161,7 +1161,7 @@ static gdImagePtr gdImageScaleBilinearPalette(gdImagePtr im, const unsigned int 
       unsigned int pixel2;
       unsigned int pixel3;
       unsigned int pixel4;
-      register gdFixed f_r1, f_r2, f_r3, f_r4,
+      gdFixed f_r1, f_r2, f_r3, f_r4,
           f_g1, f_g2, f_g3, f_g4,
           f_b1, f_b2, f_b3, f_b4,
           f_a1, f_a2, f_a3, f_a4;
@@ -1252,7 +1252,7 @@ static gdImagePtr gdImageScaleBilinearTC(gdImagePtr im, const unsigned int new_w
       unsigned int pixel2;
       unsigned int pixel3;
       unsigned int pixel4;
-      register gdFixed f_r1, f_r2, f_r3, f_r4,
+      gdFixed f_r1, f_r2, f_r3, f_r4,
           f_g1, f_g2, f_g3, f_g4,
           f_b1, f_b2, f_b3, f_b4,
           f_a1, f_a2, f_a3, f_a4;
@@ -1360,7 +1360,7 @@ gdImagePtr gdImageScaleBicubicFixed(gdImagePtr src, const unsigned int width, co
       }
       unsigned int src_offset_x[16], src_offset_y[16];
       long k;
-      register gdFixed f_red = 0, f_green = 0, f_blue = 0, f_alpha = 0;
+      gdFixed f_red = 0, f_green = 0, f_blue = 0, f_alpha = 0;
       unsigned char red, green, blue, alpha = 0;
       int *dst_row = dst->tpixels[dst_offset_y];
 
@@ -1487,9 +1487,9 @@ gdImagePtr gdImageScaleBicubicFixed(gdImagePtr src, const unsigned int width, co
       }
 
       for (k = -1; k < 3; k++) {
-        register gdFixed f_RY;
+        gdFixed f_RY;
         {
-          register gdFixed f_a = 0, f_b = 0, f_d = 0, f_c = 0;
+          gdFixed f_a = 0, f_b = 0, f_d = 0, f_c = 0;
           const gdFixed f = gd_itofx(k)-f_f;
           const gdFixed f_fm1 = f - f_1;
           const gdFixed f_fp1 = f + f_1;
@@ -1507,9 +1507,9 @@ gdImagePtr gdImageScaleBicubicFixed(gdImagePtr src, const unsigned int width, co
           const gdFixed f_fm1 = f - f_1;
           const gdFixed f_fp1 = f + f_1;
           const gdFixed f_fp2 = f + f_2;
-          register gdFixed f_a = 0, f_b = 0, f_c = 0, f_d = 0;
-          register gdFixed f_RX, f_R, f_rs, f_gs, f_bs, f_ba;
-          register int c;
+          gdFixed f_a = 0, f_b = 0, f_c = 0, f_d = 0;
+          gdFixed f_RX, f_R, f_rs, f_gs, f_bs, f_ba;
+          int c;
           const int _k = ((k+1)*4) + (l+1);
 
           if (f_fp2 > 0) f_a = gd_mulfx(f_fp2,gd_mulfx(f_fp2,f_fp2));
@@ -1685,7 +1685,7 @@ gdImagePtr gdImageRotateGeneric(gdImagePtr src, const float degrees, const int b
       if ((n <= 0) || (m <= 0) || (m >= src_h) || (n >= src_w)) {
         dst->tpixels[dst_offset_y][dst_offset_x++] = bgColor;
       } else if ((n <= 1) || (m <= 1) || (m >= src_h - 1) || (n >= src_w - 1)) {
-        register int c = getPixelInterpolated(src, n, m, bgColor);
+        int c = getPixelInterpolated(src, n, m, bgColor);
         c = c | (( gdTrueColorGetAlpha(c) + ((int)(127* gd_fxtof(f_slop)))) << 24);
 
         dst->tpixels[dst_offset_y][dst_offset_x++] = _color_blend(bgColor, c);
@@ -1759,7 +1759,7 @@ gdImagePtr gdImageRotateBilinear(gdImagePtr src, const float degrees, const int 
         }
         {
           const int pixel1 = src->tpixels[src_offset_y][src_offset_x];
-          register int pixel2, pixel3, pixel4;
+          int pixel2, pixel3, pixel4;
 
           if (src_offset_y + 1 >= src_h) {
             pixel2 = bgColor;
@@ -2019,8 +2019,8 @@ gdImagePtr gdImageRotateBicubicFixed(gdImagePtr src, const float degrees, const 
             gdFixed f_a = 0, f_b = 0, f_c = 0, f_d = 0;
             gdFixed f_RX, f_R;
             const int _k = ((k + 1) * 4) + (l + 1);
-            register gdFixed f_rs, f_gs, f_bs, f_as;
-            register int c;
+            gdFixed f_rs, f_gs, f_bs, f_as;
+            int c;
 
             if (f_fp2 > 0) {
               f_a = gd_mulfx(f_fp2,gd_mulfx(f_fp2,f_fp2));
@@ -2250,7 +2250,7 @@ int gdTransformAffineCopy(gdImagePtr dst,
   int c1x,c1y,c2x,c2y;
   int backclip = 0;
   int backup_clipx1, backup_clipy1, backup_clipx2, backup_clipy2;
-  register int x, y, src_offset_x, src_offset_y;
+  int x, y, src_offset_x, src_offset_y;
   double inv[6];
   int *dst_p;
   gdPointF pt, src_pt;

--- a/hphp/runtime/ext/gd/libgd/gd_jpeg.cpp
+++ b/hphp/runtime/ext/gd/libgd/gd_jpeg.cpp
@@ -444,8 +444,8 @@ gdImagePtr gdImageCreateFromJpegCtxEx (gdIOCtx * infile, int ignore_warning)
 
   if (cinfo.out_color_space == JCS_CMYK) {
     for (i = 0; i < cinfo.output_height; i++) {
-      register JSAMPROW currow = row;
-      register int *tpix = im->tpixels[i];
+      JSAMPROW currow = row;
+      int *tpix = im->tpixels[i];
       nrows = jpeg_read_scanlines (&cinfo, rowptr, 1);
       if (nrows != 1) {
         php_gd_error_ex(E_WARNING, "gd-jpeg: error: jpeg_read_scanlines returns %u, expected 1", nrows);
@@ -457,8 +457,8 @@ gdImagePtr gdImageCreateFromJpegCtxEx (gdIOCtx * infile, int ignore_warning)
     }
   } else {
     for (i = 0; i < cinfo.output_height; i++) {
-      register JSAMPROW currow = row;
-      register int *tpix = im->tpixels[i];
+      JSAMPROW currow = row;
+      int *tpix = im->tpixels[i];
       nrows = jpeg_read_scanlines (&cinfo, rowptr, 1);
       if (nrows != 1) {
         php_gd_error_ex(E_WARNING, "gd-jpeg: error: jpeg_read_scanlines returns %u, expected 1", nrows);

--- a/hphp/runtime/ext/gd/libgd/gd_png.cpp
+++ b/hphp/runtime/ext/gd/libgd/gd_png.cpp
@@ -360,9 +360,9 @@ gdImagePtr gdImageCreateFromPngCtx (gdIOCtx * infile)
       for (h = 0; h < height; h++) {
         int boffset = 0;
         for (w = 0; w < width; w++) {
-          register png_byte r = row_pointers[h][boffset++];
-          register png_byte g = row_pointers[h][boffset++];
-          register png_byte b = row_pointers[h][boffset++];
+          png_byte r = row_pointers[h][boffset++];
+          png_byte g = row_pointers[h][boffset++];
+          png_byte b = row_pointers[h][boffset++];
           im->tpixels[h][w] = gdTrueColor (r, g, b);
         }
       }
@@ -373,16 +373,16 @@ gdImagePtr gdImageCreateFromPngCtx (gdIOCtx * infile)
       for (h = 0; h < height; h++) {
         int boffset = 0;
         for (w = 0; w < width; w++) {
-          register png_byte r = row_pointers[h][boffset++];
-          register png_byte g = row_pointers[h][boffset++];
-          register png_byte b = row_pointers[h][boffset++];
+          png_byte r = row_pointers[h][boffset++];
+          png_byte g = row_pointers[h][boffset++];
+          png_byte b = row_pointers[h][boffset++];
 
           /* gd has only 7 bits of alpha channel resolution, and
            * 127 is transparent, 0 opaque. A moment of convenience,
            *  a lifetime of compatibility.
            */
 
-          register png_byte a = gdAlphaMax - (row_pointers[h][boffset++] >> 1);
+          png_byte a = gdAlphaMax - (row_pointers[h][boffset++] >> 1);
           im->tpixels[h][w] = gdTrueColorAlpha(r, g, b, a);
         }
       }
@@ -392,7 +392,7 @@ gdImagePtr gdImageCreateFromPngCtx (gdIOCtx * infile)
       /* Palette image, or something coerced to be one */
       for (h = 0; h < height; ++h) {
         for (w = 0; w < width; ++w) {
-          register png_byte idx = row_pointers[h][w];
+          png_byte idx = row_pointers[h][w];
           im->pixels[h][w] = idx;
           open[idx] = 0;
         }

--- a/hphp/runtime/ext/gd/libgd/gd_topal.cpp
+++ b/hphp/runtime/ext/gd/libgd/gd_topal.cpp
@@ -350,9 +350,9 @@ prescan_quantize (j_decompress_ptr cinfo, JSAMPARRAY input_buf,
 {
   my_cquantize_ptr cquantize = (my_cquantize_ptr) cinfo->cquantize;
 #endif
-  register JSAMPROW ptr;
-  register histptr histp;
-  register hist3d histogram = cquantize->histogram;
+  JSAMPROW ptr;
+  histptr histp;
+  hist3d histogram = cquantize->histogram;
   int row;
   JDIMENSION col;
 #ifdef ORIGINAL_LIB_JPEG
@@ -425,9 +425,9 @@ LOCAL (boxptr) find_biggest_color_pop (boxptr boxlist, int numboxes)
 /* Find the splittable box with the largest color population */
 /* Returns NULL if no splittable boxes remain */
 {
-  register boxptr boxp;
-  register int i;
-  register long maxc = 0;
+  boxptr boxp;
+  int i;
+  long maxc = 0;
   boxptr which = NULL;
 
   for (i = 0, boxp = boxlist; i < numboxes; i++, boxp++)
@@ -446,9 +446,9 @@ LOCAL (boxptr) find_biggest_volume (boxptr boxlist, int numboxes)
 /* Find the splittable box with the largest (scaled) volume */
 /* Returns NULL if no splittable boxes remain */
 {
-  register boxptr boxp;
-  register int i;
-  register INT32 maxv = 0;
+  boxptr boxp;
+  int i;
+  INT32 maxv = 0;
   boxptr which = NULL;
 
   for (i = 0, boxp = boxlist; i < numboxes; i++, boxp++)
@@ -608,7 +608,7 @@ median_cut (gdImagePtr oim, gdImagePtr nim, my_cquantize_ptr cquantize,
 {
   int n, lb;
   int c0, c1, c2, cmax;
-  register boxptr b1, b2;
+  boxptr b1, b2;
 
   while (numboxes < desired_colors)
     {
@@ -1113,12 +1113,12 @@ LOCAL (void) find_best_colors (
 {
   int ic0, ic1, ic2;
   int i, icolor;
-  register INT32 *bptr;   /* pointer into bestdist[] array */
+  INT32 *bptr;   /* pointer into bestdist[] array */
   JSAMPLE *cptr;    /* pointer into bestcolor[] array */
   INT32 dist0, dist1;   /* initial distance values */
-  register INT32 dist2;   /* current distance in inner loop */
+  INT32 dist2;   /* current distance in inner loop */
   INT32 xx0, xx1;   /* distance increments */
-  register INT32 xx2;
+  INT32 xx2;
   INT32 inc0, inc1, inc2; /* initial values for increments */
   /* This array holds the distance to the nearest-so-far color for each cell */
   INT32 bestdist[BOX_C0_ELEMS * BOX_C1_ELEMS * BOX_C2_ELEMS];
@@ -1217,8 +1217,8 @@ fill_inverse_cmap (
   hist3d histogram = cquantize->histogram;
   int minc0, minc1, minc2;  /* lower left corner of update box */
   int ic0, ic1, ic2;
-  register JSAMPLE *cptr; /* pointer into bestcolor[] array */
-  register histptr cachep;  /* pointer into main cache array */
+  JSAMPLE *cptr; /* pointer into bestcolor[] array */
+  histptr cachep;  /* pointer into main cache array */
   /* This array lists the candidate colormap indexes. */
   JSAMPLE colorlist[MAXNUMCOLORS];
   int numcolors;    /* number of candidate colors */
@@ -1285,8 +1285,8 @@ METHODDEF (void)
 #ifndef ORIGINAL_LIB_JPEG
 pass2_no_dither (gdImagePtr oim, gdImagePtr nim, my_cquantize_ptr cquantize)
 {
-  register int *inptr;
-  register unsigned char *outptr;
+  int *inptr;
+  unsigned char *outptr;
   int width = oim->sx;
   int num_rows = oim->sy;
 #else
@@ -1295,14 +1295,14 @@ pass2_no_dither (j_decompress_ptr cinfo,
 /* This version performs no dithering */
 {
   my_cquantize_ptr cquantize = (my_cquantize_ptr) cinfo->cquantize;
-  register JSAMPROW inptr, outptr;
+  JSAMPROW inptr, outptr;
   JDIMENSION width = cinfo->output_width;
 #endif
   hist3d histogram = cquantize->histogram;
-  register int c0, c1, c2;
+  int c0, c1, c2;
   int row;
   JDIMENSION col;
-  register histptr cachep;
+  histptr cachep;
 
 
   for (row = 0; row < num_rows; row++)
@@ -1373,10 +1373,10 @@ pass2_fs_dither (j_decompress_ptr cinfo,
   JSAMPROW inptr;   /* => current input pixel */
 #endif
   hist3d histogram = cquantize->histogram;
-  register LOCFSERROR cur0, cur1, cur2; /* current error or pixel value */
+  LOCFSERROR cur0, cur1, cur2; /* current error or pixel value */
   LOCFSERROR belowerr0, belowerr1, belowerr2; /* error for pixel below cur */
   LOCFSERROR bpreverr0, bpreverr1, bpreverr2; /* error for below/prev col */
-  register FSERRPTR errorptr; /* => fserrors[] at column before current */
+  FSERRPTR errorptr; /* => fserrors[] at column before current */
   histptr cachep;
   int dir;      /* +1 or -1 depending on direction */
   int dir3;     /* 3*dir, for advancing inptr & errorptr */
@@ -1503,7 +1503,7 @@ pass2_fs_dither (j_decompress_ptr cinfo,
 #endif
     /* Now emit the colormap index for this cell */
     {
-      register int pixcode = *cachep - 1;
+      int pixcode = *cachep - 1;
       *outptr = (JSAMPLE) pixcode;
       /* Compute representation error for this pixel */
 #undef GETJSAMPLE
@@ -1518,7 +1518,7 @@ pass2_fs_dither (j_decompress_ptr cinfo,
      * next-line error sums left by 1 column.
      */
     {
-      register LOCFSERROR bnexterr, delta;
+      LOCFSERROR bnexterr, delta;
 
       bnexterr = cur0;  /* Process component 0 */
       delta = cur0 * 2;

--- a/hphp/runtime/ext/gd/libgd/gd_transform.cpp
+++ b/hphp/runtime/ext/gd/libgd/gd_transform.cpp
@@ -2,14 +2,14 @@
 
 void gdImageFlipVertical(gdImagePtr im)
 {
-  register int x, y;
+  int x, y;
 
   if (im->trueColor) {
     for (y = 0; y < im->sy / 2; y++) {
       int *row_dst = im->tpixels[y];
       int *row_src = im->tpixels[im->sy - 1 - y];
       for (x = 0; x < im->sx; x++) {
-        register int p;
+        int p;
         p = row_dst[x];
         row_dst[x] = im->tpixels[im->sy - 1 - y][x];
         row_src[x] = p;

--- a/hphp/runtime/ext/gd/libgd/gdkanji.cpp
+++ b/hphp/runtime/ext/gd/libgd/gdkanji.cpp
@@ -227,11 +227,11 @@ DetectKanjiCode (unsigned char *str)
 static void
 SJIStoJIS (int *p1, int *p2)
 {
-  register unsigned char c1 = *p1;
-  register unsigned char c2 = *p2;
-  register int adjust = c2 < 159;
-  register int rowOffset = c1 < 160 ? 112 : 176;
-  register int cellOffset = adjust ? (31 + (c2 > 127)) : 126;
+  unsigned char c1 = *p1;
+  unsigned char c2 = *p2;
+  int adjust = c2 < 159;
+  int rowOffset = c1 < 160 ? 112 : 176;
+  int cellOffset = adjust ? (31 + (c2 > 127)) : 126;
 
   *p1 = ((c1 - rowOffset) << 1) - adjust;
   *p2 -= cellOffset;

--- a/hphp/runtime/ext/hash/hash_tiger.cpp
+++ b/hphp/runtime/ext/hash/hash_tiger.cpp
@@ -131,8 +131,8 @@ hash_tiger::hash_tiger(bool tiger3, int digest, bool invert /*= false */)
 
 #define tiger_compress(passes, str, state)                              \
   {                                                                     \
-    register uint64_t a, b, c, tmpa, x0, x1, x2, x3, x4, x5, x6, x7; \
-    uint64_t aa, bb, cc;                                           \
+    uint64_t a, b, c, tmpa, x0, x1, x2, x3, x4, x5, x6, x7;             \
+    uint64_t aa, bb, cc;                                                \
     int pass_no;                                                        \
                                                                         \
     a = state[0];                                                       \

--- a/hphp/runtime/ext/mailparse/rfc822.cpp
+++ b/hphp/runtime/ext/mailparse/rfc822.cpp
@@ -56,7 +56,7 @@
    are counted, allowing the caller to allocate enough room */
 static void tokenize(const char *header, php_rfc822_token_t *tokens,
                      int *ntokens, int report_errors) {
-  register const char *p, *q, *start;
+  const char *p, *q, *start;
   int in_bracket = 0;
 
 /* NB: parser assumes that the header has two bytes of NUL terminator */

--- a/hphp/util/portability.h
+++ b/hphp/util/portability.h
@@ -171,15 +171,15 @@
 // will fail "pretty spectacularly".
 # define DECLARE_FRAME_POINTER(fp) \
   always_assert(false);            \
-  register ActRec* fp = nullptr;
+  ActRec* fp = nullptr;
 
 #elif defined(__AARCH64EL__)
 
 # if defined(__clang__)
-# define DECLARE_FRAME_POINTER(fp) register ActRec* fp = (ActRec*) \
+# define DECLARE_FRAME_POINTER(fp) ActRec* fp = (ActRec*) \
   __builtin_frame_address(0)
 #else
-# define DECLARE_FRAME_POINTER(fp) register ActRec* fp asm("x29")
+# define DECLARE_FRAME_POINTER(fp) ActRec* fp asm("x29")
 #endif
 
 #elif defined(__powerpc64__)

--- a/hphp/zend/zend-printf.cpp
+++ b/hphp/zend/zend-printf.cpp
@@ -129,7 +129,7 @@ namespace HPHP {
 
 static char * __cvt(double value, int ndigit, int *decpt, int *sign,
                     int fmode, int pad) {
-  register char *s = nullptr;
+  char *s = nullptr;
   char *p, *rve, c;
   size_t siz;
 
@@ -356,14 +356,14 @@ char *php_gcvt(double value, int ndigit, char dec_point,
  * which is a pointer to the END of the buffer + 1 (i.e. if the buffer
  * is declared as buf[ 100 ], buf_end should be &buf[ 100 ])
  */
-char * ap_php_conv_p2(register uint64_t num, register int nbits,
-                      char format, char *buf_end, register int *len)
+char * ap_php_conv_p2(uint64_t num, int nbits, char format, char *buf_end,
+                      int *len)
 {
-  register int mask = (1 << nbits) - 1;
-  register char *p = buf_end;
+  int mask = (1 << nbits) - 1;
+  char *p = buf_end;
   static char low_digits[] = "0123456789abcdef";
   static char upper_digits[] = "0123456789ABCDEF";
-  register char *digits = (format == 'X') ? upper_digits : low_digits;
+  char *digits = (format == 'X') ? upper_digits : low_digits;
 
   do {
     *--p = digits[num & mask];
@@ -387,11 +387,10 @@ char * ap_php_conv_p2(register uint64_t num, register int nbits,
  * which is a pointer to the END of the buffer + 1 (i.e. if the buffer
  * is declared as buf[ 100 ], buf_end should be &buf[ 100 ])
  */
-char * ap_php_conv_10(register int64_t num, register bool is_unsigned,
-                      register int * is_negative, char *buf_end,
-                      register int *len) {
-  register char *p = buf_end;
-  register uint64_t magnitude;
+char * ap_php_conv_10(int64_t num, bool is_unsigned, int *is_negative,
+                      char *buf_end, int *len) {
+  char *p = buf_end;
+  uint64_t magnitude;
 
   if (is_unsigned) {
     magnitude = (uint64_t) num;
@@ -420,7 +419,7 @@ char * ap_php_conv_10(register int64_t num, register bool is_unsigned,
    * We use a do-while loop so that we write at least 1 digit
    */
   do {
-    register uint64_t new_magnitude = magnitude / 10;
+    uint64_t new_magnitude = magnitude / 10;
 
     *--p = (char)(magnitude - new_magnitude * 10 + '0');
     magnitude = new_magnitude;
@@ -438,11 +437,10 @@ char * ap_php_conv_10(register int64_t num, register bool is_unsigned,
  * The sign is returned in the is_negative argument (and is not placed
  * in buf).
  */
-char * php_conv_fp(register char format, register double num,
-                   bool add_dp, int precision, char dec_point,
-                   int *is_negative, char *buf, int *len) {
-  register char *s = buf;
-  register char *p, *p_orig;
+char * php_conv_fp(char format, double num, bool add_dp, int precision,
+                   char dec_point, int *is_negative, char *buf, int *len) {
+  char *s = buf;
+  char *p, *p_orig;
   int decimal_point;
 
   if (precision >= NDIG - 1) {
@@ -557,11 +555,11 @@ inline static void appendsimplestring(char **buffer, int *pos, int *size,
  */
 static int xbuf_format_converter(char **outbuf, const char *fmt, va_list ap)
 {
-  register char *s = nullptr;
+  char *s = nullptr;
   char *q;
   int s_len;
 
-  register int min_width = 0;
+  int min_width = 0;
   int precision = 0;
   enum {
     LEFT, RIGHT

--- a/hphp/zend/zend-string.cpp
+++ b/hphp/zend/zend-string.cpp
@@ -36,9 +36,9 @@
 namespace HPHP {
 
 int string_copy(char *dst, const char *src, int siz) {
-  register char *d = dst;
-  register const char *s = src;
-  register size_t n = siz;
+  char *d = dst;
+  const char *s = src;
+  size_t n = siz;
 
   /* Copy as many bytes as will fit */
   if (n != 0 && --n != 0) {
@@ -308,7 +308,7 @@ static const unsigned int crc32tab[256] = {
 
 int string_crc32(const char *p, int len) {
   uint32_t crcinit = 0;
-  register int32_t crc = crcinit ^ 0xFFFFFFFF;
+  int32_t crc = crcinit ^ 0xFFFFFFFF;
   for (; len--; ++p) {
     crc = ((crc >> 8) & 0x00FFFFFF) ^ crc32tab[(crc ^ (*p)) & 0xFF];
   }

--- a/hphp/zend/zend-strtod.cpp
+++ b/hphp/zend/zend-strtod.cpp
@@ -914,7 +914,7 @@ static Bigint * diff(Bigint *a, Bigint *b)
 static double ulp (double _x)
 {
   _double x;
-  register Long L;
+  Long L;
   _double a;
 
   value(x) = _x;


### PR DESCRIPTION
Summary:
On D38069049 (https://github.com/facebook/hhvm/commit/827e8e2f8230ee99e904d714c0020a2e9d207127) a linter yelled at me that a file I was touching contained the `register` keyword, which is "unused and reserved" since C++17 according to https://en.cppreference.com/w/cpp/keyword/register

Delete all instances of the keyword in our code except in bytecode.cpp where we're using a gcc extension gated by `#ifndef __clang__` https://gcc.gnu.org/onlinedocs/gcc-11.3.0/gcc/Local-Register-Variables.html

Regenerate hphp/runtime/base/ini-parser/zend-ini.ll.cpp

Differential Revision: D38097124

