### PR TITLE
Consistently check connection validity in AsyncMysqlConnection

### DIFF
--- a/hphp/runtime/ext/async_mysql/ext_async_mysql.cpp
+++ b/hphp/runtime/ext/async_mysql/ext_async_mysql.cpp
@@ -326,9 +326,11 @@ static String HHLibSQLQuery__toString__FOR_DEBUGGING_ONLY(
     val(this_->propRvalAtOffset(s_query_format_idx).tv()).pstr;
   const auto args = val(this_->propRvalAtOffset(s_query_args_idx).tv()).parr;
   const auto query = amquery_from_queryf(format, args);
-  auto mysql = Native::data<AsyncMysqlConnection>(conn)
-    ->m_conn
-    ->mysql_for_testing_only();
+
+  auto* data = Native::data<AsyncMysqlConnection>(conn);
+  data->verifyValidConnection();
+
+  auto mysql = data->m_conn->mysql_for_testing_only();
   const auto str = query.render(mysql);
   return String(str.data(), str.length(), CopyString);
 }
@@ -1286,6 +1288,8 @@ static void HHVM_METHOD(AsyncMysqlConnection, close) {
 
 static String HHVM_METHOD(AsyncMysqlConnection, getSslCertCn) {
   auto* data = Native::data<AsyncMysqlConnection>(this_);
+  data->verifyValidConnection();
+
   const auto* context = data->m_conn->getConnectionContext();
   if (context && context->sslCertCn.hasValue()) {
     return context->sslCertCn.value();
@@ -1296,6 +1300,8 @@ static String HHVM_METHOD(AsyncMysqlConnection, getSslCertCn) {
 
 static Object HHVM_METHOD(AsyncMysqlConnection, getSslCertSan) {
   auto* data = Native::data<AsyncMysqlConnection>(this_);
+  data->verifyValidConnection();
+
   auto ret = req::make<c_Vector>();
   const auto* context = data->m_conn->getConnectionContext();
   if (context && context->sslCertSan.hasValue()) {
@@ -1308,6 +1314,8 @@ static Object HHVM_METHOD(AsyncMysqlConnection, getSslCertSan) {
 
 static Object HHVM_METHOD(AsyncMysqlConnection, getSslCertExtensions) {
   auto* data = Native::data<AsyncMysqlConnection>(this_);
+  data->verifyValidConnection();
+
   auto ret = req::make<c_Vector>();
   const auto* context = data->m_conn->getConnectionContext();
   if (context && context->sslCertIdentities.hasValue()) {
@@ -1320,6 +1328,8 @@ static Object HHVM_METHOD(AsyncMysqlConnection, getSslCertExtensions) {
 
 static bool HHVM_METHOD(AsyncMysqlConnection, isSslCertValidationEnforced) {
   auto* data = Native::data<AsyncMysqlConnection>(this_);
+  data->verifyValidConnection();
+
   const auto* context = data->m_conn->getConnectionContext();
   return context && context->isServerCertValidated;
 }


### PR DESCRIPTION
The Squangle connection pointer wrapped by AsyncMysqlConnection may be nullptr if the connection was closed or is currently busy waiting for the result of an async query. Most code paths already call either verifyValidConnection() to raise an appropriate Hack exception or explicitly check for and handle a null backing connection, but Query::toString__FOR_DEBUGGING_ONLY() and the SSL-related getters from D33663743 do not, which can lead to segfaults.

Slightly simplified reproducer from #8678:
```hack
use namespace HH\Lib\SQL;

<<__EntryPoint>>
async function main_async(): Awaitable<void> {
    // connection parameters as needed
    $async_conn = await AsyncMysqlClient::connect('127.0.0.1', 3306, 'foo', 'root', 'pass');
    concurrent {
        await func_async($async_conn, new SQL\Query('SELECT %s', 'something'));
        await func_async($async_conn, new SQL\Query('SELECT %s', 'something'));
    }
}

async function func_async(AsyncMysqlConnection $asyncMysql, SQL\Query $query): Awaitable<void> {
    $query->toString__FOR_DEBUGGING_ONLY($asyncMysql);
    await $asyncMysql->queryf('SELECT %s', 'something');
}
```

and for `(get|is)Ssl.*`:
```hack
use namespace HH\Lib\SQL;

<<__EntryPoint>>
async function main_async(): Awaitable<void> {
    $async_conn = await AsyncMysqlClient::connect('127.0.0.1', 3306, 'foo', 'root', 'wikia123456');
    $async_conn->close();

    var_dump($async_conn->getSslCertCn());
}
```

Call verifyValidConnection() in all these cases, as raising an appropriate exception (e.g. closed/busy connection) seems appropriate here.

Fixes #8678