### PR TITLE
Skip all server tests in OSS test runs

### DIFF
--- a/hphp/test/cmake_builds_excluded_tests
+++ b/hphp/test/cmake_builds_excluded_tests
@@ -1,3 +1,25 @@
+# server tests are too flaky to use in contbuilds (only useful in manual runs)
+server/debugger/tests/runTest1.php
+server/fastcgi/tests/authDigestTest.php
+server/fastcgi/tests/disable_ini_zend_compat.php
+server/fastcgi/tests/global_variables_server.php
+server/fastcgi/tests/headerTest.php
+server/fastcgi/tests/httpsTest.php
+server/fastcgi/tests/invalid.php
+server/fastcgi/tests/runTest1.php
+server/http/tests/apache_proxygen_headers.php
+server/http/tests/client_blocking_read_test.php
+server/http/tests/codeCoverageTest.php
+server/http/tests/get_headers_secure_dv_array.php
+server/http/tests/globalDocumentTest.php
+server/http/tests/method.php
+server/http/tests/requesIdTest.php
+server/http/tests/rqtrace.php
+server/http/tests/runTest1.php
+server/http/tests/staticContentHeaderTest.php
+server/http/tests/staticContentTest.php
+server/http/tests/takeoverTest.php
+
 # fail apparently due to stale or out of sync tzdata
 slow/dv_array/ext_datetime.php
 slow/ext_date/date_sunrise_test.php
@@ -80,7 +102,6 @@ slow/ext_zlib/ziparchive_setencryption.php
 zend/good/ext/zip/tests/bug53885.php
 
 # TODO(alexeyt) failures not yet categorized
-server/fastcgi/tests/invalid.php
 slow/coeffects/apc_pure.php
 slow/dom_document/clone.php
 slow/ext_hsl/execve_execvpe.php

--- a/hphp/test/github_excluded_tests
+++ b/hphp/test/github_excluded_tests
@@ -1,3 +1,25 @@
+# server tests are too flaky to use in contbuilds (only useful in manual runs)
+server/debugger/tests/runTest1.php
+server/fastcgi/tests/authDigestTest.php
+server/fastcgi/tests/disable_ini_zend_compat.php
+server/fastcgi/tests/global_variables_server.php
+server/fastcgi/tests/headerTest.php
+server/fastcgi/tests/httpsTest.php
+server/fastcgi/tests/invalid.php
+server/fastcgi/tests/runTest1.php
+server/http/tests/apache_proxygen_headers.php
+server/http/tests/client_blocking_read_test.php
+server/http/tests/codeCoverageTest.php
+server/http/tests/get_headers_secure_dv_array.php
+server/http/tests/globalDocumentTest.php
+server/http/tests/method.php
+server/http/tests/requesIdTest.php
+server/http/tests/rqtrace.php
+server/http/tests/runTest1.php
+server/http/tests/staticContentHeaderTest.php
+server/http/tests/staticContentTest.php
+server/http/tests/takeoverTest.php
+
 # fail apparently due to stale or out of sync tzdata
 slow/dv_array/ext_datetime.php
 slow/ext_date/date_sunrise_test.php
@@ -92,29 +114,7 @@ zend/good/ext/intl/tests/locale_lookup_variant2.php
 zend/good/ext/intl/tests/msgfmt_millisecond_dates.php
 zend/good/ext/mbstring/tests/mb_ereg_replace_variation1.php
 
-# TODO(alexeyt) failures due to pgrep missing from system
-server/debugger/tests/runTest1.php
-server/fastcgi/tests/authDigestTest.php
-server/fastcgi/tests/disable_ini_zend_compat.php
-server/fastcgi/tests/global_variables_server.php
-server/fastcgi/tests/headerTest.php
-server/fastcgi/tests/httpsTest.php
-server/fastcgi/tests/runTest1.php
-server/http/tests/apache_proxygen_headers.php
-server/http/tests/client_blocking_read_test.php
-server/http/tests/codeCoverageTest.php
-server/http/tests/get_headers_secure_dv_array.php
-server/http/tests/globalDocumentTest.php
-server/http/tests/method.php
-server/http/tests/requesIdTest.php
-server/http/tests/rqtrace.php
-server/http/tests/runTest1.php
-server/http/tests/staticContentHeaderTest.php
-server/http/tests/staticContentTest.php
-server/http/tests/takeoverTest.php
-
 # TODO(alexeyt) failures not yet categorized
-server/fastcgi/tests/invalid.php
 slow/coeffects/apc_pure.php
 slow/dom_document/clone.php
 slow/ext_hsl/execve_execvpe.php


### PR DESCRIPTION
Summary: We've decided that these are too flaky (due to needing to start a separate server process, wait for it to come up and bind a port, then try to connect to it, all with a fairly short timeout) and too likely to cause a spurious failure.

Differential Revision: D39946657

