### PR TITLE
Update Nix flack lock file at night

### DIFF
--- a/.github/workflows/nix-flake-update.yml
+++ b/.github/workflows/nix-flake-update.yml
@@ -1,6 +1,6 @@
 on:
   schedule:
-    - cron: "42 15 * * *"
+    - cron: "0 3 * * *"
 jobs:
   nix-flake-update:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR changes the time to run the daily `nix-flake-update` job to 3:00 AM UTC, which is 8:00 PM PDT. Then the job will trigger a build, which normally finishes in 3~5 hours, so that people from either London or North America could see the finished build status in the morning.

Test Plan:
Check the GitHub Actions status once this PR gets merged.