### PR TITLE
Switch aarch64 pause to sb on armv9a+

### DIFF
--- a/third-party/folly/src/folly/portability/Asm.h
+++ b/third-party/folly/src/folly/portability/Asm.h
@@ -40,7 +40,11 @@ inline void asm_volatile_pause() {
     (defined(__mips_isa_rev) && __mips_isa_rev > 1)
   asm volatile("pause");
 #elif FOLLY_AARCH64
+#if __ARM_ARCH >= 9
+  asm volatile("sb");
+#else
   asm volatile("isb");
+#endif
 #elif (defined(__arm__) && !(__ARM_ARCH < 7))
   asm volatile("yield");
 #elif FOLLY_PPC64


### PR DESCRIPTION
Summary:
SB (Speculation Barrier) is a modern barrier, mandatory from armv8.5a.
It achieves the same result as issuing DSB+ISB, but without having the cpu drop its instruction pipeline.

We have noticed 20% to 30% increased throughput, on the 16, 32 and 64 thread-count case within the small locks benchmark.

In the below results, 'Sum' is throughput:

before:

------- folly::MicroSpinLock 16 threads
Sum: 130891978 Mean: 1817944 stddev: 147111
Lock time stats in us: mean 1 stddev 33 max 14937
------- folly::MicroSpinLock 32 threads
Sum: 54681548 Mean: 759465 stddev: 105588
Lock time stats in us: mean 5 stddev 78 max 35925
------- folly::MicroSpinLock 64 threads
Sum: 24013546 Mean: 333521 stddev: 90571
Lock time stats in us: mean 11 stddev 179 max 90498

after:

------- folly::MicroSpinLock 16 threads
Sum: 169135465 Mean: 2349103 stddev: 227369
Lock time stats in us: mean 1 stddev 25 max 8463
------- folly::MicroSpinLock 32 threads
Sum: 67853388 Mean: 942408 stddev: 108821
Lock time stats in us: mean 3 stddev 63 max 17020
------- folly::MicroSpinLock 64 threads
Sum: 28845120 Mean: 400626 stddev: 61624
Lock time stats in us: mean 9 stddev 149 max 30879

Reviewed By: Gownta

Differential Revision: D70250662


