### PR TITLE
Avoid overflow in single line calculation

### DIFF
--- a/hphp/hack/src/parser/lowerer/scour_comment.rs
+++ b/hphp/hack/src/parser/lowerer/scour_comment.rs
@@ -104,7 +104,7 @@ where
                     let start = t.start_offset();
                     let start = start + if text[start] == b'#' { 1 } else { 2 };
                     let end = t.end_offset();
-                    let len = end - start + 1;
+                    let len = end + 1 - start;
                     let p = self.pos_of_offset(start, end);
                     let mut text = self.source_text().sub_as_str(start, len).to_string();
                     text.push('\n');


### PR DESCRIPTION
Running in Rust's debug mode causes a fatal error here due to bounds checks. A simple rearrangement of arithmetic avoids integer overflow.

This should in no way affect production code — it's just a convenience for people hacking on the parser.