### PR TITLE
Upgrading to clap 4 and new rustyrepl version

### DIFF
--- a/hphp/hack/src/Cargo.lock
+++ b/hphp/hack/src/Cargo.lock
@@ -253,7 +253,7 @@ dependencies = [
  "slab",
  "socket2",
  "waker-fn",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -281,7 +281,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.16",
  "libc",
  "winapi",
 ]
@@ -629,16 +629,34 @@ checksum = "29e724a68d9319343bb3328c9cc2dfde263f4b3142ee1059a9980580171c954b"
 dependencies = [
  "atty",
  "bitflags",
- "clap_derive",
- "clap_lex",
+ "clap_derive 3.2.17",
+ "clap_lex 0.2.2",
  "indexmap",
  "once_cell",
  "regex",
  "strsim 0.10.0",
  "termcolor",
- "terminal_size",
+ "terminal_size 0.1.17",
  "textwrap 0.15.0",
  "unicase",
+]
+
+[[package]]
+name = "clap"
+version = "4.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f13b9c79b5d1dd500d20ef541215a6423c75829ef43117e1b4d17fd8af0b5d76"
+dependencies = [
+ "bitflags",
+ "clap_derive 4.1.0",
+ "clap_lex 0.3.0",
+ "is-terminal",
+ "once_cell",
+ "strsim 0.10.0",
+ "termcolor",
+ "terminal_size 0.2.1",
+ "unicase",
+ "unicode-width",
 ]
 
 [[package]]
@@ -655,10 +673,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_derive"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "684a277d672e91966334af371f1a7b5833f9aa00b07c84e92fbce95e00208ce8"
+dependencies = [
+ "heck 0.4.0",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "clap_lex"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5538cd660450ebeb4234cfecf8f2284b844ffc4c50531e66d584ad5b91293613"
+dependencies = [
+ "os_str_bytes",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
 dependencies = [
  "os_str_bytes",
 ]
@@ -704,7 +744,7 @@ dependencies = [
  "bstr 1.0.1",
  "bumpalo",
  "bytecode_printer",
- "clap 3.2.17",
+ "clap 4.1.4",
  "decl_provider",
  "elaborate_namespaces_visitor",
  "emit_unit",
@@ -790,7 +830,7 @@ dependencies = [
  "encode_unicode",
  "lazy_static",
  "libc",
- "terminal_size",
+ "terminal_size 0.1.17",
  "unicode-width",
  "winapi",
 ]
@@ -1608,6 +1648,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "errno"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14ca354e36190500e1e1fb267c647932382b54053c50b14970856c0b00a35067"
+dependencies = [
+ "gcc",
+ "libc",
+]
+
+[[package]]
 name = "error"
 version = "0.0.0"
 dependencies = [
@@ -1885,6 +1946,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "gcc"
+version = "0.3.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
+
+[[package]]
 name = "gen_hhi_contents_lib"
 version = "0.0.0"
 
@@ -1992,7 +2059,7 @@ dependencies = [
  "bumpalo",
  "byte-unit",
  "bytecode_printer",
- "clap 3.2.17",
+ "clap 4.1.4",
  "compile",
  "decl_parser",
  "decl_provider",
@@ -2176,6 +2243,12 @@ checksum = "4c30f6d0bc6b00693347368a67d41b58f2fb851215ff1da49e90fe2c5c667151"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "hermit-abi"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "856b5cb0902c2b6d65d5fd97dfa30f9b70c7538e770b98eab5ed52d8db923e01"
 
 [[package]]
 name = "hex"
@@ -2378,7 +2451,7 @@ name = "hhvm_options"
 version = "0.0.0"
 dependencies = [
  "anyhow",
- "clap 3.2.17",
+ "clap 4.1.4",
  "hdf",
  "hhvm_runtime_options",
 ]
@@ -2505,6 +2578,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-lifetimes"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ea37f355c05dde75b84bba2d767906ad522e97cd9e2eef2be7a4ab7fb442c06"
+
+[[package]]
+name = "io-lifetimes"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1abeb7a0dd0f8181267ff8adc397075586500b81b28a73e8a0208b00fc170fb3"
+dependencies = [
+ "libc",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
 name = "ir"
 version = "0.0.0"
 dependencies = [
@@ -2551,6 +2640,18 @@ dependencies = [
  "log",
  "smallvec",
  "stack_depth",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0a45d56fe973d6db23972bf5bc46f988a4a2385deac9cc29572f09daef"
+dependencies = [
+ "hermit-abi 0.3.0",
+ "io-lifetimes 1.0.5",
+ "rustix 0.36.8",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -2693,6 +2794,18 @@ dependencies = [
  "rc_pos",
  "serde",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.0.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4d2456c373231a208ad294c33dc5bff30051eafd954cd4caae83a712b12854d"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
 
 [[package]]
 name = "lock_api"
@@ -3140,7 +3253,7 @@ version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.16",
  "libc",
 ]
 
@@ -3454,7 +3567,7 @@ dependencies = [
  "libc",
  "redox_syscall 0.2.10",
  "smallvec",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -4226,6 +4339,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "0.35.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72c825b8aa8010eb9ee99b75f05e10180b9278d161583034d7574c9d617aeada"
+dependencies = [
+ "bitflags",
+ "errno",
+ "io-lifetimes 0.7.3",
+ "libc",
+ "linux-raw-sys 0.0.46",
+ "windows-sys 0.36.1",
+]
+
+[[package]]
+name = "rustix"
+version = "0.36.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f43abb88211988493c1abb44a70efa56ff0ce98f233b7b276146f1f3f7ba9644"
+dependencies = [
+ "bitflags",
+ "errno",
+ "io-lifetimes 1.0.5",
+ "libc",
+ "linux-raw-sys 0.1.4",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4824,6 +4965,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "terminal_size"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8440c860cf79def6164e4a0a983bcc2305d82419177a0e0c71930d049e3ac5a1"
+dependencies = [
+ "rustix 0.35.9",
+ "windows-sys 0.36.1",
+]
+
+[[package]]
 name = "tests"
 version = "0.0.0"
 dependencies = [
@@ -4884,7 +5035,7 @@ version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 dependencies = [
- "terminal_size",
+ "terminal_size 0.1.17",
  "unicode-width",
 ]
 
@@ -4968,7 +5119,7 @@ dependencies = [
  "bytes",
  "memchr",
  "pin-project-lite",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -5372,16 +5523,53 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
+dependencies = [
+ "windows_aarch64_msvc 0.36.1",
+ "windows_i686_gnu 0.36.1",
+ "windows_i686_msvc 0.36.1",
+ "windows_x86_64_gnu 0.36.1",
+ "windows_x86_64_msvc 0.36.1",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
+ "windows_aarch64_msvc 0.42.1",
+ "windows_i686_gnu 0.42.1",
+ "windows_i686_msvc 0.42.1",
+ "windows_x86_64_gnu 0.42.1",
  "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_x86_64_msvc 0.42.1",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2522491fbfcd58cc84d47aeb2958948c4b8982e9a2d8a2a35bbaed431390e7"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc 0.42.1",
+ "windows_i686_gnu 0.42.1",
+ "windows_i686_msvc 0.42.1",
+ "windows_x86_64_gnu 0.42.1",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc 0.42.1",
 ]
 
 [[package]]
@@ -5392,9 +5580,21 @@ checksum = "8c9864e83243fdec7fc9c5444389dcbbfd258f745e7853198f365e3c4968a608"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c8b1b673ffc16c47a9ff48570a9d85e25d265735c503681332589af6253c6c7"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5404,9 +5604,21 @@ checksum = "de3887528ad530ba7bdbb1faa8275ec7a1155a45ffa57c37993960277145d640"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf4d1122317eddd6ff351aa852118a2418ad4214e6613a50e0191f7004372605"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -5419,6 +5631,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "628bfdf232daa22b0d64fdb62b09fcc36bb01f05a3939e20ab73aaf9470d0463"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/hphp/hack/src/hackc/Cargo.toml
+++ b/hphp/hack/src/hackc/Cargo.toml
@@ -16,7 +16,7 @@ bc_to_ir = { path = "ir/conversions/bc_to_ir" }
 bumpalo = { version = "3.11.1", features = ["collections"] }
 byte-unit = "4.0.14"
 bytecode_printer = { path = "bytecode_printer" }
-clap = { version = "3.2.17", features = ["derive", "env", "regex", "unicode", "wrap_help"] }
+clap = { version = "4.1.4", features = ["derive", "env", "string", "unicode", "wrap_help"] }
 compile = { path = "compile/cargo/compile" }
 decl_parser = { path = "../hackrs/decl_parser/cargo/decl_parser" }
 decl_provider = { path = "decl_provider" }

--- a/hphp/hack/src/hackc/compile/cargo/compile/Cargo.toml
+++ b/hphp/hack/src/hackc/compile/cargo/compile/Cargo.toml
@@ -14,7 +14,7 @@ bc_to_ir = { path = "../../../ir/conversions/bc_to_ir" }
 bstr = { version = "1.0", features = ["serde", "std", "unicode"] }
 bumpalo = { version = "3.11.1", features = ["collections"] }
 bytecode_printer = { path = "../../../bytecode_printer" }
-clap = { version = "3.2.17", features = ["derive", "env", "regex", "unicode", "wrap_help"] }
+clap = { version = "4.1.4", features = ["derive", "env", "string", "unicode", "wrap_help"] }
 decl_provider = { path = "../../../decl_provider" }
 elaborate_namespaces_visitor = { path = "../../../../naming/cargo/elaborate_namespaces" }
 emit_unit = { path = "../../../emitter/cargo/emit_unit" }

--- a/hphp/hack/src/hackc/compile/compile.rs
+++ b/hphp/hack/src/hackc/compile/compile.rs
@@ -66,7 +66,7 @@ impl Default for NativeEnv {
     }
 }
 
-#[derive(Debug, Default, Clone, clap::Parser, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, clap::Args, Serialize, Deserialize)]
 pub struct EnvFlags {
     /// Enable features only allowed in systemlib
     #[clap(long)]

--- a/hphp/hack/src/hackc/hackc/asm.rs
+++ b/hphp/hack/src/hackc/hackc/asm.rs
@@ -13,7 +13,7 @@ use ::assemble as _;
 use anyhow::anyhow;
 use anyhow::Result;
 use bumpalo::Bump;
-use clap::Parser;
+use clap::Args;
 use parking_lot::Mutex;
 use rayon::prelude::*;
 use relative_path::RelativePath;
@@ -21,14 +21,14 @@ use relative_path::RelativePath;
 use crate::util::SyncWrite;
 use crate::FileOpts;
 
-#[derive(Parser, Debug)]
+#[derive(Args, Debug)]
 pub struct Opts {
     /// Output file. Creates it if necessary
     #[clap(short = 'o')]
     output_file: Option<PathBuf>,
 
     /// The input hhas file(s) to assemble back to hhbc::Unit
-    #[clap(flatten)]
+    #[command(flatten)]
     files: FileOpts,
 }
 

--- a/hphp/hack/src/hackc/hackc/asm_ir.rs
+++ b/hphp/hack/src/hackc/hackc/asm_ir.rs
@@ -13,21 +13,21 @@ use ::assemble as _;
 use anyhow::anyhow;
 use anyhow::Result;
 use bumpalo::Bump;
-use clap::Parser;
+use clap::Args;
 use parking_lot::Mutex;
 use rayon::prelude::*;
 
 use crate::util::SyncWrite;
 use crate::FileOpts;
 
-#[derive(Parser, Debug)]
+#[derive(Args, Debug)]
 pub struct Opts {
     /// Output file. Creates it if necessary
     #[clap(short = 'o')]
     output_file: Option<PathBuf>,
 
     /// The input hhas file(s) to assemble back to ir::Unit
-    #[clap(flatten)]
+    #[command(flatten)]
     files: FileOpts,
 }
 

--- a/hphp/hack/src/hackc/hackc/compile.rs
+++ b/hphp/hack/src/hackc/hackc/compile.rs
@@ -13,6 +13,7 @@ use std::sync::Arc;
 
 use anyhow::Context;
 use anyhow::Result;
+use clap::Args;
 use clap::Parser;
 use compile::EnvFlags;
 use compile::NativeEnv;
@@ -51,27 +52,27 @@ use ty::reason::Reason;
 use crate::util::SyncWrite;
 use crate::FileOpts;
 
-#[derive(Parser, Debug)]
+#[derive(Args, Debug)]
 pub struct Opts {
     /// Output file. Creates it if necessary
     #[clap(short = 'o')]
     output_file: Option<PathBuf>,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     files: FileOpts,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     single_file_opts: SingleFileOpts,
 }
 
 #[derive(Parser, Clone, Debug)]
 pub(crate) struct SingleFileOpts {
-    #[clap(flatten)]
+    #[command(flatten)]
     pub(crate) env_flags: EnvFlags,
 
     /// The level of verbosity (can be set multiple times)
-    #[clap(long = "verbose", parse(from_occurrences))]
-    pub(crate) verbosity: isize,
+    #[clap(long = "verbose", action(clap::ArgAction::Count))]
+    pub(crate) verbosity: u8,
 }
 
 pub fn run(opts: &mut Opts) -> Result<()> {

--- a/hphp/hack/src/hackc/hackc/crc.rs
+++ b/hphp/hack/src/hackc/hackc/crc.rs
@@ -17,7 +17,7 @@ use std::time::Instant;
 
 use anyhow::bail;
 use anyhow::Result;
-use clap::Parser;
+use clap::Args;
 use multifile_rust as multifile;
 use parking_lot::Mutex;
 use rayon::prelude::*;
@@ -30,17 +30,17 @@ use crate::profile::StatusTicker;
 use crate::profile::Timing;
 use crate::util::SyncWrite;
 
-#[derive(Parser, Debug)]
+#[derive(Args, Debug)]
 pub struct Opts {
     #[allow(dead_code)]
-    #[clap(flatten)]
+    #[command(flatten)]
     single_file_opts: SingleFileOpts,
 
     /// Number of parallel worker threads. By default, or if set to 0, use num-cpu threads.
     #[clap(long, default_value = "0")]
     num_threads: usize,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     files: crate::FileOpts,
 }
 

--- a/hphp/hack/src/hackc/hackc/decls.rs
+++ b/hphp/hack/src/hackc/hackc/decls.rs
@@ -5,16 +5,16 @@ use std::io::Write;
 use std::path::PathBuf;
 
 use anyhow::Result;
-use clap::Parser;
+use clap::Args;
 use direct_decl_parser::ParsedFile;
 use hash::IndexMap;
 use relative_path::Prefix;
 use relative_path::RelativePath;
 
 /// Decls subcommand options
-#[derive(Parser, Debug, Default)]
+#[derive(Args, Debug, Default)]
 pub(crate) struct Opts {
-    #[clap(flatten)]
+    #[command(flatten)]
     pub files: crate::FileOpts,
 }
 

--- a/hphp/hack/src/hackc/hackc/elaborate.rs
+++ b/hphp/hack/src/hackc/hackc/elaborate.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 use aast_parser::AastParser;
 use anyhow::anyhow;
 use anyhow::Result;
-use clap::Parser;
+use clap::Args;
 use log::info;
 use ocamlrep::rc::RcOc;
 use parser_core_types::indexed_source_text::IndexedSourceText;
@@ -16,9 +16,9 @@ use transform::Pass;
 
 use crate::FileOpts;
 
-#[derive(Parser, Debug)]
+#[derive(Args, Debug)]
 pub struct Opts {
-    #[clap(flatten)]
+    #[command(flatten)]
     files: FileOpts,
 }
 

--- a/hphp/hack/src/hackc/hackc/expr_trees.rs
+++ b/hphp/hack/src/hackc/hackc/expr_trees.rs
@@ -2,15 +2,15 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the "hack" directory of this source tree.
 use anyhow::Result;
-use clap::Parser;
+use clap::Args;
 use relative_path::Prefix;
 use relative_path::RelativePath;
 
 use crate::FileOpts;
 
-#[derive(Parser, Debug, Default)]
+#[derive(Args, Debug, Default)]
 pub(crate) struct Opts {
-    #[clap(flatten)]
+    #[command(flatten)]
     pub files: FileOpts,
 }
 

--- a/hphp/hack/src/hackc/hackc/facts.rs
+++ b/hphp/hack/src/hackc/hackc/facts.rs
@@ -4,7 +4,7 @@
 use std::io::Write;
 
 use anyhow::Result;
-use clap::Parser;
+use clap::Args;
 use facts_rust::Facts;
 use facts_rust::{self as facts};
 use relative_path::Prefix;
@@ -13,9 +13,9 @@ use serde_json::json;
 use serde_json::Value;
 
 /// Facts subcommand options
-#[derive(Parser, Debug, Default)]
+#[derive(Args, Debug, Default)]
 pub(crate) struct Opts {
-    #[clap(flatten)]
+    #[command(flatten)]
     pub files: crate::FileOpts,
 
     /// Exclude sha1sum from JSON results.

--- a/hphp/hack/src/hackc/hackc/hackc.rs
+++ b/hphp/hack/src/hackc/hackc/hackc.rs
@@ -27,6 +27,7 @@ use ::compile::EnvFlags;
 use ::compile::NativeEnv;
 use anyhow::Result;
 use byte_unit::Byte;
+use clap::Args;
 use clap::Parser;
 use hhvm_options::HhvmOptions;
 use log::info;
@@ -46,16 +47,16 @@ struct Opts {
     #[clap(long)]
     daemon: bool,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     flag_commands: FlagCommands,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     hhvm_options: HhvmOptions,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     files: FileOpts,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     pub(crate) env_flags: EnvFlags,
 
     /// Number of parallel worker threads for subcommands that support parallelism,
@@ -89,7 +90,7 @@ struct Opts {
 }
 
 /// Hack Compiler
-#[derive(Parser, Debug, Default)]
+#[derive(Args, Debug, Default)]
 struct FileOpts {
     /// Input file(s)
     filenames: Vec<PathBuf>,

--- a/hphp/hack/src/hackc/hackc/infer.rs
+++ b/hphp/hack/src/hackc/hackc/infer.rs
@@ -9,7 +9,7 @@ use std::path::Path;
 use std::path::PathBuf;
 
 use anyhow::Result;
-use clap::Parser;
+use clap::Args;
 use compile::Profile;
 use decl_provider::SelfProvider;
 use ocamlrep::rc::RcOc;
@@ -23,16 +23,16 @@ use crate::compile::SingleFileOpts;
 use crate::util::SyncWrite;
 use crate::FileOpts;
 
-#[derive(Parser, Debug)]
+#[derive(Args, Debug)]
 pub struct Opts {
     /// Output file. Creates it if necessary
     #[clap(short = 'o')]
     output_file: Option<PathBuf>,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     files: FileOpts,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     single_file_opts: SingleFileOpts,
 
     /// Skip emitting 'standard' builtins.

--- a/hphp/hack/src/hackc/hackc/parse.rs
+++ b/hphp/hack/src/hackc/hackc/parse.rs
@@ -12,7 +12,7 @@ use std::path::PathBuf;
 use aast_parser::AastParser;
 use anyhow::Context;
 use anyhow::Result;
-use clap::Parser;
+use clap::Args;
 use ocamlrep::rc::RcOc;
 use parser_core_types::indexed_source_text::IndexedSourceText;
 use parser_core_types::parser_env::ParserEnv;
@@ -25,9 +25,9 @@ use strum_macros::Display;
 use strum_macros::EnumString;
 use strum_macros::EnumVariantNames;
 
-#[derive(Parser, Clone, Debug)]
+#[derive(Args, Clone, Debug)]
 pub struct BenchOpts {
-    #[clap(default_value_t, long, possible_values(ParserKind::VARIANTS))]
+    #[clap(default_value_t, long, value_parser = clap::builder::PossibleValuesParser::new(ParserKind::VARIANTS))]
     parser: ParserKind,
 }
 
@@ -92,9 +92,9 @@ pub fn run_bench_command(bench_opts: BenchOpts) -> Result<()> {
         })
 }
 
-#[derive(Parser, Debug)]
+#[derive(Args, Debug)]
 pub(crate) struct Opts {
-    #[clap(flatten)]
+    #[command(flatten)]
     pub files: crate::FileOpts,
 
     /// Print compact JSON instead of formatted & indented JSON.

--- a/hphp/hack/src/hackc/hackc/verify.rs
+++ b/hphp/hack/src/hackc/hackc/verify.rs
@@ -12,6 +12,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::ensure;
+use clap::Args;
 use clap::Parser;
 use decl_provider::SelfProvider;
 use hash::HashMap;
@@ -71,9 +72,9 @@ thread_local! {
     pub static PANIC_MSG: RefCell<Option<String>> = RefCell::new(None);
 }
 
-#[derive(Parser, Debug)]
+#[derive(Args, Debug)]
 struct CommonOpts {
-    #[clap(flatten)]
+    #[command(flatten)]
     files: crate::FileOpts,
 
     /// Print full error messages
@@ -81,7 +82,7 @@ struct CommonOpts {
     long_msg: bool,
 
     #[allow(dead_code)]
-    #[clap(flatten)]
+    #[command(flatten)]
     single_file_opts: SingleFileOpts,
 
     /// Number of parallel worker threads. By default, or if set to 0, use num-cpu threads.
@@ -97,9 +98,9 @@ struct CommonOpts {
     show_all: bool,
 }
 
-#[derive(Parser, Debug)]
+#[derive(Args, Debug)]
 struct AssembleOpts {
-    #[clap(flatten)]
+    #[command(flatten)]
     common: CommonOpts,
 }
 
@@ -152,9 +153,9 @@ impl AssembleOpts {
     }
 }
 
-#[derive(Parser, Debug)]
+#[derive(Args, Debug)]
 struct IrOpts {
-    #[clap(flatten)]
+    #[command(flatten)]
     common: CommonOpts,
 }
 
@@ -227,7 +228,7 @@ impl IrOpts {
     }
 }
 
-#[derive(Parser, Debug)]
+#[derive(Args, Debug)]
 struct InferOpts {
     #[clap(flatten)]
     common: CommonOpts,

--- a/hphp/hack/src/utils/hhvm_options/Cargo.toml
+++ b/hphp/hack/src/utils/hhvm_options/Cargo.toml
@@ -9,6 +9,6 @@ path = "hhvm_options.rs"
 
 [dependencies]
 anyhow = "1.0.65"
-clap = { version = "3.2.17", features = ["derive", "env", "regex", "unicode", "wrap_help"] }
+clap = { version = "4.1.4", features = ["derive", "env", "string", "unicode", "wrap_help"] }
 hdf = { path = "../hdf" }
 hhvm_runtime_options = { path = "hhvm_runtime_options" }

--- a/hphp/hack/src/utils/hhvm_options/hhvm_options.rs
+++ b/hphp/hack/src/utils/hhvm_options/hhvm_options.rs
@@ -89,7 +89,7 @@ pub struct HphpOptions {
         long,
         short,
         default_value("binary"),
-        possible_values(&["binary", "hhas", "text"]),
+        value_parser = clap::builder::PossibleValuesParser::new(&["binary", "hhas", "text"]),
     )]
     pub format: String,
 


### PR DESCRIPTION
Summary: Clap4 is becoming the new standard version for Rust rootfoo and `rustyrepl` has already adopted the changen. This upgrades references of related code to `clap` 4 and `rustyrepl` 0.2

Reviewed By: zertosh, edwinsmith

Differential Revision: D43059704

