### PR TITLE
Avoid unnecessary intermediate copy of e in chainExecutor

### DIFF
--- a/third-party/folly/src/folly/futures/Future-inl.h
+++ b/third-party/folly/src/folly/futures/Future-inl.h
@@ -393,7 +393,7 @@ Future<T> chainExecutor(Executor::KeepAlive<> e, SemiFuture<T>&& f) {
   if (!e) {
     e = folly::getKeepAliveToken(InlineExecutor::instance());
   }
-  return std::move(f).via(e);
+  return std::move(f).via(std::move(e));
 }
 
 // Variant: returns a Future


### PR DESCRIPTION
Differential Revision: D41686536

