### PR TITLE
Add missing tc-print source files

### DIFF
--- a/hphp/tools/tc-print/CMakeLists.txt
+++ b/hphp/tools/tc-print/CMakeLists.txt
@@ -1,29 +1,35 @@
+set(
+  TC_PRINT_CXX_SOURCES
+  annotation-cache.cpp
+  mappers.cpp
+  offline-arm-code.cpp
+  offline-code.cpp
+  offline-trans-data.cpp
+  perf-events.cpp
+  printir-annotation.cpp
+  ../../hhvm/process-init.cpp
+  repo-wrapper.cpp
+  std-logger.cpp
+  tc-print.cpp
+)
+
 if(IS_X64)
   if (ENABLE_XED)
     find_package(LibXed)
     if (LibXed_FOUND)
       include_directories(${LibXed_INCLUDE_DIR})
     endif()
-    add_executable(tc-print "mappers.cpp" "offline-trans-data.cpp"
-                            "offline-code.cpp"
-                            "offline-x86-code.cpp"  "perf-events.cpp"
-                            "repo-wrapper.cpp"  "tc-print.cpp"
-                            "../../hhvm/process-init.cpp" "std-logger.cpp")
-    link_object_libraries(tc-print ${HHVM_WHOLE_ARCHIVE_LIBRARIES})
-    target_link_libraries(tc-print ${HHVM_LINK_LIBRARIES})
-    embed_all_systemlibs(tc-print "${CMAKE_CURRENT_BINARY_DIR}/../.."
-                                  "${CMAKE_CURRENT_BINARY_DIR}/tc-print")
+    list(APPEND TC_PRINT_CXX_SOURCES offline-x86-code.cpp)
   else()
     message(STATUS "XED disabled, tc-print will not be built")
+    return()
   endif()
 else()
-  add_executable(tc-print "mappers.cpp" "offline-trans-data.cpp"
-                          "offline-code.cpp"  "perf-events.cpp"
-                          "offline-arm-code.cpp"
-                          "repo-wrapper.cpp"  "tc-print.cpp"
-                          "../../hhvm/process-init.cpp" "std-logger.cpp")
-  link_object_libraries(tc-print ${HHVM_WHOLE_ARCHIVE_LIBRARIES})
-  target_link_libraries(tc-print ${HHVM_LINK_LIBRARIES})
-  embed_all_systemlibs(tc-print "${CMAKE_CURRENT_BINARY_DIR}/../.."
-                                "${CMAKE_CURRENT_BINARY_DIR}/tc-print")
+  list(APPEND TC_PRINT_CXX_SOURCES offline-arm-code.cpp)
 endif()
+
+add_executable(tc-print ${TC_PRINT_CXX_SOURCES})
+link_object_libraries(tc-print ${HHVM_WHOLE_ARCHIVE_LIBRARIES})
+target_link_libraries(tc-print ${HHVM_LINK_LIBRARIES})
+embed_all_systemlibs(tc-print "${CMAKE_CURRENT_BINARY_DIR}/../.."
+                              "${CMAKE_CURRENT_BINARY_DIR}/tc-print")


### PR DESCRIPTION
The listfile for tc-print is missing some source files added in recent years.

Add the missing files and use a single list of source files that we conditionally append to depending on platform specifics to reduce duplication.

NB.: most libxed-related conditionals can probably be cleaned up as a followup since it's a required dependency for hhvm on x86-64 as of c02a5f5a95b32a8039c9d72e7b7d1cf88cc4a684.