### PR TITLE
AArch64: Improve code quality during type checking on Arm targets

### DIFF
--- a/hphp/runtime/vm/jit/irlower-internal-inl.h
+++ b/hphp/runtime/vm/jit/irlower-internal-inl.h
@@ -256,6 +256,10 @@ void emitTypeTest(Vout& v, IRLS& env, Type type,
 
     auto const base = type.unspecialize();
     if (type == TStaticStr)     return test(KindOfString);
+    // On Arm targets comparisons with arbitrary bitmasks are more efficient
+    // with cmp than test.
+    if (arch() == Arch::ARM && !type.isUnion())
+      return cmp(type.toDataType(), CC_E);
     if (type.isKnownDataType()) return test(type.toDataType());
     if (base == TArrLike)       return cmp(KindOfKeyset, CC_BE);
     if (type == (TVec|TDict))   return cmp(KindOfVec, CC_BE);


### PR DESCRIPTION
When checking a type matches we often need to compare against an arbitrary bit mask (usually fits into a single byte). However, the tst instruction on AArch64 only supports masks of contiguous bits so usually the mask cannot be encoded into the tst instruction. Instead, when compiling for Arm we should prefer using the cmp instruction as this can take any 8-bit immediate.