### PR TITLE
Update rustc to 1.63.0 (2022-08-11)

### DIFF
--- a/hhvm.nix
+++ b/hhvm.nix
@@ -83,8 +83,8 @@ let
   makeVersion = major: minor: patch: suffix:
     if suffix == "-dev" then "${major}.${minor}.${patch}-dev${lastModifiedDate}" else "${major}.${minor}.${patch}";
   rustNightly = rustChannelOf {
-    sha256 = "TpJKRroEs7V2BTo2GFPJlEScYVArFY2MnGpYTxbnSo8=";
-    date = "2022-02-24";
+    sha256 = "wVnIzrnpYGqiCBtc3k55tw4VW8YLA3WZY0mSac+2yl0=";
+    date = "2022-08-11";
     channel = "nightly";
   };
 in

--- a/third-party/rustc/CMakeLists.txt
+++ b/third-party/rustc/CMakeLists.txt
@@ -28,7 +28,7 @@ if(RUSTC_EXECUTABLE)
 else()
   message(STATUS "Using bundled Rust")
 
-  set(RUST_NIGHTLY_VERSION "2022-02-24")
+  set(RUST_NIGHTLY_VERSION "2022-08-11")
 
   SET_HHVM_THIRD_PARTY_SOURCE_ARGS(
     RUST_DOWNLOAD_ARGS
@@ -37,9 +37,9 @@ else()
     Darwin_URL
     "https://static.rust-lang.org/dist/${RUST_NIGHTLY_VERSION}/rust-nightly-x86_64-apple-darwin.tar.gz"
     Linux_HASH
-    "SHA512=79e4f5a81b668fe5718b5491eb9acfd363067ab0d1220af27b3aef7b6490f291a05bd29ed761f19786e87d4ff6a63b07194f2de2f81d2631c13ba4848ab7df43"
+    "SHA512=de136959121b4117ab31a9ae4c4b3c593d4fcdf9724bd0f62e8a4ab41becccfa4b8e92ebe1460d9be508986888b95b38620bb68b58496db89706760074b9585d"
     Darwin_HASH
-    "SHA512=d44aa4da10736dd43eac32794a46cd50b8aff06b2c66cb756fdccfa828773de755a11892b27a8256ec89fe65393948abfda55880c62aa3b5225ed0d5f56f7935"
+    "SHA512=77beb1d67233d3954c2709a47c2513762e91e506041bb5ad8d0aad90124cb5a229dfc87e1fb767826f27a31b52520f148c52c2f3a595dac6e09a676c6e660462"
     # The original filename doesn't contain any version information, so add the version information as a prefix to avoid cache collisions when updating later
     FILENAME_PREFIX "rustc-${RUST_NIGHTLY_VERSION}-"
   )


### PR DESCRIPTION
Summary:
This is needed to get D39035976 to pass - the updated version of crossbeam-epoch needs a newer version of rustc.

```
$ wget `fwdproxy-config wget` https://static.rust-lang.org/dist/2022-08-11/rust-nightly-x86_64-apple-darwin.tar.gz
Length: 316593160 (302M) [application/x-tar]

$ wget `fwdproxy-config wget` https://static.rust-lang.org/dist/2022-08-11/rust-nightly-x86_64-unknown-linux-gnu.tar.gz
Length: 287820293 (274M) [application/x-tar]

$ openssl dgst -sha512 *
SHA512(rust-nightly-x86_64-apple-darwin.tar.gz)= 77beb1d67233d3954c2709a47c2513762e91e506041bb5ad8d0aad90124cb5a229dfc87e1fb767826f27a31b52520f148c52c2f3a595dac6e09a676c6e660462
SHA512(rust-nightly-x86_64-unknown-linux-gnu.tar.gz)= de136959121b4117ab31a9ae4c4b3c593d4fcdf9724bd0f62e8a4ab41becccfa4b8e92ebe1460d9be508986888b95b38620bb68b58496db89706760074b9585d

$ openssl dgst -sha256 -binary rust-nightly-x86_64-unknown-linux-gnu.tar.gz | base64
Ur3h+lgPED3 (https://github.com/facebook/hhvm/commit/31244c874ae3482b7ff091a14548a06666330bbb)iDlsLz/M+nP6Wxa5/tmi1DoZpL/IaUkc=

$ for file in *; do manifold put $file hhvm_opensource_dependency_cache/flat/rustc-2022-08-11-$file; done
```

Reviewed By: Atry, dtolnay

Differential Revision: D39148189

