### PR TITLE
Pass ASAN_OPTIONS to external-worker processes

### DIFF
--- a/hphp/util/extern-worker.cpp
+++ b/hphp/util/extern-worker.cpp
@@ -1230,6 +1230,9 @@ SubprocessImpl::doSubprocess(const RequestId& requestId,
     env.emplace_back(folly::sformat("TRACE={}", trace));
     env.emplace_back(folly::sformat("HPHP_TRACE_FILE={}", fullPath.c_str()));
   }
+  if (auto const asan_options = getenv("ASAN_OPTIONS")) {
+    env.emplace_back(folly::sformat("ASAN_OPTIONS={}", asan_options));
+  }
 
   FTRACE(
     4, "{} executing subprocess for '{}'{}(input size: {})\n",


### PR DESCRIPTION
external-worker creates new processes using Folly::Subprocess, which relies on `execve`. This means that the new process does not automatically inherit any environment variables from the current process.

ASAN's behavior can be tweaked using ASAN_OPTIONS, which is important to prevent false positives (e.g. when running with leak tracking).

This PR solves compiling repo auth under some ASAN conditions:

> $ hhvm --hphp -o repo_auth --input_dir=/path/to/codebase