### PR TITLE
Use the default C++ runtime when CLANG_FORCE_LIBSTDCXX is not set

### DIFF
--- a/CMake/HPHPCompiler.cmake
+++ b/CMake/HPHPCompiler.cmake
@@ -125,8 +125,6 @@ if (${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang" OR ${CMAKE_CXX_COMPILER_ID} STREQU
 
     if(CLANG_FORCE_LIBSTDCXX)
       list(APPEND GENERAL_CXX_OPTIONS "stdlib=libstdc++")
-    else()
-      list(APPEND GENERAL_CXX_OPTIONS "stdlib=libc++")
     endif()
   else() # using GCC
     list(APPEND DISABLED_NAMED_WARNINGS


### PR DESCRIPTION
Previously, libc++ is used when the compiler is clang and `CLANG_FORCE_LIBSTDCXX` is not set. It's a surprising behavior because the user would expect HHVM to be linked with the compiler default C++ runtime when `CLANG_FORCE_LIBSTDCXX` is not set. Especially when the default C++ runtime is libstdc++ for Clang on Linux, the linker will report an error of `cannot find -lc++: No such file or directory` when `CLANG_FORCE_LIBSTDCXX` is not set. See https://github.com/facebook/hhvm/actions/runs/3099973322/jobs/5019734982 for the build log.

This PR instead uses the default C++ runtime when CLANG_FORCE_LIBSTDCXX is not set

Test Plan:
This PR should not change the behavior on gcc, because `CLANG_FORCE_LIBSTDCXX` is ignored when building with gcc.

When rebasing #9129 onto this PR, the error of `cannot find -lc++: No such file or directory` should be gone.

