### PR TITLE
fix cmake build

### DIFF
--- a/third-party/watchman/src/CMakeLists.txt
+++ b/third-party/watchman/src/CMakeLists.txt
@@ -634,6 +634,7 @@ watchman/fs/UnixDirHandle.cpp
 watchman/fs/WindowsTime.cpp
 watchman/UserDir.cpp
 watchman/WatchmanConfig.cpp
+watchman/XattrUtils.cpp
 watchman/fs/WinDirHandle.cpp
 watchman/bser.cpp
 watchman/listener-user.cpp


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebook/watchman/pull/1285

XattrUtils.cpp file was missing from CMakeLists.txt

Windows build was including an internal only path, replace with OSS visible headers

Differential Revision: D72586735


