### PR TITLE
Implement invalidation based PACKAGES.toml config connection in HHVM

### DIFF
--- a/hphp/runtime/base/package.cpp
+++ b/hphp/runtime/base/package.cpp
@@ -1,0 +1,74 @@
+/*
+ +----------------------------------------------------------------------+
+ | HipHop for PHP                                                       |
+ +----------------------------------------------------------------------+
+ | Copyright (c) 2010-present Facebook, Inc. (http://www.facebook.com)  |
+ +----------------------------------------------------------------------+
+ | This source file is subject to version 3.01 of the PHP license,      |
+ | that is bundled with this package in the file LICENSE, and is        |
+ | available through the world-wide-web at the following url:           |
+ | http://www.php.net/license/3_01.txt                                  |
+ | If you did not receive a copy of the PHP license and are unable to   |
+ | obtain it through the world-wide-web, please send a note to          |
+ | license@php.net so we can mail you a copy immediately.               |
+ +----------------------------------------------------------------------+
+*/
+
+#include "hphp/runtime/base/package.h"
+
+#include "hphp/hack/src/package/ffi_bridge/package_ffi.rs.h"
+
+#include <folly/dynamic.h>
+#include <folly/json.h>
+#include <fstream>
+
+namespace HPHP {
+
+PackageInfo PackageInfo::fromFile(const std::filesystem::path& path) {
+  std::ifstream file(path, std::ios::in);
+  if (!file.is_open()) return {};
+
+  std::string packages_toml{
+    std::istreambuf_iterator<char>(file),
+    std::istreambuf_iterator<char>()
+  };
+
+  auto info = package::package_info_cpp_ffi(packages_toml);
+  hphp_vector_map<std::string, Package> packages;
+
+  for (auto& p : info.packages) {
+    std::vector<std::string> uses, includes;
+    for (auto& s : p.package.uses) uses.push_back(std::string(s));
+    for (auto& s : p.package.includes) includes.push_back(std::string(s));
+    packages.emplace(std::string(p.name), Package { uses, includes });
+  }
+
+  return PackageInfo { packages };
+}
+
+PackageInfo PackageInfo::defaults() {
+  // Empty package for now
+  return {};
+}
+
+std::string PackageInfo::mangleForCacheKey() const {
+  folly::dynamic result = folly::dynamic::object();
+
+  for (auto& [name, package] : packages()) {
+    folly::dynamic entry = folly::dynamic::object();
+
+    folly::dynamic uses = folly::dynamic::array();
+    for (auto& s : package.m_uses) uses.push_back(s);
+    entry["uses"] = uses;
+
+    folly::dynamic includes = folly::dynamic::array();
+    for (auto& s : package.m_includes) includes.push_back(s);
+    entry["includes"] = includes;
+
+    result[name] = entry;
+  }
+
+  return folly::toJson(result);
+}
+
+} // namespace HPHP

--- a/hphp/runtime/base/package.h
+++ b/hphp/runtime/base/package.h
@@ -1,0 +1,43 @@
+/*
+ +----------------------------------------------------------------------+
+ | HipHop for PHP                                                       |
+ +----------------------------------------------------------------------+
+ | Copyright (c) 2010-present Facebook, Inc. (http://www.facebook.com)  |
+ +----------------------------------------------------------------------+
+ | This source file is subject to version 3.01 of the PHP license,      |
+ | that is bundled with this package in the file LICENSE, and is        |
+ | available through the world-wide-web at the following url:           |
+ | http://www.php.net/license/3_01.txt                                  |
+ | If you did not receive a copy of the PHP license and are unable to   |
+ | obtain it through the world-wide-web, please send a note to          |
+ | license@php.net so we can mail you a copy immediately.               |
+ +----------------------------------------------------------------------+
+*/
+
+#pragma once
+
+#include <filesystem>
+#include <vector>
+
+#include "hphp/util/hash-map.h"
+
+namespace HPHP {
+
+struct PackageInfo {
+  struct Package {
+    std::vector<std::string> m_uses;
+    std::vector<std::string> m_includes;
+  };
+
+  using PackageMap = hphp_vector_map<std::string, Package>;
+
+  const PackageMap& packages() const { return m_packages; }
+  std::string mangleForCacheKey() const;
+
+  static PackageInfo fromFile(const std::filesystem::path&);
+  static PackageInfo defaults();
+
+  PackageMap m_packages;
+};
+
+} // namespace HPHP

--- a/hphp/runtime/base/runtime-option.cpp
+++ b/hphp/runtime/base/runtime-option.cpp
@@ -477,37 +477,6 @@ AUTOLOADFLAGS()
   m_flags.m_sha1 = SHA1{string_sha1(raw)};
 }
 
-std::string RepoOptions::toJSON() const {
-  return folly::toJson(toDynamic());
-}
-
-void RepoOptions::calcDynamic() {
-  m_cachedDynamic = folly::dynamic::object();
-#define OUT(key, var)                                \
-  {                                                  \
-    auto const ini_name = Config::IniName(key);      \
-    auto const ini_value = toIniValue(var);          \
-    folly::dynamic entry = folly::dynamic::object(); \
-    entry["global_value"] = ini_value;               \
-    entry["local_value"] = ini_value;                \
-    entry["access"] = 4;                             \
-    m_cachedDynamic[ini_name] = entry;               \
-  }
-
-#define N(_, n, ...) OUT(#n, m_flags.n)
-#define P(_, n, ...) OUT("PHP7." #n, m_flags.n)
-#define H(_, n, ...) OUT("Hack.Lang." #n, m_flags.n)
-#define E(_, n, ...) OUT("Eval." #n, m_flags.n)
-PARSERFLAGS()
-AUTOLOADFLAGS();
-#undef N
-#undef P
-#undef H
-#undef E
-
-#undef OUT
-}
-
 const RepoOptions& RepoOptions::defaults() {
   always_assert(s_init);
   return s_defaults;
@@ -561,7 +530,6 @@ AUTOLOADFLAGS();
 
   filterNamespaces();
   calcCacheKey();
-  calcDynamic();
   if (!m_path.empty()) m_repo = std::filesystem::path(m_path).parent_path();
 }
 

--- a/hphp/runtime/base/runtime-option.h
+++ b/hphp/runtime/base/runtime-option.h
@@ -16,8 +16,6 @@
 
 #pragma once
 
-#include <folly/dynamic.h>
-
 #include <unordered_map>
 #include <algorithm>
 #include <vector>
@@ -198,8 +196,6 @@ struct RepoOptions {
 
   const RepoOptionsFlags& flags() const { return m_flags; }
   const std::string& path() const { return m_path; }
-  std::string toJSON() const;
-  const folly::dynamic& toDynamic() const { return m_cachedDynamic; }
   const struct stat& stat() const { return m_stat; }
 
   const std::filesystem::path& dir() const { return m_repo; }
@@ -230,8 +226,6 @@ private:
   struct stat m_stat;
 
   std::filesystem::path m_repo;
-
-  folly::dynamic m_cachedDynamic;
 
   static bool s_init;
   static RepoOptions s_defaults;

--- a/hphp/runtime/base/runtime-option.h
+++ b/hphp/runtime/base/runtime-option.h
@@ -27,6 +27,7 @@
 #include <sys/stat.h>
 
 #include "hphp/runtime/base/config.h"
+#include "hphp/runtime/base/package.h"
 #include "hphp/runtime/base/typed-value.h"
 #include "hphp/runtime/base/types.h"
 
@@ -187,6 +188,20 @@ private:
   friend struct RepoOptions;
 };
 
+namespace Stream {
+struct Wrapper;
+}
+
+struct RepoOptionStats {
+  RepoOptionStats() = default;
+  RepoOptionStats(const std::string&, Stream::Wrapper*);
+  bool success() const { return m_success; }
+
+  struct stat m_configStat = {};
+  struct stat m_packageStat = {};
+  bool m_success = false;
+};
+
 /*
  * RepoOptionsFlags plus extra state
  */
@@ -195,8 +210,9 @@ struct RepoOptions {
   RepoOptions(RepoOptions&&) = default;
 
   const RepoOptionsFlags& flags() const { return m_flags; }
+  const PackageInfo& packageInfo() const { return m_packageInfo; }
   const std::string& path() const { return m_path; }
-  const struct stat& stat() const { return m_stat; }
+  const RepoOptionStats& stat() const { return m_stat; }
 
   const std::filesystem::path& dir() const { return m_repo; }
 
@@ -223,9 +239,11 @@ private:
   RepoOptionsFlags m_flags;
 
   std::string m_path;
-  struct stat m_stat;
+  RepoOptionStats m_stat;
 
   std::filesystem::path m_repo;
+
+  PackageInfo m_packageInfo;
 
   static bool s_init;
   static RepoOptions s_defaults;

--- a/hphp/runtime/ext/hh/ext_hh.php
+++ b/hphp/runtime/ext/hh/ext_hh.php
@@ -380,6 +380,12 @@ function enable_function_coverage(): void;
 <<__Native>>
 function collect_function_coverage(): dict<string, string>;
 
+/**
+ * Return all package information from PACKAGES.toml
+ */
+<<__Native>>
+function get_all_packages(): dict<string, shape('uses' => vec<string>, 'includes' => vec<string>)>;
+
 } // HH
 
 namespace HH\Rx {

--- a/hphp/test/slow/packages/.hhvmconfig.hdf
+++ b/hphp/test/slow/packages/.hhvmconfig.hdf
@@ -1,0 +1,3 @@
+Parser {
+  Hack.Lang.AllowUnstableFeatures = true
+}

--- a/hphp/test/slow/packages/PACKAGES.toml
+++ b/hphp/test/slow/packages/PACKAGES.toml
@@ -1,0 +1,12 @@
+[packages]
+
+[packages.foo]
+uses = ["a.*"]
+
+[packages.bar]
+uses = ["b.*"]
+includes = ["foo"]
+
+[packages.baz]
+uses = ["x.*", "y.*"]
+includes = ["foo", "bar"]

--- a/hphp/test/slow/packages/basic-1.php
+++ b/hphp/test/slow/packages/basic-1.php
@@ -1,0 +1,6 @@
+<?hh
+
+<<__EntryPoint>>
+function main() {
+  var_dump(HH\get_all_packages());
+}

--- a/hphp/test/slow/packages/basic-1.php.expect
+++ b/hphp/test/slow/packages/basic-1.php.expect
@@ -1,0 +1,36 @@
+dict(3) {
+  ["baz"]=>
+  dict(2) {
+    ["uses"]=>
+    vec(2) {
+      string(3) "x.*"
+      string(3) "y.*"
+    }
+    ["includes"]=>
+    vec(2) {
+      string(3) "foo"
+      string(3) "bar"
+    }
+  }
+  ["bar"]=>
+  dict(2) {
+    ["uses"]=>
+    vec(1) {
+      string(3) "b.*"
+    }
+    ["includes"]=>
+    vec(1) {
+      string(3) "foo"
+    }
+  }
+  ["foo"]=>
+  dict(2) {
+    ["uses"]=>
+    vec(1) {
+      string(3) "a.*"
+    }
+    ["includes"]=>
+    vec(0) {
+    }
+  }
+}


### PR DESCRIPTION
Summary: This diff piggybacks off of invalidation strategy for `.hhvmconfig.hdf` to do the same for `PACKAGES.toml` file to expose packages to HHVM.

Differential Revision: D43583718

