### PR TITLE
fix-ci: move from unmaintained `actions-rs` to a maintained alternative

### DIFF
--- a/build/fbcode_builder/getdeps.py
+++ b/build/fbcode_builder/getdeps.py
@@ -1043,11 +1043,7 @@ jobs:
                 if m != manifest:
                     if m.name == "rust":
                         out.write("    - name: Install Rust Stable\n")
-                        out.write("      uses: actions-rs/toolchain@v1\n")
-                        out.write("      with:\n")
-                        out.write("        toolchain: stable\n")
-                        out.write("        default: true\n")
-                        out.write("        profile: minimal\n")
+                        out.write("      uses: dtolnay/rust-toolchain@stable\n")
                     else:
                         ctx = loader.ctx_gen.get_context(m.name)
                         if m.get_repo_url(ctx) != main_repo_url:


### PR DESCRIPTION
Unfortunately `actions-rs` is [unmaintained](https://github.com/actions-rs/toolchain/issues/216) and I am trying to advocate a move from actions-rs to its maintained alternative such as https://github.com/dtolnay/rust-toolchain across the community.