### PR TITLE
Cancel previously triggered GitHub Actions when a pull request is updated

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -4,6 +4,10 @@ on:
   push:
   pull_request:
 
+concurrency: 
+  group: ${{ github.event_name == 'pull_request' && github.ref || github.run_id }}
+  cancel-in-progress: true
+
 permissions:
   id-token: write
   contents: read


### PR DESCRIPTION
This PR limits the number of concurrent workflow for a pull request to 1. Previously triggered GitHub Actions would be canceled when a pull request is updated, mimicking the internal CI behavior.

See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency about how it works.

## Test Plan:
Checking GitHub Actions, ensuring the setting actually takes effect.