### PR TITLE
Partly vectorize CompactProtocol list read

### DIFF
--- a/third-party/thrift/src/thrift/lib/cpp2/protocol/CompactProtocol.h
+++ b/third-party/thrift/src/thrift/lib/cpp2/protocol/CompactProtocol.h
@@ -253,6 +253,8 @@ class CompactProtocolReader : public detail::ProtocolBase {
 
   static constexpr bool kHasDeferredRead() { return true; }
 
+  static constexpr bool kSupportsArithmeticVectors() { return true; }
+
   void setStringSizeLimit(int32_t string_limit) {
     string_limit_ = string_limit;
   }
@@ -294,6 +296,8 @@ class CompactProtocolReader : public detail::ProtocolBase {
   void readI64(int64_t& i64);
   void readDouble(double& dub);
   void readFloat(float& flt);
+  template <typename T>
+  void readArithmeticVector(T* outputPtr, size_t numElements);
   template <typename StrType>
   void readString(StrType& str);
   template <typename StrType>

--- a/third-party/thrift/src/thrift/lib/cpp2/protocol/CompactV1Protocol.h
+++ b/third-party/thrift/src/thrift/lib/cpp2/protocol/CompactV1Protocol.h
@@ -139,6 +139,8 @@ class CompactV1ProtocolReader : protected CompactProtocolReader {
 
   using CompactProtocolReader::getCursor;
   using CompactProtocolReader::getCursorPosition;
+
+  static constexpr bool kSupportsArithmeticVectors() { return false; }
 };
 
 } // namespace apache::thrift

--- a/third-party/thrift/src/thrift/lib/cpp2/protocol/test/ProtocolTest.cpp
+++ b/third-party/thrift/src/thrift/lib/cpp2/protocol/test/ProtocolTest.cpp
@@ -225,7 +225,11 @@ void runBigListTest(
       } else {
         prot_method_integral::read(r, outList);
       }
-      ASSERT_EQ(intList, outList);
+      ASSERT_EQ(intList.size(), outList.size());
+      size_t len = std::min(intList.size(), outList.size());
+      for (size_t j = 0; j < len; ++j) {
+        ASSERT_EQ(intList[j], outList[j]);
+      }
     }
   }
 }


### PR DESCRIPTION
Summary:
Partly vectorize CompactProtocol's list reading, mainly on aarch64.

Performance gains varies by type:

before:
CompactProtocol_read_SmallListInt                                           36.10ns    27.70M
CompactProtocol_read_BigListByte                                            18.32us    54.57K            10005
CompactProtocol_read_BigListShort                                           27.57us    36.27K            27489
CompactProtocol_read_BigListInt                                             22.74us    43.97K            49370
CompactProtocol_read_BigListBigInt                                          25.26us    39.59K            49696
CompactProtocol_read_BigListFloat                                           18.62us    53.69K            40005
CompactProtocol_read_BigListDouble                                          18.81us    53.16K            80005

after:

CompactProtocol_read_SmallListInt                                           27.07ns    36.94M               52
CompactProtocol_read_BigListByte                                           185.48ns     5.39M            10005
CompactProtocol_read_BigListShort                                            5.97us   167.42K            27489
CompactProtocol_read_BigListInt                                              8.67us   115.37K            49370
CompactProtocol_read_BigListBigInt                                          13.01us    76.87K            49696
CompactProtocol_read_BigListFloat                                          827.75ns     1.21M            40005
CompactProtocol_read_BigListDouble                                           1.67us   600.49K            80005

Differential Revision: D73063243


