### PR TITLE
Enable verbose output from Makefile builds

### DIFF
--- a/hhvm.nix
+++ b/hhvm.nix
@@ -224,6 +224,7 @@ stdenv.mkDerivation rec {
       set(MYSQL_UNIX_SOCK_ADDR "/run/mysqld/mysqld.sock" CACHE FILEPATH "The MySQL unix socket" FORCE)
       set(CARGO_EXECUTABLE "${rustNightly.cargo}/bin/cargo" CACHE FILEPATH "The nightly cargo" FORCE)
       set(RUSTC_EXECUTABLE "${rustNightly.rust}/bin/rustc" CACHE FILEPATH "The nightly rustc" FORCE)
+      set(CMAKE_VERBOSE_MAKEFILE ON CACHE BOOL "Enable verbose output from Makefile builds" FORCE)
       ${
         lib.optionalString hostPlatform.isMacOS ''
           set(CMAKE_OSX_DEPLOYMENT_TARGET "10.15" CACHE STRING "Targeting macOS version" FORCE)


### PR DESCRIPTION
This PR enables verbose output from Makefile builds, especially each command line. The information would be useful to debug compiler cache when trying to figure out which change invalidates the cache.

# Test Plan
The build logs for GitHub Actions should include each command line.
