### PR TITLE
Use `*` instead of `\+` in  update-first-party.sh

### DIFF
--- a/third-party/update-first-party.sh
+++ b/third-party/update-first-party.sh
@@ -23,5 +23,5 @@ while read -r MATCH; do
   wget -O "$FILE" "$URL"
   HASH="$(openssl dgst -sha256 "$FILE" | awk '{print $NF}')"
   rm "$FILE"
-  sed -i.orig -e 's/SHA[0-9]\+=[0-9a-z]\+/SHA256='"$HASH/" "$CMAKE_FILE"
+  sed -i.orig -e 's/SHA[0-9]*=[0-9a-z]*/SHA256='"$HASH/" "$CMAKE_FILE"
 done


### PR DESCRIPTION
This PR uses `*` instead of `\+` in `update-first-party.sh` because the BSD `sed` from macOS does not support `\+`, which is not POSIX standard.

Test Plan:
---
#9144 is created by the updated version of this script from macOS, which was able to update the hash with `*`, but not with `\+`.