### PR TITLE
Make ROAR include internal-only

### DIFF
--- a/hphp/runtime/base/program-functions.cpp
+++ b/hphp/runtime/base/program-functions.cpp
@@ -121,7 +121,9 @@
 #include "hphp/zend/zend-string.h"
 #include "hphp/zend/zend-strtod.h"
 
+#ifdef HHVM_FACEBOOK
 #include "roarjit/Init.h"
+#endif
 
 #include <folly/CPortability.h>
 #include <folly/json/json.h>


### PR DESCRIPTION
ROAR is specific to HHVM @ Meta, so do not include it in the OSS build.