### PR TITLE
folly::detail::simdSplitByChar

### DIFF
--- a/third-party/folly/src/CMakeLists.txt
+++ b/third-party/folly/src/CMakeLists.txt
@@ -657,6 +657,12 @@ if (BUILD_TESTS OR BUILD_BENCHMARKS)
     DIRECTORY detail/test/
       TEST static_singleton_manager_test SOURCES StaticSingletonManagerTest.cpp
 
+    DIRECTORY detail/test/
+      TEST simd_for_each_test SOURCES SimdForEachTest.cpp
+
+    DIRECTORY detail/test/
+      TEST split_string_simd_test SOURCES SplitStringSimdTest.cpp
+
     DIRECTORY detail/base64_detail/tests/
       TEST base64_detail_test
       SOURCES

--- a/third-party/folly/src/folly/detail/SimdForEach.h
+++ b/third-party/folly/src/folly/detail/SimdForEach.h
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <folly/CPortability.h>
+
+#include <cstdint>
+
+namespace folly {
+namespace simd_detail {
+
+// Based on
+// https://github.com/jfalcou/eve/blob/5264e20c51aeca17675e67abf236ce1ead781c52/include/eve/module/algo/algo/for_each_iteration.hpp#L148
+// eve has much more settings (like unrolling) but we don't need them for now.
+
+struct ignore_extrema {
+  int first = 0;
+  int last = 0;
+};
+
+struct ignore_none {};
+
+// Everything is ALWAYS_INLINE because we want to have one top level noinline
+// function that does everything. Otherwise sometimes the compiler tends
+// to mess that up.
+
+template <typename T>
+FOLLY_ALWAYS_INLINE T* alignPtr(T* ptr, int to) {
+  std::uintptr_t uptr = reinterpret_cast<std::uintptr_t>(ptr);
+  std::uintptr_t uto = static_cast<std::uintptr_t>(to);
+  uptr &= ~(uto - 1);
+  return reinterpret_cast<T*>(uptr);
+}
+
+// The main idea is that you can read from the memory within the page.
+// This is how strlen works
+// https://stackoverflow.com/questions/25566302/vectorized-strlen-getting-away-with-reading-unallocated-memory
+//
+// There have to be asan disablement to make that work.
+
+// callback accepts a pointer + ignore.
+// pointer is guaranteed to be alinged and safe to read <cardinal> bytes from.
+// If ignore_extrema is passed in, you have to disable the asan.
+//
+// Unlike Stl accepting Callback as && because you often want to store state
+// in it.
+template <typename T, typename Callback>
+FOLLY_ALWAYS_INLINE void simdForEachAligning(
+    int cardinal, T* f, T* l, Callback&& callback) {
+  if (f == l) {
+    return;
+  }
+
+  T* af = alignPtr(f, cardinal);
+  T* al = alignPtr(l, cardinal);
+
+  ignore_extrema ignore{static_cast<int>(f - af), 0};
+  if (af != al) {
+    // first chunk
+    if (callback(af, ignore)) {
+      return;
+    }
+    ignore.first = 0;
+    af += cardinal;
+
+    while (af != al) {
+      if (callback(af, ignore_none{})) {
+        return;
+      }
+      af += cardinal;
+    }
+
+    // Here af might be exactly at the end of page.
+    if (af == l) {
+      return;
+    }
+  }
+
+  ignore.last = static_cast<int>(af + cardinal - l);
+  callback(af, ignore);
+}
+
+} // namespace simd_detail
+} // namespace folly

--- a/third-party/folly/src/folly/detail/SplitStringSimd.cpp
+++ b/third-party/folly/src/folly/detail/SplitStringSimd.cpp
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/detail/SplitStringSimd.h>
+#include <folly/detail/SplitStringSimdImpl.h>
+
+#include <folly/FBVector.h>
+#include <folly/small_vector.h>
+
+namespace folly {
+namespace detail {
+
+template <typename Container>
+void SimdSplitByCharImpl<Container>::process(
+    char sep, folly::StringPiece what, Container& res) {
+  PlatformSimdSplitByChar<StringSplitCurrentPlatform>{}(sep, what, res);
+}
+
+// clang-format off
+#define FOLLY_DETAIL_DEFINE_ALL_SIMD_SPLIT_OVERLOADS(...) \
+  template struct SimdSplitByCharImpl<std::vector<__VA_ARGS__>>; \
+  template struct SimdSplitByCharImpl<folly::fbvector<__VA_ARGS__, std::allocator<__VA_ARGS__>>>; \
+  template struct SimdSplitByCharImpl<folly::small_vector<__VA_ARGS__, 1, void>>; \
+  template struct SimdSplitByCharImpl<folly::small_vector<__VA_ARGS__, 2, void>>; \
+  template struct SimdSplitByCharImpl<folly::small_vector<__VA_ARGS__, 3, void>>; \
+  template struct SimdSplitByCharImpl<folly::small_vector<__VA_ARGS__, 4, void>>; \
+  template struct SimdSplitByCharImpl<folly::small_vector<__VA_ARGS__, 5, void>>; \
+  template struct SimdSplitByCharImpl<folly::small_vector<__VA_ARGS__, 6, void>>; \
+  template struct SimdSplitByCharImpl<folly::small_vector<__VA_ARGS__, 7, void>>; \
+  template struct SimdSplitByCharImpl<folly::small_vector<__VA_ARGS__, 8, void>>;
+// clang-format on
+
+FOLLY_DETAIL_DEFINE_ALL_SIMD_SPLIT_OVERLOADS(folly::StringPiece)
+
+#if FOLLY_HAS_STRING_VIEW
+FOLLY_DETAIL_DEFINE_ALL_SIMD_SPLIT_OVERLOADS(std::string_view)
+#endif
+
+#undef FOLLY_DETAIL_DEFINE_ALL_SIMD_SPLIT_OVERLOADS
+
+void simdSplitByCharVecOfStrings(
+    char sep, folly::StringPiece what, std::vector<std::string>& res) {
+  PlatformSimdSplitByChar<StringSplitCurrentPlatform>{}(sep, what, res);
+}
+
+} // namespace detail
+} // namespace folly

--- a/third-party/folly/src/folly/detail/SplitStringSimd.h
+++ b/third-party/folly/src/folly/detail/SplitStringSimd.h
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <string>
+#include <vector>
+#include <folly/Range.h>
+
+namespace folly {
+
+template <typename T, std::size_t M, typename P>
+class small_vector;
+
+template <typename T, typename Allocator>
+class fbvector;
+
+namespace detail {
+
+template <typename Container>
+struct SimdSplitByCharImpl {
+  static void process(char sep, folly::StringPiece what, Container& res);
+};
+
+template <typename T>
+constexpr bool isSimdSplitSupportedStringViewType =
+    std::is_same<T, folly::StringPiece>::value
+#if FOLLY_HAS_STRING_VIEW
+    || std::is_same<T, std::string_view>::value
+#endif
+    ;
+
+template <typename>
+struct SimdSplitByCharIsDefinedFor {
+  static constexpr bool value = false;
+};
+
+template <typename T>
+struct SimdSplitByCharIsDefinedFor<std::vector<T>> {
+  static constexpr bool value = isSimdSplitSupportedStringViewType<T>;
+};
+
+template <typename T, typename A>
+struct SimdSplitByCharIsDefinedFor<folly::fbvector<T, A>>
+    : SimdSplitByCharIsDefinedFor<std::vector<T, A>> {};
+
+template <typename T, std::size_t M>
+struct SimdSplitByCharIsDefinedFor<folly::small_vector<T, M, void>> {
+  static constexpr bool value =
+      isSimdSplitSupportedStringViewType<T> && 0 < M && M <= 8;
+};
+
+template <typename Container>
+void simdSplitByChar(char sep, folly::StringPiece what, Container& res) {
+  static_assert(
+      SimdSplitByCharIsDefinedFor<Container>::value,
+      "simd split by char is supported only for vector/fbvector/small_vector, with small size <= 8."
+      " The resulting string type has to string_view or StringPiece."
+      " There is also a special case of std::vector<std::string> for ease of migration");
+  SimdSplitByCharImpl<Container>::process(sep, what, res);
+}
+
+// Using vector of strings instead of string views is a bad idea in general.
+// We use this to have a separate name in the stack.
+void simdSplitByCharVecOfStrings(
+    char sep, folly::StringPiece what, std::vector<std::string>& res);
+
+inline void simdSplitByChar(
+    char sep, folly::StringPiece what, std::vector<std::string>& res) {
+  simdSplitByCharVecOfStrings(sep, what, res);
+}
+
+// clang-format off
+#define FOLLY_DETAIL_DECLARE_ALL_SIMD_SPLIT_OVERLOADS(...) \
+  extern template struct SimdSplitByCharImpl<std::vector<__VA_ARGS__>>; \
+  extern template struct SimdSplitByCharImpl<folly::fbvector<__VA_ARGS__, std::allocator<__VA_ARGS__>>>; \
+  extern template struct SimdSplitByCharImpl<folly::small_vector<__VA_ARGS__, 1, void>>; \
+  extern template struct SimdSplitByCharImpl<folly::small_vector<__VA_ARGS__, 2, void>>; \
+  extern template struct SimdSplitByCharImpl<folly::small_vector<__VA_ARGS__, 3, void>>; \
+  extern template struct SimdSplitByCharImpl<folly::small_vector<__VA_ARGS__, 4, void>>; \
+  extern template struct SimdSplitByCharImpl<folly::small_vector<__VA_ARGS__, 5, void>>; \
+  extern template struct SimdSplitByCharImpl<folly::small_vector<__VA_ARGS__, 6, void>>; \
+  extern template struct SimdSplitByCharImpl<folly::small_vector<__VA_ARGS__, 7, void>>; \
+  extern template struct SimdSplitByCharImpl<folly::small_vector<__VA_ARGS__, 8, void>>;
+// clang-format on
+
+FOLLY_DETAIL_DECLARE_ALL_SIMD_SPLIT_OVERLOADS(folly::StringPiece)
+
+#if FOLLY_HAS_STRING_VIEW
+FOLLY_DETAIL_DECLARE_ALL_SIMD_SPLIT_OVERLOADS(std::string_view)
+#endif
+
+#undef FOLLY_DETAIL_DECLARE_ALL_SIMD_SPLIT_OVERLOADS
+
+} // namespace detail
+} // namespace folly

--- a/third-party/folly/src/folly/detail/SplitStringSimdImpl.h
+++ b/third-party/folly/src/folly/detail/SplitStringSimdImpl.h
@@ -1,0 +1,244 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <folly/Portability.h>
+#include <folly/Range.h>
+#include <folly/detail/SimdForEach.h>
+#include <folly/lang/Bits.h>
+
+#if FOLLY_X64
+#include <immintrin.h>
+#endif
+
+#if FOLLY_AARCH64
+#include <arm_neon.h>
+#endif
+
+// This file is not supposed to be included by users.
+// It should be included in CPP file which exposes apis.
+// It is a header file to test different platforms.
+
+// All funcitons are force inline because they are merged into big hiddend
+// noinline functions
+namespace folly {
+namespace detail {
+
+#if FOLLY_X64
+
+struct StringSplitSse2Platform {
+  using reg_t = __m128i;
+
+  static constexpr int kCardinal = 16;
+  static constexpr int kMmaskBitsPerElement = 1;
+
+  // We can actually use aligned loads but our Intel people don't recommend
+  FOLLY_ALWAYS_INLINE
+  static reg_t loadu(const char* p) {
+    return _mm_loadu_si128(reinterpret_cast<const reg_t*>(p));
+  }
+
+  FOLLY_DISABLE_SANITIZERS
+  FOLLY_ALWAYS_INLINE
+  static reg_t unsafeLoadu(const char* p) {
+    return _mm_loadu_si128(reinterpret_cast<const reg_t*>(p));
+  }
+
+  FOLLY_ALWAYS_INLINE
+  static std::uint16_t equal(reg_t reg, char x) {
+    return _mm_movemask_epi8(_mm_cmpeq_epi8(reg, _mm_set1_epi8(x)));
+  }
+};
+
+#if defined(__AVX2__)
+
+struct StringSplitAVX2Platform {
+  using reg_t = __m256i;
+
+  static constexpr int kCardinal = 32;
+  static constexpr int kMmaskBitsPerElement = 1;
+
+  // We can actually use aligned loads but our Intel people don't recommend
+  FOLLY_ALWAYS_INLINE
+  static reg_t loadu(const char* p) {
+    return _mm256_loadu_si256(reinterpret_cast<const reg_t*>(p));
+  }
+
+  FOLLY_DISABLE_SANITIZERS
+  FOLLY_ALWAYS_INLINE
+  static reg_t unsafeLoadu(const char* p) {
+    return _mm256_loadu_si256(reinterpret_cast<const reg_t*>(p));
+  }
+
+  FOLLY_ALWAYS_INLINE
+  static std::uint32_t equal(reg_t reg, char x) {
+    return _mm256_movemask_epi8(_mm256_cmpeq_epi8(reg, _mm256_set1_epi8(x)));
+  }
+};
+
+using StringSplitCurrentPlatform = StringSplitAVX2Platform;
+
+#else
+using StringSplitCurrentPlatform = StringSplitSse2Platform;
+#endif
+
+#elif FOLLY_AARCH64
+
+struct StringSplitAarch64Platform {
+  using reg_t = uint8x16_t;
+
+  static constexpr int kCardinal = 16;
+  static constexpr int kMmaskBitsPerElement = 4;
+
+  FOLLY_ALWAYS_INLINE
+  static reg_t loadu(const char* p) {
+    return vld1q_u8(reinterpret_cast<const std::uint8_t*>(p));
+  }
+
+  FOLLY_DISABLE_SANITIZERS
+  FOLLY_ALWAYS_INLINE
+  static reg_t unsafeLoadu(const char* p) {
+    return vld1q_u8(reinterpret_cast<const std::uint8_t*>(p));
+  }
+
+  FOLLY_ALWAYS_INLINE
+  static std::uint64_t equal(reg_t reg, char x) {
+    reg_t test = vceqq_u8(reg, vdupq_n_u8(static_cast<std::uint8_t>(x)));
+
+    // we can do any with horizontal max but that didn't help here
+    //
+    // based on:
+    // https://github.com/jfalcou/eve/blob/5264e20c51aeca17675e67abf236ce1ead781c52/include/eve/detail/function/simd/arm/neon/movemask.hpp#L119
+    // pack 4 bits into uint64
+    uint16x8_t u16s = vreinterpretq_u8_u16(test);
+    u16s = vshrq_n_u16(u16s, 4);
+    return vget_lane_u64(vmovn_u16(u16s), 0);
+  }
+};
+
+using StringSplitCurrentPlatform = StringSplitAarch64Platform;
+
+#else
+
+using StringSplitCurrentPlatform = void;
+
+#endif
+
+template <typename Container>
+void splitByCharScalar(char sep, folly::StringPiece what, Container& res) {
+  const char* prev = what.data();
+  const char* f = prev;
+  const char* l = what.data() + what.size();
+  while (f != l) {
+    const char* next = f + 1;
+    if (*f == sep) {
+      res.emplace_back(prev, f);
+      prev = next;
+    }
+    f = next;
+  }
+  res.emplace_back(prev, f);
+}
+
+template <typename Platform>
+struct PlatformSimdSplitByChar {
+  using reg_t = typename Platform::reg_t;
+
+  // These are aligned loads but there is no point in generating
+  // aligned load instructions, so we call loadu.
+  FOLLY_ALWAYS_INLINE
+  reg_t loada(const char* ptr, simd_detail::ignore_none) const {
+    return Platform::loadu(ptr);
+  }
+
+  FOLLY_ALWAYS_INLINE
+  reg_t loada(const char* ptr, simd_detail::ignore_extrema) const {
+    return Platform::unsafeLoadu(ptr);
+  }
+
+  template <typename Uint>
+  FOLLY_ALWAYS_INLINE Uint setLowerNBits(int n) const {
+    if (sizeof(Uint) == 8 && n == 64) {
+      return static_cast<Uint>(-1);
+    }
+    return static_cast<Uint>((std::uint64_t{1} << n) - 1);
+  }
+
+  template <typename Uint>
+  FOLLY_ALWAYS_INLINE Uint
+  clear(Uint mmask, simd_detail::ignore_extrema ignore) const {
+    Uint clearFirst =
+        ~setLowerNBits<Uint>(ignore.first * Platform::kMmaskBitsPerElement);
+    Uint clearLast = setLowerNBits<Uint>(
+        (Platform::kCardinal - ignore.last) * Platform::kMmaskBitsPerElement);
+    return mmask & clearFirst & clearLast;
+  }
+
+  template <typename Uint>
+  FOLLY_ALWAYS_INLINE Uint clear(Uint mmask, simd_detail::ignore_none) const {
+    return mmask;
+  }
+
+  template <typename Uint, typename Container>
+  FOLLY_ALWAYS_INLINE void outputStringsFoMmask(
+      Uint mmask,
+      const char* pos,
+      const char*& prev,
+      Container& res) const { // reserve was not beneficial on benchmarks.
+    while (mmask) {
+      auto counted = folly::findFirstSet(mmask) - 1;
+      mmask >>= counted;
+      mmask >>= Platform::kMmaskBitsPerElement;
+      auto firstSet = counted / Platform::kMmaskBitsPerElement;
+
+      const char* split = pos + firstSet;
+      pos = split + 1;
+      res.emplace_back(prev, split);
+      prev = pos;
+    }
+  }
+
+  template <typename Container>
+  FOLLY_ALWAYS_INLINE void operator()(
+      char sep, folly::StringPiece what, Container& res) const {
+    const char* prev = what.data();
+    simd_detail::simdForEachAligning(
+        Platform::kCardinal,
+        what.data(),
+        what.data() + what.size(),
+        [&](const char* ptr, auto ignore) mutable {
+          reg_t loaded = loada(ptr, ignore);
+          auto mmask = Platform::equal(loaded, sep);
+          mmask = clear(mmask, ignore);
+          outputStringsFoMmask(mmask, ptr, prev, res);
+          return false;
+        });
+    res.emplace_back(prev, what.data() + what.size());
+  }
+};
+
+template <>
+struct PlatformSimdSplitByChar<void> {
+  template <typename Container>
+  FOLLY_ALWAYS_INLINE void operator()(
+      char sep, folly::StringPiece what, Container& res) const {
+    return splitByCharScalar(sep, what, res);
+  }
+};
+
+} // namespace detail
+} // namespace folly

--- a/third-party/folly/src/folly/detail/test/SimdForEachTest.cpp
+++ b/third-party/folly/src/folly/detail/test/SimdForEachTest.cpp
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/detail/SimdForEach.h>
+
+#include <folly/portability/GTest.h>
+
+namespace folly {
+namespace simd_detail {
+
+constexpr int kCardinal = 4;
+
+struct TestDelegate {
+  char* stopAt = nullptr;
+
+  bool operator()(char* s, ignore_extrema ignore) const {
+    int middle = kCardinal - ignore.first - ignore.last;
+    while (ignore.first--) {
+      *s++ = 'i';
+    }
+    while (middle--) {
+      *s++ = 'o';
+    }
+    while (ignore.last--) {
+      *s++ = 'i';
+    }
+
+    return stopAt != nullptr && s > stopAt;
+  }
+
+  bool operator()(char* s, ignore_none) const {
+    for (int i = 0; i != kCardinal; ++i) {
+      *s++ = 'o';
+    }
+    return stopAt != nullptr && s > stopAt;
+  }
+};
+
+std::string run(int offset, int len, int stopAt) {
+  alignas(64) std::array<char, 100u> buf;
+  buf.fill(0);
+
+  TestDelegate delegate{stopAt == -1 ? nullptr : buf.data() + stopAt};
+  simdForEachAligning(
+      kCardinal, buf.data() + offset, buf.data() + offset + len, delegate);
+  return std::string(buf.data());
+}
+
+TEST(SimdForEachAligningTest, Tails) {
+  ASSERT_EQ("", run(0, 0, -1));
+  ASSERT_EQ("", run(1, 0, -1));
+  ASSERT_EQ("", run(2, 0, -1));
+  ASSERT_EQ("", run(3, 0, -1));
+
+  ASSERT_EQ("oiii", run(0, 1, -1));
+  ASSERT_EQ("ioii", run(1, 1, -1));
+  ASSERT_EQ("iioi", run(2, 1, -1));
+  ASSERT_EQ("iiio", run(3, 1, -1));
+
+  ASSERT_EQ("ooii", run(0, 2, -1));
+  ASSERT_EQ("iooi", run(1, 2, -1));
+  ASSERT_EQ("iioo", run(2, 2, -1));
+  ASSERT_EQ("iiiooiii", run(3, 2, -1));
+
+  ASSERT_EQ("oooi", run(0, 3, -1));
+  ASSERT_EQ("iooo", run(1, 3, -1));
+  ASSERT_EQ("iioooiii", run(2, 3, -1));
+  ASSERT_EQ("iiioooii", run(3, 3, -1));
+
+  ASSERT_EQ("oooo", run(0, 4, -1));
+  ASSERT_EQ("iooooiii", run(1, 4, -1));
+  ASSERT_EQ("iiooooii", run(2, 4, -1));
+  ASSERT_EQ("iiiooooi", run(3, 4, -1));
+
+  ASSERT_EQ("oooooiii", run(0, 5, -1));
+  ASSERT_EQ("ioooooii", run(1, 5, -1));
+  ASSERT_EQ("iioooooi", run(2, 5, -1));
+  ASSERT_EQ("iiiooooo", run(3, 5, -1));
+}
+
+TEST(SimdForEachAligningTest, Large) {
+  ASSERT_EQ(
+      "oooo"
+      "oooo"
+      "oooo"
+      "oooo"
+      "ooii",
+      run(0, 18, -1));
+  ASSERT_EQ(
+      "iooo"
+      "oooo"
+      "oooo"
+      "oooo"
+      "oooi",
+      run(1, 18, -1));
+  ASSERT_EQ(
+      "iioo"
+      "oooo"
+      "oooo"
+      "oooo"
+      "oooo",
+      run(2, 18, -1));
+  ASSERT_EQ(
+      "iiio"
+      "oooo"
+      "oooo"
+      "oooo"
+      "oooo"
+      "oiii",
+      run(3, 18, -1));
+}
+
+TEST(SimdForEachAligningTest, Stops) {
+  for (int i = 0; i != 4; ++i) {
+    ASSERT_EQ("oooo", run(0, 18, i));
+  }
+  for (int i = 0; i != 4; ++i) {
+    ASSERT_EQ(
+        "oooo"
+        "oooo",
+        run(0, 18, 4 + i));
+  }
+  for (int i = 0; i != 4; ++i) {
+    ASSERT_EQ(
+        "oooo"
+        "oooo"
+        "oooo"
+        "oooo"
+        "ooii",
+        run(0, 18, 16 + i));
+  }
+}
+
+} // namespace simd_detail
+} // namespace folly

--- a/third-party/folly/src/folly/detail/test/SplitStringSimdTest.cpp
+++ b/third-party/folly/src/folly/detail/test/SplitStringSimdTest.cpp
@@ -1,0 +1,191 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/detail/SplitStringSimd.h>
+#include <folly/detail/SplitStringSimdImpl.h>
+
+#include <folly/FBVector.h>
+#include <folly/Range.h>
+#include <folly/portability/GTest.h>
+#include <folly/small_vector.h>
+
+#include <random>
+
+namespace folly {
+namespace detail {
+
+// making sure that basic scalar works
+TEST(SplitStringSimdTest, ByCharScalar) {
+  using pieces = std::vector<folly::StringPiece>;
+
+  auto run = [](folly::StringPiece s) {
+    pieces res;
+    splitByCharScalar(',', s, res);
+    return res;
+  };
+
+  ASSERT_EQ(run(""), (pieces{""}));
+  ASSERT_EQ(run("a"), (pieces{"a"}));
+  ASSERT_EQ(run(",a"), (pieces{"", "a"}));
+  ASSERT_EQ(run("a,aa"), (pieces{"a", "aa"}));
+  ASSERT_EQ(run("aaaa,aaa,aa,a"), (pieces{"aaaa", "aaa", "aa", "a"}));
+}
+
+template <typename Container>
+void testContainerSV(
+    folly::StringPiece s, const std::vector<folly::StringPiece>& expected) {
+  Container actual;
+  simdSplitByChar(',', s, actual);
+
+  ASSERT_EQ(expected.size(), actual.size());
+
+  for (std::size_t i = 0; i != expected.size(); ++i) {
+    ASSERT_EQ(expected[i].data(), actual[i].data()) << s << " : " << i;
+    ASSERT_EQ(expected[i].size(), actual[i].size()) << s << " : " << i;
+  }
+}
+
+void testAllContainersOfSVs(
+    folly::StringPiece s, const std::vector<folly::StringPiece>& expected) {
+  testContainerSV<folly::fbvector<folly::StringPiece>>(s, expected);
+  testContainerSV<folly::fbvector<std::string_view>>(s, expected);
+
+  testContainerSV<folly::small_vector<folly::StringPiece, 1>>(s, expected);
+  testContainerSV<folly::small_vector<folly::StringPiece, 2>>(s, expected);
+  testContainerSV<folly::small_vector<folly::StringPiece, 3>>(s, expected);
+  testContainerSV<folly::small_vector<folly::StringPiece, 4>>(s, expected);
+  testContainerSV<folly::small_vector<folly::StringPiece, 6>>(s, expected);
+  testContainerSV<folly::small_vector<folly::StringPiece, 7>>(s, expected);
+  testContainerSV<folly::small_vector<folly::StringPiece, 8>>(s, expected);
+  static_assert(
+      !SimdSplitByCharIsDefinedFor<
+          folly::small_vector<folly::StringPiece, 9>>::value,
+      "");
+
+  testContainerSV<folly::small_vector<std::string_view, 1>>(s, expected);
+  testContainerSV<folly::small_vector<std::string_view, 2>>(s, expected);
+  testContainerSV<folly::small_vector<std::string_view, 3>>(s, expected);
+  testContainerSV<folly::small_vector<std::string_view, 4>>(s, expected);
+  testContainerSV<folly::small_vector<std::string_view, 6>>(s, expected);
+  testContainerSV<folly::small_vector<std::string_view, 7>>(s, expected);
+  testContainerSV<folly::small_vector<std::string_view, 8>>(s, expected);
+  static_assert(
+      !SimdSplitByCharIsDefinedFor<
+          folly::small_vector<std::string_view, 9>>::value,
+      "");
+}
+
+void runTestStringSplit(folly::StringPiece s) {
+  std::vector<folly::StringPiece> expected;
+  splitByCharScalar(',', s, expected);
+
+  std::vector<std::vector<folly::StringPiece>> actuals;
+
+  actuals.emplace_back();
+  simdSplitByChar(',', s, actuals.back());
+
+#if FOLLY_X64
+  actuals.emplace_back();
+  PlatformSimdSplitByChar<StringSplitSse2Platform>{}(',', s, actuals.back());
+#if defined(__AVX2__)
+  actuals.emplace_back();
+  PlatformSimdSplitByChar<StringSplitAVX2Platform>{}(',', s, actuals.back());
+#endif
+#endif
+
+#if FOLLY_AARCH64
+  actuals.emplace_back();
+  PlatformSimdSplitChar<StringSplitAarch64Platform>{}(',', s, actuals.back());
+#endif
+
+  for (const auto& actual : actuals) {
+    ASSERT_EQ(expected.size(), actual.size()) << s;
+
+    for (std::size_t i = 0; i != expected.size(); ++i) {
+      ASSERT_EQ(expected[i].data(), actual[i].data()) << s << " : " << i;
+      ASSERT_EQ(expected[i].size(), actual[i].size()) << s << " : " << i;
+    }
+  }
+
+  testAllContainersOfSVs(s, expected);
+
+  {
+    std::vector<std::string> actual;
+    simdSplitByChar(',', s, actual);
+
+    ASSERT_EQ(expected.size(), actual.size()) << s;
+
+    for (std::size_t i = 0; i != expected.size(); ++i) {
+      ASSERT_EQ(expected[i], actual[i]) << s << " : " << i;
+    }
+  }
+}
+
+std::string repeat(std::string_view substr, std::size_t n) {
+  std::string res;
+  while (n--) {
+    res.append(substr);
+  }
+  return res;
+}
+
+// We also do fuzzing for covering more cases.
+TEST(SplitStringSimd, ByChar) {
+  runTestStringSplit("");
+  runTestStringSplit(",");
+  runTestStringSplit(",,");
+  runTestStringSplit(",,,");
+  runTestStringSplit("aa,aaa,aaaa");
+
+  runTestStringSplit(repeat("a,", 100));
+  runTestStringSplit(repeat("aa,", 100));
+  // every char (the bigger cases come from older version)
+  runTestStringSplit(repeat(",", 255));
+  runTestStringSplit(repeat(",", 512));
+  runTestStringSplit(repeat(",", 512 + 16));
+  runTestStringSplit(repeat(",", 512 + 32));
+  runTestStringSplit(repeat(",", 512 + 64));
+  runTestStringSplit(
+      repeat(",", std::numeric_limits<std::uint16_t>::max() + 512 + 16));
+
+  // special case: triggered shift right by 32 on uint32
+  {
+    alignas(32) std::array<char, 32> buf;
+    buf.fill(0);
+    std::ranges::copy(
+        std::string_view("ong_history_by_pagetype_convr:0,"), buf.data());
+    runTestStringSplit({buf.data(), buf.size()});
+  }
+}
+
+TEST(SplitStringSimd, ByCharTestDifferentOffsets) {
+  alignas(32) std::array<char, 100> buf;
+
+  std::mt19937 gen;
+  std::uniform_int_distribution<> dis(0, 1);
+  for (auto& c : buf) {
+    c = dis(gen) ? ',' : 'a';
+  }
+
+  for (auto f = buf.begin(); f != buf.end(); ++f) {
+    for (auto l = f; l != buf.end(); ++l) {
+      runTestStringSplit({f, l});
+    }
+  }
+}
+
+} // namespace detail
+} // namespace folly


### PR DESCRIPTION
Summary:
Simd optimizied version of splitting strings by char for x86 SSE2/AVX2 and AARCH64.

It's not enabled yet - I plan to let fuzzing run for a few days first.

Differential Revision: D43757774

