### PR TITLE
Fix buck2 build error in xplat/thrift

### DIFF
--- a/third-party/thrift/src/thrift/lib/cpp/test/Base64Test.cpp
+++ b/third-party/thrift/src/thrift/lib/cpp/test/Base64Test.cpp
@@ -34,7 +34,7 @@ static void setupTestData(int i, uint8_t* data, int& len) {
   ASSERT_EQ(0, i);
 }
 
-void checkEncoding(uint8_t* data, int len) {
+static void checkEncoding(uint8_t* data, int len) {
   for (int i = 0; i < len; i++) {
     ASSERT_TRUE(isalnum(data[i]) || data[i] == '/' || data[i] == '+');
   }


### PR DESCRIPTION
Summary:
Error
```
[2023-04-03T10:54:13.480-07:00] Stderr: xplat/thrift/lib/cpp/test/Base64Test.cpp:37:6: error: no previous prototype for function 'checkEncoding' [-Werror,-Wmissing-prototypes]
[2023-04-03T10:54:13.480-07:00] void checkEncoding(uint8_t* data, int len) {
[2023-04-03T10:54:13.480-07:00]      ^' in /var/sandcastle/deployment/mount/53446/flib/intern/sandcastle/core/shell/SandcastleStatusDecoderBase.php:279
```

This function needs to be static for it to be considered a prototype

Differential Revision: D44649127

