### PR TITLE
Add CMake option to force using libc++

### DIFF
--- a/CMake/HPHPCompiler.cmake
+++ b/CMake/HPHPCompiler.cmake
@@ -132,8 +132,8 @@ if (${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang" OR ${CMAKE_CXX_COMPILER_ID} STREQU
       endif()
     endif()
 
-    if(CLANG_FORCE_LIBSTDCXX)
-      list(APPEND GENERAL_CXX_OPTIONS "stdlib=libstdc++")
+    if(CLANG_FORCE_LIBCPP)
+      list(APPEND GENERAL_CXX_OPTIONS "stdlib=libc++")
     endif()
   else() # using GCC
     list(APPEND DISABLED_NAMED_WARNINGS

--- a/CMake/Options.cmake
+++ b/CMake/Options.cmake
@@ -15,7 +15,7 @@ option(FORCE_TP_JEMALLOC "Always build and statically link jemalloc instead of u
 
 option(ENABLE_HHPROF "Enable HHProf" OFF)
 
-option(CLANG_FORCE_LIBSTDCXX "Force libstdc++ when building against Clang/LLVM" OFF)
+option(CLANG_FORCE_LIBCPP "Force using libc++ as the C++ standard library" OFF)
 
 option(USE_TCMALLOC "Use tcmalloc (if jemalloc is not used)" ON)
 option(USE_GOOGLE_HEAP_PROFILER "Use Google heap profiler" OFF)


### PR DESCRIPTION
I've been unable to build HHVM master against libstdc++ with GCC 14 or clang 18. Since most distros use libstdc++ as the default C++ standard library, we need an option to force using libc++ instead.

Remove the existing option to force building against libstdc++ when using clang, which was added 10 years ago in
cc07cb59c0a15b535a2b7f11652d421e7856fbea to help workaround GCC 5 bugs and seems no longer relevant.