### PR TITLE
Add `linguist-vendored` attribute for files from first-party dependencies

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+third-party/*/src/**/* linguist-vendored
+third-party/fb-mysql/8.0.20/**/* linguist-vendored

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
-third-party/*/src/**/* linguist-vendored
-third-party/fb-mysql/8.0.20/**/* linguist-vendored
+third-party/*/src/** linguist-vendored
+third-party/fb-mysql/8.0.20/** linguist-vendored


### PR DESCRIPTION
According to https://github.com/github/linguist/blob/master/docs/overrides.md#vendored-code , the `linguist-vendored` attribute could help GitHub exclude first-party dependencies from statistics.

Test Plan:
https://github.com/facebook/hhvm/graphs/contributors should not include commits in first-party dependencies