### PR TITLE
fix typo on aarch64 test

### DIFF
--- a/third-party/folly/src/folly/detail/test/SplitStringSimdTest.cpp
+++ b/third-party/folly/src/folly/detail/test/SplitStringSimdTest.cpp
@@ -157,7 +157,7 @@ void runTestStringSplitOneType(folly::StringPiece s) {
 
 #if FOLLY_AARCH64
   actuals.emplace_back();
-  PlatformSimdSplitChar<StringSplitAarch64Platform, ignoreEmpty>{}(
+  PlatformSimdSplitByChar<StringSplitAarch64Platform, ignoreEmpty>{}(
       ',', s, actuals.back());
 #endif
 


### PR DESCRIPTION
Summary:
`PlatformSimdSplitChar` does not exist, it should be `PlatformSimdSplitByChar`
like on the other invocations. This likely was not detected because it is
gated to `FOLLY_AARCH64` - it was incorrect when introduced in D43757774

Differential Revision: D45250929

