### PR TITLE
Add various missing includes

### DIFF
--- a/hphp/runtime/vm/fcall-args-flags.h
+++ b/hphp/runtime/vm/fcall-args-flags.h
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 namespace HPHP {
 
 enum FCallArgsFlags : uint16_t {

--- a/hphp/runtime/vm/jit/timer.h
+++ b/hphp/runtime/vm/jit/timer.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <string>
 #include <vector>
 

--- a/hphp/tools/configs/generate_configs_lib.rs
+++ b/hphp/tools/configs/generate_configs_lib.rs
@@ -1180,6 +1180,7 @@ pub fn generate_loader(sections: Vec<ConfigSection>, output_dir: PathBuf) {
         let h_content = format!(
             r#"#pragma once
 
+#include <cstdint>
 #include <string>
 
 namespace HPHP {{

--- a/hphp/util/blob-encoder.h
+++ b/hphp/util/blob-encoder.h
@@ -28,6 +28,7 @@
 #include <folly/container/F14Map.h>
 #include <folly/container/F14Set.h>
 
+#include <bitset>
 #include <filesystem>
 #include <memory>
 #include <set>

--- a/hphp/util/hdf-extract.h
+++ b/hphp/util/hdf-extract.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <map>
 #include <string>
 #include <vector>

--- a/hphp/util/hdf.h
+++ b/hphp/util/hdf.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <string>
 #include <map>
 #include <set>

--- a/hphp/util/numa.cpp
+++ b/hphp/util/numa.cpp
@@ -19,6 +19,7 @@
 #include "hphp/util/portability.h"
 #include <folly/Bits.h>
 #include <numaif.h>
+#include <algorithm>
 #include <fstream>
 #include <map>
 #include <thread>


### PR DESCRIPTION
These were originally detected when I was compiling HHVM with clang and libstdc++, but it's generally good to include what you use without relying on another standard library header pulling them in.