### PR TITLE
Retry failed package installs

### DIFF
--- a/ci/bin/make-debianish-package
+++ b/ci/bin/make-debianish-package
@@ -34,9 +34,9 @@ OUT=${OUT:-/var/out}
 mkdir -p "$OUT"
 
 # Environment set up
-apt-get update -y
+apt-get -o Acquire::Retries=3 update -y
 apt-get clean
-apt-get install -y devscripts equivs
+apt-get -o Acquire::Retries=3 install -y devscripts equivs
 
 # Copy the debian directory to the root of the git repo
 # so that all the devscripts command work.
@@ -58,7 +58,7 @@ dch --create -v "${FULL_VERSION}" --package "${PKGBASE}" --controlmaint --distri
 # Build debian package that depends on build-depends, and install it
 mk-build-deps
 dpkg -i --force-depends "$BUILD_DEPS"
-apt-get install -y -f
+apt-get -o Acquire::Retries=3 install -y -f
 mv "$BUILD_DEPS" "$OUT"
 
 # Build the actual debian packages


### PR DESCRIPTION
The CI is failing due to some flaky connection to the Ubuntu repository:

> E: Failed to fetch &lt;package&gt;  Connection failed [IP: &lt;IP&gt;]

This has happened for other projects and the recommendation is to do retry those fetches:
https://github.com/actions/runner-images/issues/6894