### PR TITLE
Add the option to get a stack trace str with full line info.

### DIFF
--- a/third-party/folly/src/folly/debugging/symbolizer/Symbolizer.cpp
+++ b/third-party/folly/src/folly/debugging/symbolizer/Symbolizer.cpp
@@ -543,14 +543,17 @@ namespace {
 constexpr size_t kMaxStackTraceDepth = 100;
 
 template <size_t N, typename StackTraceFunc>
-std::string getStackTraceStrImpl(StackTraceFunc func) {
+std::string getStackTraceStrImpl(
+    StackTraceFunc func, bool showFullInfo = false) {
   FrameArray<N> addresses;
 
   if (!func(addresses)) {
     return "";
   } else {
     ElfCache elfCache;
-    Symbolizer symbolizer(&elfCache);
+    LocationInfoMode mode =
+        showFullInfo ? LocationInfoMode::FULL : LocationInfoMode::FAST;
+    Symbolizer symbolizer(&elfCache, mode);
     symbolizer.symbolize(addresses);
 
     StringSymbolizePrinter printer;
@@ -560,9 +563,9 @@ std::string getStackTraceStrImpl(StackTraceFunc func) {
 }
 } // namespace
 
-std::string getStackTraceStr() {
+std::string getStackTraceStr(bool showFullInfo) {
   return getStackTraceStrImpl<kMaxStackTraceDepth>(
-      getStackTrace<kMaxStackTraceDepth>);
+      getStackTrace<kMaxStackTraceDepth>, showFullInfo);
 }
 
 std::string getAsyncStackTraceStr() {

--- a/third-party/folly/src/folly/debugging/symbolizer/Symbolizer.h
+++ b/third-party/folly/src/folly/debugging/symbolizer/Symbolizer.h
@@ -274,8 +274,10 @@ class SafeStackTracePrinter {
  * Empty string indicates stack trace functionality is not available.
  *
  * NOT async-signal-safe.
+ * @param showFullInfo If true, include file names and line numbers (when
+ * available).
  */
-std::string getStackTraceStr();
+std::string getStackTraceStr(bool showFullInfo = false);
 
 /**
  * Gets the async stack trace for the current thread and returns a string
@@ -299,7 +301,7 @@ std::vector<std::string> getSuspendedStackTraces();
 // Define these in the header, as headers are always available, but not all
 // platforms can link against the symbolizer library cpp sources.
 
-inline std::string getStackTraceStr() {
+inline std::string getStackTraceStr(bool showFullInfo = false) {
   return "";
 }
 


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebook/folly/pull/2518

This adds the option to getStackTraceStr() to include file names and line numbers when available.

Reviewed By: skrueger

Differential Revision: D84088520


