### PR TITLE
Remove -DFOLLY_MOBILE=0

### DIFF
--- a/hhvm.nix
+++ b/hhvm.nix
@@ -191,10 +191,7 @@ stdenv.mkDerivation rec {
     ];
 
   NIX_CFLAGS_COMPILE =
-    [
-      "-DFOLLY_MOBILE=0"
-    ]
-    ++ lib.optionals stdenv.cc.isClang [
+    lib.optionals stdenv.cc.isClang [
       # Workaround for dtoa.0.3.2
       "-Wno-error=unused-command-line-argument"
     ];


### PR DESCRIPTION
CMake files in previous version of Folly do not detect non-mobile target correctly and we have to pass `-DFOLLY_MOBILE=0` as a workaround to the compiler to tell it is not a mobile target. Latest Folly can detect non-mobile target properly and we don't need the flag any more.

Test Plan:
GitHub Actions `Nix CI / build-and-test (hhvm, ubuntu-latest)` should pass