### PR TITLE
Perf: [2.08kW][Const Refable Parameter] Infer Contscan detected an issue at proxygen/lib/http/HTTPMessage.h:785

### DIFF
--- a/third-party/proxygen/src/proxygen/lib/http/HTTPMessage.h
+++ b/third-party/proxygen/src/proxygen/lib/http/HTTPMessage.h
@@ -782,7 +782,7 @@ class HTTPMessage {
     return h2Pri_;
   }
 
-  void setHTTP2Priority(HTTP2Priority h2Pri) {
+  void setHTTP2Priority(const HTTP2Priority& h2Pri) {
     h2Pri_ = h2Pri;
   }
 


### PR DESCRIPTION
Summary:
Infer detected a(n) [Const Refable Parameter](https://fbinfer.com/docs/next/all-issue-types#const refable parameter) issue.
Function parameter h2Pri is passed by-value but not modified inside the function on line 785. This might result in an unnecessary copy at the callsite of this function. Consider changing the type of this function parameter to const &.

Reviewed By: afrind

Differential Revision: D46807054

