### PR TITLE
Use gflags directly instead of via folly/portability/GFlags.h

### DIFF
--- a/third-party/squangle/src/squangle/mysql_client/AsyncMysqlClient.cpp
+++ b/third-party/squangle/src/squangle/mysql_client/AsyncMysqlClient.cpp
@@ -6,25 +6,22 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include "squangle/mysql_client/AsyncMysqlClient.h"
-#include "squangle/logger/DBEventLogger.h"
-#include "squangle/mysql_client/FutureAdapter.h"
-#include "squangle/mysql_client/Operation.h"
-
-#include <vector>
-
+#include <fcntl.h>
 #include <folly/Memory.h>
 #include <folly/Singleton.h>
 #include <folly/futures/Future.h>
 #include <folly/io/async/EventBaseManager.h>
-#include <folly/portability/GFlags.h>
 #include <folly/ssl/Init.h>
 #include <folly/system/ThreadName.h>
-
+#include <gflags/gflags.h>
 #include <mysql.h>
-
-#include <fcntl.h>
 #include <unistd.h>
+#include <vector>
+
+#include "squangle/logger/DBEventLogger.h"
+#include "squangle/mysql_client/AsyncMysqlClient.h"
+#include "squangle/mysql_client/FutureAdapter.h"
+#include "squangle/mysql_client/Operation.h"
 
 DECLARE_int64(mysql_mysql_timeout_micros);
 

--- a/third-party/squangle/src/squangle/mysql_client/Operation.cpp
+++ b/third-party/squangle/src/squangle/mysql_client/Operation.cpp
@@ -7,15 +7,14 @@
  */
 
 #include <errmsg.h> // mysql
-#include <openssl/ssl.h>
-#include <cmath>
-
 #include <folly/Memory.h>
 #include <folly/experimental/StringKeyedUnorderedMap.h>
-#include <folly/portability/GFlags.h>
 #include <folly/small_vector.h>
 #include <folly/ssl/OpenSSLPtrTypes.h>
+#include <gflags/gflags.h>
 #include <mysql_async.h>
+#include <openssl/ssl.h>
+#include <cmath>
 
 #include "squangle/base/ExceptionUtil.h"
 #include "squangle/mysql_client/AsyncMysqlClient.h"


### PR DESCRIPTION
Summary: Folly doesn't have DEFINE_xxx anymore, switch to the gflags version.

Differential Revision: D38961161

