### PR TITLE
Turn ZendPack into a singleton

### DIFF
--- a/hphp/runtime/base/zend-pack.cpp
+++ b/hphp/runtime/base/zend-pack.cpp
@@ -19,6 +19,8 @@
 #include "hphp/runtime/base/builtin-functions.h"
 #include "hphp/runtime/base/req-tiny-vector.h"
 
+#include <folly/Singleton.h>
+
 #include <algorithm>
 
 namespace HPHP {
@@ -32,6 +34,13 @@ namespace HPHP {
   outputpos += (a)*(b);
 
 ///////////////////////////////////////////////////////////////////////////////
+
+static folly::Singleton<ZendPack> zend_pack;
+ZendPack* ZendPack::getInstance() {
+  // ZendPack caches maps based on endianness
+  // so only needs to be instantiated once
+  return zend_pack.get();
+}
 
 ZendPack::ZendPack() {
   int machine_endian_check = 1;

--- a/hphp/runtime/base/zend-pack.h
+++ b/hphp/runtime/base/zend-pack.h
@@ -32,6 +32,9 @@ struct Array;
  * x, X, Z and @.
  */
 struct ZendPack {
+  static ZendPack* getInstance();
+
+  // Do not use, get the singleton through `getInstance` above.
   ZendPack();
 
   /**

--- a/hphp/runtime/ext/std/ext_std_misc.cpp
+++ b/hphp/runtime/ext/std/ext_std_misc.cpp
@@ -281,7 +281,7 @@ int64_t HHVM_FUNCTION(ignore_user_abort, bool /*setting*/ /* = false */) {
 
 Variant HHVM_FUNCTION(pack, const String& format, const Array& argv) {
   // pack() returns false if there was an error, String otherwise
-  return ZendPack().pack(format, argv);
+  return ZendPack::getInstance()->pack(format, argv);
 }
 
 int64_t HHVM_FUNCTION(sleep, int64_t seconds) {
@@ -427,7 +427,7 @@ String HHVM_FUNCTION(uniqid, const String& prefix /* = null_string */,
 }
 
 Variant HHVM_FUNCTION(unpack, const String& format, const String& data) {
-  return ZendPack().unpack(format, data);
+  return ZendPack::getInstance()->unpack(format, data);
 }
 
 Array HHVM_FUNCTION(sys_getloadavg) {


### PR DESCRIPTION
ZendPack holds a bunch of maps based on the machine's endianness. Those are not going to change during HHVM's lifetime so we can avoid allocating and recomputing those.

Allocating ZendPack accounts for 0.5 - 0.7% of the traces under perf for workloads heavy in pack/unpack.