### PR TITLE
Make sweeping HSLFileDescriptors a no-op

### DIFF
--- a/hphp/runtime/ext/hsl/ext_hsl_os.cpp
+++ b/hphp/runtime/ext/hsl/ext_hsl_os.cpp
@@ -365,6 +365,8 @@ struct HSLFileDescriptor :
     return fd;
   }
 
+  void sweep() {}
+
   void close() {
     switch (m_type) {
       case Type::FD:


### PR DESCRIPTION
A trivial CLI program that outputs to stdout, such as this one:
```hack
use namespace HH\Lib\IO;

<<__EntryPoint>>
async function main(): Awaitable<void> {
//    var_dump(new Test());
  await IO\request_output()->writeAllAsync("Hello World!\n");
}
```
will abort on exit on a dev build of HHVM with the following assertion failure:
```
hphp/runtime/base/countable.h:285: bool HPHP::MaybeCountable::countedDecRefAndCheck(): assertion `!tl_sweeping' failed.
```

GDB points to `HSLFileDescriptor` as the culprit:
```
(gdb) bt
#0  __pthread_kill_implementation (threadid=<optimized out>, signo=signo@entry=6, no_tid=no_tid@entry=0) at pthread_kill.c:44
#1  0x00007f2fcf72c1e3 in __pthread_kill_internal (threadid=<optimized out>, signo=6) at pthread_kill.c:89
#2  0x00007f2fcf6d2afe in __GI_raise (sig=6) at ../sysdeps/posix/raise.c:26
#3  0x00000000017f0b5e in HPHP::bt_handler (sigin=6, info=0x7ffc52b13e70, args=0x7ffc52b13d40) at /hhvm/hphp/runtime/base/crash-reporter.cpp:444
#4  <signal handler called>
#5  __pthread_kill_implementation (threadid=<optimized out>, signo=signo@entry=6, no_tid=no_tid@entry=0) at pthread_kill.c:44
#6  0x00007f2fcf72c1e3 in __pthread_kill_internal (threadid=<optimized out>, signo=6) at pthread_kill.c:89
#7  0x00007f2fcf6d2afe in __GI_raise (sig=sig@entry=6) at ../sysdeps/posix/raise.c:26
#8  0x00007f2fcf6ba6d0 in __GI_abort () at abort.c:73
#9  0x000000000082955c in HPHP::assert_fail (e=0xba4b8bc "!tl_sweeping", file=0xba4b8c9 "/hhvm/hphp/runtime/base/countable.h", line=285, func=0xba55974 "bool HPHP::MaybeCountable::countedDecRefAndCheck()", 
    msg=...) at /hhvm/hphp/util/assertions.cpp:73
#10 0x00000000006d4780 in HPHP::MaybeCountable::countedDecRefAndCheck (this=0x7f2fcb10a590) at /hhvm/hphp/runtime/base/countable.h:285
#11 0x00000000006d45f5 in HPHP::Countable::decReleaseCheck (this=0x7f2fcb10a590) at /hhvm/hphp/runtime/base/countable.h:293
#12 0x0000000001746732 in HPHP::ResourceHdr::decRefAndRelease (this=0x7f2fcb10a590) at /hhvm/hphp/runtime/base/resource-data.h:71
#13 0x00000000017466ad in HPHP::ResourceData::decRefAndRelease (this=0x7f2fcb10a5a0) at /hhvm/hphp/runtime/base/resource-data.h:133
#14 0x0000000001869cbc in HPHP::req::ptr<HPHP::PlainFile>::decRefPtr (ptr=0x7f2fcb10a5a0) at /hhvm/hphp/runtime/base/req-ptr.h:185
#15 0x000000000186947c in HPHP::req::ptr<HPHP::PlainFile>::~ptr (this=0x7f2fcb103d68) at /hhvm/hphp/runtime/base/req-ptr.h:71
#16 0x0000000004d19db9 in HPHP::HSLFileDescriptor::~HSLFileDescriptor (this=0x7f2fcb103d58) at /hhvm/hphp/runtime/ext/hsl/ext_hsl_os.cpp:265
#17 0x0000000004d19d8d in HPHP::Native::nativeDataInfoDestroy<HPHP::HSLFileDescriptor> (obj=0x7f2fcb103d70) at /hhvm/hphp/runtime/vm/native-data.h:119
#18 0x00000000019334df in HPHP::MemoryManager::sweep (this=0x7f2fce103120) at /hhvm/hphp/runtime/base/memory-manager.cpp:346
#19 0x0000000001995d32 in HPHP::hphp_memory_cleanup () at /hhvm/hphp/runtime/base/program-functions.cpp:3048
#20 0x000000000198f738 in HPHP::hphp_session_exit () at /hhvm/hphp/runtime/base/program-functions.cpp:3117
#21 0x000000000198f4c1 in HPHP::execute_command_line_end (coverage=true, program=0x7ffc52b15b71 "index.hack", runCleanup=true) at /hhvm/hphp/runtime/base/program-functions.cpp:829
#22 0x0000000001994ead in HPHP::execute_program_impl (argc=2, argv=0x7ffc52b17698) at /hhvm/hphp/runtime/base/program-functions.cpp:2325
#23 0x000000000198fc55 in HPHP::execute_program (argc=2, argv=0x7ffc52b17698) at /hhvm/hphp/runtime/base/program-functions.cpp:1357
#24 0x00000000005208a1 in main (argc=2, argv=0x7ffc52b17698) at /hhvm/hphp/hhvm/main.cpp:94

```

`HSLFileDescriptor` may either be initialized with a raw FD or a `req::ptr` holding a `File`. In the former case, sweeping is already a no-op since the extension maintains a request-local set of FDs to be closed and processes it on request shutdown. For the `File` case, we only ever seem to pass in builtin files (namely STDOUT and co.), which should likewise already be closed by `BuiltinFile::sweep()` /`BuiltinFiles::requestShutdown()`.

So, define a no-op sweep() for `HSLFileDescriptor` to avoid triggering redundant cleanup and the assert.