### PR TITLE
Update aws-sdk-s3 to 0.18.0

### DIFF
--- a/hphp/hack/Cargo.lock
+++ b/hphp/hack/Cargo.lock
@@ -645,11 +645,11 @@ dependencies = [
 
 [[package]]
 name = "crc32fast"
-version = "1.2.0"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba125de2af0df55319f41944744ad91c71113bf74a4646efff39afe1f6842db1"
+checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]


### PR DESCRIPTION
Summary:
In order to use, multipart upload in AWS SDK S3, we require following functions.

- https://docs.rs/aws-smithy-http/0.48.0/aws_smithy_http/byte_stream/struct.ByteStream.html#method.read_from
- https://docs.rs/aws-smithy-http/0.48.0/aws_smithy_http/byte_stream/struct.FsBuilder.html#method.offset
- https://docs.rs/aws-sdk-s3/0.18.0/aws_sdk_s3/client/struct.Client.html#method.create_multipart_upload

In this diff, we are updating aws_sdk_s3 from 0.8.0 to 0.18.0.

Differential Revision: D39518119

