### PR TITLE
Fix crash when running `hhvm --modules`

### DIFF
--- a/hphp/runtime/base/program-functions.cpp
+++ b/hphp/runtime/base/program-functions.cpp
@@ -1742,6 +1742,8 @@ static int execute_program_impl(int argc, char** argv) {
     return 0;
   }
   if (vm.count("modules")) {
+    rds::local::init();
+    SCOPE_EXIT { rds::local::fini(); };
     tl_heap.getCheck();
     Array exts = ExtensionRegistry::getLoaded();
     cout << "[PHP Modules]" << "\n";


### PR DESCRIPTION
Initialize RDS locals before attempting to use the MemoryManager, otherwise `hhvm --modules` segfaults:

```
* thread #1, name = 'hhvm', stop reason = signal SIGSEGV: address not mapped to object (fault address: 0x1448)
    frame #0: 0x0000000000bac347 hhvm`HPHP::MemoryManager::MemoryManager() [inlined] HPHP::rds::local::RDSLocal<HPHP::RequestLocalGCData, (HPHP::rds::local::Initialize)1, HPHP::rds::local::detail::LocalsStorage>::getCheck(this=<unavailable>) const at rds-local.h:462:7
   459  template<typename T, Initialize Init, typename StorageT>
   460  T* RDSLocal<T, Init, StorageT>::getCheck() const {
   461    assertx(detail::rl_hotSection.rdslocal_base);
-> 462    if (!node().has_value()) {
   463      const_cast<RDSLocal*>(this)->create();
   464    }
   465    rehInit();
(lldb) bt
* thread #1, name = 'hhvm', stop reason = signal SIGSEGV: address not mapped to object (fault address: 0x1448)
  * frame #0: 0x0000000000bac347 hhvm`HPHP::MemoryManager::MemoryManager() [inlined] HPHP::rds::local::RDSLocal<HPHP::RequestLocalGCData, (HPHP::rds::local::Initialize)1, HPHP::rds::local::detail::LocalsStorage>::getCheck(this=<unavailable>) const at rds-local.h:462:7
    frame #1: 0x0000000000bac336 hhvm`HPHP::MemoryManager::MemoryManager(this=0x00007ffff2521d28) at memory-manager.cpp:119:13
    frame #2: 0x0000000000bd8877 hhvm`HPHP::execute_program_impl(int, char**) [inlined] HPHP::ThreadLocalFlat<HPHP::MemoryManager>::getCheck(this=0x00007ffff2521d28) at thread-local.h:255:22
    frame #3: 0x0000000000bd886f hhvm`HPHP::execute_program_impl(argc=2, argv=0x00007fffffffd418) at program-functions.cpp:1745:13
    frame #4: 0x0000000000bd6490 hhvm`HPHP::execute_program(argc=<unavailable>, argv=<unavailable>) at program-functions.cpp:1369:18
    frame #5: 0x00000000004e4c18 hhvm`main(argc=2, argv=0x00007fffffffd418) at main.cpp:95:12
    frame #6: 0x00007ffff4426248 libc.so.6`__libc_start_call_main + 120
    frame #7: 0x00007ffff442630b libc.so.6`__libc_start_main@@GLIBC_2.34 + 139
    frame #8: 0x00000000004e4945 hhvm`_start + 37
```