### PR TITLE
Fix HPHP::Facts::Clock formatter compat with newer libfmt

### DIFF
--- a/hphp/runtime/ext/facts/file-facts.h
+++ b/hphp/runtime/ext/facts/file-facts.h
@@ -152,7 +152,7 @@ struct fmt::formatter<HPHP::Facts::Clock> {
   }
 
   template <typename FormatContext>
-  auto format(const HPHP::Facts::Clock& c, FormatContext& ctx)
+  auto format(const HPHP::Facts::Clock& c, FormatContext& ctx) const
       -> decltype(ctx.out()) {
     return format_to(ctx.out(), "Clock({}, {})", c.m_clock, c.m_mergebase);
   }


### PR DESCRIPTION
The formatter function should be const as per [docs](https://fmt.dev/11.1/api/#formatting-user-defined-types).

Avoid the following:

```
In file included from /hhvm/hphp/runtime/ext/facts/facts-store.cpp:26:
In file included from /hhvm/_build/third-party/folly/bundled_folly-prefix/include/folly/Synchronized.h:32:
In file included from /hhvm/_build/third-party/folly/bundled_folly-prefix/include/folly/Function.h:215:
In file included from /hhvm/_build/third-party/folly/bundled_folly-prefix/include/folly/lang/Exception.h:27:
In file included from /hhvm/_build/third-party/fmt/bundled_fmt-prefix/include/fmt/format.h:41:
/hhvm/_build/third-party/fmt/bundled_fmt-prefix/include/fmt/base.h:2240:23: error: no matching member function for call to 'format'
 2240 |     ctx.advance_to(cf.format(*static_cast<qualified_type*>(arg), ctx));
      |                    ~~~^~~~~~
/hhvm/_build/third-party/fmt/bundled_fmt-prefix/include/fmt/base.h:2220:21: note: in instantiation of function template specialization 'fmt::detail::value<fmt::context>::format_custom<HPHP::Facts::Clock, fmt::formatter<HPHP::Facts::Clock>>' requested here
 2220 |     custom.format = format_custom<value_type, formatter<value_type, char_type>>;
      |                     ^
/hhvm/_build/third-party/folly/bundled_folly-prefix/include/folly/logging/LogStreamProcessor.h:255:13: note: in instantiation of function template specialization 'folly::LogStreamProcessor::formatLogString<HPHP::Facts::Clock, HPHP::Facts::Clock, unsigned long, unsigned long>' requested here
  255 |             formatLogString(fmt, std::forward<Args>(args)...)) {}
      |             ^
/hhvm/hphp/runtime/ext/facts/facts-store.cpp:1176:5: note: in instantiation of function template specialization 'folly::LogStreamProcessor::LogStreamProcessor<HPHP::Facts::Clock &, HPHP::Facts::Clock &, unsigned long, unsigned long>' requested here
 1176 |     XLOGF(
      |     ^
/hhvm/_build/third-party/folly/bundled_folly-prefix/include/folly/logging/xlog.h:108:3: note: expanded from macro 'XLOGF'
  108 |   XLOG_IMPL(                               \
      |   ^
/hhvm/_build/third-party/folly/bundled_folly-prefix/include/folly/logging/xlog.h:481:3: note: expanded from macro 'XLOG_IMPL'
  481 |   XLOG_ACTUAL_IMPL(                 \
      |   ^
/hhvm/_build/third-party/folly/bundled_folly-prefix/include/folly/logging/xlog.h:534:11: note: expanded from macro 'XLOG_ACTUAL_IMPL'
  534 |           ::folly::LogStreamProcessor(                                      \
      |           ^
/hhvm/hphp/runtime/ext/facts/file-facts.h:155:8: note: candidate function template not viable: 'this' argument has type 'const fmt::formatter<HPHP::Facts::Clock>', but method is not marked const
  155 |   auto format(const HPHP::Facts::Clock& c, FormatContext& ctx)
      |        ^
18 warnings and 1 error generated.
```