### PR TITLE
Attempt to fix duplicate flag issue

### DIFF
--- a/third-party/thrift/src/thrift/lib/cpp2/CMakeLists.txt
+++ b/third-party/thrift/src/thrift/lib/cpp2/CMakeLists.txt
@@ -42,15 +42,13 @@ add_library(
 
   ${metadata-cpp2-SOURCES}
   gen/module_types_cpp.cpp
-  protocol/CompactProtocol.cpp # can't link against thriftprotocol, dep cycle
-  ../cpp/protocol/TProtocolException.cpp
-  ../cpp/util/VarintUtils.cpp
 )
 add_dependencies(thriftmetadata metadata-cpp2-target)
 target_link_libraries(
   thriftmetadata
   PUBLIC
     Folly::folly
+    thriftprotocol
 )
 
 bypass_source_check("${frozen-cpp2-SOURCES}")
@@ -141,18 +139,13 @@ add_library(
 
   ${RpcMetadata-cpp2-SOURCES}
   gen/module_types_cpp.cpp
-  protocol/CompactProtocol.cpp # can't link against thriftprotocol, dep cycle
-  protocol/JSONProtocolCommon.cpp
-  ../cpp/protocol/TBase64Utils.cpp
-  ../cpp/protocol/TJSONProtocol.cpp
-  ../cpp/protocol/TProtocolException.cpp
-  ../cpp/util/VarintUtils.cpp
 )
 add_dependencies(rpcmetadata RpcMetadata-cpp2-target)
 target_link_libraries(
   rpcmetadata
   PUBLIC
     Folly::folly
+    thriftprotocol
 )
 
 bypass_source_check("${reflection-cpp2-SOURCES}")


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebook/fbthrift/pull/579

CacheLib noticed OSS build failures due to JSONProtocolCommon.cpp being linked into the build twice, after we added a GFLAG to that file.

This diff attempts to fix the issue by depending on thriftprotocol rather than duplicating the files.

The code claims that it couldn't depend on thriftprotocol due to a circular dependency (added in [D24720566](https://www.internalfb.com/diff/D24720566)), but Sandcastle and GitHub Actions is passing, so it doesn't seem to still be an issue.

Differential Revision: D50505357


