### PR TITLE
Use single Rust staticlib for FFI

### DIFF
--- a/CMake/HPHPFindLibs.cmake
+++ b/CMake/HPHPFindLibs.cmake
@@ -408,11 +408,7 @@ macro(hphp_link target)
   target_link_libraries(${target} ${VISIBILITY} fizz)
   target_link_libraries(${target} ${VISIBILITY} brotli)
   target_link_libraries(${target} ${VISIBILITY} hhbc_ast_header)
-  target_link_libraries(${target} ${VISIBILITY} compiler_ffi)
-  target_link_libraries(${target} ${VISIBILITY} package_ffi)
-  target_link_libraries(${target} ${VISIBILITY} parser_ffi)
-  target_link_libraries(${target} ${VISIBILITY} hhvm_types_ffi)
-  target_link_libraries(${target} ${VISIBILITY} hhvm_hhbc_defs_ffi)
+  target_link_libraries(${target} ${VISIBILITY} hack_rust_ffi_bridge)
 
   target_link_libraries(${target} ${VISIBILITY} tbb)
 

--- a/hphp/compiler/compiler-systemlib.cpp
+++ b/hphp/compiler/compiler-systemlib.cpp
@@ -17,7 +17,7 @@
 #include "hphp/compiler/compiler-systemlib.h"
 
 #include "hphp/hack/src/hackc/ffi_bridge/decl_provider.h"
-#include "hphp/hack/src/hackc/ffi_bridge/compiler_ffi.rs.h"
+#include "hphp/hack/src/hhvm_ffi/compiler_ffi.rs.h"
 
 #include "hphp/hhvm/process-init.h"
 

--- a/hphp/compiler/compiler.cpp
+++ b/hphp/compiler/compiler.cpp
@@ -19,7 +19,7 @@
 #include "hphp/compiler/option.h"
 #include "hphp/compiler/package.h"
 
-#include "hphp/hack/src/hackc/ffi_bridge/compiler_ffi.rs.h"
+#include "hphp/hack/src/hhvm_ffi/compiler_ffi.rs.h"
 
 #include "hphp/hhbbc/hhbbc.h"
 #include "hphp/hhbbc/misc.h"

--- a/hphp/compiler/package.cpp
+++ b/hphp/compiler/package.cpp
@@ -33,7 +33,7 @@
 
 #include "hphp/compiler/decl-provider.h"
 #include "hphp/compiler/option.h"
-#include "hphp/hack/src/hackc/ffi_bridge/compiler_ffi.rs.h"
+#include "hphp/hack/src/hhvm_ffi/compiler_ffi.rs.h"
 #include "hphp/hhvm/process-init.h"
 #include "hphp/runtime/base/execution-context.h"
 #include "hphp/runtime/base/file-util-defs.h"

--- a/hphp/hack/CMakeLists.txt
+++ b/hphp/hack/CMakeLists.txt
@@ -225,114 +225,81 @@ HHVM_RENDER_CONFIG_SPECIFICATION(
   OUTPUT_PATH "${CMAKE_BINARY_DIR}/hphp/hack/src/hackc/compile"
 )
 
-# Compiling cxx entrypoints for hhvm
-#
-# Usage:
-#     build_cxx_bridge(
-#       name
-#       DIR directory
-#       [EXTRA_SRCS src [src ...]]
-#       [LINK_LIBS lib [lib ...]]
-#     )
-#
-# Where:
-#   `name` is the target name of the cxx_bridge.
-#   `directory` is the required directory of the cxx_bridge sources.
-#   `src` are extra source files to include in the bridge.
-#   `lib` are extra link libraries to include in the bridge.
-#
-function(build_cxx_bridge NAME)
-  cmake_parse_arguments(CXX_BRIDGE "" "DIR" "EXTRA_SRCS;LINK_LIBS" ${ARGN})
+set(
+  FFI_CRATES
+  "package_ffi"
+  "parser_ffi"
+  "compiler_ffi"
+  "hdf"
+  "hhvm_types_ffi"
+  "hhvm_hhbc_defs_ffi"
+)
 
-  if ("${CXX_BRIDGE_DIR}" STREQUAL "")
-    message(FATAL_ERROR "Missing DIR parameter")
-  endif()
-  if (NOT "${CXX_BRIDGE_UNPARSED_ARGUMENTS}" STREQUAL "")
-    message(FATAL_ERROR "Unexpected parameters: ${CXX_BRIDGE_UNPARSED_ARGUMENTS}")
-  endif()
+set(FFI_BRIDGE_SRC "${CMAKE_CURRENT_SOURCE_DIR}/src/hhvm_ffi")
+set(FFI_BRIDGE_BIN "${RUST_FFI_BUILD_ROOT}/hphp/hack/src/hhvm_ffi")
+set(RUST_PART_LIB "${RUST_FFI_BUILD_ROOT}/hphp/hack/src/hhvm_ffi/${PROFILE}/${CMAKE_STATIC_LIBRARY_PREFIX}hhvm_ffi${CMAKE_STATIC_LIBRARY_SUFFIX}")
 
-  set(FFI_BRIDGE_SRC "${CMAKE_CURRENT_SOURCE_DIR}/${CXX_BRIDGE_DIR}")
-  set(FFI_BRIDGE_BIN "${RUST_FFI_BUILD_ROOT}/hphp/hack/${CXX_BRIDGE_DIR}")
+foreach(NAME ${FFI_CRATES})
+  list(APPEND FFI_CXXBRIDGE_ORIG_SRCS "${FFI_BRIDGE_BIN}/cxxbridge/${NAME}/${NAME}.rs.cc")
+  list(APPEND FFI_CXXBRIDGE_SRCS "${FFI_BRIDGE_BIN}/${NAME}.rs.cc")
 
-  set(RUST_PART_LIB "${FFI_BRIDGE_BIN}/${PROFILE}/${CMAKE_STATIC_LIBRARY_PREFIX}${NAME}${CMAKE_STATIC_LIBRARY_SUFFIX}")
-  set(RUST_PART_CXX "${FFI_BRIDGE_BIN}/${NAME}.cpp")
-  set(RUST_PART_HEADER "${FFI_BRIDGE_BIN}/${NAME}.rs.h")
-  set(GENERATED "${FFI_BRIDGE_BIN}/cxxbridge/${NAME}/${NAME}")
-  set(GENERATED_CXXBRIDGE "${FFI_BRIDGE_BIN}/cxxbridge")
+  list(APPEND FFI_CXXBRIDGE_ORIG_HEADERS "${FFI_BRIDGE_BIN}/cxxbridge/${NAME}/${NAME}.rs.h")
+  list(APPEND FFI_CXXBRIDGE_HEADERS "${FFI_BRIDGE_BIN}/${NAME}.rs.h")
+endforeach()
 
-  add_custom_command(
-      OUTPUT
-        ${RUST_PART_CXX}
-        ${RUST_PART_HEADER}
-        ${RUST_PART_LIB}
-        ${GENERATED_CXXBRIDGE}
-      COMMAND
-        ${CMAKE_COMMAND} -E make_directory "${FFI_BRIDGE_BIN}" &&
-        . "${CMAKE_CURRENT_BINARY_DIR}/dev_env_rust_only.sh" &&
-        ${INVOKE_CARGO} "${NAME}" "${NAME}" --target-dir "${FFI_BRIDGE_BIN}" &&
-        ${CMAKE_COMMAND} -E copy "${GENERATED}.rs.cc" "${RUST_PART_CXX}" &&
-        ${CMAKE_COMMAND} -E copy "${GENERATED}.rs.h" "${RUST_PART_HEADER}"
-      WORKING_DIRECTORY ${FFI_BRIDGE_SRC}
-      DEPENDS rustc cargo "${OPCODE_DATA}"
-  )
-  add_custom_target(
-    "${NAME}_cxx"
+add_custom_command(
+    OUTPUT
+    ${RUST_PART_LIB} ${FFI_CXXBRIDGE_ORIG_SRCS} ${FFI_CXXBRIDGE_ORIG_HEADERS}
+    COMMAND
+    ${CMAKE_COMMAND} -E make_directory "${FFI_BRIDGE_BIN}" &&
+    . "${CMAKE_CURRENT_BINARY_DIR}/dev_env_rust_only.sh" &&
+    ${CMAKE_COMMAND} -E env CXX=${CMAKE_CXX_COMPILER} CXXFLAGS=${CMAKE_CXX_FLAGS} ${INVOKE_CARGO} hhvm_ffi hhvm_ffi --target-dir "${FFI_BRIDGE_BIN}"
+    WORKING_DIRECTORY ${FFI_BRIDGE_SRC}
+    DEPENDS rustc cargo hackc_options "${OPCODE_DATA}"
+)
+
+add_custom_target(
+    hack_rust_ffi_bridge_rust_build
     DEPENDS ${RUST_PART_LIB}
-  )
-  add_library("${NAME}" STATIC ${RUST_PART_CXX} ${CXX_BRIDGE_EXTRA_SRCS} )
-  add_dependencies(hack_rust_ffi_bridge_targets "${NAME}")
-  add_library("${NAME}_rust_part" STATIC IMPORTED)
-  add_dependencies("${NAME}_rust_part" "${NAME}_cxx")
+)
 
-  # Intentionally create link-time cyclic dependency between ${NAME}_rust_part
-  # and ${NAME} so that CMake will automatically construct the link line so
-  # that the linker will scan through involved static libraries multiple times.
-  set_target_properties(
-    "${NAME}_rust_part"
-    PROPERTIES
-    IMPORTED_LOCATION ${RUST_PART_LIB}
-    IMPORTED_LINK_DEPENDENT_LIBRARIES "${NAME}"
-  )
-  target_link_libraries(
-    "${NAME}"
-    PUBLIC
-      "${NAME}_rust_part"
-      ${CXX_BRIDGE_LINK_LIBS}
-  )
-  target_include_directories("${NAME}" INTERFACE "${RUST_FFI_BUILD_ROOT}")
-  target_include_directories("${NAME}" PRIVATE "${GENERATED_CXXBRIDGE}")
-endfunction()
+add_custom_command(
+    OUTPUT ${FFI_CXXBRIDGE_HEADERS} ${FFI_CXXBRIDGE_SRCS}
+    COMMAND
+    ${CMAKE_COMMAND} -E make_directory "${FFI_BRIDGE_BIN}" &&
+    ${CMAKE_COMMAND} -E copy_if_different ${FFI_CXXBRIDGE_ORIG_HEADERS} ${FFI_BRIDGE_BIN} &&
+    ${CMAKE_COMMAND} -E copy_if_different ${FFI_CXXBRIDGE_ORIG_SRCS} ${FFI_BRIDGE_BIN}
+    DEPENDS ${FFI_CXXBRIDGE_ORIG_HEADERS} ${FFI_CXXBRIDGE_ORIG_SRCS}
+)
 
-build_cxx_bridge(
-  package_ffi
-  DIR "src/package/ffi_bridge"
+add_custom_target(
+    hack_rust_ffi_bridge_copy_cxxbridge
+    DEPENDS ${FFI_CXXBRIDGE_HEADERS} ${FFI_CXXBRIDGE_SRCS}
 )
-build_cxx_bridge(
-  parser_ffi
-  DIR "src/parser/ffi_bridge"
+
+add_library(hack_rust_ffi_bridge_rust_part STATIC IMPORTED)
+add_dependencies(hack_rust_ffi_bridge_rust_part hack_rust_ffi_bridge_rust_build hack_rust_ffi_bridge_copy_cxxbridge)
+set_target_properties(
+  hack_rust_ffi_bridge_rust_part
+  PROPERTIES
+  IMPORTED_LOCATION ${RUST_PART_LIB}
+  # Intentionally create a link-time cyclic dependency between the Rust library
+  # and the dependent C++ library so that CMake will automatically construct the link line,
+  # causing the linker to scan through involved static libraries multiple times.
+  IMPORTED_LINK_DEPENDENT_LIBRARIES hack_rust_ffi_bridge
 )
-build_cxx_bridge(
-  compiler_ffi
-  DIR "src/hackc/ffi_bridge"
-  EXTRA_SRCS "${CMAKE_CURRENT_SOURCE_DIR}/src/hackc/ffi_bridge/external_decl_provider.cpp"
-  LINK_LIBS hdf
+
+add_library(
+    hack_rust_ffi_bridge
+    ${FFI_CXXBRIDGE_SRCS}
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/hackc/ffi_bridge/external_decl_provider.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/hackc/hhvm_cxx/hhvm_types/as-base-ffi.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/hackc/hhvm_cxx/hhvm_hhbc_defs/as-hhbc-ffi.cpp"
 )
-build_cxx_bridge(
-  hdf
-  DIR "src/utils/hdf"
-  EXTRA_SRCS "${CMAKE_CURRENT_SOURCE_DIR}/src/utils/hdf/hdf-wrap.cpp"
-  LINK_LIBS folly
-)
-build_cxx_bridge(
-  hhvm_types_ffi
-  DIR "src/hackc/hhvm_cxx/hhvm_types"
-  EXTRA_SRCS "${CMAKE_CURRENT_SOURCE_DIR}/src/hackc/hhvm_cxx/hhvm_types/as-base-ffi.cpp"
-)
-build_cxx_bridge(
- hhvm_hhbc_defs_ffi
- DIR "src/hackc/hhvm_cxx/hhvm_hhbc_defs"
- EXTRA_SRCS "${CMAKE_CURRENT_SOURCE_DIR}/src/hackc/hhvm_cxx/hhvm_hhbc_defs/as-hhbc-ffi.cpp"
-)
+
+target_link_libraries(hack_rust_ffi_bridge PRIVATE folly hack_rust_ffi_bridge_rust_part)
+target_include_directories(hack_rust_ffi_bridge INTERFACE "${RUST_FFI_BUILD_ROOT}")
+target_include_directories(hack_rust_ffi_bridge PRIVATE "${FFI_BRIDGE_BIN}/cxxbridge")
 
 if (NOT LZ4_FOUND)
   add_dependencies(hack_dune lz4)

--- a/hphp/hack/src/Cargo.lock
+++ b/hphp/hack/src/Cargo.lock
@@ -2599,6 +2599,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "hhvm_ffi"
+version = "0.0.0"
+dependencies = [
+ "compiler_ffi",
+ "hdf",
+ "hhvm_hhbc_defs_ffi",
+ "hhvm_types_ffi",
+ "package_ffi",
+ "parser_ffi",
+]
+
+[[package]]
 name = "hhvm_hhbc_defs_ffi"
 version = "0.0.0"
 dependencies = [

--- a/hphp/hack/src/Cargo.toml
+++ b/hphp/hack/src/Cargo.toml
@@ -42,6 +42,7 @@ members = [
     "hh_fanout/cargo/hh_fanout_dep_graph_is_subgraph_rust",
     "hh_fanout/cargo/hh_fanout_dep_graph_stats_rust",
     "hh_naming_table_builder/cargo/naming_table_builder_ffi",
+    "hhvm_ffi",
     "naming",
     "naming/cargo/elaborate_namespaces",
     "naming/cargo/naming_attributes",

--- a/hphp/hack/src/hackc/ffi_bridge/Cargo.toml
+++ b/hphp/hack/src/hackc/ffi_bridge/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT"
 
 [lib]
 path = "compiler_ffi.rs"
-crate-type = ["lib", "staticlib"]
+crate-type = ["rlib"]
 
 [dependencies]
 anyhow = "1.0.95"

--- a/hphp/hack/src/hackc/ffi_bridge/decl_provider.h
+++ b/hphp/hack/src/hackc/ffi_bridge/decl_provider.h
@@ -6,7 +6,7 @@
 
 #pragma once
 #include <string>
-#include "hphp/hack/src/hackc/ffi_bridge/compiler_ffi.rs.h"
+#include "hphp/hack/src/hhvm_ffi/compiler_ffi.rs.h"
 
 namespace HPHP {
 namespace hackc {

--- a/hphp/hack/src/hackc/hhvm_cxx/hhvm_hhbc_defs/Cargo.toml
+++ b/hphp/hack/src/hackc/hhvm_cxx/hhvm_hhbc_defs/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT"
 
 [lib]
 path = "hhvm_hhbc_defs_ffi.rs"
-crate-type = ["lib", "staticlib"]
+crate-type = ["rlib"]
 
 [dependencies]
 cxx = "1.0.119"

--- a/hphp/hack/src/hackc/hhvm_cxx/hhvm_types/Cargo.toml
+++ b/hphp/hack/src/hackc/hhvm_cxx/hhvm_types/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT"
 
 [lib]
 path = "hhvm_types_ffi.rs"
-crate-type = ["lib", "staticlib"]
+crate-type = ["rlib"]
 
 [dependencies]
 cxx = "1.0.119"

--- a/hphp/hack/src/hhvm_ffi/Cargo.toml
+++ b/hphp/hack/src/hhvm_ffi/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "hhvm_ffi"
+version = "0.0.0"
+edition = "2021"
+repository = "https://github.com/facebook/hhvm"
+license = "MIT"
+
+[lib]
+path = "lib.rs"
+crate-type = ["staticlib"]
+
+[dependencies]
+hdf = { path = "../utils/hdf" }
+compiler_ffi = { path = "../hackc/ffi_bridge" }
+package_ffi = { path = "../package/ffi_bridge" }
+parser_ffi = { path = "../parser/ffi_bridge" }
+hhvm_hhbc_defs_ffi = { path = "../hackc/hhvm_cxx/hhvm_hhbc_defs" }
+hhvm_types_ffi = { path = "../hackc/hhvm_cxx/hhvm_types" }

--- a/hphp/hack/src/hhvm_ffi/lib.rs
+++ b/hphp/hack/src/hhvm_ffi/lib.rs
@@ -1,0 +1,6 @@
+extern crate hdf;
+extern crate compiler_ffi;
+extern crate package_ffi;
+extern crate parser_ffi;
+extern crate hhvm_hhbc_defs_ffi;
+extern crate hhvm_types_ffi;

--- a/hphp/hack/src/parser/ffi_bridge/Cargo.toml
+++ b/hphp/hack/src/parser/ffi_bridge/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT"
 path = "parser_ffi.rs"
 test = false
 doctest = false
-crate-type = ["lib", "staticlib"]
+crate-type = ["rlib"]
 
 [dependencies]
 bumpalo = { version = "3.14.0", features = ["allocator_api", "collections"] }

--- a/hphp/hack/src/utils/hdf/Cargo.toml
+++ b/hphp/hack/src/utils/hdf/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT"
 
 [lib]
 path = "lib.rs"
-crate-type = ["lib", "staticlib"]
+crate-type = ["rlib"]
 
 [dependencies]
 cxx = "1.0.119"

--- a/hphp/runtime/base/package.cpp
+++ b/hphp/runtime/base/package.cpp
@@ -27,7 +27,7 @@
 #include <re2/re2.h>
 #include "hphp/util/rds-local.h"
 
-#include "hphp/hack/src/package/ffi_bridge/package_ffi.rs.h"
+#include "hphp/hack/src/hhvm_ffi/package_ffi.rs.h"
 
 #include <folly/json/dynamic.h>
 #include <folly/json/json.h>

--- a/hphp/runtime/base/runtime-option.cpp
+++ b/hphp/runtime/base/runtime-option.cpp
@@ -17,7 +17,7 @@
 #include "hphp/runtime/base/runtime-option.h"
 
 #include "hphp/hack/src/hackc/compile/options_gen.h"
-#include "hphp/hack/src/hackc/ffi_bridge/compiler_ffi.rs.h"
+#include "hphp/hack/src/hhvm_ffi/compiler_ffi.rs.h"
 #include "hphp/runtime/base/autoload-handler.h"
 #include "hphp/runtime/base/bespoke-array.h"
 #include "hphp/runtime/base/builtin-functions.h"

--- a/hphp/runtime/base/runtime-option.h
+++ b/hphp/runtime/base/runtime-option.h
@@ -45,7 +45,7 @@
 #include "hphp/util/hash-map.h"
 #include "hphp/util/sha1.h"
 
-#include "hphp/hack/src/parser/ffi_bridge/parser_ffi.rs.h"
+#include "hphp/hack/src/hhvm_ffi/parser_ffi.rs.h"
 
 namespace HPHP {
 ///////////////////////////////////////////////////////////////////////////////

--- a/hphp/runtime/ext/decl/decl-extractor.cpp
+++ b/hphp/runtime/ext/decl/decl-extractor.cpp
@@ -6,7 +6,7 @@
 #include <folly/futures/Future.h>
 #include <folly/json/dynamic.h>
 #include <folly/logging/xlog.h>
-#include "hphp/hack/src/hackc/ffi_bridge/compiler_ffi.rs.h"
+#include "hphp/hack/src/hhvm_ffi/compiler_ffi.rs.h"
 #include "hphp/runtime/base/program-functions.h"
 #include "hphp/runtime/base/stream-wrapper-registry.h"
 #include "hphp/runtime/base/unit-cache.h"

--- a/hphp/runtime/ext/decl/decl-extractor.h
+++ b/hphp/runtime/ext/decl/decl-extractor.h
@@ -9,7 +9,7 @@
 #include <folly/Try.h>
 #include <folly/executors/IOThreadPoolExecutor.h>
 #include <folly/futures/Future.h>
-#include "hphp/hack/src/hackc/ffi_bridge/compiler_ffi.rs.h"
+#include "hphp/hack/src/hhvm_ffi/compiler_ffi.rs.h"
 #include "hphp/runtime/ext/facts/path-and-hash.h"
 
 namespace HPHP {

--- a/hphp/runtime/ext/facts/file-facts.h
+++ b/hphp/runtime/ext/facts/file-facts.h
@@ -23,7 +23,7 @@
 #include <fmt/format.h>
 #include <folly/Format.h>
 #include <folly/json/dynamic.h>
-#include "hphp/hack/src/hackc/ffi_bridge/compiler_ffi.rs.h"
+#include "hphp/hack/src/hhvm_ffi/compiler_ffi.rs.h"
 
 namespace HPHP {
 namespace Facts {

--- a/hphp/runtime/vm/builtin-symbol-map.cpp
+++ b/hphp/runtime/vm/builtin-symbol-map.cpp
@@ -15,7 +15,7 @@
 */
 
 #include "hphp/hack/src/hackc/ffi_bridge/decl_provider.h"
-#include "hphp/hack/src/hackc/ffi_bridge/compiler_ffi.rs.h"
+#include "hphp/hack/src/hhvm_ffi/compiler_ffi.rs.h"
 
 #include "hphp/runtime/base/autoload-map.h"
 #include "hphp/runtime/base/static-string-table.h"

--- a/hphp/runtime/vm/hackc-translator.h
+++ b/hphp/runtime/vm/hackc-translator.h
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#include "hphp/hack/src/hackc/ffi_bridge/compiler_ffi.rs.h"
+#include "hphp/hack/src/hhvm_ffi/compiler_ffi.rs.h"
 #include "hphp/hack/src/hackc/hhbc-unit.h"
 #include "hphp/runtime/vm/native-func-table.h"
 #include "hphp/runtime/vm/unit-emitter.h"

--- a/hphp/runtime/vm/unit-parser.cpp
+++ b/hphp/runtime/vm/unit-parser.cpp
@@ -35,9 +35,9 @@
 #include <folly/FileUtil.h>
 #include <folly/system/ThreadName.h>
 
-#include "hphp/hack/src/hackc/ffi_bridge/compiler_ffi.rs.h"
+#include "hphp/hack/src/hhvm_ffi/compiler_ffi.rs.h"
 #include "hphp/hack/src/hackc/hhbc-unit.h"
-#include "hphp/hack/src/parser/ffi_bridge/parser_ffi.rs.h"
+#include "hphp/hack/src/hhvm_ffi/parser_ffi.rs.h"
 #include "hphp/runtime/base/autoload-map.h"
 #include "hphp/runtime/base/autoload-handler.h"
 #include "hphp/runtime/base/file-stream-wrapper.h"


### PR DESCRIPTION
Currently, each Rust FFI library is built and linked into the HHVM binaries as separate static libraries. This is [explicitly unsupported](https://cxx.rs/build/other.html#linking-the-c-and-rust-together) by the `cxx` crate, which recommends either using rustc as the final linker or using a single Rust staticlib for the Rust components, and has been the cause of linking errors for the last couple of years (see T146965521).

The former does not seem to be feasible for HHVM OSS, so go with the latter approach and combine Rust FFI libraries into a single staticlib, then link that into HHVM. This will likely need corresponding changes in the internal buck2 build.