### PR TITLE
update hack cmake to resolve build breakage on certain cmake versions

### DIFF
--- a/hphp/hack/CMakeLists.txt
+++ b/hphp/hack/CMakeLists.txt
@@ -293,11 +293,8 @@ function(build_cxx_bridge NAME)
       "${NAME}_rust_part"
       ${CXX_BRIDGE_LINK_LIBS}
   )
-  # `-iquote` is like `-I` (or target_include_directories()`), except:
-  # - it takes precedence over `-I`
-  # - it only applies to `#include "foo"`, not `#include <foo>`
-  target_compile_options("${NAME}" INTERFACE "-iquote" "${RUST_FFI_BUILD_ROOT}")
-  target_compile_options("${NAME}" PRIVATE "-iquote" "${GENERATED_CXXBRIDGE}")
+  target_include_directories("${NAME}" INTERFACE "${RUST_FFI_BUILD_ROOT}")
+  target_include_directories("${NAME}" PRIVATE "${GENERATED_CXXBRIDGE}")
 endfunction()
 
 build_cxx_bridge(


### PR DESCRIPTION
This resolves a build failure which occurs on Ubuntu 18.04 with cmake 3.10. It may occur on other distros and with other cmake versions as well. The error is:
```
16:25:25 [ 25%] Building CXX object hphp/hack/CMakeFiles/compiler_ffi.dir/src/hackc/ffi_bridge/external_decl_provider.cpp.o
16:25:25 In file included from /build/hhvm/hphp/hack/src/hackc/ffi_bridge/external_decl_provider.cpp:7:0:
16:25:25 /build/hhvm/hphp/hack/src/hackc/ffi_bridge/decl_provider.h:9:10: fatal error: hphp/hack/src/hackc/ffi_bridge/compiler_ffi.rs.h: No such file or directory
16:25:25  #include "hphp/hack/src/hackc/ffi_bridge/compiler_ffi.rs.h"
```

Using `CMAKE_VERBOSE_MAKEFILE`, the compilation command for `external_decl_provider.cpp` ends in:
```
-iquote /build/hhvm/hphp/hack/_build/rust_ffi/hphp/hack/src/hackc/ffi_bridge/cxxbridge /build/hhvm/hphp/hack/_build/rust_ffi -o CMakeFiles/compiler_ffi.dir/src/hackc/ffi_bridge/external_decl_provider.cpp.o -c /build/hhvm/hphp/hack/src/hackc/ffi_bridge/external_decl_provider.cpp
```

The `-iquote` option is [deduplicated](https://cmake.org/cmake/help/latest/command/target_compile_options.html#option-de-duplication), but this deduplication breaks the compilation and the necessary directory is not included. 

However, my understanding is that this `-iquote` was put in place from a time when HHVM was importing `.rs` files directly, and after [this commit](https://github.com/facebook/hhvm/commit/b5ff41260534ee006e299d6b217603f580d195f8) we shouldn't need to use `target_compile_options()` like this anymore and can use `target_include_directories()` instead.

I confirmed that this commit resolves that error.