### PR TITLE
Provide OCaml env vars for ocamlrep crate

### DIFF
--- a/hphp/hack/dev_env_rust_only.sh.in
+++ b/hphp/hack/dev_env_rust_only.sh.in
@@ -11,4 +11,6 @@
 #  . $BUILD_DIR/hphp/hack/dev_env_rust_only.sh
 
 . "@CMAKE_CURRENT_BINARY_DIR@/dev_env_common.sh"
-# Nothing else to do for rust :)
+
+# Export OCaml variables, needed by ocamlrep
+eval $(opam env)


### PR DESCRIPTION
build.rs in the ocamlrep crate expects a working OPAM env, so provide it in the setup file.