### PR TITLE
Fix int64 handling sqlite3

### DIFF
--- a/hphp/runtime/ext/sqlite3/ext_sqlite3.cpp
+++ b/hphp/runtime/ext/sqlite3/ext_sqlite3.cpp
@@ -70,7 +70,7 @@ static Variant get_value(sqlite3_value *argv) {
   Variant value;
   switch (sqlite3_value_type(argv)) {
   case SQLITE_INTEGER:
-    value = (int64_t)sqlite3_value_int(argv);
+    value = (int64_t)sqlite3_value_int64(argv);
     break;
   case SQLITE_FLOAT:
     value = (double)sqlite3_value_double(argv);
@@ -115,7 +115,7 @@ static void sqlite3_do_callback(sqlite3_context *context,
     /* only set the sqlite return value if we are a scalar function,
      * or if we are finalizing an aggregate */
     if (ret.isInteger()) {
-      sqlite3_result_int(context, ret.toInt64());
+      sqlite3_result_int64(context, ret.toInt64());
     } else if (ret.isNull()) {
       sqlite3_result_null(context);
     } else if (ret.isDouble()) {
@@ -596,7 +596,7 @@ Variant HHVM_METHOD(SQLite3Stmt, execute) {
 
     switch (p.type) {
     case SQLITE_INTEGER:
-      sqlite3_bind_int(data->m_raw_stmt, p.index, p.value.toInt64());
+      sqlite3_bind_int64(data->m_raw_stmt, p.index, p.value.toInt64());
       break;
     case SQLITE_FLOAT:
       sqlite3_bind_double(data->m_raw_stmt, p.index, p.value.toDouble());

--- a/hphp/test/slow/ext_sqlite3/sqlite3_int64.php
+++ b/hphp/test/slow/ext_sqlite3/sqlite3_int64.php
@@ -1,0 +1,128 @@
+<?hh
+
+function VR(mixed $got, dict<string, mixed> $exp) {
+  if ($got === false) {
+    echo "Failed: no row\n";
+  } else if ($got is null) {
+    echo "Failed: error fetching the row\n";
+  } else if ($got === $exp) {
+    echo "Passed: row matched\n";
+  } else {
+    echo "Failed, expected:";
+    var_dump($exp);
+    echo "\nBut got:";
+    var_dump($got);
+    var_dump(debug_backtrace());
+  }
+}
+
+function VS(int $x, int $y) {
+  var_dump($x === $y);
+  if ($x !== $y) {
+    echo "Failed: $y\n"; echo "Got: $x\n";
+    var_dump(debug_backtrace());
+  }
+}
+
+function VERIFY($x) { VS((int)($x != false), (int)true); }
+
+//////////////////////////////////////////////////////////////////////
+
+function identity($r) {
+ return (int)$r;
+}
+
+<<__EntryPoint>>
+function main_ext_sqlite3() {
+  $db = new SQLite3(':memory:');
+  $db->exec("CREATE TABLE numbers (name STRING, val INTEGER)");
+
+  $db->exec("INSERT INTO numbers VALUES ('small', 1234)");
+  // All those values are bigger than an int32.
+  $db->exec("INSERT INTO numbers VALUES ('large', 845868619338)");
+  $db->exec("INSERT INTO numbers VALUES ('large_neg', -845787619309)");
+  $db->exec("INSERT INTO numbers VALUES ('max64', " . PHP_INT_MAX . ")");
+  $db->exec("INSERT INTO numbers VALUES ('min64', " . PHP_INT_MIN . ")");
+
+  echo "testing query() and SQLite3Result\n";
+  {
+    $res = $db->query("SELECT * FROM numbers");
+    VR($res->fetcharray(SQLITE3_ASSOC), dict["name" => "small", "val" => 1234]);
+    VR($res->fetcharray(SQLITE3_ASSOC), dict["name" => "large", "val" => 845868619338]);
+    VR($res->fetcharray(SQLITE3_ASSOC), dict["name" => "large_neg", "val" => -845787619309]);
+    VR($res->fetcharray(SQLITE3_ASSOC), dict["name" => "max64", "val" => PHP_INT_MAX]);
+    VR($res->fetcharray(SQLITE3_ASSOC), dict["name" => "min64", "val" => PHP_INT_MIN]);
+    $res->finalize();
+  }
+
+  echo "testing bind with name\n";
+  {
+    $stmt = $db->prepare("SELECT * FROM numbers WHERE val = :val");
+    VS($stmt->paramcount(), 1);
+
+    $val = PHP_INT_MAX;
+    VERIFY($stmt->bindvalue(":val", $val, SQLITE3_INTEGER));
+    {
+      $res = $stmt->execute();
+      VR($res->fetcharray(SQLITE3_ASSOC), dict["name" => "max64", "val" => $val]);
+      $res->finalize();
+    }
+
+    VERIFY($stmt->clear());
+    VERIFY($stmt->reset());
+  }
+
+  {
+    $stmt = $db->prepare("SELECT * FROM numbers WHERE val = :val");
+    VS($stmt->paramcount(), 1);
+
+    $val = PHP_INT_MIN;
+    VERIFY($stmt->bindvalue(":val", $val, SQLITE3_INTEGER));
+    {
+      $res = $stmt->execute();
+      VR($res->fetcharray(SQLITE3_ASSOC), dict["name" => "min64", "val" => $val]);
+      $res->finalize();
+    }
+
+    VERIFY($stmt->clear());
+    VERIFY($stmt->reset());
+  }
+
+  echo "testing bind with number\n";
+  {
+    $stmt = $db->prepare("SELECT * FROM numbers WHERE name in (?, ?, ?, ?)");
+    VS($stmt->paramcount(), 4);
+
+    VERIFY($stmt->bindvalue(1, "large", SQLITE3_TEXT));
+    VERIFY($stmt->bindvalue(2, "large_neg", SQLITE3_TEXT));
+    VERIFY($stmt->bindvalue(3, "max64", SQLITE3_TEXT));
+    VERIFY($stmt->bindvalue(4, "min64", SQLITE3_TEXT));
+
+    {
+      $res = $stmt->execute();
+      VR($res->fetcharray(SQLITE3_ASSOC), dict["name" => "large", "val" => 845868619338]);
+      VR($res->fetcharray(SQLITE3_ASSOC), dict["name" => "large_neg", "val" => -845787619309]);
+      VR($res->fetcharray(SQLITE3_ASSOC), dict["name" => "max64", "val" => PHP_INT_MAX]);
+      VR($res->fetcharray(SQLITE3_ASSOC), dict["name" => "min64", "val" => PHP_INT_MIN]);
+      $res->finalize();
+    }
+
+    VERIFY($stmt->clear());
+    VERIFY($stmt->reset());
+  }
+
+  echo "testing UDF\n";
+  {
+    VERIFY($db->createfunction("identity", identity<>, 1));
+    $res = $db->query("SELECT identity(val) FROM numbers");
+    VR($res->fetcharray(SQLITE3_NUM), dict[0 => 1234]);
+    VR($res->fetcharray(SQLITE3_NUM), dict[0 => 845868619338]);
+    VR($res->fetcharray(SQLITE3_NUM), dict[0 => -845787619309]);
+    VR($res->fetcharray(SQLITE3_NUM), dict[0 => PHP_INT_MAX]);
+    VR($res->fetcharray(SQLITE3_NUM), dict[0 => PHP_INT_MIN]);
+    $res->finalize();
+  }
+
+  $stmt->close();
+  $db->close();
+}

--- a/hphp/test/slow/ext_sqlite3/sqlite3_int64.php.expectf
+++ b/hphp/test/slow/ext_sqlite3/sqlite3_int64.php.expectf
@@ -1,0 +1,36 @@
+testing query() and SQLite3Result
+Passed: row matched
+Passed: row matched
+Passed: row matched
+Passed: row matched
+Passed: row matched
+testing bind with name
+bool(true)
+bool(true)
+Passed: row matched
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+Passed: row matched
+bool(true)
+bool(true)
+testing bind with number
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+Passed: row matched
+Passed: row matched
+Passed: row matched
+Passed: row matched
+bool(true)
+bool(true)
+testing UDF
+bool(true)
+Passed: row matched
+Passed: row matched
+Passed: row matched
+Passed: row matched
+Passed: row matched

--- a/hphp/test/slow/ext_sqlite3/sqlite3_int64.php.noserver
+++ b/hphp/test/slow/ext_sqlite3/sqlite3_int64.php.noserver
@@ -1,0 +1,1 @@
+Used banned symbol :memory:


### PR DESCRIPTION
The extension was using the sqlite3_*_int API, which would truncate 64-bits
int to 32-bits on some code paths. The fix is to use the 64-bits API variants
constantly throughout the extension.

Added a test that manipulates int64 that are not
representable as int32 to make sure we handle
those correctly.