### PR TITLE
Link new mvfst libraries

### DIFF
--- a/third-party/mvfst/CMakeLists.txt
+++ b/third-party/mvfst/CMakeLists.txt
@@ -69,6 +69,7 @@ set(
   mvfst_codec_pktrebuilder
   mvfst_codec_packet_number_cipher
   mvfst_codec
+  mvfst_contiguous_cursor
   mvfst_looper
   mvfst_buf_accessor
   mvfst_bufutil
@@ -81,6 +82,7 @@ set(
   mvfst_fizz_client
   mvfst_fizz_handshake
   mvfst_flowcontrol
+  mvfst_folly_utils
   mvfst_handshake
   mvfst_happyeyeballs
   mvfst_qlogger


### PR DESCRIPTION
mvfst added some new library outputs that need to be linked into HHVM.