### PR TITLE
Teach implVecElemLval to emit operations better suited for AArch64

### DIFF
--- a/hphp/runtime/vm/jit/irlower-minstr.cpp
+++ b/hphp/runtime/vm/jit/irlower-minstr.cpp
@@ -904,6 +904,11 @@ irlower::LvalPtrs implVecElemLval(IRLS& env, Vreg rarr,
     v << lea{ridx[ridx * 8], ridx_times_9};
     auto const type_offset = VanillaVec::entriesOffset() + offsetof(UnalignedTypedValue, m_type);
     auto const data_offset = VanillaVec::entriesOffset() + offsetof(UnalignedTypedValue, m_data);
+    if (arch() == Arch::ARM) {
+      auto new_base = v.makeReg();
+      v << lea{rarr[ridx_times_9], new_base};
+      return {new_base + type_offset, new_base + data_offset};
+    }
     return {rarr[ridx_times_9] + type_offset, rarr[ridx_times_9] + data_offset};
   } else {
     // See PackedBlock::LvalAt for an explanation of this math.


### PR DESCRIPTION
When creating an lval pair for the value and the type we currently bundle the entire address calculation in a Vptr, which stays bundled with each load until lowering to assembly. This has the disadvantage that we end up duplicating work constructing addresses that only differ by 1 byte. I think it's better to use explicit lea operations to set up a common base in advance, then construct a pair of Vptrs that only differ by a constant offset. We can then make use of the reg+imm addressing mode for the loads.