### PR TITLE
Parse non-fixme /* comments not preceded by newlines

### DIFF
--- a/hphp/hack/src/parser/core/lexer.rs
+++ b/hphp/hack/src/parser/core/lexer.rs
@@ -1979,7 +1979,7 @@ where
                         acc.push(t);
                         return acc;
                     }
-                    TriviaKind::FixMe | TriviaKind::IgnoreError => {
+                    TriviaKind::FixMe | TriviaKind::IgnoreError | TriviaKind::DelimitedComment => {
                         return acc;
                     }
                     _ => {


### PR DESCRIPTION
This fixes an issue where the contents of `/* ... */` comments are swallowed when they appear on the same line as the previous token.

```hack
function foo(string $a): void {
        // this currently works
	echo(
		/* HH_NOT_A_FIXME[4110] */ $a as nonnull);

	// this currently does not work
	echo(/* HH_NOT_A_FIXME[4110] */ $a as nonnull);
}
```