### PR TITLE
Switch Ubuntu CI to LLVM

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -32,6 +32,7 @@ jobs:
       env:
         DISTRO: ubuntu-20.04-focal
         IS_NIGHTLY: 1
+        CLANG_VERSION: 12
     steps:
     - name: Installing dependencies to bootstrap env
       run: apt update -y && apt install -y git wget lsb-release software-properties-common gpg
@@ -40,7 +41,15 @@ jobs:
         wget https://apt.llvm.org/llvm.sh
         chmod +x llvm.sh
         # Note: Keep this version in sync with the one in the Debian control file.
-        ./llvm.sh 12
+        ./llvm.sh ${CLANG_VERSION}
+    - name: Making LLVM the default compiler
+      run: |
+        update-alternatives --remove-all cc
+        update-alternatives --remove-all c++
+        update-alternatives --install /usr/bin/cc cc /usr/bin/clang++-${CLANG_VERSION} 500
+        update-alternatives --set cc /usr/bin/clang++-${CLANG_VERSION}
+        update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-${CLANG_VERSION} 500
+        update-alternatives --set c++ /usr/bin/clang++-${CLANG_VERSION}
     - name: Fetching HHVM and its submodules
       uses: actions/checkout@v3
       with:

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -22,6 +22,7 @@ concurrency:
 # https://github.com/actions/runner/issues/480
 env:
   OUT: ${{ format('{0}/out', github.workspace) }}
+  DEBIAN_FRONTEND: "noninteractive"
 
 jobs:
   build_ubuntu_focal_nightly:
@@ -32,8 +33,14 @@ jobs:
         DISTRO: ubuntu-20.04-focal
         IS_NIGHTLY: 1
     steps:
-    - name: Installing git
-      run: apt update -y && apt install -y git
+    - name: Installing dependencies to bootstrap env
+      run: apt update -y && apt install -y git wget lsb-release software-properties-common gpg
+    - name: Installing llvm
+      run: |
+        wget https://apt.llvm.org/llvm.sh
+        chmod +x llvm.sh
+        # Note: Keep this version in sync with the one in the Debian control file.
+        ./llvm.sh 12
     - name: Fetching HHVM and its submodules
       uses: actions/checkout@v3
       with:

--- a/ci/ubuntu-20.04-focal/debian/control
+++ b/ci/ubuntu-20.04-focal/debian/control
@@ -14,7 +14,7 @@ Build-Depends:
   curl,
   debhelper (>= 9),
   flex,
-  g++,
+  clang-12,
   gawk,
   git,
   gperf,

--- a/third-party/tbb/CMakeLists.txt
+++ b/third-party/tbb/CMakeLists.txt
@@ -25,6 +25,11 @@ ExternalProject_Add(
   INSTALL_COMMAND ""
 )
 
+# CLang uses the GCC file too.
+if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
+ execute_process(COMMAND "patch" "-p1" "-f" INPUT_FILE "${CMAKE_CURRENT_SOURCE_DIR}/clang_fix.patch")
+endif()
+
 add_library(tbb INTERFACE)
 add_dependencies(tbb bundled_tbb)
 

--- a/third-party/tbb/clang_fix.patch
+++ b/third-party/tbb/clang_fix.patch
@@ -1,0 +1,13 @@
+diff --git a/third-party/tbb/src/build/linux.gcc.inc b/third-party/tbb/src/build/linux.gcc.inc
+index 214b38377bc..91345012017 100644
+--- a/third-party/tbb/src/build/linux.gcc.inc
++++ b/third-party/tbb/src/build/linux.gcc.inc
+@@ -67,7 +67,7 @@ endif
+ # elimination of stores done outside the object lifetime
+ ifneq (,$(shell $(CONLY) -dumpfullversion -dumpversion | egrep  "^([6-9]|1[0-9])"))
+     # keep pre-contruction stores for zero initialization
+-    DSE_KEY = -flifetime-dse=1
++    DSE_KEY =
+ endif
+ 
+ ifeq ($(cfg), release)


### PR DESCRIPTION
I chose LLVM 12 as a good start. It should be fairly easy for us to switch to newer version of LLVM.