### PR TITLE
always use extent hook when using jemalloc

### DIFF
--- a/hphp/runtime/server/http-server.cpp
+++ b/hphp/runtime/server/http-server.cpp
@@ -238,7 +238,8 @@ void HttpServer::onServerShutdown() {
 #ifdef USE_JEMALLOC
   shutdown_slab_managers();
 #if USE_JEMALLOC_EXTENT_HOOKS
-  if (use_lowptr && HPHP::alloc::BumpEmergencyMapper::s_emergencyFlag.test()) {
+  if (HPHP::alloc::BumpEmergencyMapper::
+      s_emergencyFlag.load(std::memory_order_acquire)) {
     // Server is shutting down when it almost exhausted low memory.
     if (StructuredLog::enabled()) {
       auto record = StructuredLogEntry{};

--- a/hphp/util/alloc-defs.h
+++ b/hphp/util/alloc-defs.h
@@ -34,8 +34,7 @@
 #if (JEMALLOC_VERSION_MAJOR < 5)
 #  error "jemalloc 5 is required"
 #endif
-#if defined(USE_LOWPTR) && defined(__linux__) \
-  && !defined(USE_JEMALLOC_EXTENT_HOOKS)
+#if defined(__linux__) && !defined(USE_JEMALLOC_EXTENT_HOOKS)
 #  define USE_JEMALLOC_EXTENT_HOOKS 1
 #endif
 #endif

--- a/hphp/util/bump-mapper.cpp
+++ b/hphp/util/bump-mapper.cpp
@@ -216,7 +216,7 @@ bool BumpFileMapper::addMappingImpl() {
   return true;
 }
 
-std::atomic_flag BumpEmergencyMapper::s_emergencyFlag = ATOMIC_FLAG_INIT;
+std::atomic_bool BumpEmergencyMapper::s_emergencyFlag{false};
 
 bool BumpEmergencyMapper::addMappingImpl() {
   auto _ = m_state.lock();
@@ -226,7 +226,7 @@ bool BumpEmergencyMapper::addMappingImpl() {
   mprotect(reinterpret_cast<void*>(low), high - low,
            PROT_READ | PROT_WRITE);
   m_state.low_map.store(high, std::memory_order_release);
-  s_emergencyFlag.test_and_set();
+  s_emergencyFlag.store(true, std::memory_order_release);
   if (m_exit) m_exit();
   return true;
 }

--- a/hphp/util/bump-mapper.h
+++ b/hphp/util/bump-mapper.h
@@ -177,7 +177,7 @@ struct BumpEmergencyMapper : public RangeMapper {
   explicit BumpEmergencyMapper(ExitFun&& exitFn, Args&&... args)
     : RangeMapper(std::forward<Args>(args)...)
     , m_exit(exitFn) {}
-  static std::atomic_flag s_emergencyFlag;
+  static std::atomic_bool s_emergencyFlag;
  protected:
   Direction direction() const override { return Direction::LowToHigh; }
   bool addMappingImpl() override;


### PR DESCRIPTION
Summary: This way, some huge pages can be used in non-lowptr mode.

Reviewed By: ottoni

Differential Revision: D39220017

