### PR TITLE
Use writeTextFile instead writeTextDir

### DIFF
--- a/hhvm.nix
+++ b/hhvm.nix
@@ -65,7 +65,7 @@
 , unzip
 , uwimap
 , which
-, writeTextDir
+, writeTextFile
 , zlib
 , zstd
 }:
@@ -214,26 +214,23 @@ stdenv.mkDerivation rec {
       "-Wno-error=unused-command-line-argument"
     ];
 
-  CMAKE_INIT_CACHE =
-    let
-      # Use writeTextDir instead of writeTextFile as a workaround of https://github.com/xtruder/nix-devcontainer/issues/9
-      dir = writeTextDir "init-cache.cmake"
+  CMAKE_INIT_CACHE = writeTextFile {
+    name = "init-cache.cmake";
+    text = ''
+      set(ENABLE_SYSTEM_LOCALE_ARCHIVE ON CACHE BOOL "Use system locale archive as the default LOCALE_ARCHIVE for nix patched glibc" FORCE)
+      set(CAN_USE_SYSTEM_ZSTD ON CACHE BOOL "Use system zstd" FORCE)
+      set(HAVE_SYSTEM_TZDATA_PREFIX "${tzdata}/share/zoneinfo" CACHE PATH "The zoneinfo directory" FORCE)
+      set(HAVE_SYSTEM_TZDATA ON CACHE BOOL "Use system zoneinfo" FORCE)
+      set(MYSQL_UNIX_SOCK_ADDR "/run/mysqld/mysqld.sock" CACHE FILEPATH "The MySQL unix socket" FORCE)
+      set(CARGO_EXECUTABLE "${rustNightly.cargo}/bin/cargo" CACHE FILEPATH "The nightly cargo" FORCE)
+      set(RUSTC_EXECUTABLE "${rustNightly.rust}/bin/rustc" CACHE FILEPATH "The nightly rustc" FORCE)
+      ${
+        lib.optionalString hostPlatform.isMacOS ''
+          set(CMAKE_OSX_DEPLOYMENT_TARGET "10.15" CACHE STRING "Targeting macOS version" FORCE)
         ''
-          set(ENABLE_SYSTEM_LOCALE_ARCHIVE ON CACHE BOOL "Use system locale archive as the default LOCALE_ARCHIVE for nix patched glibc" FORCE)
-          set(CAN_USE_SYSTEM_ZSTD ON CACHE BOOL "Use system zstd" FORCE)
-          set(HAVE_SYSTEM_TZDATA_PREFIX "${tzdata}/share/zoneinfo" CACHE PATH "The zoneinfo directory" FORCE)
-          set(HAVE_SYSTEM_TZDATA ON CACHE BOOL "Use system zoneinfo" FORCE)
-          set(MYSQL_UNIX_SOCK_ADDR "/run/mysqld/mysqld.sock" CACHE FILEPATH "The MySQL unix socket" FORCE)
-          set(CARGO_EXECUTABLE "${rustNightly.cargo}/bin/cargo" CACHE FILEPATH "The nightly cargo" FORCE)
-          set(RUSTC_EXECUTABLE "${rustNightly.rust}/bin/rustc" CACHE FILEPATH "The nightly rustc" FORCE)
-          ${
-            lib.optionalString hostPlatform.isMacOS ''
-              set(CMAKE_OSX_DEPLOYMENT_TARGET "10.15" CACHE STRING "Targeting macOS version" FORCE)
-            ''
-          }
-        '';
-    in
-    dir + "/init-cache.cmake";
+      }
+    '';
+  };
 
   cmakeFlags = [ "-C" CMAKE_INIT_CACHE ];
 


### PR DESCRIPTION
`writeTextDir ` was introduced as a workaround for https://github.com/xtruder/nix-devcontainer/issues/9. This PR removes the workaround, because https://github.com/xtruder/nix-devcontainer/issues/9 has been fixed.

## Test Plan:

1. Create a GitHub Codespace for this PR
2. Open `hhvm.code-workspace`

There should be no error like `error: suspicious ownership or permission` as previously reported in https://github.com/xtruder/nix-devcontainer/issues/9 