### PR TITLE
thrift: to stop relying on operator->

### DIFF
--- a/third-party/thrift/src/thrift/lib/cpp2/protocol/detail/protocol_methods.h
+++ b/third-party/thrift/src/thrift/lib/cpp2/protocol/detail/protocol_methods.h
@@ -770,12 +770,12 @@ struct protocol_methods<type_class::map<KeyClass, MappedClass>, Type> {
         iters.push_back(it);
       }
       std::sort(iters.begin(), iters.end(), [](auto a, auto b) {
-        return a->first < b->first;
+        return (*a).first < (*b).first;
       });
       for (auto it : iters) {
         xfer += writeMapValueBegin(protocol);
-        xfer += key_methods::write(protocol, it->first);
-        xfer += mapped_methods::write(protocol, it->second);
+        xfer += key_methods::write(protocol, (*it).first);
+        xfer += mapped_methods::write(protocol, (*it).second);
         xfer += writeMapValueEnd(protocol);
       }
     } else {


### PR DESCRIPTION
Summary:
C++20 supports iterators with no operator->
We have a usecase where I care for that and arrow_proxy trick leads to some undesired behaviour.

In C++23 there is a standard one - std::flat_map::iterator won't have operator->, as far as I understand.
(I judge by std::views::zip which doesn't have operator->)

Differential Revision: D53665618


