### PR TITLE
Keep out-dated universal deb packages in the Apt repository

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -162,7 +162,7 @@ jobs:
           reprepro export nightly
         fi
     - if: startsWith(github.ref_name, 'nightly-')
-      run: reprepro includedeb nightly bundle.deb
+      run: reprepro --keepunreferencedfiles --keepunusednewfiles includedeb nightly bundle.deb
     - name: Create release suite
       if: startsWith(github.ref_name, 'HHVM-')
       run: |
@@ -182,7 +182,7 @@ jobs:
           reprepro export release
         fi
     - if: startsWith(github.ref_name, 'HHVM-')
-      run: reprepro includedeb release bundle.deb
+      run: reprepro--keepunreferencedfiles --keepunusednewfiles includedeb release bundle.deb
     - name: Determine HHVM version
       if: startsWith(github.ref_name, 'HHVM-')
       run: |
@@ -207,4 +207,4 @@ jobs:
           reprepro export "release-$HHVM_VERSION_MAJAR_MINOR"
         fi
     - if: startsWith(github.ref_name, 'HHVM-')
-      run: reprepro includedeb "release-$HHVM_VERSION_MAJAR_MINOR" bundle.deb
+      run: reprepro --keepunreferencedfiles --keepunusednewfiles includedeb "release-$HHVM_VERSION_MAJAR_MINOR" bundle.deb


### PR DESCRIPTION
The policy to keep out-dated deb packages is inconsistent, between native packages and universal packages:
- We kept only the latest universal deb package in an Apt suite, according to https://dl.hhvm.com/universal/pool/main/h/hhvm/
- We kept all the native deb packages in an Apt suite, according to https://dl.hhvm.com/ubuntu/pool/main/h/hhvm/

This PR adds `--keepunreferencedfiles --keepunusednewfiles` flags to `reprepro` to make the behavior consistent, similar to what we did in https://github.com/hhvm/packaging/blob/6d301967b15491b4c504947ec9bf0215ffb1a803/bin/update-debianish-repo#L42

Test Plan:
---

Once this PR gets merged, check https://dl.hhvm.com/universal/pool/main/h/hhvm/ , which should include deb packages that are not the latest version.