### PR TITLE
zstd compress serialized decls

### DIFF
--- a/hphp/compiler/compiler.cpp
+++ b/hphp/compiler/compiler.cpp
@@ -909,14 +909,22 @@ bool compute_index(
     extern_worker::Client& client,
     UnitIndex& index
 ) {
-  auto const onIndex = [&] (std::string&& rpath, Package::IndexMeta&& meta) {
-    auto const interned_rpath = makeStaticString(rpath);
+  std::atomic<size_t> declBytes{0};
+  auto const onIndex = [&] (
+      std::string&& rpath,
+      Package::IndexMeta&& meta,
+      Ref<Package::UnitDecls>&& declsRef
+  ) {
+    declBytes += declsRef.id().m_size;
+    auto locations = std::make_shared<UnitIndex::Locations>(
+        std::move(rpath), std::move(declsRef)
+    );
     auto insert = [&](auto const& names, auto& map, const char* kind) {
       for (auto name : names) {
-        auto const ret = map.emplace(name, interned_rpath);
+        auto const ret = map.emplace(name, locations);
         if (!ret.second) {
           Logger::FWarning("Duplicate {} {} in {} and {}",
-              kind, name, ret.first->first, interned_rpath
+              kind, name, ret.first->first, locations->rpath
           );
         }
       }
@@ -924,6 +932,7 @@ bool compute_index(
     insert(meta.types, index.types, "type");
     insert(meta.funcs, index.funcs, "function");
     insert(meta.constants, index.constants, "constant");
+    insert(meta.modules, index.modules, "module");
   };
 
   Package index_package{po.inputDir, false, executor, client};
@@ -943,10 +952,12 @@ bool compute_index(
 
   logPhaseStats("index", index_package, client, sample,
                 indexTimer.getMicroSeconds());
-  Logger::FInfo("index size: types={:,} funcs={:,} constants={:,}",
+  Logger::FInfo("decls extern bytes={:,}", declBytes.load());
+  Logger::FInfo("index size: types={:,} funcs={:,} constants={:,} modules={:,}",
       index.types.size(),
       index.funcs.size(),
-      index.constants.size()
+      index.constants.size(),
+      index.modules.size()
   );
   client.resetStats();
 
@@ -969,8 +980,9 @@ struct ParseJob {
   }
 
   static UnitEmitterSerdeWrapper run(const std::string& contents,
-                                     const RepoOptionsFlags& flags) {
-    return Package::parseRun(contents, flags);
+                                     const RepoOptionsFlags& flags,
+                                     Variadic<Package::UnitDecls> decls) {
+    return Package::parseRun(contents, flags, std::move(decls.vals));
   }
 };
 
@@ -994,8 +1006,9 @@ struct ParseForHHBBCJob {
   }
 
   static Variadic<WPI::Value> run(const std::string& contents,
-                                  const RepoOptionsFlags& flags) {
-    auto wrapper = Package::parseRun(contents, flags);
+                                  const RepoOptionsFlags& flags,
+                                  Variadic<Package::UnitDecls> decls) {
+    auto wrapper = Package::parseRun(contents, flags, std::move(decls.vals));
     if (!wrapper.m_ue) return {};
 
     std::vector<WPI::Value> values;
@@ -1183,7 +1196,7 @@ bool process(const CompilerOptions &po) {
                            Ref<Package::FileMetaVec> fileMetas,
                            std::vector<Package::FileData> files,
                            bool optimistic)
-    -> coro::Task<Package::ParseMetaVec> {
+    -> coro::Task<std::pair<bool,Package::ParseMetaVec>> {
     if (RO::EvalUseHHBBC) {
       // Run the HHBBC parse job, which produces WholeProgramInput
       // key/values.
@@ -1206,6 +1219,12 @@ bool process(const CompilerOptions &po) {
       auto [parseMetas, inputKeys] =
         HPHP_CORO_AWAIT(client->load(std::move(metaRefs)));
 
+      // Stop now if the index contains any missing decls.
+      // parseRun() will retry this job with additional inputs.
+      if (index.containsAnyMissing(parseMetas)) {
+        HPHP_CORO_RETURN(std::make_pair(true, parseMetas));
+      }
+
       // We don't have unit-emitters to do uniqueness checking, but
       // the parse metadata has the definitions we can use instead.
       for (auto const& p : parseMetas) {
@@ -1224,7 +1243,7 @@ bool process(const CompilerOptions &po) {
       }
       always_assert(keyIdx == numKeys);
 
-      HPHP_CORO_MOVE_RETURN(parseMetas);
+      HPHP_CORO_MOVE_RETURN(std::make_pair(false, parseMetas));
     }
 
     // Otherwise, do a "normal" (non-HHBBC parse job), load the
@@ -1246,11 +1265,17 @@ bool process(const CompilerOptions &po) {
       client->load(std::move(metaRefs))
     ));
 
+    // Stop now if the index contains any missing decls.
+    // parseRun() will retry this job with additional inputs.
+    if (index.containsAnyMissing(parseMetas)) {
+      HPHP_CORO_RETURN(std::make_pair(true, parseMetas));
+    }
+
     for (auto& wrapper : wrappers) {
       if (!wrapper.m_ue) continue;
       emit(std::move(wrapper.m_ue));
     }
-    HPHP_CORO_MOVE_RETURN(parseMetas);
+    HPHP_CORO_MOVE_RETURN(std::make_pair(false, parseMetas));
   };
 
   {
@@ -1268,7 +1293,10 @@ bool process(const CompilerOptions &po) {
   }
 
   // We don't need the ondemand/autoload index after this point.
-  index.clear();
+  {
+    UnitIndex empty;
+    std::swap(index, empty);
+  }
 
   std::thread fileCache{
     [&, package = std::move(package)] () mutable {

--- a/hphp/compiler/decl-provider.cpp
+++ b/hphp/compiler/decl-provider.cpp
@@ -1,0 +1,80 @@
+/*
+   +----------------------------------------------------------------------+
+   | HipHop for PHP                                                       |
+   +----------------------------------------------------------------------+
+   | Copyright (c) 2010-present Facebook, Inc. (http://www.facebook.com)  |
+   +----------------------------------------------------------------------+
+   | This source file is subject to version 3.01 of the PHP license,      |
+   | that is bundled with this package in the file LICENSE, and is        |
+   | available through the world-wide-web at the following url:           |
+   | http://www.php.net/license/3_01.txt                                  |
+   | If you did not receive a copy of the PHP license and are unable to   |
+   | obtain it through the world-wide-web, please send a note to          |
+   | license@php.net so we can mail you a copy immediately.               |
+   +----------------------------------------------------------------------+
+*/
+#include "hphp/compiler/decl-provider.h"
+
+namespace HPHP {
+
+BatchDeclProvider::BatchDeclProvider(
+    const std::vector<Package::UnitDecls>& decls
+) {
+  for (auto const& unit_decls : decls) {
+    assertx(!unit_decls.symbols.empty());
+    auto const& symbols = unit_decls.symbols;
+    auto const& data = unit_decls.decls;
+    for (auto name : symbols.types) m_types.emplace(name, data);
+    for (auto name : symbols.funcs) m_funcs.emplace(name, data);
+    for (auto name : symbols.constants) m_constants.emplace(name, data);
+    for (auto name : symbols.modules) m_modules.emplace(name, data);
+  }
+}
+
+template<typename T, typename V> ExternalDeclProviderResult find(
+  std::string_view symbol, const T& map, V& list
+) {
+  // TODO(T110866581): symbol should be normalized by hackc
+  std::string_view normalized(normalizeNS(symbol));
+  auto interned = makeStaticString(normalized);
+  auto const it = map.find(interned);
+  if (it != map.end()) {
+    return ExternalDeclProviderResult::from_string(it->second);
+  }
+  list.emplace_back(interned);
+  return ExternalDeclProviderResult::missing();
+}
+
+ExternalDeclProviderResult
+BatchDeclProvider::getType(std::string_view symbol, uint64_t) noexcept {
+  return find(symbol, m_types, m_missing.types);
+}
+
+ExternalDeclProviderResult
+BatchDeclProvider::getFunc(std::string_view symbol) noexcept {
+  return find(symbol, m_funcs, m_missing.funcs);
+}
+
+ExternalDeclProviderResult
+BatchDeclProvider::getConst(std::string_view symbol) noexcept {
+  return find(symbol, m_constants, m_missing.constants);
+}
+
+ExternalDeclProviderResult
+BatchDeclProvider::getModule(std::string_view symbol) noexcept {
+  return find(symbol, m_modules, m_missing.modules);
+}
+
+void BatchDeclProvider::finish() {
+  // Dedup but preserve case so we can see all case mismatches.
+  auto dedup = [&](auto& names) {
+    std::sort(names.begin(), names.end());
+    names.erase(std::unique(names.begin(), names.end()), names.end());
+  };
+  dedup(m_missing.types);
+  dedup(m_missing.funcs);
+  dedup(m_missing.constants);
+  dedup(m_missing.modules);
+}
+
+}

--- a/hphp/compiler/decl-provider.h
+++ b/hphp/compiler/decl-provider.h
@@ -1,0 +1,63 @@
+/*
+   +----------------------------------------------------------------------+
+   | HipHop for PHP                                                       |
+   +----------------------------------------------------------------------+
+   | Copyright (c) 2010-present Facebook, Inc. (http://www.facebook.com)  |
+   +----------------------------------------------------------------------+
+   | This source file is subject to version 3.01 of the PHP license,      |
+   | that is bundled with this package in the file LICENSE, and is        |
+   | available through the world-wide-web at the following url:           |
+   | http://www.php.net/license/3_01.txt                                  |
+   | If you did not receive a copy of the PHP license and are unable to   |
+   | obtain it through the world-wide-web, please send a note to          |
+   | license@php.net so we can mail you a copy immediately.               |
+   +----------------------------------------------------------------------+
+*/
+#pragma once
+#include "hphp/hack/src/hackc/ffi_bridge/decl_provider.h"
+#include "hphp/compiler/package.h"
+
+namespace HPHP {
+
+// A BatchDeclProvider is populated with a list of UnitDecls to make
+// available to hackc. Each UnitDecl contains a list of symbols from
+// that source unit and the serialized decls. These names are used
+// to constructed a unified local autoload map of all the available decls.
+//
+// When hackc requests a symbol we don't have in the local map,
+// remember it in m_missing so hphpc can look it up in its UnitIndex,
+// then retry hackc with additional UnitDecls.
+struct BatchDeclProvider final: ::DeclProvider {
+  explicit BatchDeclProvider(const std::vector<Package::UnitDecls>&);
+  virtual ~BatchDeclProvider() = default;
+
+  ExternalDeclProviderResult
+  getType(std::string_view symbol, uint64_t) noexcept override;
+
+  ExternalDeclProviderResult
+  getFunc(std::string_view symbol) noexcept override;
+
+  ExternalDeclProviderResult
+  getConst(std::string_view symbol) noexcept override;
+
+  ExternalDeclProviderResult
+  getModule(std::string_view symbol) noexcept override;
+
+  void finish();
+
+  using Map = hphp_fast_map<const StringData*, const std::string&>;
+  using IMap = hphp_fast_map<
+    const StringData*, const std::string&, string_data_hash, string_data_isame
+  >;
+
+  // Symbols requested but not found
+  Package::DeclNames m_missing;
+
+  // Maps from Name to serialize decls
+  IMap m_types;
+  IMap m_funcs;
+  Map m_constants;
+  Map m_modules;
+};
+
+}

--- a/hphp/compiler/package.h
+++ b/hphp/compiler/package.h
@@ -38,31 +38,7 @@
 namespace HPHP {
 ///////////////////////////////////////////////////////////////////////////////
 
-struct UnitIndex final {
-  using IMap = folly_concurrent_hash_map_simd<
-    const StringData*,
-    const StringData*,
-    string_data_hash,
-    string_data_isame
-  >;
-  using Map = folly_concurrent_hash_map_simd<
-    const StringData*,
-    const StringData*
-  >;
-
-  IMap types;
-  IMap funcs;
-  Map constants;
-
-  // TODO: add Map<filename, decls_ref>
-  // TODO: will need modules for DeclProvider but not for parseOnDemand.
-
-  void clear() {
-    types.clear();
-    funcs.clear();
-    constants.clear();
-  }
-};
+struct UnitIndex;
 
 struct Package {
   Package(const std::string& root,
@@ -96,8 +72,8 @@ struct Package {
       Config c;
       #define R(Opt) c.Opt = RO::Opt;
       UNITCACHEFLAGS()
-        #undef R
-        c.EvalAbortBuildOnCompilerError = RO::EvalAbortBuildOnCompilerError;
+      #undef R
+      c.EvalAbortBuildOnCompilerError = RO::EvalAbortBuildOnCompilerError;
       c.EvalAbortBuildOnVerifyError = RO::EvalAbortBuildOnVerifyError;
       c.IncludeRoots = RO::IncludeRoots;
       c.coeffects = CoeffectsConfig::exportForParse();
@@ -107,8 +83,8 @@ struct Package {
     void apply() const {
       #define R(Opt) RO::Opt = Opt;
       UNITCACHEFLAGS()
-        #undef R
-        RO::EvalAbortBuildOnCompilerError = EvalAbortBuildOnCompilerError;
+      #undef R
+      RO::EvalAbortBuildOnCompilerError = EvalAbortBuildOnCompilerError;
       RO::EvalAbortBuildOnVerifyError = EvalAbortBuildOnVerifyError;
       RO::IncludeRoots = IncludeRoots;
       CoeffectsConfig::importForParse(coeffects);
@@ -117,8 +93,8 @@ struct Package {
     template <typename SerDe> void serde(SerDe& sd) {
       #define R(Opt) sd(Opt);
       UNITCACHEFLAGS()
-        #undef R
-        sd(EvalAbortBuildOnCompilerError)
+      #undef R
+      sd(EvalAbortBuildOnCompilerError)
         (EvalAbortBuildOnVerifyError)
         (IncludeRoots)
         (coeffects);
@@ -152,21 +128,34 @@ struct Package {
     }
   };
 
-  // Index information collected during parsing, used to construct
-  // an autoload index for parse-on-demand.
-  struct IndexMeta {
+  struct DeclNames {
     std::vector<const StringData*> types;
     std::vector<const StringData*> funcs;
     std::vector<const StringData*> constants;
+    std::vector<const StringData*> modules;
 
+    bool empty() const {
+      return types.empty() && funcs.empty() && constants.empty() &&
+        modules.empty();
+    }
+
+    template <typename SerDe> void serde(SerDe& sd) {
+      sd(types)
+        (funcs)
+        (constants)
+        (modules);
+    }
+  };
+
+  // Index information collected during parsing, used to construct
+  // an autoload index for parse-on-demand.
+  struct IndexMeta: DeclNames {
     // If not empty, indexing resulted in an ICE or had parse errors.
     std::string error;
 
     template<typename SerDe> void serde(SerDe& sd) {
-      sd(types)
-        (funcs)
-        (constants)
-        (error);
+      DeclNames::serde(sd);
+      sd(error);
     }
   };
 
@@ -174,9 +163,13 @@ struct Package {
   // drive on-demand parsing as well as toplevel decl names (from UEs)
   // for use later by HHBBC's whole-program Index.
   struct ParseMeta {
-    // Symbols present in the unit. This will be used to find new files
-    // for parse on-demand.
+    // Unresolved symbols required by hackc before bytecode generation.
+    DeclNames m_missing;
+
+    // Unresolved symbols needed by the Unit at runtime but not before
+    // bytecode generation. Used to find new files for parse on-demand.
     SymbolRefs m_symbol_refs;
+
     // If not empty, parsing resulted in an ICE and configuration
     // indicated that this should be fatal.
     std::string m_abort;
@@ -205,14 +198,29 @@ struct Package {
     const StringData* m_filepath{nullptr};
 
     template <typename SerDe> void serde(SerDe& sd) {
-      sd(m_symbol_refs)
+      sd(m_missing)
+        (m_symbol_refs)
         (m_abort)
         (m_definitions)
         (m_filepath);
     }
   };
 
-  using IndexCallback = std::function<void(std::string&&, IndexMeta&&)>;
+  // Serialized decls for a single file, along with the IndexMeta
+  // enumerating the symbols defined in the file.
+  struct UnitDecls {
+    DeclNames symbols;
+    std::string decls;
+
+    template <typename SerDe> void serde(SerDe& sd) {
+      sd(symbols)
+        (decls);
+    }
+  };
+
+  using IndexCallback = std::function<
+    void(std::string&&, IndexMeta&&, extern_worker::Ref<UnitDecls>&&)
+  >;
   using IndexMetaVec = std::vector<IndexMeta>;
   coro::Task<bool> index(const IndexCallback&);
 
@@ -220,10 +228,11 @@ struct Package {
   using FileMetaVec = std::vector<FileMeta>;
   using ParseMetaVec = std::vector<ParseMeta>;
   using FileData = std::tuple<extern_worker::Ref<std::string>,
-                              extern_worker::Ref<RepoOptionsFlags>>;
+                              extern_worker::Ref<RepoOptionsFlags>,
+                              std::vector<extern_worker::Ref<UnitDecls>>>;
 
   using LocalCallback = std::function<coro::Task<void>(UEVec)>;
-  using ParseCallback = std::function<coro::Task<ParseMetaVec>(
+  using ParseCallback = std::function<coro::Task<std::pair<bool,ParseMetaVec>>(
     const extern_worker::Ref<Config>&,
     extern_worker::Ref<FileMetaVec>,
     std::vector<FileData>,
@@ -239,7 +248,8 @@ struct Package {
   static IndexMetaVec indexFini();
   static ParseMetaVec parseFini();
   static UnitEmitterSerdeWrapper parseRun(const std::string&,
-                                          const RepoOptionsFlags&);
+                                          const RepoOptionsFlags&,
+                                          const std::vector<UnitDecls>&);
 private:
 
   struct FileAndSize {
@@ -280,6 +290,8 @@ private:
   coro::Task<FileAndSizeVec> parseGroups(Groups, const UnitIndex&);
   coro::Task<FileAndSizeVec> parseGroup(Group, const UnitIndex&);
 
+  void resolveDecls(const UnitIndex&, const FileMetaVec&,
+      const std::vector<ParseMeta>&, std::vector<FileData>&, size_t attempts);
   void resolveOnDemand(FileAndSizeVec&, const SymbolRefs&, const UnitIndex&,
       bool report = false);
 
@@ -312,6 +324,53 @@ private:
 
   // Content-store for options: Map<hash(options), options>
   extern_worker::RefCache<SHA1, RepoOptionsFlags> m_repoOptions;
+};
+
+struct UnitIndex final {
+  struct Locations {
+    Locations(std::string&& rpath,
+              extern_worker::Ref<Package::UnitDecls>&& ref)
+      : rpath(std::move(rpath)), declsRef(std::move(ref))
+    {}
+
+    // Relative path to source file in local filesystem
+    std::string rpath;
+
+    // handle to serialized decls in extern blob store
+    extern_worker::Ref<Package::UnitDecls> declsRef;
+  };
+
+  using IMap = folly_concurrent_hash_map_simd<
+    const StringData*, std::shared_ptr<Locations>,
+    string_data_hash,
+    string_data_isame
+  >;
+  using Map = folly_concurrent_hash_map_simd<
+    const StringData*, std::shared_ptr<Locations>
+  >;
+
+  IMap types;
+  IMap funcs;
+  Map constants;
+  Map modules;
+
+  bool containsAnyMissing(const Package::ParseMetaVec& parseMetas) const {
+    auto any = [&](auto const& names, auto const& map) -> bool {
+      for (auto name : names) {
+        if (map.find(name) != map.end()) return true;
+      }
+      return false;
+    };
+    for (auto const& p : parseMetas) {
+      if (any(p.m_missing.types, types) ||
+          any(p.m_missing.funcs, funcs) ||
+          any(p.m_missing.constants, constants) ||
+          any(p.m_missing.modules, modules)) {
+        return true;
+      }
+    }
+    return false;
+  }
 };
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/hphp/hack/Cargo.lock
+++ b/hphp/hack/Cargo.lock
@@ -409,6 +409,9 @@ name = "cc"
 version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c0496836a84f8d0495758516b8621a622beb77c0fed418570e50764093ced48"
+dependencies = [
+ "jobserver",
+]
 
 [[package]]
 name = "cfg-if"
@@ -946,6 +949,7 @@ dependencies = [
  "oxidized_by_ref",
  "sha-1",
  "thiserror",
+ "zstd",
 ]
 
 [[package]]
@@ -1922,6 +1926,15 @@ name = "itoa"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
+
+[[package]]
+name = "jobserver"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af25a77299a7f711a01975c35a6a424eb6862092cc2d6c72c4ed6cbc56dfc1fa"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -3844,4 +3857,33 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "zstd"
+version = "0.11.1+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a16b8414fde0414e90c612eba70985577451c4c504b99885ebed24762cb81a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "5.0.1+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c12659121420dd6365c5c3de4901f97145b79651fb1d25814020ed2ed0585ae"
+dependencies = [
+ "libc",
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.1+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fd07cbbc53846d9145dbffdf6dd09a7a0aa52be46741825f5c97bdd4f73f12b"
+dependencies = [
+ "cc",
+ "libc",
 ]

--- a/hphp/hack/src/hackc/decl_provider/Cargo.toml
+++ b/hphp/hack/src/hackc/decl_provider/Cargo.toml
@@ -15,3 +15,4 @@ hash = { path = "../../utils/hash" }
 oxidized_by_ref = { path = "../../oxidized_by_ref" }
 sha-1 = "0.10"
 thiserror = "1.0.30"
+zstd = "0.11.1+zstd.1.5.2"

--- a/hphp/runtime/vm/unit-parser.h
+++ b/hphp/runtime/vm/unit-parser.h
@@ -22,6 +22,8 @@
 #include "hphp/runtime/vm/as.h"
 #include "hphp/runtime/vm/unit-emitter.h"
 
+struct DeclProvider;
+
 namespace HPHP {
 
 namespace Native {
@@ -141,5 +143,18 @@ using UnitEmitterCacheHook =
     const Native::FuncTable&
   );
 extern UnitEmitterCacheHook g_unit_emitter_cache_hook;
+
+// Invoke hackc directly without any caching.
+std::unique_ptr<UnitEmitter> compile_unit(
+  const char* code,
+  const char* filename,
+  const SHA1& sha1,
+  const Native::FuncTable& nativeFuncs,
+  bool isSystemLib,
+  bool forDebuggerEval,
+  const RepoOptionsFlags& options,
+  CompileAbortMode mode,
+  DeclProvider* provider
+);
 
 }

--- a/hphp/util/extern-worker-inl.h
+++ b/hphp/util/extern-worker-inl.h
@@ -237,6 +237,10 @@ inline bool RefId::operator!=(const RefId& o) const {
   return !(*this == o);
 }
 
+inline bool RefId::operator<(const RefId& o) const {
+  return m_size != o.m_size ? (m_size < o.m_size) : (m_id < o.m_id);
+}
+
 inline std::string RefId::toString() const {
   return folly::sformat("{}:{}", m_id, m_size);
 }

--- a/hphp/util/extern-worker.h
+++ b/hphp/util/extern-worker.h
@@ -208,6 +208,7 @@ struct RefId {
   std::string toString() const;
   bool operator==(const RefId&) const;
   bool operator!=(const RefId&) const;
+  bool operator<(const RefId&) const;
 
   // Despite their names, these fields can be used for anything.
   std::string m_id;
@@ -234,6 +235,11 @@ struct Ref {
   template <typename U> Ref<U> cast() const {
     return Ref<U>{m_id, m_fromFallback};
   }
+
+  bool operator==(const Ref<T>& x) const { return m_id == x.m_id; }
+  bool operator!=(const Ref<T>& x) const { return m_id != x.m_id; }
+  bool operator<(const Ref<T>& x) const { return m_id < x.m_id; }
+
 private:
   Ref(RefId, bool);
   RefId m_id;


### PR DESCRIPTION
Summary:
Should we unconditionally compress decls (when serializing)?

pro: in practice, these are almost always cached somewhere, so it
saves space and only requires recompression when a source file changes.

con: has not been evaluated in integrated tests yet

Differential Revision: D38624288

