### PR TITLE
Upload hhvm_clang universal packages as GitHub Action artifacts

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -52,34 +52,34 @@ jobs:
     - run: hhvm --version
     - name: Build the deb package
       if: runner.os == 'Linux'
-      run: nix bundle --print-build-logs --bundler "git+file://$(pwd)?submodules=1&shallow=1#deb" "git+file://$(pwd)?submodules=1&shallow=1#${{matrix.package}}"
+      run: nix bundle --out-link ${{matrix.package}}.deb --print-build-logs --bundler "git+file://$(pwd)?submodules=1&shallow=1#deb" "git+file://$(pwd)?submodules=1&shallow=1#${{matrix.package}}"
     - name: Show the deb package's information
       if: runner.os == 'Linux'
-      run: dpkg-deb --info bundle.deb
+      run: dpkg-deb --info ${{matrix.package}}.deb
     - name: Show the deb package's content
       if: runner.os == 'Linux'
-      run: dpkg-deb --contents bundle.deb
+      run: dpkg-deb --contents ${{matrix.package}}.deb
     - name: Save the deb package as build artifact
-      if: runner.os == 'Linux' && matrix.package == 'hhvm'
+      if: runner.os == 'Linux'
       uses: actions/upload-artifact@v2
       with:
-        name: bundle.deb
-        path: bundle.deb
+        name: ${{matrix.package}}.deb
+        path: ${{matrix.package}}.deb
     - name: Build the rpm package
       if: runner.os == 'Linux'
-      run: nix bundle --print-build-logs --bundler "git+file://$(pwd)?submodules=1&shallow=1#rpm" "git+file://$(pwd)?submodules=1&shallow=1#${{matrix.package}}"
+      run: nix bundle --out-link ${{matrix.package}}.rpm --print-build-logs --bundler "git+file://$(pwd)?submodules=1&shallow=1#rpm" "git+file://$(pwd)?submodules=1&shallow=1#${{matrix.package}}"
     - name: Show the rpm package's information
       if: runner.os == 'Linux'
-      run: rpm --query --info --package bundle.rpm
+      run: rpm --query --info --package ${{matrix.package}}.rpm
     - name: Show the rpm package's content
       if: runner.os == 'Linux'
-      run: rpm --query --list --package bundle.rpm
+      run: rpm --query --list --package ${{matrix.package}}.rpm
     - name: Save the rpm package as build artifact
-      if: runner.os == 'Linux' && matrix.package == 'hhvm'
+      if: runner.os == 'Linux'
       uses: actions/upload-artifact@v2
       with:
-        name: bundle.rpm
-        path: bundle.rpm
+        name: ${{matrix.package}}.rpm
+        path: ${{matrix.package}}.rpm
     - name: Assume the AWS role
       continue-on-error: true
       id: configure-aws-credentials
@@ -105,10 +105,10 @@ jobs:
       with:
         role-to-assume: arn:aws:iam::223121549624:role/hhvm-github-actions
         aws-region: us-west-2
-    - name: Download the bundle.deb from build-and-test job
+    - name: Download the hhvm.deb from build-and-test job
       uses: actions/download-artifact@v2
       with:
-        name: bundle.deb
+        name: hhvm.deb
     - uses: cachix/install-nix-action@v15
       with:
         extra_nix_config: |
@@ -164,7 +164,7 @@ jobs:
           reprepro export nightly
         fi
     - if: startsWith(github.ref_name, 'nightly-')
-      run: reprepro --keepunreferencedfiles --keepunusednewfiles includedeb nightly bundle.deb
+      run: reprepro --keepunreferencedfiles --keepunusednewfiles includedeb nightly hhvm.deb
     - name: Create release suite
       if: startsWith(github.ref_name, 'HHVM-')
       run: |
@@ -184,7 +184,7 @@ jobs:
           reprepro export release
         fi
     - if: startsWith(github.ref_name, 'HHVM-')
-      run: reprepro --keepunreferencedfiles --keepunusednewfiles includedeb release bundle.deb
+      run: reprepro --keepunreferencedfiles --keepunusednewfiles includedeb release hhvm.deb
     - name: Determine HHVM version
       if: startsWith(github.ref_name, 'HHVM-')
       run: |
@@ -209,4 +209,4 @@ jobs:
           reprepro export "release-$HHVM_VERSION_MAJAR_MINOR"
         fi
     - if: startsWith(github.ref_name, 'HHVM-')
-      run: reprepro --keepunreferencedfiles --keepunusednewfiles includedeb "release-$HHVM_VERSION_MAJAR_MINOR" bundle.deb
+      run: reprepro --keepunreferencedfiles --keepunusednewfiles includedeb "release-$HHVM_VERSION_MAJAR_MINOR" hhvm.deb


### PR DESCRIPTION
This PR uploads both `hhvm.deb` and `hhvm_clang.deb` as GitHub Action artifacts, while only `hhvm.deb` is uploaded to the apt repository.

This PR is required by #9227, to download and test both universal deb packages.

Test Plan:
The GitHub Action page for this PR should include both `hhvm.deb` and `hhvm_clang.deb` as GitHub Action artifacts.