### PR TITLE
Let clang++ dynamically link HHVM with libstdc++

### DIFF
--- a/hhvm.nix
+++ b/hhvm.nix
@@ -13,6 +13,7 @@
 , fmt_8
 , freetype
 , fribidi
+, gcc-unwrapped
 , gd
 , gdb
 , gettext
@@ -129,6 +130,8 @@ stdenv.mkDerivation rec {
       (fmt_8.override { inherit stdenv; })
       freetype
       fribidi
+      # Workaround for https://github.com/NixOS/nixpkgs/issues/192665
+      gcc-unwrapped.lib
       gd
       gdb
       gettext


### PR DESCRIPTION
Because of https://github.com/NixOS/nixpkgs/issues/192665 , clang++ from nixpkgs statically link HHVM with libstdc++ by default. Unfortunately Forlly does not support statically linked libstdc++, and the following error will be reported:

```
hhvm> /nix/store/jfkmqz20q8fsaqizcml86adxqyzlwllx-binutils-2.38/bin/ld: /nix/store/l4dvshb0bw0ipyx17f6rknzk83mdx81y-gcc-11.3.0/lib64/gcc/x86_64-unknown-linux-gnu/11.3.0/../../../../lib64/libstdc++.a(eh_ptr.o): in function `std::rethrow_exception(std::__exception_ptr::exception_ptr)':
hhvm> (.text._ZSt17rethrow_exceptionNSt15__exception_ptr13exception_ptrE+0x0): multiple definition of `std::rethrow_exception(std::__exception_ptr::exception_ptr)'; /nix/store/jfkmqz20q8fsaqizcml86adxqyzlwllx-binutils-2.38/bin/ld: DWARF error: invalid or unhandled FORM value: 0x23
hhvm> ../../../third-party/folly/bundled_folly-prefix/lib/libfolly.a(ExceptionTracerLib.cpp.o):ExceptionTracerLib.cpp:(.text+0x1050): first defined here
hhvm> /nix/store/jfkmqz20q8fsaqizcml86adxqyzlwllx-binutils-2.38/bin/ld: /nix/store/l4dvshb0bw0ipyx17f6rknzk83mdx81y-gcc-11.3.0/lib64/gcc/x86_64-unknown-linux-gnu/11.3.0/../../../../lib64/libstdc++.a(eh_catch.o): in function `__cxa_begin_catch':
hhvm> (.text.__cxa_begin_catch+0x0): multiple definition of `__cxa_begin_catch'; ../../../third-party/folly/bundled_folly-prefix/lib/libfolly.a(ExceptionTracerLib.cpp.o):ExceptionTracerLib.cpp:(.text+0x260): first defined here
hhvm> /nix/store/jfkmqz20q8fsaqizcml86adxqyzlwllx-binutils-2.38/bin/ld: /nix/store/l4dvshb0bw0ipyx17f6rknzk83mdx81y-gcc-11.3.0/lib64/gcc/x86_64-unknown-linux-gnu/11.3.0/../../../../lib64/libstdc++.a(eh_catch.o): in function `__cxa_end_catch':
hhvm> (.text.__cxa_end_catch+0x0): multiple definition of `__cxa_end_catch'; ../../../third-party/folly/bundled_folly-prefix/lib/libfolly.a(ExceptionTracerLib.cpp.o):ExceptionTracerLib.cpp:(.text+0xea0): first defined here
hhvm> clang-14: error: linker command failed with exit code 1 (use -v to see invocation)
hhvm> make[2]: *** [hphp/tools/hfsort/CMakeFiles/hfsort.dir/build.make:215: hphp/tools/hfsort/hfsort] Error 1
hhvm> make[1]: *** [CMakeFiles/Makefile2:1626: hphp/tools/hfsort/CMakeFiles/hfsort.dir/all] Error 2
hhvm> make: *** [Makefile:136: all] Error 2
```

This diff applies the workaround described in https://github.com/NixOS/nixpkgs/issues/192665 to let clang++ dynamically link HHVM with libstdc++.

# Test Plan:
Rebase #9129 onto this PR, the error about `multiple definition of __cxa_end_catch` should be gone