### PR TITLE
AArch64: Fold shqri/testl/jcc into cmp/jcc

### DIFF
--- a/hphp/runtime/vm/jit/vasm-simplify-arm.cpp
+++ b/hphp/runtime/vm/jit/vasm-simplify-arm.cpp
@@ -110,8 +110,9 @@ bool simplify(Env& env, const shrqi& inst, Vlabel b, size_t i) {
     if (tstl.s1 != inst.d || env.use_counts[tstl.sf] != 1) return false;
 
     uint64_t Val;
-    if (!get_const_int(env, tstl.s0, Val) || folly::popcount(Val) != 1)
+    if (!get_const_int(env, tstl.s0, Val) || folly::popcount(Val) != 1) {
       return false;
+    }
 
     auto shift_amt = inst.s0.l();
     return simplify_impl(env, b, i, [&] (Vout& v) {
@@ -126,8 +127,9 @@ bool simplify(Env& env, const testq& inst, Vlabel b, size_t i) {
   if (env.use_counts[inst.sf] != 1) return false;
 
   uint64_t Val;
-  if (!get_const_int(env, inst.s0, Val) || Val != 0x8000000000000000ull)
+  if (!get_const_int(env, inst.s0, Val) || Val != 0x8000000000000000ull) {
     return false;
+  }
 
   return if_inst<Vinstr::jcc>(env, b, i + 1, [&] (const jcc& jcci) {
     if (jcci.sf != inst.sf || jcci.cc != CC_E) return false;


### PR DESCRIPTION
We often see patterns like this:

shrqi 32, %v0, %v1
testl 0x80000000, %v1
jcc CC_E, ...

but really this is the same as asking if %v0 is >= 0. Rewriting this in the form

cmp 0, %v0
jcc CC_GE, ...

saves two instructions, i.e. a lsr and a mov.