### PR TITLE
Improve readVarint by ~20% on aarch64

### DIFF
--- a/third-party/thrift/src/thrift/lib/cpp/util/VarintUtils-inl.h
+++ b/third-party/thrift/src/thrift/lib/cpp/util/VarintUtils-inl.h
@@ -110,7 +110,7 @@ void readVarintSlow(CursorT& c, T& value) {
 [[noreturn]] void throwInvalidVarint();
 
 template <class T>
-size_t readVarintMediumSlowUnrolled(T& value, const uint8_t* p) {
+size_t readVarintMediumSlowUnrolledX86(T& value, const uint8_t* p) {
   uint64_t result;
   const uint8_t* start = p;
   do {
@@ -134,6 +134,36 @@ size_t readVarintMediumSlowUnrolled(T& value, const uint8_t* p) {
   } while (false);
   value = static_cast<T>(result);
   return p - start;
+}
+
+template <class T>
+size_t readVarintMediumSlowUnrolledAarch64(T& result, const uint8_t* p) {
+  T byte;
+  // clang-format off
+  byte = *p++; result  = (byte & 0x7f);       if (UNLIKELY(!(byte & 0x80))) return 1;
+  byte = *p++; result |= (byte & 0x7f) <<  7; if (UNLIKELY(!(byte & 0x80))) return 2;
+  if constexpr (sizeof(T) <= 1) throwInvalidVarint();
+  byte = *p++; result |= (byte & 0x7f) << 14; if (UNLIKELY(!(byte & 0x80))) return 3;
+  if constexpr (sizeof(T) <= 2) throwInvalidVarint();
+  byte = *p++; result |= (byte & 0x7f) << 21; if (UNLIKELY(!(byte & 0x80))) return 4;
+  byte = *p++; result |= (byte & 0x7f) << 28; if (UNLIKELY(!(byte & 0x80))) return 5;
+  if constexpr (sizeof(T) <= 4) throwInvalidVarint();
+  byte = *p++; result |= (byte & 0x7f) << 35; if (UNLIKELY(!(byte & 0x80))) return 6;
+  byte = *p++; result |= (byte & 0x7f) << 42; if (UNLIKELY(!(byte & 0x80))) return 7;
+  byte = *p++; result |= (byte & 0x7f) << 49; if (UNLIKELY(!(byte & 0x80))) return 8;
+  byte = *p++; result |= (byte & 0x7f) << 56; if (UNLIKELY(!(byte & 0x80))) return 9;
+  byte = *p++; result |= (byte & 0x7f) << 63; if (UNLIKELY(!(byte & 0x80))) return 10;
+  // clang-format on
+  throwInvalidVarint();
+}
+
+template <class T>
+size_t readVarintMediumSlowUnrolled(T& result, const uint8_t* p) {
+  if constexpr (folly::kIsArchAArch64) {
+    return readVarintMediumSlowUnrolledAarch64(result, p);
+  } else {
+    return readVarintMediumSlowUnrolledX86(result, p);
+  }
 }
 
 // The fast-path of the optimized medium-slow paths. Decodes the first two bytes


### PR DESCRIPTION
Summary:
By looking into disassemblies, it turns out the compiler was generating too many jumps. Additionally, extra computation was performed to get the return value.
Return branches are now marked as UNLIKELY, to have the decompressing code in the same block. Values to be returned are now hardcoded, to avoid extra instructions.

Changes resulted in ~20% latency reduction towards reading integer variables on a Grace-powered system.

Proposed changes resulted in regression for x86 systems, thus new method is only executed on aarch64 builds.

Old code asm: https://godbolt.org/z/PeTfnEaxs

New code asm: https://godbolt.org/z/EhE4TcGEz

Benchmarks on a T11:

before:
bench_read(u8_any)                                          1.92ns   522.00M
bench_read(u8_1b)                                           1.90ns   524.97M
bench_read(u8_2b)                                           1.92ns   521.46M
bench_read(u16_any)                                         2.03ns   492.06M
bench_read(u16_1b)                                          1.92ns   521.50M
bench_read(u16_2b)                                          2.00ns   500.81M
bench_read(u16_3b)                                          2.08ns   480.64M
bench_read(u32_any)                                         2.10ns   476.31M
bench_read(u32_1b)                                          1.92ns   520.16M
bench_read(u32_2b)                                          1.97ns   506.54M
bench_read(u32_3b)                                          2.00ns   500.82M
bench_read(u32_4b)                                          2.00ns   500.01M
bench_read(u32_5b)                                          2.11ns   474.56M
bench_read(u64_any)                                         3.43ns   291.14M
bench_read(u64_1b)                                          1.53ns   652.71M
bench_read(u64_2b)                                          2.23ns   448.10M
bench_read(u64_3b)                                          2.33ns   429.38M
bench_read(u64_4b)                                          2.47ns   405.49M
bench_read(u64_5b)                                          2.40ns   416.72M
bench_read(u64_6b)                                          2.37ns   421.38M
bench_read(u64_7b)                                          2.44ns   409.55M
bench_read(u64_8b)                                          2.75ns   363.71M
bench_read(u64_9b)                                          3.06ns   326.87M
bench_read(u64_10b)                                         3.04ns   328.67M

after:
bench_read(u8_any)                                          1.51ns   662.62M
bench_read(u8_1b)                                           1.52ns   656.08M
bench_read(u8_2b)                                           1.54ns   649.48M
bench_read(u16_any)                                         2.27ns   439.67M
bench_read(u16_1b)                                          1.53ns   653.65M
bench_read(u16_2b)                                          1.58ns   633.92M
bench_read(u16_3b)                                          1.54ns   648.39M
bench_read(u32_any)                                         1.89ns   528.60M
bench_read(u32_1b)                                          1.54ns   651.01M
bench_read(u32_2b)                                          1.63ns   613.80M
bench_read(u32_3b)                                          1.57ns   637.27M
bench_read(u32_4b)                                          1.54ns   650.97M
bench_read(u32_5b)                                          1.65ns   607.02M
bench_read(u64_any)                                         2.75ns   363.75M
bench_read(u64_1b)                                          1.53ns   652.63M
bench_read(u64_2b)                                          1.56ns   641.21M
bench_read(u64_3b)                                          1.56ns   642.89M
bench_read(u64_4b)                                          1.59ns   629.19M
bench_read(u64_5b)                                          1.71ns   584.95M
bench_read(u64_6b)                                          1.90ns   527.56M
bench_read(u64_7b)                                          2.10ns   476.81M
bench_read(u64_8b)                                          2.39ns   418.32M
bench_read(u64_9b)                                          2.65ns   377.81M
bench_read(u64_10b)                                         2.88ns   346.69M

Differential Revision: D72522727


