### PR TITLE
Trigger GitHub Actions for `@facebook-github-bot has imported this pull request.` comments

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -3,6 +3,8 @@ name: Nix CI
 on:
   push:
   pull_request:
+  issue_comment:
+    types: [created]
 
 permissions:
   id-token: write
@@ -10,6 +12,16 @@ permissions:
 
 jobs:
   build-and-test:
+    if: |
+      github.event_name == 'push' ||
+      github.event_name == 'pull_request' ||
+      (
+        github.event_name == 'issue_comment' &&
+        github.event.issue.pull_request &&
+        github.event.issue.user.login == 'github-actions[bot]' &&
+        github.event.comment.user.login == 'facebook-github-bot' &&
+        startsWith(github.event.comment.body, '@facebook-github-bot has imported this pull request.')
+      )
     strategy:
       # Run tests on all OS's and HHVM versions, even if one fails
       fail-fast: false
@@ -21,6 +33,10 @@ jobs:
     continue-on-error: ${{ matrix.os == 'macos-latest' }}
     steps:
     - uses: actions/checkout@v2.4.0
+    - if: github.event_name == 'issue_comment'
+      uses: dawidd6/action-checkout-pr@v1
+      with:
+        pr: ${{ github.event.issue.number }}
     - uses: cachix/install-nix-action@v15
       with:
         extra_nix_config: |


### PR DESCRIPTION
This PR should fix #9139 by triggering GitHub Actions for `@facebook-github-bot has imported this pull request.` comments. 

Test Plan:
---
This PR should not affect existing CI runs on `push` and `pull_requests` events according to https://github.com/facebook/hhvm/runs/7733353301?check_suite_focus=true and https://github.com/facebook/hhvm/runs/7733360928?check_suite_focus=true

The ability to trigger CI for comments should be tested once this PR gets merged to `master`.