### PR TITLE
Option to set where the perf maps go

### DIFF
--- a/hphp/runtime/base/runtime-option.h
+++ b/hphp/runtime/base/runtime-option.h
@@ -880,12 +880,13 @@ struct RuntimeOption {
   F(bool, JitNoGdb,                    true)                            \
   F(bool, SpinOnCrash,                 false)                           \
   F(uint32_t, DumpRingBufferOnCrash,   0)                               \
+  F(string, PerfMapsDir,               "/tmp")                          \
   F(bool, PerfPidMap,                  true)                            \
   F(bool, PerfPidMapIncludeFilePath,   true)                            \
+  F(bool, KeepPerfPidMap,              false)                           \
   F(bool, PerfJitDump,                 false)                           \
   F(string, PerfJitDumpDir,            "/tmp")                          \
   F(bool, PerfDataMap,                 false)                           \
-  F(bool, KeepPerfPidMap,              false)                           \
   F(uint32_t, ThreadTCMainBufferSize,  6 << 20)                         \
   F(uint32_t, ThreadTCColdBufferSize,  6 << 20)                         \
   F(uint32_t, ThreadTCFrozenBufferSize,4 << 20)                         \


### PR DESCRIPTION
This matches other options like PerfJitDumpDir
or CoreDumpReportDirectory.

For simplicity, this controls both the perf
map and the perf id map.