### PR TITLE
Remove macOS build and test

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -28,9 +28,7 @@ jobs:
       matrix:
         os:
         - ubuntu-latest
-        - macos-latest
     runs-on: ${{matrix.os}}
-    continue-on-error: ${{ matrix.os == 'macos-latest' }}
     steps:
     - uses: actions/checkout@v2.4.0
     - if: github.event_name == 'issue_comment'


### PR DESCRIPTION
The CI on macOS fails continuously and we don't fix it. Let's just remove it given that we have announced we will likely remove macOS build soon.
https://hhvm.com/blog/2022/07/12/experimenting-with-nix-github-actions-and-visual-studio-code.html#:~:text=we%20will%20also%20stop%20building%20HHVM%20with%20Nix%20on%20macOS%20in%20the%20future%2C%20too.