### PR TITLE
Fix ill-formed req::Allocator rebind

### DIFF
--- a/hphp/runtime/base/req-malloc.h
+++ b/hphp/runtime/base/req-malloc.h
@@ -170,14 +170,18 @@ struct Allocator {
 
   template <class U>
   struct rebind {
-    using other = Allocator<
-      U,
-      typename action_helper<
-        typename std::remove_const<
-          typename std::remove_pointer<U>::type
-        >::type, Action
-      >::type
-    >;
+    using other = std::conditional_t<
+        std::is_same<U, T>::value,
+        Allocator<T, Action>,
+        Allocator<
+          U,
+          typename action_helper<
+            typename std::remove_const<
+              typename std::remove_pointer<U>::type
+            >::type, Action
+          >::type
+        >
+      >;
   };
 
   pointer address(reference value) {
@@ -275,4 +279,3 @@ template<class T> T* calloc_raw_array(size_t count) {
 ////////////////////////////////////////////////////////////////////////////////
 
 }
-


### PR DESCRIPTION
Given an Allocator A<T> and some cv-unqualified object type U, let `B = A::template rebind<U>::other`. The C++ standard stipulates[1] that in this case, `B::template rebind<T>::other` must be A for any U. HPHP::req::Allocator does not satisfy this constraint at present, but this does not fail compilation at all times because the constraint is inconsistently enforced by different standard library implementations.

Consider the simplified reproducer in https://godbolt.org/z/9b19z4Yz8. If using libstdc++, the code won't compile with any libstdc++ > 12, because alloc_traits.h enforces this requirement.
If using libc++, the code will compile, but uncomment the std::vector variable definition in main() and it will trigger libc++'s own check for this constraint and fail.

So, make req::Allocator::rebind conform to the standard by having it return the original allocator in this case.

[1] https://en.cppreference.com/w/cpp/named_req/Allocator.html