### PR TITLE
Avoid unnecessary copy of follyRequestContext

### DIFF
--- a/third-party/thrift/src/thrift/lib/cpp2/async/AsyncProcessor.h
+++ b/third-party/thrift/src/thrift/lib/cpp2/async/AsyncProcessor.h
@@ -407,7 +407,7 @@ class ServerRequest {
         serializedRequest_(std::move(serializedRequest)),
         ctx_(ctx),
         protocol_(protocol),
-        follyRequestContext_(follyRequestContext),
+        follyRequestContext_(std::move(follyRequestContext)),
         asyncProcessor_(asyncProcessor),
         methodMetadata_(methodMetadata) {}
 


### PR DESCRIPTION
Summary: Use std::move to efficiently transfer the object "follyRequestContext" rather than copying it.

Differential Revision: D45532563

