### PR TITLE
Add ocamlformat dependency to OSS

### DIFF
--- a/hphp/hack/ocaml_deps_data.sh
+++ b/hphp/hack/ocaml_deps_data.sh
@@ -38,6 +38,7 @@ export HACK_OPAM_DEPS=(
   wtf8.1.0.2
   yojson.2.0.2
   ocamlbuild.0.14.3
+  ocamlformat.0.26.2
   ocaml-option-flambda
   ocaml-option-no-compression
 )


### PR DESCRIPTION
This is needed to remain consistent with preexisting formatting.