### PR TITLE
fix race in range-for

### DIFF
--- a/third-party/watchman/src/watchman/CookieSync.cpp
+++ b/third-party/watchman/src/watchman/CookieSync.cpp
@@ -64,7 +64,8 @@ void CookieSync::setCookieDir(const w_string& dir) {
 
 std::vector<w_string> CookieSync::getOutstandingCookieFileList() const {
   std::vector<w_string> result;
-  for (auto& it : *cookies_.rlock()) {
+  auto cookiesLocked = cookies_.rlock();
+  for (auto& it : *cookiesLocked) {
     result.push_back(it.first);
   }
 


### PR DESCRIPTION
Summary: acquiring the lock of folly::Synchronized<T> in a range-for will drop the lock.  This is racy on the container / iterator.

Reviewed By: chadaustin

Differential Revision: D39397524

