### PR TITLE
Provide less cryptic error for missing systemlib sections

### DIFF
--- a/hphp/runtime/vm/runtime-compiler.cpp
+++ b/hphp/runtime/vm/runtime-compiler.cpp
@@ -44,6 +44,7 @@
 #include "hphp/zend/zend-string.h"
 #include "unit-emitter.h"
 
+#include <stdexcept>
 #include <folly/Likely.h>
 #include <folly/Range.h>
 
@@ -258,6 +259,10 @@ Unit* get_systemlib(const std::string& path, const Extension* extension) {
   }
 
   auto buffer = get_embedded_section(path+".ue");
+
+  if (buffer.empty()) {
+    throw std::invalid_argument("Missing systemlib unit emitter for path: " + path);
+  }
 
   UnitEmitterSerdeWrapper uew;
   BlobDecoder decoder(buffer.data(), buffer.size());


### PR DESCRIPTION
If a new extension systemlib isn't wired up with the build system, its unit emitters and decls won't be embedded in the HHVM binary, causing a cryptic crash when trying to run Hack code ("Invalid varint value: too few bytes."). One then has to fire up a debugger to determine what systemlib is missing.

Instead, raise a more informative error if a specific systemlib was not found in the binary.

Split from https://github.com/facebook/hhvm/pull/9564.