### PR TITLE
Add fbcode_builder to module path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,12 @@ cmake_policy(SET CMP0046 NEW)
 INCLUDE("${CMAKE_CURRENT_SOURCE_DIR}/CMake/VisualStudioToolset.cmake")
 
 # includes
-SET(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/CMake" ${CMAKE_MODULE_PATH})
+SET(
+  CMAKE_MODULE_PATH
+  "${CMAKE_CURRENT_SOURCE_DIR}/CMake"
+  "${CMAKE_CURRENT_SOURCE_DIR}/build/fbcode_builder/CMake"
+  ${CMAKE_MODULE_PATH}
+)
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
 PROJECT(hhvm C CXX ASM)

--- a/third-party/folly/CMakeLists.txt
+++ b/third-party/folly/CMakeLists.txt
@@ -133,7 +133,7 @@ endif()
 if(UNIX AND NOT APPLE)
   # symbolizer implementation details
   find_package(Libiberty)
-  find_package(LibUnwind)
+  find_package(LibUnwind NO_MODULE)
   target_link_libraries(folly INTERFACE ${LIBIBERTY_LIBRARIES} ${LIBELF_LIBRARIES} ${LIBDWARF_LIBRARIES} ${LIBUNWIND_LIBRARIES})
   target_include_directories(folly INTERFACE ${LIBIBERTY_INCLUDE_DIRS} ${LIBUNWIND_INCLUDE_DIRS})
 endif()


### PR DESCRIPTION
Summary:
This diff adds fbcode_builder to module path so that we could use find modules that are consistent with other OSS projects. This diff should not change the find_package behavior for now because HHVM's own find modules still have higher priority.

I will create more diff to remove some HHVM's own find modules to switch to fbcode_builder's find modules, especially find modules for glog and gflags.

The `NO_MODULE` option is added, because `fbcode_builder` provided a `FindLibUnwind.cmake` that is incompatible with existing `find_package(LibUnwind)` call.

Differential Revision: D39313365

