### PR TITLE
Don't print checkPhase

### DIFF
--- a/hhvm.nix
+++ b/hhvm.nix
@@ -254,7 +254,7 @@ stdenv.mkDerivation rec {
 
   checkPhase =
     ''
-      set -ex
+      set -e
       runHook preCheck
       export HHVM_BIN="$PWD/hphp/hhvm/hhvm"
       (cd ${./.} && "$HHVM_BIN" hphp/test/run.php quick)


### PR DESCRIPTION
Currently the logs are to verbose in https://github.com/facebook/hhvm/actions/runs/3146806098/jobs/5115665873. This PR suppress the printed command line to shorten the logs.