### PR TITLE
Don't run nix-flake-update in forked repository

### DIFF
--- a/.github/workflows/nix-flake-update.yml
+++ b/.github/workflows/nix-flake-update.yml
@@ -6,7 +6,7 @@ permissions:
 
 jobs:
   nix-flake-update:
-    if: github.repository != 'hhvm/hhvm-staging'
+    if: github.repository == 'facebook/hhvm'
     permissions:
       # for aws-actions/configure-aws-credentials to assume an AWS role
       id-token: write


### PR DESCRIPTION
The purpose of the GitHub Action workflow `nix-flake-update` is to build HHVM with latest nixpkgs dependencies in a pull request, so we could know if there is any security updates or breaking changes in nix dependencies.

However it cannot be triggered in forked repositories because the deploy SSH private key used is for `facebook/hhvm` only. Therefore it is useless for forked repositories.

This PR disables it in forked repositories.

Test Plan:
The GitHub Action workflow `nix-flake-update`  should not be triggered in a forked repository any more once the forked repository sync its default branch to a commit including this PR.