### PR TITLE
Exclude Meta-specific code in ext/fb

### DIFF
--- a/hphp/runtime/ext/fb/VariantController.h
+++ b/hphp/runtime/ext/fb/VariantController.h
@@ -14,8 +14,10 @@
    | license@php.net so we can mail you a copy immediately.               |
    +----------------------------------------------------------------------+
 */
-#ifndef VARIANTCONTROLLER_H
-#define VARIANTCONTROLLER_H
+
+#pragma once
+
+#ifndef HPHP_OSS
 
 #include "hphp/runtime/base/array-init.h"
 #include "hphp/runtime/base/array-iterator.h"
@@ -394,4 +396,4 @@ using VariantControllerPostHackArrayMigration =
 }
 
 
-#endif
+#endif // HPHP_OSS


### PR DESCRIPTION
FBSerialize.h and related files were removed from OSS in 9b12e0bc3bdd8321f33bbc8a4765c6085229c6ae due to them being referenced in many other projects in fbcode, not just HHVM.

As the HHVM functions exposing this serialization are unlikely to have been of use to non-Meta end users to begin with, exclude code referencing FBSerialize in the OSS build.