### PR TITLE
Build gen-rust.cpp in C++ mode

### DIFF
--- a/hphp/tools/hhbc-gen/build.rs
+++ b/hphp/tools/hhbc-gen/build.rs
@@ -13,7 +13,7 @@ fn main() -> Result<()> {
 
     // cc will normally only build a library - so we need to massage
     // it a little to build an exe.
-    let mut build = cc::Build::new();
+    let mut build = cc::Build::new().cpp(true);
     build.include("../../..");
     let compiler = build.get_compiler();
     let mut cmd = compiler.to_command();

--- a/hphp/tools/hhbc-gen/build.rs
+++ b/hphp/tools/hhbc-gen/build.rs
@@ -13,7 +13,8 @@ fn main() -> Result<()> {
 
     // cc will normally only build a library - so we need to massage
     // it a little to build an exe.
-    let mut build = cc::Build::new().cpp(true);
+    let mut build = cc::Build::new();
+    build.cpp(true);
     build.include("../../..");
     let compiler = build.get_compiler();
     let mut cmd = compiler.to_command();


### PR DESCRIPTION
I encountered an error about `'cstdio' file not found` when trying to build HHVM with CMake and Clang. See https://github.com/facebook/hhvm/actions/runs/3041342472/jobs/4898360446
It seems that `build.rs` tries to compile `gen-rust.cpp` as a C source file.
This PR added `.cpp(true)` option so that `gen-rust.cpp` can be built as a C++ source file.
Test Plan:
Rebase #9129 onto this PR and the error `'cstdio' file not found`  should be gone.