### PR TITLE
Fix OPAM build for Arm

### DIFF
--- a/hphp/hack/ocaml_deps_data.sh
+++ b/hphp/hack/ocaml_deps_data.sh
@@ -49,12 +49,13 @@ export OCAML_BASE_NAME=ocaml-variants
 export OCAML_COMPILER_NAME="${OCAML_BASE_NAME}.${HACK_OCAML_VERSION}"
 
 UNAME=$(uname -s)
-if [ "$UNAME" != "Linux" ]; then
+ARCH=$(uname -m)
+if [ "$UNAME" != "Linux" ] || [ "$ARCH" == "aarch64" ]; then
   # Some variants are not supported on other platforms, so we use the base
   # version instead.
-  # +fp is known not to work on Macs, but other combinations have not been
+  # +fp is known not to work on Macs or on arm64, but other combinations have not been
   # tested.
-  echo 'Non linux platform detected, skipping +fp'
+  echo 'Platform is not Linux or is arm64, skipping +fp'
 else
   HACK_OPAM_DEPS+=(ocaml-option-fp)
   export HACK_OPAM_DEPS

--- a/third-party/opam/CMakeLists.txt
+++ b/third-party/opam/CMakeLists.txt
@@ -10,16 +10,26 @@
 # This also avoids the need to depend on gpg in the installation.
 include(HPHPFunctions)
 
+if (IS_X64)
+  set(OPAM_ARCH "x86_64")
+  set(OPAM_LINUX_HASH "03c6a85f13a452749fdb2271731f3624a3993498ff2b304123231a8f2b26ccf1182d12119466e9a85f4de370fca51bd61d0eefe6280d3ca087cf4620fdc59a22")
+  set(OPAM_DARWIN_HASH "1c9acee545c851dd3701229e3a6aa7b5650620e37e01400d797a4b1fbeeb614adc459411283684e223a72fda8b14ba6c6e5482661485f888819f6a2a02e4d279")
+elseif (IS_AARCH64)
+  set(OPAM_ARCH "arm64")
+  set(OPAM_LINUX_HASH "216185106deb81db0e9cb329dd7f01d097173e1e7a055a1af8525cdb4dde6d443e4bf4ef8377f1cbd4c9fecdc7ea03e6f294dad30b10a0e83959476018e24972")
+  set(OPAM_DARWIN_HASH "c8a46b2d554e4b2a68d5004ad4cee24425c75a6957c40af49d21e05875925e59d29ef3c9f0d7703f9c209b3f50107959fa853b32143f9e7deb7b4cc54006d668")
+endif()
+
 SET_HHVM_THIRD_PARTY_SOURCE_ARGS(
   OPAM_DOWNLOAD_ARGS
   Linux_URL
-  "https://github.com/ocaml/opam/releases/download/2.1.0/opam-2.1.0-x86_64-linux"
+  "https://github.com/ocaml/opam/releases/download/2.1.0/opam-2.1.0-${OPAM_ARCH}-linux"
   Darwin_URL
-  "https://github.com/ocaml/opam/releases/download/2.1.0/opam-2.1.0-x86_64-macos"
+  "https://github.com/ocaml/opam/releases/download/2.1.0/opam-2.1.0-${OPAM_ARCH}-macos"
   Linux_HASH
-  "SHA512=03c6a85f13a452749fdb2271731f3624a3993498ff2b304123231a8f2b26ccf1182d12119466e9a85f4de370fca51bd61d0eefe6280d3ca087cf4620fdc59a22"
+  "SHA512=${OPAM_LINUX_HASH}"
   Darwin_HASH
-  "SHA512=1c9acee545c851dd3701229e3a6aa7b5650620e37e01400d797a4b1fbeeb614adc459411283684e223a72fda8b14ba6c6e5482661485f888819f6a2a02e4d279"
+  "SHA512=${OPAM_DARWIN_HASH}"
 )
 
 include(ExternalProject)


### PR DESCRIPTION
Fetch the arm64 version of opam for installing deps, and disable the `ocaml-option-fp` flag which is not supported on aarch64.

The pinned versions of `dune` and `landmarks-ppx` still need updating to work on aarch64. This will be done as a followup since it seems to be causing issues in internal CI at the moment.