### PR TITLE
Use gflags/gflags.h instead of folly/portability/GFlags.h to fix compilation errors

### DIFF
--- a/third-party/squangle/src/squangle/mysql_client/AsyncMysqlClient.cpp
+++ b/third-party/squangle/src/squangle/mysql_client/AsyncMysqlClient.cpp
@@ -17,7 +17,7 @@
 #include <folly/Singleton.h>
 #include <folly/futures/Future.h>
 #include <folly/io/async/EventBaseManager.h>
-#include <folly/portability/GFlags.h>
+#include <gflags/gflags_declare.h>
 #include <folly/ssl/Init.h>
 #include <folly/system/ThreadName.h>
 

--- a/third-party/squangle/src/squangle/mysql_client/Operation.cpp
+++ b/third-party/squangle/src/squangle/mysql_client/Operation.cpp
@@ -12,7 +12,7 @@
 
 #include <folly/Memory.h>
 #include <folly/experimental/StringKeyedUnorderedMap.h>
-#include <folly/portability/GFlags.h>
+#include <gflags/gflags.h>
 #include <folly/small_vector.h>
 #include <folly/ssl/OpenSSLPtrTypes.h>
 #include <mysql_async.h>


### PR DESCRIPTION
I encountered some compile errors due to undefined `DEFINE_int64` and `DECLARE_int64` when updating squangle to the latest version in https://github.com/facebook/hhvm/runs/7981198183?check_suite_focus=true

`DEFINE_int64` and `DECLARE_int64` are defined in `gflags/gflags.h`, not `folly/portability/GFlags.h`, since https://github.com/facebook/folly/commit/4dadde1256f74e756510a499c86459967f78afb9. What defined in `folly/portability/GFlags.h` are `FOLLY_GFLAGS_DEFINE_int64` and `FOLLY_GFLAGS_DECLARE_uint64`.

`folly/portability/GFlags.h` can indirectly include `gflags/gflags.h` under certain compile flags but it is not reliable. https://github.com/facebook/folly/blob/618973dacb5d16ffbcd72e848d156cd0c2c1aafe/folly/portability/GFlags.h#L25

This PR directly use `gflags/gflags.h`, fixing the compilation errors

Test Plan:
I will rebase #9144 onto this PR, then we will eliminate the compilation errors because of gflags in #9144 