### PR TITLE
ZipArchive::getFromIndex: return a nullable string

### DIFF
--- a/hphp/hack/hhi/stdlib/builtins_zip.hhi
+++ b/hphp/hack/hhi/stdlib/builtins_zip.hhi
@@ -112,7 +112,7 @@ class ZipArchive {
     int $index,
     int $length = 0,
     int $flags = 0,
-  ): string;
+  ): ?string;
   public function getFromName(
     string $name,
     int $length = 0,

--- a/hphp/runtime/ext/zip/ext_zip.cpp
+++ b/hphp/runtime/ext/zip/ext_zip.cpp
@@ -913,7 +913,7 @@ static Variant HHVM_METHOD(ZipArchive, getFromIndex, int64_t index,
 
   struct zip_stat zipStat;
   if (zip_stat_index(zipDir->getZip(), index, 0, &zipStat) != 0) {
-    return false;
+    return Variant{Variant::NullInit{}};
   }
 
   if (zipStat.size < 1) {

--- a/hphp/runtime/ext/zip/ext_zip.php
+++ b/hphp/runtime/ext/zip/ext_zip.php
@@ -166,12 +166,12 @@ class ZipArchive {
    *   following values may be ORed to it.    ZipArchive::FL_UNCHANGED
    *   ZipArchive::FL_COMPRESSED
    *
-   * @return string - Returns the contents of the entry on success.
+   * @return string - Returns the contents of the entry on success. null on error.
    */
   <<__Native>>
   public function getFromIndex(int $index,
                         int $length = 0,
-                        int $flags = 0): mixed;
+                        int $flags = 0): ?string;
 
   /**
    * Returns the entry contents using its name

--- a/hphp/test/slow/ext_zip/can_manipulate_with_index.php
+++ b/hphp/test/slow/ext_zip/can_manipulate_with_index.php
@@ -1,0 +1,31 @@
+<?hh
+
+// Create test ZIP file
+<<__EntryPoint>>
+function main_write_after_read_works() {
+  $tempfile = __SystemLib\hphp_test_tmppath('hello.zip');
+  $zip_setup = new ZipArchive();
+  $zip_setup->open($tempfile, ZipArchive::OVERWRITE | ZipArchive::CREATE);
+  $zip_setup->addFromString('hello.txt', 'Value here');
+  $zip_setup->addFromString('hello2.txt', 'Other value here');
+  $zip_setup->close();
+
+  // Load the file fresh to modify it
+  $zip = new ZipArchive();
+  $zip->open($tempfile);
+
+  // Get the 2 strings.
+  echo 'First section: ', $zip->getFromIndex(0), "\n";
+  echo 'Second section: ', $zip->getFromIndex(1), "\n";
+  echo 'Third section: ', var_dump($zip->getFromIndex(2));
+
+  // Remove first.
+  echo "\nRemoving first section\n";
+  $zip->deleteIndex(0);
+  echo 'First section: ', var_dump($zip->getFromIndex(0));
+  echo 'Second section: ', $zip->getFromIndex(1), "\n";
+  echo 'Third section: ', var_dump($zip->getFromIndex(2));
+
+  $zip->close();
+  unlink($tempfile);
+}

--- a/hphp/test/slow/ext_zip/can_manipulate_with_index.php.expectf
+++ b/hphp/test/slow/ext_zip/can_manipulate_with_index.php.expectf
@@ -1,0 +1,8 @@
+First section: Value here
+Second section: Other value here
+Third section: NULL
+
+Removing first section
+First section: NULL
+Second section: Other value here
+Third section: NULL


### PR DESCRIPTION
This updates this function to return null instead of false on error. This allows typing the return as `?string` instead of `mixed`.

Also fixed a return mismatch between builtins_zip.hhi and the extension that was reported by some Slack engineer.