### PR TITLE
Workaround for dtoa.0.3.2

### DIFF
--- a/hhvm.nix
+++ b/hhvm.nix
@@ -182,7 +182,7 @@ stdenv.mkDerivation rec {
     [
       "-DFOLLY_MOBILE=0"
     ]
-    ++ lib.optionals hostPlatform.isMacOS [
+    ++ lib.optionals stdenv.cc.isClang [
       # Workaround for dtoa.0.3.2
       "-Wno-error=unused-command-line-argument"
     ];


### PR DESCRIPTION
`dtoa` 0.3.2 would fail to compile with clang 
```
clang-12: error: argument unused during compilation: '-fno-strict-overflow' [-Werror,-Wunused-command-line-argument]
```
This happens on #9129 without this PR.
See https://github.com/facebook/hhvm/actions/runs/3047122508/jobs/4910756753 for the build log.

This PR suppress the error by adding a `-Wno-error=unused-command-line-argument` flag to the compile.

Test Plan:
Rebase #9129 onto this PR, the error about `argument unused` should be gone.
