### PR TITLE
Clean up some poor usage of folly::split

### DIFF
--- a/third-party/proxygen/src/proxygen/httpclient/samples/httperf2/HTTPerf2.cpp
+++ b/third-party/proxygen/src/proxygen/httpclient/samples/httperf2/HTTPerf2.cpp
@@ -354,8 +354,7 @@ ClientRunner::ClientRunner(HTTPerfStats& parentStats,
   }
 
   std::vector<std::string> headers;
-  folly::split<std::string, std::string, std::string>(
-      "::", FLAGS_headers, headers);
+  folly::split(std::string_view("::"), FLAGS_headers, headers);
   for (const auto& header : headers) {
     if (header.length() == 0) {
       continue;


### PR DESCRIPTION
Summary: These usages were an issue for enabling the new implementation.

Differential Revision: D43982765

