### PR TITLE
Raise required CMake version to 3.18

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,4 @@
-CMAKE_MINIMUM_REQUIRED(VERSION 2.8.7 FATAL_ERROR)
-# Make `get_target_property()` on a target that does not exist a fatal error
-# https://cmake.org/cmake/help/v3.0/policy/CMP0045.html
-cmake_policy(SET CMP0045 NEW)
-# ditto for add_dependencies(): https://cmake.org/cmake/help/v3.0/policy/CMP0046.html
-cmake_policy(SET CMP0046 NEW)
+cmake_minimum_required(VERSION 3.18 FATAL_ERROR)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -63,7 +58,7 @@ if(NOT SKIP_CCACHE)
       message(STATUS "Found ccache: ${CCACHE_FOUND} - enabling ccache as compiler wrapper")
     else()
       message(STATUS "Found ccache - ccache already in use as C and/or CXX compiler wrapper")
-   endif()
+    endif()
   endif(CCACHE_FOUND)
 endif(NOT SKIP_CCACHE)
 


### PR DESCRIPTION
CMake 3.31 deprecates compatibility with CMake < 3.10 and CMake 4.0 removes compatibility with CMake < 3.5 entirely. As the required CMake version hasn't been raised in 12 years, select 3.18 as a reasonably recent minimum CMake version with wide availability (Ubuntu Jammy ships 3.22, Debian oldstable Bullseye ships 3.18). Remove cmake_policy() calls that now default to NEW due to the higher minimum version requirement.

A further benefit of this is that CMP0065[1] now also defaults to NEW, which means that the `hhvm` binary is no longer linked with `--export-dynamic`, making the (stripped) binary around 30MiB smaller. OSS could also choose to supply an explicit dynamic list as a followup as done in D2747334 and D67114451, but it doesn't seem to be required just now.

[1] https://cmake.org/cmake/help/latest/policy/CMP0065.html