### PR TITLE
Optimize multiple symbol lookup: return early on empty `symbols`

### DIFF
--- a/third-party/folly/src/folly/experimental/symbolizer/Elf.h
+++ b/third-party/folly/src/folly/experimental/symbolizer/Elf.h
@@ -275,6 +275,10 @@ class ElfFile {
       std::initializer_list<uint32_t> types = {
           STT_OBJECT, STT_FUNC, STT_GNU_IFUNC}) const noexcept {
     std::unordered_map<std::string, Symbol> result(names.size());
+    if (names.empty()) {
+      return result;
+    }
+
     for (const std::string& name : names) {
       result[name] = {nullptr, nullptr};
     }

--- a/third-party/folly/src/folly/experimental/symbolizer/test/ElfTest.cpp
+++ b/third-party/folly/src/folly/experimental/symbolizer/test/ElfTest.cpp
@@ -93,7 +93,7 @@ TEST_F(ElfTest, SymbolByName) {
 }
 
 TEST_F(ElfTest, SymbolsByNameSuccess) {
-  auto names = {"sum_func", "sub_func"};
+  std::vector<std::string> names = {"sum_func", "sub_func"};
   auto result = elfFile_.getSymbolsByName(names, {STT_FUNC});
 
   EXPECT_EQ(names.size(), result.size());
@@ -110,7 +110,7 @@ TEST_F(ElfTest, SymbolsByNameSuccess) {
 }
 
 TEST_F(ElfTest, SymbolsByNamePartial) {
-  auto names = {"sum_func", "sub_func", "foo_func"};
+  std::vector<std::string> names = {"sum_func", "sub_func", "foo_func"};
   auto result = elfFile_.getSymbolsByName(names, {STT_FUNC});
 
   EXPECT_EQ(names.size(), result.size());
@@ -121,6 +121,14 @@ TEST_F(ElfTest, SymbolsByNamePartial) {
   const auto& fooFuncSymbol = result.at("foo_func");
   EXPECT_EQ(nullptr, fooFuncSymbol.first);
   EXPECT_EQ(nullptr, fooFuncSymbol.second);
+}
+
+TEST_F(ElfTest, SymbolsByNameEmpty) {
+  std::vector<std::string> names;
+  auto result = elfFile_.getSymbolsByName(names, {STT_FUNC});
+
+  EXPECT_EQ(0, result.size());
+  EXPECT_EQ(names.size(), result.size());
 }
 
 TEST_F(ElfTest, iterateProgramHeaders) {


### PR DESCRIPTION
Summary: This change will avoid unnecessarily scanning all Elf sections when `symbols` to look-up are empty. In this case, `getSymbolsByName` will return early. Also added a test.

Reviewed By: nslingerland

Differential Revision: D53765727


