### PR TITLE
Fix Ubuntu CI

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -44,12 +44,12 @@ jobs:
         ./llvm.sh ${CLANG_VERSION}
     - name: Making LLVM the default compiler
       run: |
-        if command -v cc &> /dev/null
+        if [ -f /etc/alternatives/cc ]
         then
           update-alternatives --remove-all cc
         fi
 
-        if command -v c++ &> /dev/null
+        if [ -f /etc/alternatives/c++ ]
         then
           update-alternatives --remove-all c++
         fi

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -44,8 +44,16 @@ jobs:
         ./llvm.sh ${CLANG_VERSION}
     - name: Making LLVM the default compiler
       run: |
-        update-alternatives --remove-all cc
-        update-alternatives --remove-all c++
+        if command -v cc &> /dev/null
+        then
+          update-alternatives --remove-all cc
+        fi
+
+        if command -v c++ &> /dev/null
+        then
+          update-alternatives --remove-all c++
+        fi
+        
         update-alternatives --install /usr/bin/cc cc /usr/bin/clang++-${CLANG_VERSION} 500
         update-alternatives --set cc /usr/bin/clang++-${CLANG_VERSION}
         update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-${CLANG_VERSION} 500


### PR DESCRIPTION
Not all exists command have a alternative, but if there is one, a soft link will in the `/etc/alternatives`.
If you try to delete a alternative that not exists, will get this:`update-alternatives: error: no alternatives for cc`.
This PR added a condition when deleting the alternative, and the error not raised:
![image](https://github.com/facebook/hhvm/assets/120731947/473b927e-00dd-4120-bcb2-f2e5f7ed7526)


Footnote: The failing of step `Installing HHVM deps and building HHVM` is unrelated to this PR.