### PR TITLE
Aarch64: emit prefix/postfix-indexed memory accesses

### DIFF
--- a/hphp/runtime/vm/jit/vasm-info.cpp
+++ b/hphp/runtime/vm/jit/vasm-info.cpp
@@ -333,6 +333,12 @@ bool effectsImpl(const Vinstr& inst, bool pure) {
     case Vinstr::testqm:
     case Vinstr::testwim:
     case Vinstr::testwm:
+#define VASM_LOAD_UPDATE_CASE(name, pre, post, ...) \
+    case Vinstr::pre: \
+    case Vinstr::post:
+    VASM_LOAD_UPDATE_SINGLE_LIST(VASM_LOAD_UPDATE_CASE)
+    VASM_LOAD_UPDATE_PAIR_LIST(VASM_LOAD_UPDATE_CASE)
+#undef VASM_LOAD_UPDATE_CASE
       assertx(!writesMemory(inst));
       assertx(!isCall(inst));
       return false;
@@ -433,6 +439,12 @@ bool effectsImpl(const Vinstr& inst, bool pure) {
     case Vinstr::storewi:
     case Vinstr::storepair:
     case Vinstr::storepairl:
+#define VASM_STORE_UPDATE_CASE(name, pre, post, ...) \
+    case Vinstr::pre: \
+    case Vinstr::post:
+    VASM_STORE_UPDATE_SINGLE_LIST(VASM_STORE_UPDATE_CASE)
+    VASM_STORE_UPDATE_PAIR_LIST(VASM_STORE_UPDATE_CASE)
+#undef VASM_STORE_UPDATE_CASE
     case Vinstr::stublogue:
     case Vinstr::stubret:
     case Vinstr::stubtophp:

--- a/hphp/runtime/vm/jit/vasm-instr.cpp
+++ b/hphp/runtime/vm/jit/vasm-instr.cpp
@@ -91,6 +91,15 @@ bool isCall(Vinstr::Opcode op) {
 }
 
 Width width(Vinstr::Opcode op) {
+#if defined(__aarch64__)
+#define CASE_WITH_UPDATES(name)                 \
+    case Vinstr::name:                          \
+    case Vinstr::name##pri:                     \
+    case Vinstr::name##pi:
+#else
+#define CASE_WITH_UPDATES(name)                 \
+    case Vinstr::name:
+#endif
   switch (op) {
     // service requests
     case Vinstr::bindjmp:
@@ -113,8 +122,8 @@ Width width(Vinstr::Opcode op) {
     case Vinstr::ldimml:
     case Vinstr::ldimmq:
     case Vinstr::ldundefq:
-    case Vinstr::load:
-    case Vinstr::store:
+    CASE_WITH_UPDATES(load)
+    CASE_WITH_UPDATES(store)
     case Vinstr::mcprep:
     case Vinstr::phidef:
     case Vinstr::phijmp:
@@ -257,9 +266,9 @@ Width width(Vinstr::Opcode op) {
     case Vinstr::csincb:
     case Vinstr::setcc:
     case Vinstr::movb:
-    case Vinstr::loadb:
-    case Vinstr::loadtqb:
-    case Vinstr::storeb:
+    CASE_WITH_UPDATES(loadb)
+    CASE_WITH_UPDATES(loadtqb)
+    CASE_WITH_UPDATES(storeb)
     case Vinstr::storebi:
       return Width::Byte;
 
@@ -279,9 +288,9 @@ Width width(Vinstr::Opcode op) {
     case Vinstr::testwi:
     case Vinstr::testwim:
     case Vinstr::testwm:
-    case Vinstr::loadw:
+    CASE_WITH_UPDATES(loadw)
     case Vinstr::movw:
-    case Vinstr::storew:
+    CASE_WITH_UPDATES(storew)
     case Vinstr::storewi:
     case Vinstr::xorw:
     case Vinstr::xorwi:
@@ -314,14 +323,14 @@ Width width(Vinstr::Opcode op) {
     case Vinstr::testlim:
     case Vinstr::testlm:
     case Vinstr::movl:
-    case Vinstr::loadl:
-    case Vinstr::loadpairl:
-    case Vinstr::loadzbl:
-    case Vinstr::loadsbl:
-    case Vinstr::loadtql:
-    case Vinstr::storel:
+    CASE_WITH_UPDATES(loadl)
+    CASE_WITH_UPDATES(loadpairl)
+    CASE_WITH_UPDATES(loadzbl)
+    CASE_WITH_UPDATES(loadsbl)
+    CASE_WITH_UPDATES(loadtql)
+    CASE_WITH_UPDATES(storel)
     case Vinstr::storeli:
-    case Vinstr::storepairl:
+    CASE_WITH_UPDATES(storepairl)
     case Vinstr::ubfmli:
       return Width::Long;
 
@@ -377,19 +386,19 @@ Width width(Vinstr::Opcode op) {
     case Vinstr::lead:
     case Vinstr::loadqp:
     case Vinstr::loadqd:
-    case Vinstr::loadzbq:
-    case Vinstr::loadzwq:
-    case Vinstr::loadzlq:
-    case Vinstr::loadsbq:
-    case Vinstr::loadpair:
+    CASE_WITH_UPDATES(loadzbq)
+    CASE_WITH_UPDATES(loadzwq)
+    CASE_WITH_UPDATES(loadzlq)
+    CASE_WITH_UPDATES(loadsbq)
+    CASE_WITH_UPDATES(loadpair)
     case Vinstr::storeqi:
-    case Vinstr::storepair:
+    CASE_WITH_UPDATES(storepair)
     case Vinstr::addsd:
     case Vinstr::subsd:
     case Vinstr::cmpsd:
     case Vinstr::ucomisd:
-    case Vinstr::loadsd:
-    case Vinstr::storesd:
+    CASE_WITH_UPDATES(loadsd)
+    CASE_WITH_UPDATES(storesd)
     case Vinstr::absdbl:
     case Vinstr::divsd:
     case Vinstr::mulsd:
@@ -403,6 +412,7 @@ Width width(Vinstr::Opcode op) {
     case Vinstr::storeups:
       return Width::Octa;
   }
+#undef CASE_WITH_UPDATES
   not_reached();
 }
 

--- a/hphp/runtime/vm/jit/vasm-instr.h
+++ b/hphp/runtime/vm/jit/vasm-instr.h
@@ -80,7 +80,7 @@ struct Vunit;
   _(loadzbl, loadzblpri, loadzblpi, Vreg32, 1, s) \
   _(loadzbq, loadzbqpri, loadzbqpi, Vreg64, 1, s) \
   _(loadzwq, loadzwqpri, loadzwqpi, Vreg64, 2, s) \
-  _(loadzlq, loadzlpri, loadzlpi, Vreg64, 4, s) \
+  _(loadzlq, loadzlqpri, loadzlqpi, Vreg64, 4, s) \
   _(loadsbl, loadsblpri, loadsblpi, Vreg32, 1, s) \
   _(loadsbq, loadsbqpri, loadsbqpi, Vreg64, 1, s) \
   _(loadtqb, loadtqbpri, loadtqbpi, Vreg8, 1, s) \

--- a/hphp/runtime/vm/jit/vasm-instr.h
+++ b/hphp/runtime/vm/jit/vasm-instr.h
@@ -58,6 +58,67 @@ struct Vunit;
  *    DH(d,h)   define d, try assigning same register as h
  *    Un,Dn     no uses, defs
  */
+
+#if defined(__aarch64__)
+#define VASM_STORE_UPDATE_SINGLE_LIST(_) \
+  _(store, storepri, storepi, Vreg, 8, d) \
+  _(storeb, storebpri, storebpi, Vreg8, 1, m) \
+  _(storew, storewpri, storewpi, Vreg16, 2, m) \
+  _(storel, storelpri, storelpi, Vreg32, 4, m) \
+  _(storesd, storesdpri, storesdpi, VregDbl, 8, m)
+
+#define VASM_STORE_UPDATE_PAIR_LIST(_) \
+  _(storepair, storepairpri, storepairpi, Vreg64, 8, 2, d) \
+  _(storepairl, storepairlpri, storepairlpi, Vreg32, 4, 2, d)
+
+#define VASM_LOAD_UPDATE_SINGLE_LIST(_) \
+  _(load, loadpri, loadpi, Vreg, 8, s) \
+  _(loadb, loadbpri, loadbpi, Vreg8, 1, s) \
+  _(loadw, loadwpri, loadwpi, Vreg16, 2, s) \
+  _(loadl, loadlpri, loadlpi, Vreg32, 4, s) \
+  _(loadsd, loadsdpri, loadsdpi, VregDbl, 8, s) \
+  _(loadzbl, loadzblpri, loadzblpi, Vreg32, 1, s) \
+  _(loadzbq, loadzbqpri, loadzbqpi, Vreg64, 1, s) \
+  _(loadzwq, loadzwqpri, loadzwqpi, Vreg64, 2, s) \
+  _(loadzlq, loadzlpri, loadzlpi, Vreg64, 4, s) \
+  _(loadsbl, loadsblpri, loadsblpi, Vreg32, 1, s) \
+  _(loadsbq, loadsbqpri, loadsbqpi, Vreg64, 1, s) \
+  _(loadtqb, loadtqbpri, loadtqbpi, Vreg8, 1, s) \
+  _(loadtql, loadtqlpri, loadtqlpi, Vreg32, 4, s)
+
+#define VASM_LOAD_UPDATE_PAIR_LIST(_) \
+  _(loadpair, loadpairpri, loadpairpi, Vreg64, 8, 2, s) \
+  _(loadpairl, loadpairlpri, loadpairlpi, Vreg32, 4, 2, s)
+#else
+#define VASM_STORE_UPDATE_SINGLE_LIST(_)
+#define VASM_STORE_UPDATE_PAIR_LIST(_)
+#define VASM_LOAD_UPDATE_SINGLE_LIST(_)
+#define VASM_LOAD_UPDATE_PAIR_LIST(_)
+#endif
+
+#if defined(__aarch64__)
+#define VASM_LOAD_UPDATE_SINGLE_OP_ENTRY(name, pre, post, reg, size, ptr) \
+  O(pre, I(s0), U(s), DH(base,s) D(d))\
+  O(post, I(s0), U(s), DH(base,s) D(d))
+
+#define VASM_LOAD_UPDATE_PAIR_OP_ENTRY(name, pre, post, reg, size, lanes, ptr) \
+  O(pre, I(s0), U(s), DH(base,s) D(d0) D(d1))\
+  O(post, I(s0), U(s), DH(base,s) D(d0) D(d1))
+
+#define VASM_STORE_UPDATE_SINGLE_OP_ENTRY(name, pre, post, reg, size, ptr) \
+  O(pre, I(s0), U(s) U(v), DH(base,s))\
+  O(post, I(s0), U(s) U(v), DH(base,s))
+
+#define VASM_STORE_UPDATE_PAIR_OP_ENTRY(name, pre, post, reg, size, lanes, ptr) \
+  O(pre, I(s0), U(s) U(v0) U(v1), DH(base,s))\
+  O(post, I(s0), U(s) U(v0) U(v1), DH(base,s))
+#else
+#define VASM_LOAD_UPDATE_SINGLE_OP_ENTRY(name, pre, post, reg, size, ptr)
+#define VASM_LOAD_UPDATE_PAIR_OP_ENTRY(name, pre, post, reg, size, lanes, ptr)
+#define VASM_STORE_UPDATE_SINGLE_OP_ENTRY(name, pre, post, reg, size, ptr)
+#define VASM_STORE_UPDATE_PAIR_OP_ENTRY(name, pre, post, reg, size, lanes, ptr)
+#endif
+
 #define VASM_OPCODES\
   /* service requests */\
   O(bindjmp, I(target) I(spOff), U(args), Dn)\
@@ -80,7 +141,11 @@ struct Vunit;
   O(ldimmq, I(s), Un, D(d))\
   O(ldundefq, Inone, Un, D(d))\
   O(load, Inone, U(s), D(d))\
+  VASM_LOAD_UPDATE_SINGLE_LIST(VASM_LOAD_UPDATE_SINGLE_OP_ENTRY)\
+  VASM_LOAD_UPDATE_PAIR_LIST(VASM_LOAD_UPDATE_PAIR_OP_ENTRY)\
   O(store, Inone, U(s) UW(d), Dn)\
+  VASM_STORE_UPDATE_SINGLE_LIST(VASM_STORE_UPDATE_SINGLE_OP_ENTRY)\
+  VASM_STORE_UPDATE_PAIR_LIST(VASM_STORE_UPDATE_PAIR_OP_ENTRY)\
   O(mcprep, Inone, Un, D(d))\
   O(phidef, Inone, Un, D(defs))\
   O(phijmp, Inone, U(uses), Dn)\
@@ -542,7 +607,27 @@ struct ldundefq { Vreg d; };
  * Memory operand load and store.
  */
 struct load { Vptr64 s; Vreg d; };
+#define VASM_LOAD_UPDATE_SINGLE_STRUCT(name, pre, post, reg, size, ptr) \
+struct pre { Immed s0; Vreg64 s, base; reg d; }; \
+struct post { Immed s0; Vreg64 s, base; reg d; };
+VASM_LOAD_UPDATE_SINGLE_LIST(VASM_LOAD_UPDATE_SINGLE_STRUCT)
+#undef VASM_LOAD_UPDATE_SINGLE_STRUCT
+#define VASM_LOAD_UPDATE_PAIR_STRUCT(name, pre, post, reg, size, lanes, ptr) \
+struct pre { Immed s0; Vreg64 s, base; reg d0, d1; }; \
+struct post { Immed s0; Vreg64 s, base; reg d0, d1; };
+VASM_LOAD_UPDATE_PAIR_LIST(VASM_LOAD_UPDATE_PAIR_STRUCT)
+#undef VASM_LOAD_UPDATE_PAIR_STRUCT
 struct store { Vreg s; Vptr64 d; };
+#define VASM_STORE_UPDATE_SINGLE_STRUCT(name, pre, post, reg, size, ptr) \
+struct pre { Immed s0; Vreg64 s, base; reg v; }; \
+struct post { Immed s0; Vreg64 s, base; reg v; };
+VASM_STORE_UPDATE_SINGLE_LIST(VASM_STORE_UPDATE_SINGLE_STRUCT)
+#undef VASM_STORE_UPDATE_SINGLE_STRUCT
+#define VASM_STORE_UPDATE_PAIR_STRUCT(name, pre, post, reg, size, lanes, ptr) \
+struct pre { Immed s0; Vreg64 s, base; reg v0, v1; }; \
+struct post { Immed s0; Vreg64 s, base; reg v0, v1; };
+VASM_STORE_UPDATE_PAIR_LIST(VASM_STORE_UPDATE_PAIR_STRUCT)
+#undef VASM_STORE_UPDATE_PAIR_STRUCT
 
 /*
  * Method cache smashable prime data.

--- a/hphp/runtime/vm/jit/vasm-simplify-arm.cpp
+++ b/hphp/runtime/vm/jit/vasm-simplify-arm.cpp
@@ -393,7 +393,6 @@ bool foldPreUpdateImpl(Env& env,
                        int laneSize,
                        int lanes,
                        EmitFn emitFn) {
-  auto const& inst = env.unit.blocks[b].code[i];
   auto const match = matchPreUpdate(env, b, i, base);
   if (!match) return false;
   if (!validUpdateOffset(match->offset, laneSize, lanes)) return false;
@@ -412,7 +411,6 @@ bool foldPostUpdateImpl(Env& env,
                         int laneSize,
                         int lanes,
                         EmitFn emitFn) {
-  auto const& inst = env.unit.blocks[b].code[i];
   auto const match = matchPostUpdate(env, b, i, base);
   if (!match) return false;
   if (!validUpdateOffset(match->offset, laneSize, lanes)) return false;

--- a/hphp/runtime/vm/jit/vasm-simplify-arm.cpp
+++ b/hphp/runtime/vm/jit/vasm-simplify-arm.cpp
@@ -287,21 +287,274 @@ bool simplify(Env& env, const loadl& inst, Vlabel b, size_t i) {
 
 ///////////////////////////////////////////////////////////////////////////////
 
-bool psimplify(Env& env, const store& inst, Vlabel b, size_t i) {
-  return simplify(env, inst, b, i);
+constexpr int64_t kSimpleUpdateMin = -256;
+constexpr int64_t kSimpleUpdateMax = 255;
+
+bool validUpdateOffset(int64_t offset, int laneSize, int lanes) {
+  if (lanes > 1) {
+    if (laneSize <= 0 || (offset % laneSize) != 0) return false;
+    auto const scaled = offset / laneSize;
+    return scaled >= -64 && scaled <= 63;
+  }
+  return offset >= kSimpleUpdateMin && offset <= kSimpleUpdateMax;
 }
 
-bool psimplify(Env& env, const storel& inst, Vlabel b, size_t i) {
-  return simplify(env, inst, b, i);
+struct UpdateMatch {
+  size_t index;
+  int64_t offset;
+};
+
+Optional<UpdateMatch> matchPreUpdate(Env& env,
+                                     Vlabel b,
+                                     size_t i,
+                                     Vreg64 base) {
+  if (i == 0) return {};
+  auto const idx = i - 1;
+  auto const& inst = env.unit.blocks[b].code[idx];
+  int64_t offset;
+  switch (inst.op) {
+    case Vinstr::addqi: {
+      auto const& add = inst.addqi_;
+      if (add.d != base || add.s1 != base) return {};
+      if (add.sf.isValid() && env.use_counts[add.sf]) return {};
+      offset = add.s0.l();
+      break;
+    }
+    case Vinstr::lea: {
+      auto const& lea = inst.lea_;
+      if (lea.d != base || lea.s.base != base) return {};
+      if (lea.s.index.isValid()) return {};
+      offset = lea.s.disp;
+      break;
+    }
+    case Vinstr::subqi: {
+      auto const& sub = inst.subqi_;
+      if (sub.d != base || sub.s1 != base) return {};
+      if (sub.sf.isValid() && env.use_counts[sub.sf]) return {};
+      offset = -sub.s0.l();
+      break;
+    }
+    default:
+      return {};
+  }
+  return UpdateMatch{idx, offset};
 }
 
-bool psimplify(Env& env, const load& inst, Vlabel b, size_t i) {
-  return simplify(env, inst, b, i);
+Optional<UpdateMatch> matchPostUpdate(Env& env,
+                                      Vlabel b,
+                                      size_t i,
+                                      Vreg64 base) {
+  auto const& code = env.unit.blocks[b].code;
+  if (i + 1 >= code.size()) return {};
+  auto const idx = i + 1;
+  auto const& inst = code[idx];
+  int64_t offset;
+  switch (inst.op) {
+    case Vinstr::addqi: {
+      auto const& add = inst.addqi_;
+      if (add.d != base || add.s1 != base) return {};
+      if (add.sf.isValid() && env.use_counts[add.sf]) return {};
+      offset = add.s0.l();
+      break;
+    }
+    case Vinstr::lea: {
+      auto const& lea = inst.lea_;
+      if (lea.d != base || lea.s.base != base) return {};
+      if (lea.s.index.isValid()) return {};
+      offset = lea.s.disp;
+      break;
+    }
+    case Vinstr::subqi: {
+      auto const& sub = inst.subqi_;
+      if (sub.d != base || sub.s1 != base) return {};
+      if (sub.sf.isValid() && env.use_counts[sub.sf]) return {};
+      offset = -sub.s0.l();
+      break;
+    }
+    default:
+      return {};
+  }
+  return UpdateMatch{idx, offset};
 }
 
-bool psimplify(Env& env, const loadl& inst, Vlabel b, size_t i) {
-  return simplify(env, inst, b, i);
+template<class Ptr>
+bool isSimpleAddress(const Ptr& ptr, Vreg64 base) {
+  return base.isValid() &&
+         ptr.base == base &&
+         !ptr.index.isValid() &&
+         ptr.disp == 0;
 }
+
+template<class EmitFn>
+bool foldPreUpdateImpl(Env& env,
+                       Vlabel b,
+                       size_t i,
+                       Vreg64 base,
+                       int laneSize,
+                       int lanes,
+                       EmitFn emitFn) {
+  auto const& inst = env.unit.blocks[b].code[i];
+  auto const match = matchPreUpdate(env, b, i, base);
+  if (!match) return false;
+  if (!validUpdateOffset(match->offset, laneSize, lanes)) return false;
+  auto const offset = match->offset;
+  return simplify_impl(env, b, match->index, [&] (Vout& v) {
+    emitFn(v, offset);
+    return 2;
+  });
+}
+
+template<class EmitFn>
+bool foldPostUpdateImpl(Env& env,
+                        Vlabel b,
+                        size_t i,
+                        Vreg64 base,
+                        int laneSize,
+                        int lanes,
+                        EmitFn emitFn) {
+  auto const& inst = env.unit.blocks[b].code[i];
+  auto const match = matchPostUpdate(env, b, i, base);
+  if (!match) return false;
+  if (!validUpdateOffset(match->offset, laneSize, lanes)) return false;
+  auto const offset = match->offset;
+  assertx(match->index == i + 1);
+  return simplify_impl(env, b, i, [&] (Vout& v) {
+    emitFn(v, offset);
+    return 2;
+  });
+}
+
+#define DEFINE_STORE_UPDATE_SIMPLIFY(name, pre, post, reg, size, ptr_field)    \
+  static bool fold_pre_##name(Env& env, const name& inst, Vlabel b, size_t i) {\
+    auto const& addr = inst.ptr_field;                                         \
+    auto const base = addr.base;                                               \
+    if (!isSimpleAddress(addr, base)) return false;                            \
+    return foldPreUpdateImpl(env, b, i, base, size, 1,                         \
+      [&](Vout& v, int64_t off) {                                              \
+        v << pre{Immed(static_cast<int32_t>(off)), base, base, inst.s};        \
+      });                                                                      \
+  }                                                                            \
+  static bool fold_post_##name(Env& env, const name& inst, Vlabel b, size_t i) {\
+    auto const& addr = inst.ptr_field;                                         \
+    auto const base = addr.base;                                               \
+    if (!isSimpleAddress(addr, base)) return false;                            \
+    return foldPostUpdateImpl(env, b, i, base, size, 1,                        \
+      [&](Vout& v, int64_t off) {                                              \
+        v << post{Immed(static_cast<int32_t>(off)), base, base, inst.s};       \
+      });                                                                      \
+  }
+
+VASM_STORE_UPDATE_SINGLE_LIST(DEFINE_STORE_UPDATE_SIMPLIFY)
+#undef DEFINE_STORE_UPDATE_SIMPLIFY
+
+#define DEFINE_STORE_PAIR_UPDATE_SIMPLIFY(name, pre, post, reg, size, lanes, ptr_field) \
+  static bool fold_pre_##name(Env& env, const name& inst, Vlabel b, size_t i) {    \
+    auto const& addr = inst.ptr_field;                                            \
+    auto const base = addr.base;                                                  \
+    if (!isSimpleAddress(addr, base)) return false;                               \
+    return foldPreUpdateImpl(env, b, i, base, size, lanes,                        \
+      [&](Vout& v, int64_t off) {                                                 \
+        v << pre{Immed(static_cast<int32_t>(off)), base, base, inst.s0, inst.s1}; \
+      });                                                                         \
+  }                                                                               \
+  static bool fold_post_##name(Env& env, const name& inst, Vlabel b, size_t i) {  \
+    auto const& addr = inst.ptr_field;                                            \
+    auto const base = addr.base;                                                  \
+    if (!isSimpleAddress(addr, base)) return false;                               \
+    return foldPostUpdateImpl(env, b, i, base, size, lanes,                       \
+      [&](Vout& v, int64_t off) {                                                 \
+        v << post{Immed(static_cast<int32_t>(off)), base, base, inst.s0, inst.s1};\
+      });                                                                         \
+  }
+
+VASM_STORE_UPDATE_PAIR_LIST(DEFINE_STORE_PAIR_UPDATE_SIMPLIFY)
+#undef DEFINE_STORE_PAIR_UPDATE_SIMPLIFY
+
+#define DEFINE_LOAD_UPDATE_SIMPLIFY(name, pre, post, reg, size, ptr_field)      \
+  static bool fold_pre_##name(Env& env, const name& inst, Vlabel b, size_t i) { \
+    auto const& addr = inst.ptr_field;                                         \
+    auto const base = addr.base;                                               \
+    if (!isSimpleAddress(addr, base)) return false;                            \
+    return foldPreUpdateImpl(env, b, i, base, size, 1,                         \
+      [&](Vout& v, int64_t off) {                                              \
+        v << pre{Immed(static_cast<int32_t>(off)), base, base, inst.d};        \
+      });                                                                      \
+  }                                                                            \
+  static bool fold_post_##name(Env& env, const name& inst, Vlabel b, size_t i) {\
+    auto const& addr = inst.ptr_field;                                         \
+    auto const base = addr.base;                                               \
+    if (!isSimpleAddress(addr, base)) return false;                            \
+    return foldPostUpdateImpl(env, b, i, base, size, 1,                        \
+      [&](Vout& v, int64_t off) {                                              \
+        v << post{Immed(static_cast<int32_t>(off)), base, base, inst.d};       \
+      });                                                                      \
+  }
+
+VASM_LOAD_UPDATE_SINGLE_LIST(DEFINE_LOAD_UPDATE_SIMPLIFY)
+#undef DEFINE_LOAD_UPDATE_SIMPLIFY
+
+#define DEFINE_LOAD_PAIR_UPDATE_SIMPLIFY(name, pre, post, reg, size, lanes, ptr_field) \
+  static bool fold_pre_##name(Env& env, const name& inst, Vlabel b, size_t i) {  \
+    auto const& addr = inst.ptr_field;                                         \
+    auto const base = addr.base;                                               \
+    if (!isSimpleAddress(addr, base)) return false;                            \
+    return foldPreUpdateImpl(env, b, i, base, size, lanes,                     \
+      [&](Vout& v, int64_t off) {                                              \
+        v << pre{Immed(static_cast<int32_t>(off)), base, base, inst.d0, inst.d1};\
+      });                                                                      \
+  }                                                                            \
+  static bool fold_post_##name(Env& env, const name& inst, Vlabel b, size_t i) {\
+    auto const& addr = inst.ptr_field;                                         \
+    auto const base = addr.base;                                               \
+    if (!isSimpleAddress(addr, base)) return false;                            \
+    return foldPostUpdateImpl(env, b, i, base, size, lanes,                    \
+      [&](Vout& v, int64_t off) {                                              \
+        v << post{Immed(static_cast<int32_t>(off)), base, base, inst.d0, inst.d1};\
+      });                                                                      \
+  }
+
+VASM_LOAD_UPDATE_PAIR_LIST(DEFINE_LOAD_PAIR_UPDATE_SIMPLIFY)
+#undef DEFINE_LOAD_PAIR_UPDATE_SIMPLIFY
+
+#define DEFINE_STORE_PS(name, pre, post, reg, size, ptr_field)                \
+bool psimplify(Env& env, const name& inst, Vlabel b, size_t i) {              \
+  if (fold_pre_##name(env, inst, b, i)) return true;                          \
+  if (fold_post_##name(env, inst, b, i)) return true;                         \
+  return simplify(env, inst, b, i);                                           \
+}
+
+VASM_STORE_UPDATE_SINGLE_LIST(DEFINE_STORE_PS)
+#undef DEFINE_STORE_PS
+
+#define DEFINE_STORE_PAIR_PS(name, pre, post, reg, size, lanes, ptr_field)    \
+bool psimplify(Env& env, const name& inst, Vlabel b, size_t i) {              \
+  if (fold_pre_##name(env, inst, b, i)) return true;                          \
+  if (fold_post_##name(env, inst, b, i)) return true;                         \
+  return simplify(env, inst, b, i);                                           \
+}
+
+VASM_STORE_UPDATE_PAIR_LIST(DEFINE_STORE_PAIR_PS)
+#undef DEFINE_STORE_PAIR_PS
+
+#define DEFINE_LOAD_PS(name, pre, post, reg, size, ptr_field)                 \
+bool psimplify(Env& env, const name& inst, Vlabel b, size_t i) {              \
+  if (fold_pre_##name(env, inst, b, i)) return true;                          \
+  if (fold_post_##name(env, inst, b, i)) return true;                         \
+  return simplify(env, inst, b, i);                                           \
+}
+
+VASM_LOAD_UPDATE_SINGLE_LIST(DEFINE_LOAD_PS)
+#undef DEFINE_LOAD_PS
+
+#define DEFINE_LOAD_PAIR_PS(name, pre, post, reg, size, lanes, ptr_field)     \
+bool psimplify(Env& env, const name& inst, Vlabel b, size_t i) {              \
+  if (fold_pre_##name(env, inst, b, i)) return true;                          \
+  if (fold_post_##name(env, inst, b, i)) return true;                         \
+  return simplify(env, inst, b, i);                                           \
+}
+
+VASM_LOAD_UPDATE_PAIR_LIST(DEFINE_LOAD_PAIR_PS)
+#undef DEFINE_LOAD_PAIR_PS
 
 ///////////////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
 - teach Vgen to generate prefix and postfix indexed forms for scalar/pair memory ops
 - validate update immediates before encoding the indexed memory instructions
 - let psimplify fold plain memory accesses into the new prefix/postfix variants