### PR TITLE
Load the legacy providers from OpenSSL 3

### DIFF
--- a/hphp/runtime/ext/openssl/ext_openssl.cpp
+++ b/hphp/runtime/ext/openssl/ext_openssl.cpp
@@ -28,6 +28,9 @@
 #include <openssl/conf.h>
 #include <openssl/pem.h>
 #include <openssl/pkcs12.h>
+#if defined(OPENSSL_VERSION_MAJOR) && (OPENSSL_VERSION_MAJOR >= 3)
+#include <openssl/provider.h>
+#endif
 #include <openssl/rand.h>
 #include <vector>
 
@@ -65,6 +68,12 @@ struct OpenSSLInitializer {
     ERR_load_ERR_strings();
     ERR_load_crypto_strings();
     ERR_load_EVP_strings();
+
+// RC4 is only available in legacy providers
+#if defined(OPENSSL_VERSION_MAJOR) && (OPENSSL_VERSION_MAJOR >= 3)
+    OSSL_PROVIDER_load(nullptr, "default");
+    OSSL_PROVIDER_load(nullptr, "legacy");
+#endif
 
     /* Determine default SSL configuration file */
     char *config_filename = getenv("OPENSSL_CONF");


### PR DESCRIPTION
Summary:
`openssl_seal` is by default using RC4. However RC4 is only available from the legacy providers in OpenSSL 3, which is not loaded by default.

This diff loads the legacy providers so that `openssl_seal` will not fail with default parameters.

See https://www.openssl.org/docs/man3.0/man7/crypto.html#:~:text=md_whirlpool)%3B%0AEVP_MD_free(md_sha256)%3B-,OPENSSL%20PROVIDERS,-OpenSSL%20comes%20with for providers in OpenSSL 3

## Internal:
We should also consider removing the default value `'RC4'` from `openssl_seal` like [what PHP 8.0 did](https://www.php.net/manual/en/function.openssl-seal.php), because RC4 is vulnerable.

Differential Revision: D40942189

