### PR TITLE
Remove nonexistent dso_tests reference

### DIFF
--- a/hphp/CMakeLists.txt
+++ b/hphp/CMakeLists.txt
@@ -164,7 +164,5 @@ endif ()
 
 add_subdirectory(tools/gdb)
 
-include(test/dso_test/dso_test.cmake)
-
 # Keep this last
 add_subdirectory(tools/hphpize)


### PR DESCRIPTION
This directory was removed in 71e6b01ff54d7511483626cf964033b71177c630.