### PR TITLE
Revert "Update flake lock file (#9253)"

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -33,11 +33,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1665723124,
-        "narHash": "sha256-J1JY2cN0L+CNDSrGkNdbiTl2EFV8hpqqsDJFICsYSBw=",
+        "lastModified": 1665387968,
+        "narHash": "sha256-ooKVuc+8zIs58zpMqW3z78qokwN1nkv2Iv6dMqqKjXI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "31d567846255e122846548255101980162bbf641",
+        "rev": "91d1eb9f2a9c4e3c9d68a59f6c0cada8c63d5340",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
This reverts commit 16afd2ac08600c6a2d183ee0a7370f51d0df1cef.


The GitHub Action for #9253 successfully built on `16-core`, while failed on `ubuntu-latest`. The exact root cause is still unknown but this PR tried to revert #9253, trying to mitigate the failure.

## Test Plan

See GitHub Actions, which should pass on both `16-core` and `ubuntu-latest`.