### PR TITLE
Change default CMake build directory to _build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@
 .mkdir
 .DS_Store
 hphp.log
-/build
 /_build
 hphp/hack/_build/
 hphp/hack/cargo_home/

--- a/clang.code-workspace
+++ b/clang.code-workspace
@@ -27,6 +27,7 @@
       "-C",
       "${env:CMAKE_INIT_CACHE}"
     ],
+    "cmake.buildDirectory": "${workspaceFolder}/_build"
   },
   "extensions": {
     "recommendations": [

--- a/hhvm.code-workspace
+++ b/hhvm.code-workspace
@@ -21,6 +21,7 @@
       "-C",
       "${env:CMAKE_INIT_CACHE}"
     ],
+    "cmake.buildDirectory": "${workspaceFolder}/_build"
   },
   "extensions": {
     "recommendations": [


### PR DESCRIPTION
`build` directory is used by `fbcode_builder` in most Meta Platforms' open source project, therefore we should avoid the `build` directory for CMake generated files.

This PR let VS Code's CMake tool uses `_build` directory for CMake generated files.

Test Plan:
1. Create a GitHub Codespace for this PR
2. Open `hhvm.code-workspace`
3. Click the `Configure All Projects` button from VS Code's CMake tool

The `_build` directory should include CMake generated files.