### PR TITLE
Fix a compilation error with Clang 12 when inferring the duration type

### DIFF
--- a/third-party/squangle/src/squangle/mysql_client/ConnectionPool.h
+++ b/third-party/squangle/src/squangle/mysql_client/ConnectionPool.h
@@ -849,7 +849,7 @@ class ConnectPoolOperation : public ConnectOperation {
 
     auto now = std::chrono::steady_clock::now();
     // Adjust timeout
-    auto timeout_attempt_based = getConnectionOptions().getTimeout() +
+    std::chrono::duration<uint64_t, std::micro> timeout_attempt_based = getConnectionOptions().getTimeout() +
         std::chrono::duration_cast<std::chrono::milliseconds>(
                                      now - start_time_);
     timeout_ =

--- a/third-party/squangle/src/squangle/mysql_client/ConnectionPool.h
+++ b/third-party/squangle/src/squangle/mysql_client/ConnectionPool.h
@@ -849,9 +849,11 @@ class ConnectPoolOperation : public ConnectOperation {
 
     auto now = std::chrono::steady_clock::now();
     // Adjust timeout
-    std::chrono::duration<uint64_t, std::micro> timeout_attempt_based = getConnectionOptions().getTimeout() +
+    std::chrono::duration<uint64_t, std::micro> timeout_attempt_based =
+        getConnectionOptions().getTimeout() +
         std::chrono::duration_cast<std::chrono::milliseconds>(
-                                     now - start_time_);
+            now - start_time_);
+
     timeout_ =
         min(timeout_attempt_based, getConnectionOptions().getTotalTimeout());
 

--- a/third-party/squangle/src/squangle/mysql_client/Operation.cpp
+++ b/third-party/squangle/src/squangle/mysql_client/Operation.cpp
@@ -585,7 +585,7 @@ void ConnectOperation::attemptFailed(OperationResult result) {
 
   auto now = std::chrono::steady_clock::now();
   // Adjust timeout
-  auto timeout_attempt_based = conn_options_.getTimeout() +
+  std::chrono::duration<uint64_t, std::micro> timeout_attempt_based = conn_options_.getTimeout() +
       std::chrono::duration_cast<std::chrono::milliseconds>(now - start_time_);
   timeout_ = min(timeout_attempt_based, conn_options_.getTotalTimeout());
   specializedRun();
@@ -640,6 +640,7 @@ void ConnectOperation::specializedRunImpl() {
         (*conn_options_.getSniServerName()).c_str());
   }
 
+#ifdef MYSQL_OPT_TOS
   if (conn_options_.getDscp().has_value()) {
     // DS field (QOS/TOS level) is 8 bits with DSCP packed into the most
     // significant 6 bits.
@@ -651,6 +652,7 @@ void ConnectOperation::specializedRunImpl() {
           *conn_options_.getDscp());
     }
   }
+#endif
 
   if (conn_options_.getCertValidationCallback()) {
     MysqlCertValidatorCallback callback = mysqlCertValidator;

--- a/third-party/squangle/src/squangle/mysql_client/Operation.cpp
+++ b/third-party/squangle/src/squangle/mysql_client/Operation.cpp
@@ -585,7 +585,8 @@ void ConnectOperation::attemptFailed(OperationResult result) {
 
   auto now = std::chrono::steady_clock::now();
   // Adjust timeout
-  std::chrono::duration<uint64_t, std::micro> timeout_attempt_based = conn_options_.getTimeout() +
+  std::chrono::duration<uint64_t, std::micro> timeout_attempt_based =
+      conn_options_.getTimeout() +
       std::chrono::duration_cast<std::chrono::milliseconds>(now - start_time_);
   timeout_ = min(timeout_attempt_based, conn_options_.getTotalTimeout());
   specializedRun();

--- a/third-party/squangle/src/squangle/mysql_client/Operation.cpp
+++ b/third-party/squangle/src/squangle/mysql_client/Operation.cpp
@@ -641,7 +641,6 @@ void ConnectOperation::specializedRunImpl() {
         (*conn_options_.getSniServerName()).c_str());
   }
 
-#ifdef MYSQL_OPT_TOS
   if (conn_options_.getDscp().has_value()) {
     // DS field (QOS/TOS level) is 8 bits with DSCP packed into the most
     // significant 6 bits.
@@ -653,7 +652,6 @@ void ConnectOperation::specializedRunImpl() {
           *conn_options_.getDscp());
     }
   }
-#endif
 
   if (conn_options_.getCertValidationCallback()) {
     MysqlCertValidatorCallback callback = mysqlCertValidator;


### PR DESCRIPTION
It seems that clang 12 cannot infer the duration type when using `auto`. This PR instead specifies the type, fixing the compilation error.

Test Plan:
---
### Without this PR
Run CMake build from a GitHub Codespace, checking out #9129, but without this PR
```
/workspaces/hhvm/third-party/squangle/src/squangle/mysql_client/Operation.cpp:590:14: error: no matching function for call to 'min'
  timeout_ = min(timeout_attempt_based, conn_options_.getTotalTimeout());
             ^~~
/nix/store/ag4xvx92f351n78fp7kfms928ihrq13j-libcxx-12.0.1-dev/include/c++/v1/algorithm:2594:1: note: candidate template ignored: deduced conflicting types for parameter '_Tp' ('duration<unsigned long long, [...]>' vs. 'duration<unsigned long, [...]>')
min(const _Tp& __a, const _Tp& __b)
^
/nix/store/ag4xvx92f351n78fp7kfms928ihrq13j-libcxx-12.0.1-dev/include/c++/v1/algorithm:2605:1: note: candidate template ignored: could not match 'initializer_list' against 'duration'
min(initializer_list<_Tp> __t, _Compare __comp)
^
/nix/store/ag4xvx92f351n78fp7kfms928ihrq13j-libcxx-12.0.1-dev/include/c++/v1/algorithm:2614:1: note: candidate function template not viable: requires single argument '__t', but 2 arguments were provided
min(initializer_list<_Tp> __t)
^
/nix/store/ag4xvx92f351n78fp7kfms928ihrq13j-libcxx-12.0.1-dev/include/c++/v1/algorithm:2585:1: note: candidate function template not viable: requires 3 arguments, but 2 were provided
min(const _Tp& __a, const _Tp& __b, _Compare __comp)
^
1 error generated.
make[2]: *** [CMakeFiles/squangle.dir/build.make:258: CMakeFiles/squangle.dir/squangle/mysql_client/Operation.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:83: CMakeFiles/squangle.dir/all] Error 2
make: *** [Makefile:136: all] Error 2
```
### With this PR
Run CMake build from a GitHub Codespace, checking out #9129, and cherrying pick this PR

```
...
[  4%] Building CXX object CMakeFiles/squangle.dir/squangle/mysql_client/Operation.cpp.o
[  9%] Building CXX object CMakeFiles/squangle.dir/squangle/mysql_client/SyncConnectionPool.cpp.o
[ 13%] Linking CXX static library libsquangle.a
[100%] Built target squangle
```

Note that there are other errors when building HHVM OSS with Clang, even though the error related to `squangle` is fixed in this PR.