### PR TITLE
Update third party may 2025

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1650374568,
-        "narHash": "sha256-Z+s0J8/r907g149rllvwhb4pKi8Wam5ij0st8PwAh+E=",
+        "lastModified": 1747046372,
+        "narHash": "sha256-CIVLLkVgvHYbgI2UpXvIIBJ12HWgX+fjA8Xf8PUmqCY=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "b4a34015c698c7793d592d66adbab377907a2be8",
+        "rev": "9100a0f413b0c601e0533d1d94ffd501ce2e7885",
         "type": "github"
       },
       "original": {
@@ -17,12 +17,15 @@
       }
     },
     "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
       "locked": {
-        "lastModified": 1667395993,
-        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
@@ -33,11 +36,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1667758139,
-        "narHash": "sha256-CbDAP6wttlaVs9s4DPZlJ5Wf6Ozz9lX7SdJVtFA8cAo=",
+        "lastModified": 1748662220,
+        "narHash": "sha256-7gGa49iB9nCnFk4h/g9zwjlQAyjtpgcFkODjcOQS0Es=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8993cc730d11148ef59e84a8f15f94f688e1bfd1",
+        "rev": "59138c7667b7970d205d6a05a8bfa2d78caa3643",
         "type": "github"
       },
       "original": {
@@ -47,11 +50,11 @@
     },
     "nixpkgs-mozilla": {
       "locked": {
-        "lastModified": 1664789696,
-        "narHash": "sha256-UGWJHQShiwLCr4/DysMVFrYdYYHcOqAOVsWNUu+l6YU=",
+        "lastModified": 1744624473,
+        "narHash": "sha256-S6zT/w5SyAkJ//dYdjbrXgm+6Vkd/k7qqUl4WgZ6jjk=",
         "owner": "mozilla",
         "repo": "nixpkgs-mozilla",
-        "rev": "80627b282705101e7b38e19ca6e8df105031b072",
+        "rev": "2292d4b35aa854e312ad2e95c4bb5c293656f21a",
         "type": "github"
       },
       "original": {
@@ -66,6 +69,21 @@
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
         "nixpkgs-mozilla": "nixpkgs-mozilla"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     }
   },

--- a/third-party/brotli/CMakeLists.txt
+++ b/third-party/brotli/CMakeLists.txt
@@ -29,7 +29,7 @@ target_include_directories(brotli INTERFACE "${INSTALL_DIR}/include")
 target_link_libraries(
   brotli
   INTERFACE
+  "${INSTALL_DIR}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}brotlicommon-static${CMAKE_STATIC_LIBRARY_SUFFIX}"
   "${INSTALL_DIR}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}brotlidec-static${CMAKE_STATIC_LIBRARY_SUFFIX}"
   "${INSTALL_DIR}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}brotlienc-static${CMAKE_STATIC_LIBRARY_SUFFIX}"
-  "${INSTALL_DIR}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}brotlicommon-static${CMAKE_STATIC_LIBRARY_SUFFIX}"
 )

--- a/third-party/brotli/CMakeLists.txt
+++ b/third-party/brotli/CMakeLists.txt
@@ -5,9 +5,9 @@ include(HPHPFunctions)
 SET_HHVM_THIRD_PARTY_SOURCE_ARGS(
   BROTLI_SOURCE_ARGS
   SOURCE_URL
-  "https://github.com/google/brotli/archive/refs/tags/v1.0.9.tar.gz"
+  "https://github.com/google/brotli/archive/refs/tags/v1.1.0.tar.gz"
   SOURCE_HASH
-  "SHA256=f9e8d81d0405ba66d181529af42a3354f838c939095ff99930da6aa9cdf6fe46"
+  "SHA256=e720a6ca29428b803f4ad165371771f5398faba397edf6778837a18599ea13ff"
   FILENAME_PREFIX "brotli-"
 )
 

--- a/third-party/brotli/CMakeLists.txt.new
+++ b/third-party/brotli/CMakeLists.txt.new
@@ -1,0 +1,35 @@
+add_library(brotli INTERFACE)
+include(ExternalProject)
+
+include(HPHPFunctions)
+SET_HHVM_THIRD_PARTY_SOURCE_ARGS(
+  BROTLI_SOURCE_ARGS
+  SOURCE_URL
+  "https://github.com/google/brotli/archive/refs/tags/v1.1.0.tar.gz"
+  SOURCE_HASH
+  "SHA256=e720a6ca29428b803f4ad165371771f5398faba397edf6778837a18599ea13ff"
+  FILENAME_PREFIX "brotli-"
+)
+
+ExternalProject_Add(
+  bundled_brotli
+  ${BROTLI_SOURCE_ARGS}
+  CMAKE_ARGS
+    -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+    -DCMAKE_INSTALL_INCLUDEDIR=include
+    -DCMAKE_INSTALL_LIBDIR=lib
+    -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+    -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
+    -DCMAKE_OSX_SYSROOT=${CMAKE_OSX_SYSROOT}
+)
+add_dependencies(brotli bundled_brotli)
+
+ExternalProject_Get_Property(bundled_brotli INSTALL_DIR)
+target_include_directories(brotli INTERFACE "${INSTALL_DIR}/include")
+target_link_libraries(
+  brotli
+  INTERFACE
+  "${INSTALL_DIR}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}brotlicommon-static${CMAKE_STATIC_LIBRARY_SUFFIX}"
+  "${INSTALL_DIR}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}brotlidec-static${CMAKE_STATIC_LIBRARY_SUFFIX}"
+  "${INSTALL_DIR}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}brotlienc-static${CMAKE_STATIC_LIBRARY_SUFFIX}"
+)

--- a/third-party/fmt/CMakeLists.txt
+++ b/third-party/fmt/CMakeLists.txt
@@ -3,8 +3,8 @@ if (TARGET fmt::fmt AND NOT CLANG_FORCE_LIBCPP)
   message(STATUS "Using system fmt: ${fmt_DIR}")
   add_library(fmt INTERFACE)
   add_dependencies(fmt fmt::fmt)
-  get_target_property(FMT_INCLUDE_DIR fmt::fmt INTERFACE_INCLUDE_DIRECTORIES)
   target_link_libraries(fmt INTERFACE fmt::fmt)
+  get_target_property(FMT_INCLUDE_DIR fmt::fmt INTERFACE_INCLUDE_DIRECTORIES)
   target_include_directories(fmt INTERFACE ${FMT_INCLUDE_DIR})
 else()
   message(STATUS "Using third-party bundled fmt")
@@ -19,29 +19,29 @@ else()
     "SHA512=8b2a6793ab252bb31a63e54f808d6c48e2c6346ab5deaee7a1c4b5dc9ebc3faf493d31e5e1958e8fa0a6f9c6c0a7ec63ed778bd8d29f9e533bf8ffed281c1397"
   )
 
-  set(INSTALL_DIR "${CMAKE_CURRENT_BINARY_DIR}/fmt-prefix")
-  ExternalProject_add(
+  set(INSTALL_DIR "${CMAKE_CURRENT_BINARY_DIR}/fmt-prefix/install")
+  set(LIB_DIR "${INSTALL_DIR}/lib")
+  if(MSVC)
+    set(DEBUG_LIB_DIR "${INSTALL_DIR}/debug/lib")
+  endif()
+
+  ExternalProject_Add(
     bundled_fmt
     ${FMT_SOURCE_ARGS}
     CMAKE_ARGS
-      -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
       -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
       -DCMAKE_INSTALL_INCLUDEDIR=include
       -DCMAKE_INSTALL_LIBDIR=lib
+      -DBUILD_SHARED_LIBS=OFF
+      -DFMT_DOC=OFF
+      -DFMT_TEST=OFF
+      -DFMT_INSTALL=ON
       -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
       -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
       -DCMAKE_OSX_SYSROOT=${CMAKE_OSX_SYSROOT}
-      -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}
-      -DFMT_TEST=Off
   )
-  cmake_minimum_required(VERSION 2.8.0)
-  ExternalProject_get_property(bundled_fmt INSTALL_DIR)
-
-  add_library(fmt INTERFACE)
   add_dependencies(fmt bundled_fmt)
+
   target_include_directories(fmt INTERFACE "${INSTALL_DIR}/include")
-  target_link_libraries(fmt INTERFACE
-    "${INSTALL_DIR}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}fmt$<$<CONFIG:Debug>:d>${CMAKE_STATIC_LIBRARY_SUFFIX}"
-  )
-  set(fmt_DIR "${INSTALL_DIR}/lib/cmake/fmt" PARENT_SCOPE)
+  target_link_libraries(fmt INTERFACE "${LIB_DIR}/${CMAKE_STATIC_LIBRARY_PREFIX}fmt${CMAKE_STATIC_LIBRARY_SUFFIX}")
 endif()

--- a/third-party/fmt/CMakeLists.txt
+++ b/third-party/fmt/CMakeLists.txt
@@ -14,9 +14,9 @@ else()
   SET_HHVM_THIRD_PARTY_SOURCE_ARGS(
     FMT_SOURCE_ARGS
     SOURCE_URL
-    "https://github.com/fmtlib/fmt/releases/download/11.1.1/fmt-11.1.1.zip"
+    "https://github.com/fmtlib/fmt/releases/download/11.2.0/fmt-11.2.0.zip"
     SOURCE_HASH
-    "SHA512=6321f29b4ddabfcd92362883ca54039f5f2f90d85d95af1410ba98607acdde02c8c02b61c4fad212337aa2938681e038cd4533013b4e1f500c6839f77a74aeca"
+    "SHA512=8b2a6793ab252bb31a63e54f808d6c48e2c6346ab5deaee7a1c4b5dc9ebc3faf493d31e5e1958e8fa0a6f9c6c0a7ec63ed778bd8d29f9e533bf8ffed281c1397"
   )
 
   set(INSTALL_DIR "${CMAKE_CURRENT_BINARY_DIR}/fmt-prefix")

--- a/third-party/fmt/CMakeLists.txt.new
+++ b/third-party/fmt/CMakeLists.txt.new
@@ -1,0 +1,47 @@
+find_package(fmt 9 CONFIG)
+if (TARGET fmt::fmt AND NOT CLANG_FORCE_LIBCPP)
+  message(STATUS "Using system fmt: ${fmt_DIR}")
+  add_library(fmt INTERFACE)
+  add_dependencies(fmt fmt::fmt)
+  target_link_libraries(fmt INTERFACE fmt::fmt)
+  get_target_property(FMT_INCLUDE_DIR fmt::fmt INTERFACE_INCLUDE_DIRECTORIES)
+  target_include_directories(fmt INTERFACE ${FMT_INCLUDE_DIR})
+else()
+  message(STATUS "Using third-party bundled fmt")
+  include(ExternalProject)
+  include(HPHPFunctions)
+
+  SET_HHVM_THIRD_PARTY_SOURCE_ARGS(
+    FMT_SOURCE_ARGS
+    SOURCE_URL
+    "https://github.com/fmtlib/fmt/releases/download/11.2.0/fmt-11.2.0.zip"
+    SOURCE_HASH
+    "SHA512=8b2a6793ab252bb31a63e54f808d6c48e2c6346ab5deaee7a1c4b5dc9ebc3faf493d31e5e1958e8fa0a6f9c6c0a7ec63ed778bd8d29f9e533bf8ffed281c1397"
+  )
+
+  set(INSTALL_DIR "${CMAKE_CURRENT_BINARY_DIR}/fmt-prefix/install")
+  set(LIB_DIR "${INSTALL_DIR}/lib")
+  if(MSVC)
+    set(DEBUG_LIB_DIR "${INSTALL_DIR}/debug/lib")
+  endif()
+
+  ExternalProject_Add(
+    bundled_fmt
+    ${FMT_SOURCE_ARGS}
+    CMAKE_ARGS
+      -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+      -DCMAKE_INSTALL_INCLUDEDIR=include
+      -DCMAKE_INSTALL_LIBDIR=lib
+      -DBUILD_SHARED_LIBS=OFF
+      -DFMT_DOC=OFF
+      -DFMT_TEST=OFF
+      -DFMT_INSTALL=ON
+      -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+      -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
+      -DCMAKE_OSX_SYSROOT=${CMAKE_OSX_SYSROOT}
+  )
+  add_dependencies(fmt bundled_fmt)
+
+  target_include_directories(fmt INTERFACE "${INSTALL_DIR}/include")
+  target_link_libraries(fmt INTERFACE "${LIB_DIR}/${CMAKE_STATIC_LIBRARY_PREFIX}fmt${CMAKE_STATIC_LIBRARY_SUFFIX}")
+endif()

--- a/third-party/glog/CMakeLists.txt
+++ b/third-party/glog/CMakeLists.txt
@@ -5,9 +5,9 @@ if(CLANG_FORCE_LIBCPP)
   SET_HHVM_THIRD_PARTY_SOURCE_ARGS(
     GLOG_SOURCE_ARGS
     SOURCE_URL
-    "https://github.com/google/glog/archive/refs/tags/v0.5.0.zip"
+    "https://github.com/google/glog/archive/refs/tags/v0.7.1.zip"
     SOURCE_HASH
-    "SHA512=46669f603279edc05e98153247897c8a7b50ebc9e800132cc8c3eef531687691e616b5210ed9a1dfbb5170ea354b76fb9244b383a8d309bacbfcf2810ec07546"
+    "SHA512=86b5b76bf95dcb46e9c29b9d1db32f6fb1be62d21438e283a3d9d79e87a4c8d8aabf5dba1b40b72c8ffe898a9a39e53642ed9e5b04dba9931e136e2c5c4c05a4"
   )
 
   set(INSTALL_DIR "${CMAKE_CURRENT_BINARY_DIR}/glog-prefix")

--- a/third-party/zstd/CMakeLists.txt
+++ b/third-party/zstd/CMakeLists.txt
@@ -37,9 +37,9 @@ include(HPHPFunctions)
 SET_HHVM_THIRD_PARTY_SOURCE_ARGS(
   ZSTD_DOWNLOAD_ARGS
   SOURCE_URL
-  "https://github.com/facebook/zstd/releases/download/v1.4.9/zstd-1.4.9.tar.gz"
+  "https://github.com/facebook/zstd/releases/download/v1.5.7/zstd-1.5.7.tar.gz"
   SOURCE_HASH
-  "SHA512=10d325c844be43f801c798158c6f1d1ab57401abf1e783e04f6b9e4ac0ba53cf487204fa3244370b1ade239d5f3a784bf1829e206c4ba61fdd9c2f4e9502b238"
+  "SHA512=dd28a0778d47ed4f8da09ea4de1613add3b52fa8e7daa046f7e47c0216471605feb98d1ccd130ecc6ddab7571dcdac0b8bbf501f873cffa3bfa425eb5f46db54"
 )
 ExternalProject_Add(
   bundled_zstd


### PR DESCRIPTION
This PR updates several third-party dependencies to their latest versions:

- fmt: 11.1.1 → 11.2.0
- zstd: 1.4.9 → 1.5.7
- brotli: 1.0.9 → 1.1.0
- glog: 0.5.0 → 0.7.1
- Updated Nix dependencies in flake.lock

These updates include bug fixes, performance improvements, and security patches from the upstream projects.