### PR TITLE
Remove internal type from __Sealed attribute in implicit_context.hhi

### DIFF
--- a/hphp/hack/hhi/implicit_context.hhi
+++ b/hphp/hack/hhi/implicit_context.hhi
@@ -48,7 +48,9 @@ namespace HH {
     )[this::CRun, ctx $f]: Tout;
   }
 
-  <<__Sealed(FBMemoSensitiveImplicitContext::class)>>
+  <<__Sealed(
+    FBMemoAgnosticImplicitContext::class // @oss-disable
+  )>>
   abstract class MemoSensitiveImplicitContext extends ImplicitContextBase {
     abstract const type TData as IPureMemoizeParam;
 


### PR DESCRIPTION
D74667088 marked MemoSensitiveImplicitContext as __Sealed, with only a single class permitted to directly extend it. This class is however internal to Meta, causing typechecking errors in OSS Hack.

As a fix, mark the attribute parameter with `// @oss-disable` to remove it during the code export process.

NOTE: If I'm understanding the docs[1] for `@oss-disable` / `@oss-enable` correctly, this should be the correct way to make this change, which should then transform into `// @oss-disable FBMemoAgnosticImplicitContext::class` once this patch is merged and exported. Let me know if this assumption is incorrect.

[1] https://github.com/facebook/buck2/blob/239ab927a5be7dee3035141d29e2e9c91e8ea771/HACKING.md?plain=1#L168