### PR TITLE
Implement exponential backoff in spinlock

### DIFF
--- a/third-party/folly/src/folly/portability/Asm.h
+++ b/third-party/folly/src/folly/portability/Asm.h
@@ -40,7 +40,11 @@ inline void asm_volatile_pause() {
     (defined(__mips_isa_rev) && __mips_isa_rev > 1)
   asm volatile("pause");
 #elif FOLLY_AARCH64
+#if __ARM_ARCH >= 9
+  asm volatile("sb");
+#else
   asm volatile("isb");
+#endif
 #elif (defined(__arm__) && !(__ARM_ARCH < 7))
   asm volatile("yield");
 #elif FOLLY_PPC64


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebook/folly/pull/2391

Implement exponential backoff in spinlocks runniong on ARM, as suggested by: https://community.arm.com/arm-community-blogs/b/architectures-and-processors-blog/posts/multi-threaded-applications-arm

We have noticed throughput almost doubles, on the 32 and 64 thread-count cases within the small locks benchmark.

In the below results, 'Sum' is throughput:

before:

------- folly::MicroSpinLock 32 threads
Sum: 67853388 Mean: 942408 stddev: 108821
Lock time stats in us: mean 3 stddev 63 max 17020
------- folly::MicroSpinLock 64 threads
Sum: 28845120 Mean: 400626 stddev: 61624
Lock time stats in us: mean 9 stddev 149 max 30879

after:

------- folly::MicroSpinLock 32 threads
Sum: 116020339 Mean: 1611393 stddev: 27242
Lock time stats in us: mean 1 stddev 3 max 8394
------- folly::MicroSpinLock 64 threads
Sum: 54264302 Mean: 753670 stddev: 30988
Lock time stats in us: mean 4 stddev 3 max 12924

Reviewed By: Gownta

Differential Revision: D70250664


