### PR TITLE
Remove use of unsupported std::shared_ptr::unique()

### DIFF
--- a/hphp/runtime/base/file.cpp
+++ b/hphp/runtime/base/file.cpp
@@ -185,7 +185,7 @@ File::File(bool nonblocking /* = true */,
 { }
 
 File::~File() {
-  if (m_data.unique()) {
+  if (m_data.use_count() == 1) {
     File::close();
   }
   m_data.reset();


### PR DESCRIPTION
libc++ 18 and newer gate this behind the
`_LIBCPP_ENABLE_CXX20_REMOVED_SHARED_PTR_UNIQUE` macro, since the feature was deprecated in C++17 and removed in C++20.

Since this is the only reference, replace it with use_count() == 1 directly instead of using the macro.