### PR TITLE
Correct alternative of cc

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -54,8 +54,8 @@ jobs:
           update-alternatives --remove-all c++
         fi
         
-        update-alternatives --install /usr/bin/cc cc /usr/bin/clang++-${CLANG_VERSION} 500
-        update-alternatives --set cc /usr/bin/clang++-${CLANG_VERSION}
+        update-alternatives --install /usr/bin/cc cc /usr/bin/clang-${CLANG_VERSION} 500
+        update-alternatives --set cc /usr/bin/clang-${CLANG_VERSION}
         update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-${CLANG_VERSION} 500
         update-alternatives --set c++ /usr/bin/clang++-${CLANG_VERSION}
     - name: Fetching HHVM and its submodules


### PR DESCRIPTION
## Summary
The `cc` command is to compile C source file by default.And the compiler to compile C source in `LLVM` is `clang-XX`
But, we are using `clang++-XX` to be the alternative of `cc`.
Obviously, this is wrong.So, let's fix it!

## Test Plan
Before:
![image](https://github.com/facebook/hhvm/assets/120731947/8628f89f-24dd-4462-8166-0e322883f206)
After:
![image](https://github.com/facebook/hhvm/assets/120731947/146529ff-2e53-48ca-8447-d2b1fa1d39d7)

