### PR TITLE
Add portable sysconf support for _SC_LEVEL1_DCACHE_LINESIZE

### DIFF
--- a/third-party/folly/src/folly/portability/Unistd.cpp
+++ b/third-party/folly/src/folly/portability/Unistd.cpp
@@ -312,6 +312,40 @@ unsigned int sleep(unsigned int seconds) {
   return 0;
 }
 
+// Most x86 and Arm64 CPUs have a 64-byte cache line, so
+// if we can't find the cache line size, assume 64.
+static const DWORD default_cacheline_size = 64;
+
+static DWORD get_L1D_cacheline_size(void) {
+  DWORD len = 0;
+  DWORD cache_line_size = default_cacheline_size;
+
+  if (!GetLogicalProcessorInformation(nullptr, &len) &&
+      GetLastError() != ERROR_INSUFFICIENT_BUFFER) {
+    return cache_line_size;
+  }
+
+  std::unique_ptr<char[]> buffer(new char[len]);
+  auto info =
+      reinterpret_cast<SYSTEM_LOGICAL_PROCESSOR_INFORMATION*>(buffer.get());
+
+  if (!GetLogicalProcessorInformation(info, &len)) {
+    return cache_line_size;
+  }
+
+  DWORD count = len / sizeof(SYSTEM_LOGICAL_PROCESSOR_INFORMATION);
+  for (DWORD i = 0; i < count; i++) {
+    if (info[i].Relationship == RelationCache) {
+      const auto& cache = info[i].Cache;
+      if (cache.Level == 1 && cache.Type == CacheData) {
+        return cache.LineSize;
+      }
+    }
+  }
+
+  return cache_line_size;
+}
+
 long sysconf(int tp) {
   switch (tp) {
     case _SC_PAGESIZE: {
@@ -323,6 +357,9 @@ long sysconf(int tp) {
       SYSTEM_INFO inf;
       GetSystemInfo(&inf);
       return (long)inf.dwNumberOfProcessors;
+    }
+    case _SC_LEVEL1_DCACHE_LINESIZE: {
+      return (long)get_L1D_cacheline_size();
     }
     default:
       return -1L;

--- a/third-party/folly/src/folly/portability/Unistd.h
+++ b/third-party/folly/src/folly/portability/Unistd.h
@@ -49,6 +49,7 @@ ssize_t pread64(int fd, void* buf, size_t count, off64_t offset);
 #define _SC_PAGE_SIZE _SC_PAGESIZE
 #define _SC_NPROCESSORS_ONLN 2
 #define _SC_NPROCESSORS_CONF 2
+#define _SC_LEVEL1_DCACHE_LINESIZE 3
 
 // Windows doesn't define these, but these are the correct values
 // for Windows.


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebook/folly/pull/2514

Add a win32-specific function get_L1D_cacheline_size that allows querying _SC_LEVEL1_DCACHE_LINESIZE.

Differential Revision: D84034170


