### PR TITLE
feat: add HostBreakpoint support for AArch64

### DIFF
--- a/hphp/vixl/platform.h
+++ b/hphp/vixl/platform.h
@@ -43,7 +43,7 @@ inline void HostBreakpoint() {
   __debugbreak();
 #elif defined(__AARCH64EL__)
   // TODO: Implement HostBreakpoint on a64.
-  not_implemented();
+  asm("brk #0xCC")
 #else
 # error How do you set a host breakpoint on your architecture?
 #endif


### PR DESCRIPTION
AArch64 supports the [`brk`](https://developer.arm.com/documentation/dui0802/b/A64-General-Instructions/BRK) instruction for breakpoints, like so:

```
BRK  #imm
```

where imm is an unsigned immediate from 0 to 65535.

For consistency, the value of the breakpoint here has been set to 0xCC.