### PR TITLE
BinaryProtocol: Optimize reading/writing of fundamental lists on aarch64

### DIFF
--- a/third-party/folly/src/folly/Portability.h
+++ b/third-party/folly/src/folly/Portability.h
@@ -484,6 +484,12 @@ constexpr auto kIsMobile = true;
 constexpr auto kIsMobile = false;
 #endif
 
+#if defined(FOLLY_IS_AR_VR) && FOLLY_IS_AR_VR
+constexpr auto kIsArVr = true;
+#else
+constexpr auto kIsArVr = false;
+#endif
+
 #if defined(__linux__) && !FOLLY_MOBILE
 constexpr auto kIsLinux = true;
 #else

--- a/third-party/thrift/src/thrift/lib/cpp2/protocol/BinaryProtocol.cpp
+++ b/third-party/thrift/src/thrift/lib/cpp2/protocol/BinaryProtocol.cpp
@@ -16,6 +16,8 @@
 
 #include <thrift/lib/cpp2/protocol/BinaryProtocol.h>
 
+#include <functional>
+#include <type_traits>
 #include <folly/Conv.h>
 #include <folly/portability/GFlags.h>
 
@@ -44,6 +46,83 @@ namespace apache::thrift {
           "No version identifier... old protocol client in strict mode? sz=",
           sz));
 }
+
+template <typename T>
+void BinaryProtocolReader::readArithmeticVector(
+    T* outputPtr, size_t numElements) {
+  const T* inPtr = reinterpret_cast<const T*>(in_.data());
+  size_t i = 0;
+  size_t loopLen = std::min(numElements, in_.length() / sizeof(T));
+  for (; i < loopLen; ++i) {
+    outputPtr[i] = folly::Endian::big<T>(inPtr[i]);
+  }
+  in_.skip(i * sizeof(T));
+  // read elements one-by-one beyond what initially fits into the buffer
+  for (; i < numElements; ++i) {
+    outputPtr[i] = in_.readBE<T>();
+  }
+}
+
+template void BinaryProtocolReader::readArithmeticVector<int64_t>(
+    int64_t* outputPtr, size_t numElements);
+template void BinaryProtocolReader::readArithmeticVector<uint64_t>(
+    uint64_t* outputPtr, size_t numElements);
+template void BinaryProtocolReader::readArithmeticVector<int32_t>(
+    int32_t* outputPtr, size_t numElements);
+template void BinaryProtocolReader::readArithmeticVector<uint32_t>(
+    uint32_t* outputPtr, size_t numElements);
+template void BinaryProtocolReader::readArithmeticVector<int16_t>(
+    int16_t* outputPtr, size_t numElements);
+template void BinaryProtocolReader::readArithmeticVector<uint16_t>(
+    uint16_t* outputPtr, size_t numElements);
+template void BinaryProtocolReader::readArithmeticVector<int8_t>(
+    int8_t* outputPtr, size_t numElements);
+template void BinaryProtocolReader::readArithmeticVector<uint8_t>(
+    uint8_t* outputPtr, size_t numElements);
+template void BinaryProtocolReader::readArithmeticVector<float>(
+    float* outputPtr, size_t numElements);
+template void BinaryProtocolReader::readArithmeticVector<double>(
+    double* outputPtr, size_t numElements);
+
+template <typename T>
+inline size_t BinaryProtocolWriter::writeArithmeticVector(
+    const T* inputPtr, size_t numElements) {
+  size_t len = numElements * sizeof(T);
+  out_.ensure(len);
+  T* outPtr = reinterpret_cast<T*>(out_.writableData());
+  size_t i = 0;
+  size_t loopLen = std::min(numElements, out_.length() / sizeof(T));
+  for (; i < loopLen; ++i) {
+    outPtr[i] = folly::Endian::big<T>(inputPtr[i]);
+  }
+  out_.append(i * sizeof(T));
+  // write out one-by-one beyond what initially fits into the buffer
+  for (; i < numElements; ++i) {
+    out_.writeBE(inputPtr[i]);
+  }
+  return len;
+}
+
+template size_t BinaryProtocolWriter::writeArithmeticVector<int64_t>(
+    const int64_t* inputPtr, size_t numElements);
+template size_t BinaryProtocolWriter::writeArithmeticVector<uint64_t>(
+    const uint64_t* inputPtr, size_t numElements);
+template size_t BinaryProtocolWriter::writeArithmeticVector<int32_t>(
+    const int32_t* inputPtr, size_t numElements);
+template size_t BinaryProtocolWriter::writeArithmeticVector<uint32_t>(
+    const uint32_t* inputPtr, size_t numElements);
+template size_t BinaryProtocolWriter::writeArithmeticVector<int16_t>(
+    const int16_t* inputPtr, size_t numElements);
+template size_t BinaryProtocolWriter::writeArithmeticVector<uint16_t>(
+    const uint16_t* inputPtr, size_t numElements);
+template size_t BinaryProtocolWriter::writeArithmeticVector<int8_t>(
+    const int8_t* inputPtr, size_t numElements);
+template size_t BinaryProtocolWriter::writeArithmeticVector<uint8_t>(
+    const uint8_t* inputPtr, size_t numElements);
+template size_t BinaryProtocolWriter::writeArithmeticVector<float>(
+    const float* inputPtr, size_t numElements);
+template size_t BinaryProtocolWriter::writeArithmeticVector<double>(
+    const double* inputPtr, size_t numElements);
 
 void BinaryProtocolReader::skip(TType type, int depth) {
   if (depth >= FLAGS_thrift_protocol_max_depth) {

--- a/third-party/thrift/src/thrift/lib/cpp2/protocol/BinaryProtocol.h
+++ b/third-party/thrift/src/thrift/lib/cpp2/protocol/BinaryProtocol.h
@@ -24,7 +24,6 @@
 #include <folly/portability/GFlags.h>
 #include <thrift/lib/cpp/protocol/TProtocol.h>
 #include <thrift/lib/cpp2/protocol/Protocol.h>
-
 FOLLY_GFLAGS_DECLARE_int32(thrift_cpp2_protocol_reader_string_limit);
 FOLLY_GFLAGS_DECLARE_int32(thrift_cpp2_protocol_reader_container_limit);
 
@@ -62,6 +61,8 @@ class BinaryProtocolWriter : public detail::ProtocolBase {
 
   static constexpr bool kHasIndexSupport() { return true; }
 
+  static constexpr bool kSupportsArithmeticVectors() { return true; }
+
   /**
    * ...
    * The IOBuf itself is managed by the caller.
@@ -98,6 +99,8 @@ class BinaryProtocolWriter : public detail::ProtocolBase {
   uint32_t writeI16(int16_t i16);
   uint32_t writeI32(int32_t i32);
   uint32_t writeI64(int64_t i64);
+  template <typename T>
+  size_t writeArithmeticVector(const T* inputPtr, size_t numElements);
   uint32_t writeDouble(double dub);
   uint32_t writeFloat(float flt);
   uint32_t writeString(folly::StringPiece str);
@@ -204,6 +207,8 @@ class BinaryProtocolReader : public detail::ProtocolBase {
 
   static constexpr bool kHasDeferredRead() { return false; }
 
+  static constexpr bool kSupportsArithmeticVectors() { return true; }
+
   void setStringSizeLimit(int32_t string_limit) {
     string_limit_ = string_limit;
   }
@@ -245,6 +250,8 @@ class BinaryProtocolReader : public detail::ProtocolBase {
   void readI16(int16_t& i16);
   void readI32(int32_t& i32);
   void readI64(int64_t& i64);
+  template <typename T>
+  void readArithmeticVector(T* outputPtr, size_t numElements);
   void readDouble(double& dub);
   void readFloat(float& flt);
   template <typename StrType>

--- a/third-party/thrift/src/thrift/lib/cpp2/protocol/Protocol.h
+++ b/third-party/thrift/src/thrift/lib/cpp2/protocol/Protocol.h
@@ -52,6 +52,7 @@ FOLLY_GFLAGS_DECLARE_int32(thrift_protocol_max_depth);
 namespace apache::thrift {
 
 class BinaryProtocolReader;
+class BinaryProtocolWriter;
 
 namespace detail {
 

--- a/third-party/thrift/src/thrift/lib/cpp2/protocol/detail/protocol_methods.h
+++ b/third-party/thrift/src/thrift/lib/cpp2/protocol/detail/protocol_methods.h
@@ -31,6 +31,7 @@
 #include <folly/Utility.h>
 #include <folly/container/Reserve.h>
 #include <folly/container/View.h>
+#include <folly/container/range_traits.h>
 #include <folly/functional/Invoke.h>
 #include <folly/io/IOBuf.h>
 #include <folly/memory/UninitializedMemoryHacks.h>
@@ -594,17 +595,28 @@ struct protocol_methods<type_class::list<ElemClass>, Type> {
         // resizeWithoutInitialization first, then resize.
         if constexpr (should_resize_without_initialization) {
           folly::resizeWithoutInitialization(out, list_size);
-          auto outIt = out.begin();
-          const auto outEnd = out.end();
-          try {
-            for (; outIt != outEnd; ++outIt) {
-              elem_methods::read(protocol, *outIt);
+          // Check if we can do a fast path (memcpy that reverses byte order)
+          // instead of processing elements sequentially
+          if constexpr (kShouldProcessAsArithmeticVector<
+                            Protocol,
+                            Type,
+                            elem_type>) {
+            protocol.template readArithmeticVector<elem_type>(
+                out.data(), out.size());
+          } else {
+            // fallback: process element by element
+            auto outIt = out.begin();
+            const auto outEnd = out.end();
+            try {
+              for (; outIt != outEnd; ++outIt) {
+                elem_methods::read(protocol, *outIt);
+              }
+            } catch (...) {
+              // For behaviour parity, initialize the leftover elements when
+              // exceptions happen
+              std::fill(outIt, outEnd, elem_type());
+              throw;
             }
-          } catch (...) {
-            // For behaviour parity, initialize the leftover elements when
-            // exceptions happen
-            std::fill(outIt, outEnd, elem_type());
-            throw;
           }
         } else if constexpr (should_resize) {
           out.resize(list_size);
@@ -627,6 +639,21 @@ struct protocol_methods<type_class::list<ElemClass>, Type> {
     read(protocol, out);
   }
 
+  template <typename Protocol, typename = void>
+  struct supportsArithmeticVectors : std::false_type {};
+
+  template <typename Protocol>
+  struct supportsArithmeticVectors<
+      Protocol,
+      std::void_t<decltype(Protocol::kSupportsArithmeticVectors())>>
+      : std::bool_constant<Protocol::kSupportsArithmeticVectors()> {};
+
+  template <typename Protocol, typename ContainerType, typename ElementType>
+  static constexpr bool kShouldProcessAsArithmeticVector =
+      !folly::kIsArVr && folly::is_contiguous_range_v<ContainerType> &&
+      std::is_arithmetic_v<ElementType> &&
+      supportsArithmeticVectors<Protocol>::value;
+
   template <typename Protocol>
   static std::size_t write(Protocol& protocol, const Type& out) {
     std::size_t xfer = 0;
@@ -634,8 +661,16 @@ struct protocol_methods<type_class::list<ElemClass>, Type> {
     xfer += protocol.writeListBegin(
         elem_ttype::value, checked_container_size(out.size()));
 
-    for (const auto& elem : out) {
-      xfer += elem_methods::write(protocol, elem);
+    if constexpr (kShouldProcessAsArithmeticVector<Protocol, Type, elem_type>) {
+      const elem_type* inputPtr = out.data();
+      if (inputPtr != nullptr) {
+        xfer += protocol.template writeArithmeticVector<elem_type>(
+            inputPtr, out.size());
+      }
+    } else {
+      for (const auto& elem : out) {
+        xfer += elem_methods::write(protocol, elem);
+      }
     }
     xfer += protocol.writeListEnd();
     return xfer;

--- a/third-party/thrift/src/thrift/lib/cpp2/protocol/test/BinaryProtocolTest.cpp
+++ b/third-party/thrift/src/thrift/lib/cpp2/protocol/test/BinaryProtocolTest.cpp
@@ -17,7 +17,10 @@
 #include <folly/CPortability.h>
 #include <folly/portability/GTest.h>
 
+#include <algorithm>
+#include <random>
 #include <thrift/lib/cpp2/protocol/BinaryProtocol.h>
+#include <thrift/lib/cpp2/protocol/detail/protocol_methods.h>
 
 using namespace apache::thrift;
 using namespace apache::thrift::protocol;
@@ -87,12 +90,67 @@ TEST_F(BinaryProtocolTest, writeStringExactly4GB) {
   EXPECT_THROW(w.writeString(monster), TProtocolException);
 }
 
-TEST_F(BinaryProtocolTest, writeStringExceeds4GB) {
-  auto w = BinaryProtocolWriter();
-  auto q = folly::IOBufQueue();
-  w.setOutput(&q);
-  std::string monster(((uint64_t)1 << 32) + 100, 'x');
-  EXPECT_THROW(w.writeString(monster), TProtocolException);
+template <typename T>
+class ArithmeticTypeListBinaryProtocolTest : public BinaryProtocolTest {};
+
+using ArithmeticTypes =
+    ::testing::Types<int64_t, int32_t, int16_t, int8_t, float, double>;
+TYPED_TEST_SUITE(ArithmeticTypeListBinaryProtocolTest, ArithmeticTypes);
+
+TYPED_TEST(ArithmeticTypeListBinaryProtocolTest, readBigListFixedInt) {
+  for (int randomInit = 0; randomInit <= 1; ++randomInit) {
+    for (int i = 1; i < 256; ++i) {
+      auto w = BinaryProtocolWriter();
+      auto q = folly::IOBufQueue();
+      w.setOutput(&q);
+      std::vector<TypeParam> intList(i);
+      // Specify the engine and distribution.
+      if (randomInit) {
+        std::mt19937 mersenne_engine(1337); // Generates random integers
+        if constexpr (std::is_floating_point_v<TypeParam>) {
+          std::uniform_real_distribution<TypeParam> dist{};
+          std::generate(intList.begin(), intList.end(), [&]() {
+            return dist(mersenne_engine);
+          });
+        } else {
+          std::uniform_int_distribution<TypeParam> dist{};
+          std::generate(intList.begin(), intList.end(), [&]() {
+            return dist(mersenne_engine);
+          });
+        }
+
+      } else {
+        TypeParam t = 0;
+        std::generate_n(intList.begin(), intList.size(), [&]() { return ++t; });
+      }
+      using prot_method_integral =
+          ::apache::thrift::detail::pm::protocol_methods<
+              ::apache::thrift::type_class::list<
+                  ::apache::thrift::type_class::integral>,
+              ::std::vector<TypeParam>>;
+      using prot_method_float = ::apache::thrift::detail::pm::protocol_methods<
+          ::apache::thrift::type_class::list<
+              ::apache::thrift::type_class::floating_point>,
+          ::std::vector<TypeParam>>;
+
+      if constexpr (std::is_floating_point_v<TypeParam>) {
+        prot_method_float::write(w, intList);
+      } else {
+        prot_method_integral::write(w, intList);
+      }
+
+      auto r = BinaryProtocolReader();
+      r.setInput(q.front());
+      std::vector<TypeParam> outList;
+      outList.resize(intList.size());
+      if constexpr (std::is_floating_point_v<TypeParam>) {
+        prot_method_float::read(r, outList);
+      } else {
+        prot_method_integral::read(r, outList);
+      }
+      ASSERT_EQ(intList, outList);
+    }
+  }
 }
 
 } // namespace

--- a/third-party/thrift/src/thrift/lib/cpp2/test/ProtocolBench.cpp
+++ b/third-party/thrift/src/thrift/lib/cpp2/test/ProtocolBench.cpp
@@ -175,7 +175,12 @@ constexpr SerializerMethod getSerializerMethod(std::string_view prefix) {
   X2(Prefix, proto, MixedInt)           \
   X2(Prefix, proto, LargeMixed)         \
   X2(Prefix, proto, SmallListInt)       \
+  X2(Prefix, proto, BigListByte)        \
+  X2(Prefix, proto, BigListShort)       \
   X2(Prefix, proto, BigListInt)         \
+  X2(Prefix, proto, BigListBigInt)      \
+  X2(Prefix, proto, BigListFloat)       \
+  X2(Prefix, proto, BigListDouble)      \
   X2(Prefix, proto, BigListMixed)       \
   X2(Prefix, proto, BigListMixedInt)    \
   X2(Prefix, proto, LargeListMixed)     \
@@ -183,7 +188,7 @@ constexpr SerializerMethod getSerializerMethod(std::string_view prefix) {
   X2(Prefix, proto, UnorderedSetInt)    \
   X2(Prefix, proto, SortedVecSetInt)    \
   X2(Prefix, proto, LargeMapInt)        \
-  X2(Prefix, proto, LargeMapMixed)        \
+  X2(Prefix, proto, LargeMapMixed)      \
   X2(Prefix, proto, LargeUnorderedMapMixed)        \
   X2(Prefix, proto, LargeSortedVecMapMixed)        \
   X2(Prefix, proto, UnorderedMapInt)    \
@@ -199,7 +204,7 @@ constexpr SerializerMethod getSerializerMethod(std::string_view prefix) {
   OpEncodeX2(Prefix, proto, BigString)          \
   OpEncodeX2(Prefix, proto, Mixed)              \
   OpEncodeX2(Prefix, proto, MixedInt)           \
-  OpEncodeX2(Prefix, proto, LargeMixed)           \
+  OpEncodeX2(Prefix, proto, LargeMixed)         \
   OpEncodeX2(Prefix, proto, SmallListInt)       \
   OpEncodeX2(Prefix, proto, BigListInt)         \
   OpEncodeX2(Prefix, proto, BigListMixed)       \
@@ -209,7 +214,7 @@ constexpr SerializerMethod getSerializerMethod(std::string_view prefix) {
   OpEncodeX2(Prefix, proto, UnorderedSetInt)    \
   OpEncodeX2(Prefix, proto, SortedVecSetInt)    \
   OpEncodeX2(Prefix, proto, LargeMapInt)        \
-  OpEncodeX2(Prefix, proto, LargeMapMixed)        \
+  OpEncodeX2(Prefix, proto, LargeMapMixed)      \
   OpEncodeX2(Prefix, proto, LargeUnorderedMapMixed)        \
   OpEncodeX2(Prefix, proto, LargeSortedVecMapMixed)        \
   OpEncodeX2(Prefix, proto, UnorderedMapInt)    \

--- a/third-party/thrift/src/thrift/lib/cpp2/test/ProtocolBenchData.thrift
+++ b/third-party/thrift/src/thrift/lib/cpp2/test/ProtocolBenchData.thrift
@@ -60,8 +60,28 @@ struct SmallListInt {
   1: list<i32> lst;
 }
 
+struct BigListByte {
+  1: list<byte> lst;
+}
+
+struct BigListShort {
+  1: list<i16> lst;
+}
+
 struct BigListInt {
   1: list<i32> lst;
+}
+
+struct BigListBigInt {
+  1: list<i64> lst;
+}
+
+struct BigListFloat {
+  1: list<float> lst;
+}
+
+struct BigListDouble {
+  1: list<double> lst;
 }
 
 struct BigListMixed {

--- a/third-party/thrift/src/thrift/lib/cpp2/test/ThriftStructs-inl.h
+++ b/third-party/thrift/src/thrift/lib/cpp2/test/ThriftStructs-inl.h
@@ -134,8 +134,9 @@ template <class T>
 inline T createList(int size) {
   std::mt19937 rng;
   T d;
-  while (size-- != 0) {
-    d.lst()->push_back(rng());
+  d.lst()->resize(size);
+  for (int i = 0; i < size; ++i) {
+    d.lst()->at(i) = rng();
   }
   return d;
 }
@@ -153,6 +154,17 @@ create<thrift::benchmark::OpSmallListInt>() {
 }
 
 template <>
+inline thrift::benchmark::BigListByte create<thrift::benchmark::BigListByte>() {
+  return createList<thrift::benchmark::BigListByte>(10000);
+}
+
+template <>
+inline thrift::benchmark::BigListShort
+create<thrift::benchmark::BigListShort>() {
+  return createList<thrift::benchmark::BigListShort>(10000);
+}
+
+template <>
 inline thrift::benchmark::BigListInt create<thrift::benchmark::BigListInt>() {
   return createList<thrift::benchmark::BigListInt>(10000);
 }
@@ -161,6 +173,22 @@ template <>
 inline thrift::benchmark::OpBigListInt
 create<thrift::benchmark::OpBigListInt>() {
   return createList<thrift::benchmark::OpBigListInt>(10000);
+}
+
+template <>
+inline thrift::benchmark::BigListBigInt
+create<thrift::benchmark::BigListBigInt>() {
+  return createList<thrift::benchmark::BigListBigInt>(10000);
+}
+template <>
+inline thrift::benchmark::BigListFloat
+create<thrift::benchmark::BigListFloat>() {
+  return createList<thrift::benchmark::BigListFloat>(10000);
+}
+template <>
+inline thrift::benchmark::BigListDouble
+create<thrift::benchmark::BigListDouble>() {
+  return createList<thrift::benchmark::BigListDouble>(10000);
 }
 
 template <>


### PR DESCRIPTION
Summary:
Diff applies nvidia suggestion of paralelizing endianness swap. We are actually relying on autovec instead of using explicit SIMD code. Changes end up improving both x86
 and aarch64.
We've verified autovec codegen here: https://godbolt.org/z/3rzYs5EbG

We've observed 20x performance increase on Grace and over 12x on BGM

aarch64:
before:
BinaryProtocol_write_BigListInt                            18.67us    53.57K

after:
BinaryProtocol_write_BigListInt                           723.10ns     1.38M

BGM:
before:
BinaryProtocol_write_BigListInt                            15.16us    65.98K

after:
BinaryProtocol_write_BigListInt                             1.18us   850.59K

Original PR summary:

This pull request introduces significant optimizations for reading and writing vectors of fundamental values (integer and floating types) in the BinaryProtocol for ARM. Previously, each vector element was processed individually, involving repeated checks for buffer capacity, potential buffer fetching, value reading, and buffer tail adjustments. This approach incurred substantial overhead and prevented vectorization.

To address this, we've replaced the existing method with a memcpy-like operation that reverses the byte order for each vector element (converting from Little Endian to Big Endian) that is copied. A naive implementation did not achieve optimal performance on the ARM Neoverse-V2 core, as it only generated scalar ldp and stp instructions. Using vector ldp and stp instructions doubles the theoretical throughput.

To overcome this limitation, we've implemented a custom solution utilizing NEON intrinsics, which yields almost optimal performance for large input vectors. This enhancement results in a remarkable speedup of approximately 140x for writing Byte vectors and 18x for I64 vectors. Importantly, no performance regression is introduced for small vectors. If the NEON implementation is not used, the fallback implementation still gives a reasonable speedup.

Differential Revision: D71488580


