### PR TITLE
directory-structure.md: src/hhbc -> src/hackc

### DIFF
--- a/hphp/doc/hackers-guide/directory-structure.md
+++ b/hphp/doc/hackers-guide/directory-structure.md
@@ -3,7 +3,7 @@
 There are over 1000 C++ files in HHVM's codebase, split into a number of
 different directories. This is a rough overview of what lives where (all paths are under `hphp/`):
 
-`compiler/`: The old parser and bytecode emitter. This is deprecated and is currently being removed; the new replacement is in `hack/src/hhbc`.
+`compiler/`: The old parser and bytecode emitter. This is deprecated and is currently being removed; the new replacement is in `hack/src/hackc/`.
 
 `doc/`: Documentation, of varying age and quality.
 


### PR DESCRIPTION
The new byte-compiler got renamed in commit:
43f86984885592c6b2d55a7bdc9e242fab38efcf (Rename directory hhbc to hackc), presumably to disabiguate it from the bytecode format.

I'm not sure how to write tests for this file, but it would be nice if it had some.