### PR TITLE
Fix trivial OSS test failures

### DIFF
--- a/hphp/test/slow/checked_unsafe_cast/config.opts
+++ b/hphp/test/slow/checked_unsafe_cast/config.opts
@@ -1,0 +1,1 @@
+-vPHP7.EngineExceptions=false

--- a/hphp/test/slow/class-ptr/class-serde.php.skipif
+++ b/hphp/test/slow/class-ptr/class-serde.php.skipif
@@ -1,0 +1,6 @@
+<<__EntryPoint>>
+function skipif(): void {
+    if (!HHVM_FACEBOOK) {
+        exit('skip fb_serialize() not available in OSS');
+    }
+}

--- a/hphp/test/slow/dict/fb_serialize.php.skipif
+++ b/hphp/test/slow/dict/fb_serialize.php.skipif
@@ -1,0 +1,8 @@
+<?hh
+
+<<__EntryPoint>>
+function skipif(): void {
+    if (!HHVM_FACEBOOK) {
+        exit('skip fb_serialize() not available in OSS');
+    }
+}

--- a/hphp/test/slow/dv_array_hack_arr/fb_serialize.php.skipif
+++ b/hphp/test/slow/dv_array_hack_arr/fb_serialize.php.skipif
@@ -1,0 +1,8 @@
+<?hh
+
+<<__EntryPoint>>
+function skipif(): void {
+    if (!HHVM_FACEBOOK) {
+        exit('skip fb_serialize() not available in OSS');
+    }
+}

--- a/hphp/test/slow/dv_array_hack_arr/fb_serialize_2.php.skipif
+++ b/hphp/test/slow/dv_array_hack_arr/fb_serialize_2.php.skipif
@@ -1,0 +1,8 @@
+<?hh
+
+<<__EntryPoint>>
+function skipif(): void {
+    if (!HHVM_FACEBOOK) {
+        exit('skip fb_serialize() not available in OSS');
+    }
+}

--- a/hphp/test/slow/eden/config.runif
+++ b/hphp/test/slow/eden/config.runif
@@ -1,0 +1,1 @@
+extension eden

--- a/hphp/test/slow/ext_configerator/config.runif
+++ b/hphp/test/slow/ext_configerator/config.runif
@@ -1,0 +1,1 @@
+extension configerator

--- a/hphp/test/slow/ext_fb/compact_serialize.php.skipif
+++ b/hphp/test/slow/ext_fb/compact_serialize.php.skipif
@@ -1,0 +1,8 @@
+<?hh
+
+<<__EntryPoint>>
+function skipif(): void {
+    if (!HHVM_FACEBOOK) {
+        exit('skip fb_serialize() not available in OSS');
+    }
+}

--- a/hphp/test/slow/ext_fb/fb_serialize_hack_array_notices.php.skipif
+++ b/hphp/test/slow/ext_fb/fb_serialize_hack_array_notices.php.skipif
@@ -1,0 +1,8 @@
+<?hh
+
+<<__EntryPoint>>
+function skipif(): void {
+    if (!HHVM_FACEBOOK) {
+        exit('skip fb_serialize() not available in OSS');
+    }
+}

--- a/hphp/test/slow/ext_fb/migratory_serialize.php.skipif
+++ b/hphp/test/slow/ext_fb/migratory_serialize.php.skipif
@@ -1,0 +1,8 @@
+<?hh
+
+<<__EntryPoint>>
+function skipif(): void {
+    if (!HHVM_FACEBOOK) {
+        exit('skip fb_serialize() not available in OSS');
+    }
+}

--- a/hphp/test/slow/ext_fb/serialize.php.skipif
+++ b/hphp/test/slow/ext_fb/serialize.php.skipif
@@ -1,0 +1,8 @@
+<?hh
+
+<<__EntryPoint>>
+function skipif(): void {
+    if (!HHVM_FACEBOOK) {
+        exit('skip fb_serialize() not available in OSS');
+    }
+}

--- a/hphp/test/slow/ext_fb/serialize_post_ham.php.skipif
+++ b/hphp/test/slow/ext_fb/serialize_post_ham.php.skipif
@@ -1,0 +1,8 @@
+<?hh
+
+<<__EntryPoint>>
+function skipif(): void {
+    if (!HHVM_FACEBOOK) {
+        exit('skip fb_serialize() not available in OSS');
+    }
+}

--- a/hphp/test/slow/ext_fb/unserialize_max_depth.php.skipif
+++ b/hphp/test/slow/ext_fb/unserialize_max_depth.php.skipif
@@ -1,0 +1,8 @@
+<?hh
+
+<<__EntryPoint>>
+function skipif(): void {
+    if (!HHVM_FACEBOOK) {
+        exit('skip fb_serialize() not available in OSS');
+    }
+}

--- a/hphp/test/slow/func-ptr-no-interop/func-serde.php.skipif
+++ b/hphp/test/slow/func-ptr-no-interop/func-serde.php.skipif
@@ -1,0 +1,6 @@
+<<__EntryPoint>>
+function skipif(): void {
+    if (!HHVM_FACEBOOK) {
+        exit('skip fb_serialize() not available in OSS');
+    }
+}

--- a/hphp/test/slow/hack_arr_compat/fb_unserialize.php.skipif
+++ b/hphp/test/slow/hack_arr_compat/fb_unserialize.php.skipif
@@ -1,0 +1,8 @@
+<?hh
+
+<<__EntryPoint>>
+function skipif(): void {
+    if (!HHVM_FACEBOOK) {
+        exit('skip fb_serialize() not available in OSS');
+    }
+}

--- a/hphp/test/slow/hack_arr_compat/legacy_serialize/fb_compact_serialize.php.skipif
+++ b/hphp/test/slow/hack_arr_compat/legacy_serialize/fb_compact_serialize.php.skipif
@@ -1,0 +1,8 @@
+<?hh
+
+<<__EntryPoint>>
+function skipif(): void {
+    if (!HHVM_FACEBOOK) {
+        exit('skip fb_serialize() not available in OSS');
+    }
+}

--- a/hphp/test/slow/hack_arr_compat/serialization-notices.php.skipif
+++ b/hphp/test/slow/hack_arr_compat/serialization-notices.php.skipif
@@ -1,0 +1,8 @@
+<?hh
+
+<<__EntryPoint>>
+function skipif(): void {
+    if (!HHVM_FACEBOOK) {
+        exit('skip fb_serialize() not available in OSS');
+    }
+}

--- a/hphp/test/slow/implicit-context/memo-agnostic-ic-all-types.php.skipif
+++ b/hphp/test/slow/implicit-context/memo-agnostic-ic-all-types.php.skipif
@@ -1,0 +1,7 @@
+<?hh
+
+<<__EntryPoint>> function skipif(): void {
+    if (!function_exists('HH\Coeffects\fb\backdoor_from_leak_safe__DO_NOT_USE')) {
+        exit('skip HH\Coeffects\fb\backdoor_from_leak_safe__DO_NOT_USE() not available in OSS');
+    }
+}

--- a/hphp/test/slow/keyset/fb_serialize.php.skipif
+++ b/hphp/test/slow/keyset/fb_serialize.php.skipif
@@ -1,0 +1,6 @@
+<<__EntryPoint>>
+function skipif(): void {
+    if (!HHVM_FACEBOOK) {
+        exit('skip fb_serialize() not available in OSS');
+    }
+}

--- a/hphp/test/slow/meth-caller-serialize-native.php.skipif
+++ b/hphp/test/slow/meth-caller-serialize-native.php.skipif
@@ -1,0 +1,6 @@
+<<__EntryPoint>>
+function skipif(): void {
+    if (!HHVM_FACEBOOK) {
+        exit('skip fb_serialize() not available in OSS');
+    }
+}

--- a/hphp/test/slow/meth-caller-serialize-throw.php.skipif
+++ b/hphp/test/slow/meth-caller-serialize-throw.php.skipif
@@ -1,0 +1,6 @@
+<<__EntryPoint>>
+function skipif(): void {
+    if (!HHVM_FACEBOOK) {
+        exit('skip fb_serialize() not available in OSS');
+    }
+}

--- a/hphp/test/slow/meth-caller-serialize.php.skipif
+++ b/hphp/test/slow/meth-caller-serialize.php.skipif
@@ -1,0 +1,6 @@
+<<__EntryPoint>>
+function skipif(): void {
+    if (!HHVM_FACEBOOK) {
+        exit('skip fb_serialize() not available in OSS');
+    }
+}

--- a/hphp/test/slow/static-analysis-error.php.expectf
+++ b/hphp/test/slow/static-analysis-error.php.expectf
@@ -1,5 +1,5 @@
 %A
-%|{Detected jit::trap at 0x%s: from fbcode/hphp/runtime/vm/jit/irlower-intrinsic.cpp:%d|fbcode/hphp/runtime/vm/bytecode.cpp:%d: void HPHP::iopStaticAnalysisError(): assertion `!Cfg::Eval::CrashOnStaticAnalysisError' failed.}
+%|{Detected jit::trap at 0x%s: from %s/hphp/runtime/vm/jit/irlower-intrinsic.cpp:%d|%s/hphp/runtime/vm/bytecode.cpp:%d: void HPHP::iopStaticAnalysisError(): assertion `!Cfg::Eval::CrashOnStaticAnalysisError' failed.}
 %A
 PHP Stacktrace:
 

--- a/hphp/test/slow/typed_locals/config.opts
+++ b/hphp/test/slow/typed_locals/config.opts
@@ -1,0 +1,1 @@
+-vPHP7.EngineExceptions=false

--- a/hphp/test/slow/vec/fb_serialize.php.skipif
+++ b/hphp/test/slow/vec/fb_serialize.php.skipif
@@ -1,0 +1,6 @@
+<<__EntryPoint>>
+function skipif(): void {
+    if (!HHVM_FACEBOOK) {
+        exit('skip fb_serialize() not available in OSS');
+    }
+}

--- a/hphp/test/slow/vle/config.runif
+++ b/hphp/test/slow/vle/config.runif
@@ -1,0 +1,1 @@
+extension vle


### PR DESCRIPTION
Address some straightforward test failures in HHVM OSS:

* Gate tests for internal Meta extensions behind appropriate runif checks.
* Set `-vPHP7.EngineExceptions=false` for some tests that assume this, as this knob defaults to false in internal builds but to true in OSS.
* Skip tests that exercise fb_(un)serialize() outside internal builds, since FBSerialize was removed from HHVM OSS in D46525242.