### PR TITLE
Allow optional newline in OpenSSL output

### DIFF
--- a/hphp/runtime/ext/openssl/ext_openssl.cpp
+++ b/hphp/runtime/ext/openssl/ext_openssl.cpp
@@ -1907,7 +1907,7 @@ Array HHVM_FUNCTION(openssl_pkey_get_details, const Resource& key) {
   case EVP_PKEY_RSA2:
     {
       ktype = OPENSSL_KEYTYPE_RSA;
-      RSA *rsa = EVP_PKEY_get0_RSA(pkey);
+      auto rsa = EVP_PKEY_get0_RSA(pkey);
       assertx(rsa);
       const BIGNUM *n, *e, *d, *p, *q, *dmp1, *dmq1, *iqmp;
       RSA_get0_key(rsa, &n, &e, &d);
@@ -1930,7 +1930,7 @@ Array HHVM_FUNCTION(openssl_pkey_get_details, const Resource& key) {
   case EVP_PKEY_DSA4:
     {
       ktype = OPENSSL_KEYTYPE_DSA;
-      DSA *dsa = EVP_PKEY_get0_DSA(pkey);
+      auto dsa = EVP_PKEY_get0_DSA(pkey);
       assertx(dsa);
       const BIGNUM *p, *q, *g, *pub_key, *priv_key;
       DSA_get0_pqg(dsa, &p, &q, &g);
@@ -1946,7 +1946,7 @@ Array HHVM_FUNCTION(openssl_pkey_get_details, const Resource& key) {
   case EVP_PKEY_DH:
     {
       ktype = OPENSSL_KEYTYPE_DH;
-      DH *dh = EVP_PKEY_get0_DH(pkey);
+      auto dh = EVP_PKEY_get0_DH(pkey);
       assertx(dh);
       const BIGNUM *p, *q, *g, *pub_key, *priv_key;
       DH_get0_pqg(dh, &p, &q, &g);
@@ -2060,11 +2060,17 @@ bool HHVM_FUNCTION(openssl_private_decrypt, const String& data,
   switch (EVP_PKEY_id(pkey)) {
   case EVP_PKEY_RSA:
   case EVP_PKEY_RSA2:
-    cryptedlen = RSA_private_decrypt(data.size(),
-                                     (unsigned char *)data.data(),
-                                     cryptedbuf,
-                                     EVP_PKEY_get0_RSA(pkey),
-                                     padding);
+    {
+      auto rsa = EVP_PKEY_get1_RSA(pkey);
+      SCOPE_EXIT {
+        RSA_free(rsa);
+      };
+      cryptedlen = RSA_private_decrypt(data.size(),
+                                      (unsigned char *)data.data(),
+                                      cryptedbuf,
+                                      rsa,
+                                      padding);
+    }
     if (cryptedlen != -1) {
       successful = 1;
     }
@@ -2100,11 +2106,17 @@ bool HHVM_FUNCTION(openssl_private_encrypt, const String& data,
   switch (EVP_PKEY_id(pkey)) {
   case EVP_PKEY_RSA:
   case EVP_PKEY_RSA2:
-    successful = (RSA_private_encrypt(data.size(),
-                                      (unsigned char *)data.data(),
-                                      cryptedbuf,
-                                      EVP_PKEY_get0_RSA(pkey),
-                                      padding) == cryptedlen);
+    {
+      auto rsa = EVP_PKEY_get1_RSA(pkey);
+      SCOPE_EXIT {
+        RSA_free(rsa);
+      };
+      successful = (RSA_private_encrypt(data.size(),
+                                        (unsigned char *)data.data(),
+                                        cryptedbuf,
+                                        rsa,
+                                        padding) == cryptedlen);
+    }
     break;
   default:
     raise_warning("key type not supported");
@@ -2136,11 +2148,17 @@ bool HHVM_FUNCTION(openssl_public_decrypt, const String& data,
   switch (EVP_PKEY_id(pkey)) {
   case EVP_PKEY_RSA:
   case EVP_PKEY_RSA2:
-    cryptedlen = RSA_public_decrypt(data.size(),
-                                    (unsigned char *)data.data(),
-                                    cryptedbuf,
-                                    EVP_PKEY_get0_RSA(pkey),
-                                    padding);
+    {
+      auto rsa = EVP_PKEY_get1_RSA(pkey);
+      SCOPE_EXIT {
+        RSA_free(rsa);
+      };
+      cryptedlen = RSA_public_decrypt(data.size(),
+                                      (unsigned char *)data.data(),
+                                      cryptedbuf,
+                                      rsa,
+                                      padding);
+    }
     if (cryptedlen != -1) {
       successful = 1;
     }
@@ -2176,11 +2194,17 @@ bool HHVM_FUNCTION(openssl_public_encrypt, const String& data,
   switch (EVP_PKEY_id(pkey)) {
   case EVP_PKEY_RSA:
   case EVP_PKEY_RSA2:
-    successful = (RSA_public_encrypt(data.size(),
-                                     (unsigned char *)data.data(),
-                                     cryptedbuf,
-                                     EVP_PKEY_get0_RSA(pkey),
-                                     padding) == cryptedlen);
+    {
+      auto rsa = EVP_PKEY_get1_RSA(pkey);
+      SCOPE_EXIT {
+        RSA_free(rsa);
+      };
+      successful = (RSA_public_encrypt(data.size(),
+                                      (unsigned char *)data.data(),
+                                      cryptedbuf,
+                                      rsa,
+                                      padding) == cryptedlen);
+    }
     break;
   default:
     raise_warning("key type not supported");

--- a/hphp/runtime/ext/openssl/ext_openssl.cpp
+++ b/hphp/runtime/ext/openssl/ext_openssl.cpp
@@ -28,6 +28,9 @@
 #include <openssl/conf.h>
 #include <openssl/pem.h>
 #include <openssl/pkcs12.h>
+#if defined(OPENSSL_VERSION_MAJOR) && (OPENSSL_VERSION_MAJOR >= 3)
+#include <openssl/provider.h>
+#endif
 #include <openssl/rand.h>
 #include <vector>
 
@@ -65,6 +68,12 @@ struct OpenSSLInitializer {
     ERR_load_ERR_strings();
     ERR_load_crypto_strings();
     ERR_load_EVP_strings();
+
+// RC4 is only available in legacy providers
+#if defined(OPENSSL_VERSION_MAJOR) && (OPENSSL_VERSION_MAJOR >= 3)
+    OSSL_PROVIDER_load(nullptr, "default");
+    OSSL_PROVIDER_load(nullptr, "legacy");
+#endif
 
     /* Determine default SSL configuration file */
     char *config_filename = getenv("OPENSSL_CONF");

--- a/hphp/test/slow/ext_openssl/openssl_x509_parse_basic.php.expectf
+++ b/hphp/test/slow/ext_openssl/openssl_x509_parse_basic.php.expectf
@@ -105,10 +105,9 @@ dict(13) {
     ["subjectKeyIdentifier"]=>
     string(59) "DB:7E:40:72:BD:5C:35:85:EC:29:29:81:12:E8:62:68:6A:B7:3F:7D"
     ["authorityKeyIdentifier"]=>
-    string(202) "keyid:DB:7E:40:72:BD:5C:35:85:EC:29:29:81:12:E8:62:68:6A:B7:3F:7D
+    string(%d) "keyid:DB:7E:40:72:BD:5C:35:85:EC:29:29:81:12:E8:62:68:6A:B7:3F:7D
 DirName:/C=BR/ST=Rio Grande do Sul/L=Porto Alegre/CN=Henrique do N. Angelo/emailAddress=hnangelo@php.net
-serial:AE:C5:56:CC:72:37:50:A2
-"
+serial:AE:C5:56:CC:72:37:50:A2%w"
     ["basicConstraints"]=>
     string(7) "CA:TRUE"
   }
@@ -220,10 +219,9 @@ dict(13) {
     ["subjectKeyIdentifier"]=>
     string(59) "DB:7E:40:72:BD:5C:35:85:EC:29:29:81:12:E8:62:68:6A:B7:3F:7D"
     ["authorityKeyIdentifier"]=>
-    string(202) "keyid:DB:7E:40:72:BD:5C:35:85:EC:29:29:81:12:E8:62:68:6A:B7:3F:7D
+    string(%d) "keyid:DB:7E:40:72:BD:5C:35:85:EC:29:29:81:12:E8:62:68:6A:B7:3F:7D
 DirName:/C=BR/ST=Rio Grande do Sul/L=Porto Alegre/CN=Henrique do N. Angelo/emailAddress=hnangelo@php.net
-serial:AE:C5:56:CC:72:37:50:A2
-"
+serial:AE:C5:56:CC:72:37:50:A2%w"
     ["basicConstraints"]=>
     string(7) "CA:TRUE"
   }

--- a/hphp/test/zend/good/ext/openssl/tests/bug28382.php.expectf
+++ b/hphp/test/zend/good/ext/openssl/tests/bug28382.php.expectf
@@ -6,8 +6,7 @@ dict(11) {
   ["nsCertType"]=>
   string(30) "SSL Client, SSL Server, S/MIME"
   ["crlDistributionPoints"]=>
-  string(%d) "%AURI:http://mobile.blue-software.ro:90/ca/crl.shtml
-"
+  string(%d) "%AURI:http://mobile.blue-software.ro:90/ca/crl.shtml%w"
   ["nsCaPolicyUrl"]=>
   string(38) "http://mobile.blue-software.ro:90/pub/"
   ["subjectAltName"]=>
@@ -15,9 +14,8 @@ dict(11) {
   ["subjectKeyIdentifier"]=>
   string(59) "B0:A7:FF:F9:41:15:DE:23:39:BD:DD:31:0F:97:A0:B2:A2:74:E0:FC"
   ["authorityKeyIdentifier"]=>
-  string(115) "DirName:/C=RO/ST=Romania/L=Craiova/O=Sergiu/OU=Sergiu SRL/CN=Sergiu CA/emailAddress=n_sergiu@hotmail.com
-serial:00
-"
+  string(%d) "DirName:/C=RO/ST=Romania/L=Craiova/O=Sergiu/OU=Sergiu SRL/CN=Sergiu CA/emailAddress=n_sergiu@hotmail.com
+serial:00%w"
   ["keyUsage"]=>
   string(71) "Digital Signature, Non Repudiation, Key Encipherment, Data Encipherment"
   ["nsBaseUrl"]=>

--- a/hphp/test/zend/good/ext/openssl/tests/cve2013_4073.php.expectf
+++ b/hphp/test/zend/good/ext/openssl/tests/cve2013_4073.php.expectf
@@ -2,6 +2,5 @@ dict [
   'basicConstraints' => 'CA:FALSE',
   'subjectKeyIdentifier' => '88:5A:55:C0:52:FF:61:CD:52:A3:35:0F:EA:5A:9C:24:38:22:F7:5C',
   'keyUsage' => 'Digital Signature, Non Repudiation, Key Encipherment',
-  'subjectAltName' => 'DNS:altnull.python.org' . "\0" . 'example.com, email:null@python.org' . "\0" . 'user@example.org, URI:http://null.python.org' . "\0" . 'http://example.org, IP Address:192.0.2.1, IP Address:2001:DB8:0:0:0:0:0:1
-',
+  'subjectAltName' => 'DNS:altnull.python.org' . "\0" . 'example.com, email:null@python.org' . "\0" . 'user@example.org, URI:http://null.python.org' . "\0" . 'http://example.org, IP Address:192.0.2.1, IP Address:2001:DB8:0:0:0:0:0:1%w',
 ]


### PR DESCRIPTION
Summary: OpenSSL 3 does not include the trailing newline in its output. This diff adjust `expectf` so that it is now compatible with both OpenSSL 1.1 and 3.0.

Differential Revision: D40942191

