### PR TITLE
Avoid copying in makeInstruction

### DIFF
--- a/hphp/runtime/vm/jit/ir-unit-inl.h
+++ b/hphp/runtime/vm/jit/ir-unit-inl.h
@@ -167,7 +167,7 @@ template<class Func, class... Args>
 typename std::result_of<Func(IRInstruction*)>::type
 makeInstruction(Func func, Args&&... args) {
   typedef typename std::result_of<Func(IRInstruction*)>::type Ret;
-  return irunit_detail::InstructionBuilder<Ret,Func>(func).go(args...);
+  return irunit_detail::InstructionBuilder<Ret,Func>(func).go(std::forward<Args>(args)...);
 }
 
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Summary: Avoid unnecessary copy by std::forward

Reviewed By: ricklavoie

Differential Revision: D45296624

