### PR TITLE
Set up some DX features for OSS

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,3 @@
+[{CMakeLists.txt,*.cmake,*.h,*.cpp}]
+indent_style = space
+indent_size = 2

--- a/.gitignore
+++ b/.gitignore
@@ -100,3 +100,6 @@ CPackSourceConfig.cmake
 
 # python scripts
 *.pyc
+
+# clangd JSON Compilation Database
+compile_commands.json

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,8 @@ cmake_policy(SET CMP0046 NEW)
 # projects are created.
 INCLUDE("${CMAKE_CURRENT_SOURCE_DIR}/CMake/VisualStudioToolset.cmake")
 
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
 # includes
 SET(
   CMAKE_MODULE_PATH


### PR DESCRIPTION
These will be helpful both in the future and when applying parts of #9564.

* Set up .editorconfig to ensure consistent indents.
* Instruct CMake to export a clangd JSON compilation database that IDEs can integrate with.