### PR TITLE
Drop unused headers

### DIFF
--- a/hphp/runtime/ext/facts/config.cmake
+++ b/hphp/runtime/ext/facts/config.cmake
@@ -30,7 +30,6 @@ HHVM_DEFINE_EXTENSION(
     logging.h
     path-and-hash.h
     path-symbols-map.h
-    path-versions.h
     sqlite-autoload-db.h
     sqlite-key.h
     static-watcher.h

--- a/hphp/runtime/ext/fileinfo/config.cmake
+++ b/hphp/runtime/ext/fileinfo/config.cmake
@@ -20,7 +20,6 @@ HHVM_DEFINE_EXTENSION("fileinfo"
   HEADERS
     libmagic/cdf.h
     libmagic/compat.h
-    libmagic/elfclass.h
     libmagic/file.h
     libmagic/magic.h
     libmagic/names.h


### PR DESCRIPTION
These were removed in D73829898 and D74533154.
Drop them from the CMake build system too.