### PR TITLE
Exclude redundant squangle test file

### DIFF
--- a/third-party/squangle/squangle-CMakeLists.txt
+++ b/third-party/squangle/squangle-CMakeLists.txt
@@ -8,6 +8,7 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 # - use CONFIGURE_DEPENDS in these globs
 
 file(GLOB_RECURSE SOURCES "squangle/*.cpp")
+list(REMOVE_ITEM SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/squangle/util/tests/StorageRowTest.cpp")
 
 add_library(squangle STATIC ${SOURCES})
 target_include_directories(squangle PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")


### PR DESCRIPTION
The Squangle repo contains a single GTest file that gets caught up in the glob used by the listfile and included in HHVM builds. Let's exclude it.