### PR TITLE
Add #include <array>

### DIFF
--- a/third-party/fb-mysql/8.0.20/libbinlogevents/include/control_events.h
+++ b/third-party/fb-mysql/8.0.20/libbinlogevents/include/control_events.h
@@ -40,6 +40,7 @@
 #include <time.h>
 #include <list>
 #include <map>
+#include <array>
 #include <vector>
 
 #include "binlog_event.h"


### PR DESCRIPTION
`control_events.h` does not compile with clang because `std::array` is used but the header is missing. This PR fixes the compilation error.

Test Plan:
---
When https://github.com/facebook/hhvm/pull/9129 is rebased onto this PR, the CI would not raise error from `control_events.h` any more