### PR TITLE
Don't run GitHub Actions on the push event for exported diffs

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -2,6 +2,10 @@ name: Nix CI
 
 on:
   push:
+    branches-ignore:
+      # Exclude the push event for exported diffs, because the CI for export
+      # should have been covered by GitHub Actions triggered by pull requests.
+      - 'export-D+'
   pull_request:
 
 permissions:


### PR DESCRIPTION
Summary: This diff avoids running GitHub Actions on the push event for exported diffs, because the CI for exported diff should have been covered by GitHub Actions triggered by pull requests.

Differential Revision: D40405055

