### PR TITLE
Fix vixl build in debug mode

### DIFF
--- a/hphp/vixl/a64/cpu-a64.cc
+++ b/hphp/vixl/a64/cpu-a64.cc
@@ -25,6 +25,9 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "hphp/vixl/a64/cpu-a64.h"
+#ifndef NDEBUG
+#include "hphp/vixl/utils.h"
+#endif
 
 namespace vixl {
 


### PR DESCRIPTION
Include utils.h as it's needed for CountSetBits() in debug asserts.