### PR TITLE
Migrate google java format from 1.7 -> 1.19.2

### DIFF
--- a/third-party/thrift/src/thrift/lib/java/benchmarks/src/main/java/com/facebook/thrift/runner/AsyncNetty4Client.java
+++ b/third-party/thrift/src/thrift/lib/java/benchmarks/src/main/java/com/facebook/thrift/runner/AsyncNetty4Client.java
@@ -32,7 +32,8 @@ public class AsyncNetty4Client extends AbstractAsyncClient {
     ResourceLeakDetector.setLevel(ResourceLeakDetector.Level.DISABLED);
     if (args.length < 3) {
       throw new IllegalArgumentException(
-          "Incorrect number of arguments. <hostname> <port/Uds Path> <warmupSeconds> <benchmarkSeconds>");
+          "Incorrect number of arguments. <hostname> <port/Uds Path> <warmupSeconds>"
+              + " <benchmarkSeconds>");
     }
 
     SocketAddress address;

--- a/third-party/thrift/src/thrift/lib/java/common/src/main/java/com/facebook/thrift/enums/BaseEnum.java
+++ b/third-party/thrift/src/thrift/lib/java/common/src/main/java/com/facebook/thrift/enums/BaseEnum.java
@@ -22,10 +22,14 @@ package com.facebook.thrift.enums;
  */
 public interface BaseEnum {
 
-  /** @return Returns the i32 value of the enum */
+  /**
+   * @return Returns the i32 value of the enum
+   */
   public int getValue();
 
-  /** @return true for java enums, false for open enums. */
+  /**
+   * @return true for java enums, false for open enums.
+   */
   public default boolean isClosedEnum() {
     return true;
   }

--- a/third-party/thrift/src/thrift/lib/java/common/src/main/java/com/facebook/thrift/enums/ThriftEnum.java
+++ b/third-party/thrift/src/thrift/lib/java/common/src/main/java/com/facebook/thrift/enums/ThriftEnum.java
@@ -33,25 +33,35 @@ public abstract class ThriftEnum<T extends ThriftEnum>
   protected int value;
   protected int unrecognizedValue;
 
-  /** @return Returns the integer value of the defined enum. */
+  /**
+   * @return Returns the integer value of the defined enum.
+   */
   @Override
   @ThriftEnumValue
   public int getValue() {
     return this.value;
   }
 
-  /** @return Returns the unrecognized value of the enum if the value is not defined. */
+  /**
+   * @return Returns the unrecognized value of the enum if the value is not defined.
+   */
   public int getUnrecognizedValue() {
     return unrecognizedValue;
   }
 
-  /** @return true if the enum value is unrecognized, false otherwise. */
+  /**
+   * @return true if the enum value is unrecognized, false otherwise.
+   */
   public abstract boolean isValueUnrecognized();
 
-  /** @return Ordinal value of the enum. Unrecognized value has the last ordinal value. */
+  /**
+   * @return Ordinal value of the enum. Unrecognized value has the last ordinal value.
+   */
   public abstract int ordinal();
 
-  /** @return Name of the enum defined in the IDL. */
+  /**
+   * @return Name of the enum defined in the IDL.
+   */
   public abstract String name();
 
   public boolean isClosedEnum() {

--- a/third-party/thrift/src/thrift/lib/java/common/src/main/java/com/facebook/thrift/protocol/ByteBufAbstractTSimpleJSONProtocol.java
+++ b/third-party/thrift/src/thrift/lib/java/common/src/main/java/com/facebook/thrift/protocol/ByteBufAbstractTSimpleJSONProtocol.java
@@ -787,7 +787,8 @@ public abstract class ByteBufAbstractTSimpleJSONProtocol extends ByteBufTProtoco
   @Override
   public TStruct readStructBegin() {
     throw new UnsupportedOperationException(
-        "You need to specify a \"field name\" -> \"field Id\" mapping to deserialize with TSimpleJSON");
+        "You need to specify a \"field name\" -> \"field Id\" mapping to deserialize with"
+            + " TSimpleJSON");
   }
 
   @Override

--- a/third-party/thrift/src/thrift/lib/java/common/src/main/java/com/facebook/thrift/protocol/ByteBufTProtocol.java
+++ b/third-party/thrift/src/thrift/lib/java/common/src/main/java/com/facebook/thrift/protocol/ByteBufTProtocol.java
@@ -80,7 +80,9 @@ public abstract class ByteBufTProtocol extends TProtocol {
    */
   public abstract ByteBuf readBinaryAsSlice() throws TException;
 
-  /** @return Returns the current writer index of the ByteBuf */
+  /**
+   * @return Returns the current writer index of the ByteBuf
+   */
   public int mark() {
     return this.byteBuf.writerIndex();
   }
@@ -102,5 +104,6 @@ public abstract class ByteBufTProtocol extends TProtocol {
    */
   public int getEmptyStructSize() {
     return 1;
-  };
+  }
+  ;
 }

--- a/third-party/thrift/src/thrift/lib/java/common/src/main/java/com/facebook/thrift/util/Utf8Util.java
+++ b/third-party/thrift/src/thrift/lib/java/common/src/main/java/com/facebook/thrift/util/Utf8Util.java
@@ -49,7 +49,8 @@ public class Utf8Util {
       createStr = lookup.unreflect(m);
     } catch (Throwable t) {
       logger.warn(
-          "Add JVM option for faster UTF-8 validation. --add-opens java.base/java.lang=ALL-UNNAMED");
+          "Add JVM option for faster UTF-8 validation. --add-opens"
+              + " java.base/java.lang=ALL-UNNAMED");
       // Ignore, validation will be done before creating the String
     }
 

--- a/third-party/thrift/src/thrift/lib/java/common/src/main/java/org/apache/thrift/transport/TTransport.java
+++ b/third-party/thrift/src/thrift/lib/java/common/src/main/java/org/apache/thrift/transport/TTransport.java
@@ -81,7 +81,8 @@ public abstract class TTransport implements Closeable {
                 + len
                 + " bytes, but only got "
                 + got
-                + " bytes. (This is often indicative of an internal error on the server side. Please check your server logs.)");
+                + " bytes. (This is often indicative of an internal error on the server side."
+                + " Please check your server logs.)");
       }
       got += ret;
     }

--- a/third-party/thrift/src/thrift/lib/java/runtime/src/main/java/com/facebook/swift/service/stats/ServerStats.java
+++ b/third-party/thrift/src/thrift/lib/java/runtime/src/main/java/com/facebook/swift/service/stats/ServerStats.java
@@ -37,6 +37,7 @@ public class ServerStats {
 
   // Counter properties
   private final AtomicLong receivedRequests;
+
   /**
    * DecayCounters decays exponentially using a formula to calculate counts in a rolling time window
    * https://github.com/airlift/airlift/blob/master/stats/src/main/java/io/airlift/stats/DecayCounter.java

--- a/third-party/thrift/src/thrift/lib/java/runtime/src/main/java/com/facebook/thrift/any/AbstractAny.java
+++ b/third-party/thrift/src/thrift/lib/java/runtime/src/main/java/com/facebook/thrift/any/AbstractAny.java
@@ -95,10 +95,14 @@ abstract class AbstractAny<T, A> {
     deserializerId.put(id, deserializer);
   }
 
-  /** @return Returns payload of Any and SemiAny */
+  /**
+   * @return Returns payload of Any and SemiAny
+   */
   public abstract T get();
 
-  /** @return Returns AnyStruct or SemiAnyStruct */
+  /**
+   * @return Returns AnyStruct or SemiAnyStruct
+   */
   public abstract A getAny();
 
   @Override

--- a/third-party/thrift/src/thrift/lib/java/runtime/src/main/java/com/facebook/thrift/any/SerializedAny.java
+++ b/third-party/thrift/src/thrift/lib/java/runtime/src/main/java/com/facebook/thrift/any/SerializedAny.java
@@ -35,7 +35,9 @@ class SerializedAny<T> extends Any<T> {
     this.any = Objects.requireNonNull(any);
   }
 
-  /** @return Any payload */
+  /**
+   * @return Any payload
+   */
   public T get() {
     if (lazyValue != null) {
       return (T) lazyValue;
@@ -56,7 +58,9 @@ class SerializedAny<T> extends Any<T> {
     }
   }
 
-  /** @return AnyStruct */
+  /**
+   * @return AnyStruct
+   */
   @Override
   public AnyStruct getAny() {
     return any;

--- a/third-party/thrift/src/thrift/lib/java/runtime/src/main/java/com/facebook/thrift/any/SerializedSemiAny.java
+++ b/third-party/thrift/src/thrift/lib/java/runtime/src/main/java/com/facebook/thrift/any/SerializedSemiAny.java
@@ -40,7 +40,9 @@ class SerializedSemiAny<T> extends SemiAny<T> {
     this.any = Objects.requireNonNull(any);
   }
 
-  /** @return SemiAny payload. Data, protocol and type must be provided to get the value. */
+  /**
+   * @return SemiAny payload. Data, protocol and type must be provided to get the value.
+   */
   public T get() {
     if (lazyValue != null) {
       return (T) lazyValue;
@@ -64,7 +66,9 @@ class SerializedSemiAny<T> extends SemiAny<T> {
     }
   }
 
-  /** @return SemiAnyStruct */
+  /**
+   * @return SemiAnyStruct
+   */
   @Override
   public SemiAnyStruct getAny() {
     return any;

--- a/third-party/thrift/src/thrift/lib/java/runtime/src/main/java/com/facebook/thrift/any/ThriftAnyDeserializer.java
+++ b/third-party/thrift/src/thrift/lib/java/runtime/src/main/java/com/facebook/thrift/any/ThriftAnyDeserializer.java
@@ -94,7 +94,8 @@ public class ThriftAnyDeserializer {
     } else {
       return deserializeObject(typeStruct);
     }
-  };
+  }
+  ;
 
   private Type findByType(String uri) {
     Type type = uriCache.get(uri);

--- a/third-party/thrift/src/thrift/lib/java/runtime/src/main/java/com/facebook/thrift/util/RpcClientUtils.java
+++ b/third-party/thrift/src/thrift/lib/java/runtime/src/main/java/com/facebook/thrift/util/RpcClientUtils.java
@@ -109,7 +109,8 @@ public final class RpcClientUtils {
                 : unavailabilityCause.getMessage();
         throw new UnsupportedOperationException(
             String.format(
-                "Unsupported combination of EventLoopGroup-{%s} & SocketAddress-{%s}. Likely due to system support for Epoll unavailable due to {%s}",
+                "Unsupported combination of EventLoopGroup-{%s} & SocketAddress-{%s}. Likely due to"
+                    + " system support for Epoll unavailable due to {%s}",
                 group.getClass(), socketAddress.getClass(), errorMsg),
             unavailabilityCause);
       }
@@ -123,7 +124,8 @@ public final class RpcClientUtils {
                 : unavailabilityCause.getMessage();
         throw new UnsupportedOperationException(
             String.format(
-                "Unsupported combination of EventLoopGroup-{%s} & SocketAddress-{%s}. Likely due to system support for Kqueue unavailable due to {%s}.",
+                "Unsupported combination of EventLoopGroup-{%s} & SocketAddress-{%s}. Likely due to"
+                    + " system support for Kqueue unavailable due to {%s}.",
                 group.getClass(), socketAddress.getClass(), errorMsg),
             unavailabilityCause);
       }

--- a/third-party/thrift/src/thrift/lib/java/runtime/src/main/java/com/facebook/thrift/util/RpcServerUtils.java
+++ b/third-party/thrift/src/thrift/lib/java/runtime/src/main/java/com/facebook/thrift/util/RpcServerUtils.java
@@ -93,7 +93,8 @@ public final class RpcServerUtils {
                 : unavailabilityCause.getMessage();
         throw new UnsupportedOperationException(
             String.format(
-                "Unsupported combination of EventLoopGroup-{%s} & SocketAddress-{%s}. Likely due to system support for Epoll unavailable due to {%s}.",
+                "Unsupported combination of EventLoopGroup-{%s} & SocketAddress-{%s}. Likely due to"
+                    + " system support for Epoll unavailable due to {%s}.",
                 group.getClass(), socketAddress.getClass(), errorMsg),
             unavailabilityCause);
       }
@@ -107,7 +108,8 @@ public final class RpcServerUtils {
                 : unavailabilityCause.getMessage();
         throw new UnsupportedOperationException(
             String.format(
-                "Unsupported combination of EventLoopGroup-{%s} & SocketAddress-{%s}. Likely due to system support for Kqueue unavailable due to {%s}.",
+                "Unsupported combination of EventLoopGroup-{%s} & SocketAddress-{%s}. Likely due to"
+                    + " system support for Kqueue unavailable due to {%s}.",
                 group.getClass(), socketAddress.getClass(), errorMsg),
             unavailabilityCause);
       }

--- a/third-party/thrift/src/thrift/lib/java/runtime/src/test/java/com/facebook/thrift/util/resources/AbstractSchedulerTest.java
+++ b/third-party/thrift/src/thrift/lib/java/runtime/src/test/java/com/facebook/thrift/util/resources/AbstractSchedulerTest.java
@@ -28,7 +28,9 @@ import reactor.core.Exceptions;
 import reactor.core.scheduler.Scheduler;
 import reactor.core.scheduler.Schedulers;
 
-/** @author Stephane Maldini */
+/**
+ * @author Stephane Maldini
+ */
 public abstract class AbstractSchedulerTest {
 
   protected abstract Scheduler scheduler();

--- a/third-party/thrift/src/thrift/lib/javadeprecated/src/main/java/com/facebook/thrift/protocol/AbstractTSimpleJSONProtocol.java
+++ b/third-party/thrift/src/thrift/lib/javadeprecated/src/main/java/com/facebook/thrift/protocol/AbstractTSimpleJSONProtocol.java
@@ -784,7 +784,8 @@ abstract class AbstractTSimpleJSONProtocol extends TProtocol {
   @Override
   public TStruct readStructBegin() {
     throw new UnsupportedOperationException(
-        "You need to specify a \"field name\" -> \"field Id\" mapping to deserialize with TSimpleJSON");
+        "You need to specify a \"field name\" -> \"field Id\" mapping to deserialize with"
+            + " TSimpleJSON");
   }
 
   @Override

--- a/third-party/thrift/src/thrift/lib/javadeprecated/src/main/java/com/facebook/thrift/server/THsHaServer.java
+++ b/third-party/thrift/src/thrift/lib/javadeprecated/src/main/java/com/facebook/thrift/server/THsHaServer.java
@@ -223,7 +223,9 @@ public class THsHaServer extends TNonblockingServer {
     options_ = options;
   }
 
-  /** @inheritDoc */
+  /**
+   * @inheritDoc
+   */
   @Override
   public void serve() {
     if (!startInvokerPool()) {

--- a/third-party/thrift/src/thrift/lib/javadeprecated/src/main/java/com/facebook/thrift/server/TServlet.java
+++ b/third-party/thrift/src/thrift/lib/javadeprecated/src/main/java/com/facebook/thrift/server/TServlet.java
@@ -45,7 +45,9 @@ public class TServlet extends HttpServlet {
 
   private final Collection<Map.Entry<String, String>> customHeaders;
 
-  /** @see HttpServlet#HttpServlet() */
+  /**
+   * @see HttpServlet#HttpServlet()
+   */
   public TServlet(
       TProcessor processor,
       TProtocolFactory inProtocolFactory,
@@ -57,12 +59,16 @@ public class TServlet extends HttpServlet {
     this.customHeaders = new ArrayList<Map.Entry<String, String>>();
   }
 
-  /** @see HttpServlet#HttpServlet() */
+  /**
+   * @see HttpServlet#HttpServlet()
+   */
   public TServlet(TProcessor processor, TProtocolFactory protocolFactory) {
     this(processor, protocolFactory, protocolFactory);
   }
 
-  /** @see HttpServlet#doPost(HttpServletRequest request, HttpServletResponse response) */
+  /**
+   * @see HttpServlet#doPost(HttpServletRequest request, HttpServletResponse response)
+   */
   @Override
   protected void doPost(HttpServletRequest request, HttpServletResponse response)
       throws ServletException, IOException {
@@ -96,7 +102,9 @@ public class TServlet extends HttpServlet {
     }
   }
 
-  /** @see HttpServlet#doGet(HttpServletRequest request, HttpServletResponse response) */
+  /**
+   * @see HttpServlet#doGet(HttpServletRequest request, HttpServletResponse response)
+   */
   protected void doGet(HttpServletRequest request, HttpServletResponse response)
       throws ServletException, IOException {
     doPost(request, response);

--- a/third-party/thrift/src/thrift/lib/javadeprecated/src/main/java/com/facebook/thrift/transport/THttpClient.java
+++ b/third-party/thrift/src/thrift/lib/javadeprecated/src/main/java/com/facebook/thrift/transport/THttpClient.java
@@ -75,7 +75,8 @@ public class THttpClient extends TTransport {
     if (null != inputStream_) {
       try {
         inputStream_.close();
-      } catch (IOException ioe) {;
+      } catch (IOException ioe) {
+        ;
       }
       inputStream_ = null;
     }


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebook/SoLoader/pull/122

This diff migrates google java format form 1.7 to 1.19.2. This update will allow for new language features from java 17 and 21. This diff also formats all necessary files.

 Changelog:
    [Internal][Changed] - Updated format from google-java-format 1.7 -> 1.19.2

Reviewed By: IanChilds

Differential Revision: D52786052


