### PR TITLE
Exclude test slow/ext_apc/apc_expire.php

### DIFF
--- a/hphp/test/cmake_builds_excluded_tests
+++ b/hphp/test/cmake_builds_excluded_tests
@@ -115,6 +115,9 @@ slow/ext_zlib/zip_stream.php
 slow/ext_zlib/ziparchive_setencryption.php
 zend/good/ext/zip/tests/bug53885.php
 
+# TODO(atry) a flaky test
+slow/ext_apc/apc_expire.php
+
 # TODO(alexeyt) failures not yet categorized
 slow/coeffects/apc_pure.php
 slow/dom_document/clone.php

--- a/hphp/test/github_excluded_tests
+++ b/hphp/test/github_excluded_tests
@@ -134,6 +134,9 @@ slow/coeffects/closure-inherit-2.php
 # TODO(atry) the CAA record for google.com is flaky (maybe network issue?)
 slow/ext_network/dns_get_record_caa.php
 
+# TODO(atry) another flaky test
+slow/ext_apc/apc_expire.php
+
 # TODO(alexeyt) failures not yet categorized
 slow/coeffects/apc_pure.php
 slow/dom_document/clone.php


### PR DESCRIPTION
The test is flaky according to https://github.com/facebook/hhvm/actions/runs/3366655755/jobs/5583775098 . This PR removes it.

## Test Plan
There should be no failure due to slow/ext_apc/apc_expire.php in further GitHub Action runs