### PR TITLE
Rename CMAKE_INIT_CACHE to CMAKE_TOOLCHAIN_FILE

### DIFF
--- a/clang.code-workspace
+++ b/clang.code-workspace
@@ -23,10 +23,6 @@
         ]
       }
     },
-    "cmake.configureArgs": [
-      "-C",
-      "${env:CMAKE_INIT_CACHE}"
-    ],
     "cmake.buildDirectory": "${workspaceFolder}/_build"
   },
   "extensions": {

--- a/flake.nix
+++ b/flake.nix
@@ -39,7 +39,7 @@
                 ];
                 inherit (hhvm)
                   NIX_CFLAGS_COMPILE
-                  CMAKE_INIT_CACHE;
+                  CMAKE_TOOLCHAIN_FILE;
               };
         in
         rec {

--- a/hhvm.code-workspace
+++ b/hhvm.code-workspace
@@ -17,10 +17,6 @@
         "path": "nix-shell"
       }
     },
-    "cmake.configureArgs": [
-      "-C",
-      "${env:CMAKE_INIT_CACHE}"
-    ],
     "cmake.buildDirectory": "${workspaceFolder}/_build"
   },
   "extensions": {

--- a/hhvm.nix
+++ b/hhvm.nix
@@ -214,8 +214,8 @@ stdenv.mkDerivation rec {
       "-Wno-error=unused-command-line-argument"
     ];
 
-  CMAKE_INIT_CACHE = writeTextFile {
-    name = "init-cache.cmake";
+  CMAKE_TOOLCHAIN_FILE = writeTextFile {
+    name = "toolchain.cmake";
     text = ''
       set(ENABLE_SYSTEM_LOCALE_ARCHIVE ON CACHE BOOL "Use system locale archive as the default LOCALE_ARCHIVE for nix patched glibc" FORCE)
       set(CAN_USE_SYSTEM_ZSTD ON CACHE BOOL "Use system zstd" FORCE)
@@ -231,8 +231,6 @@ stdenv.mkDerivation rec {
       }
     '';
   };
-
-  cmakeFlags = [ "-C" CMAKE_INIT_CACHE ];
 
   prePatch = ''
     patchShebangs .


### PR DESCRIPTION
As discussed in the slack channel, `CMAKE_TOOLCHAIN_FILE` is good to be used to specify properties applied to all external projects. Since the existing init cache settings are dependency locations and target OS versions, they should be inherited by external projects. Using `CMAKE_TOOLCHAIN_FILE` makes more sense and it could simplify VS Code settings.

Test Plan:
See GitHub Actions.