### PR TITLE
Fix a comments typo in StaticTracepoint-ELFx86.h

### DIFF
--- a/third-party/folly/src/folly/tracing/StaticTracepoint-ELFx86.h
+++ b/third-party/folly/src/folly/tracing/StaticTracepoint-ELFx86.h
@@ -57,7 +57,7 @@
                                : sizeof(x))
 
 // Format of each probe arguments as operand.
-// Size of the arugment tagged with FOLLY_SDT_Sn, with "n" constraint.
+// Size of the argument tagged with FOLLY_SDT_Sn, with "n" constraint.
 // Value of the argument tagged with FOLLY_SDT_An, with configured constraint.
 #define FOLLY_SDT_ARG(n, x)                                                    \
   [FOLLY_SDT_S##n] "n"                ((size_t)FOLLY_SDT_ARGSIZE(x)),          \


### PR DESCRIPTION
Summary:
This diff removes a typo in comments:

// Size of the **arugment** tagged with FOLLY_SDT_Sn, with "n" constraint.
-->
// Size of the **argument** tagged with FOLLY_SDT_Sn, with "n" constraint.

Reviewed By: jordalgo

Differential Revision: D47069505

