### PR TITLE
Fix PIE builds

### DIFF
--- a/hphp/runtime/base/program-functions.cpp
+++ b/hphp/runtime/base/program-functions.cpp
@@ -2055,13 +2055,15 @@ static int execute_program_impl(int argc, char** argv) {
   }
 
 #if USE_JEMALLOC
-  if (Cfg::Server::Mode) {
-    purge_all();
-    setup_auto_arenas({Cfg::Eval::Num1GPagesForA0, Cfg::Eval::Num2MPagesForA0});
-  }
-  if (Cfg::Eval::FileBackedColdArena) {
-    set_cold_file_dir(Cfg::Eval::ColdArenaFileDir.c_str());
-    enable_high_cold_file();
+  if constexpr (use_position_dependent_jemalloc_arenas) {
+    if (Cfg::Server::Mode) {
+      purge_all();
+      setup_auto_arenas({Cfg::Eval::Num1GPagesForA0, Cfg::Eval::Num2MPagesForA0});
+    }
+    if (Cfg::Eval::FileBackedColdArena) {
+      set_cold_file_dir(Cfg::Eval::ColdArenaFileDir.c_str());
+      enable_high_cold_file();
+    }
   }
 #endif
 
@@ -2991,7 +2993,7 @@ static bool hphp_warmup(ExecutionContext *context,
 
 void hphp_session_init(Treadmill::SessionKind session_kind,
                        Transport* transport,
-                       RequestId id, 
+                       RequestId id,
                        RequestId root_req_id) {
   if (id.unallocated()) id = RequestId::allocate();
   assertx(!*s_sessionInitialized);

--- a/hphp/runtime/vm/func.h
+++ b/hphp/runtime/vm/func.h
@@ -1854,8 +1854,10 @@ private:
   // should not be inherited from.
   jit::AtomicLowTCA m_prologueTable[1];
 };
-static constexpr size_t kFuncSize = debug ? (use_lowptr ? 72 : 96)
-                                          : (use_lowptr ? 64 : 88);
+
+static constexpr size_t kTCAPtrDiff = sizeof(jit::AtomicLowTCA) == 8 ? 16 : 0;
+static constexpr size_t kFuncSize = kTCAPtrDiff + (debug ? (use_lowptr ? 72 : 96)
+                                          : (use_lowptr ? 64 : 88));
 static_assert(CheckSize<Func, kFuncSize>(), "");
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/hphp/runtime/vm/jit/code-gen-helpers.h
+++ b/hphp/runtime/vm/jit/code-gen-helpers.h
@@ -63,6 +63,10 @@ void emitLdPackedPtr(Vout& v, Vptr mem, Vreg reg) {
   ldLowPtrImpl(v, mem, reg, PackedPtr<T>::bits);
 }
 
+inline void emitLdTCAPtr(Vout& v, Vptr mem, Vreg reg) {
+  ldLowPtrImpl(v, mem, reg, LowTCA::bits);
+}
+
 /*
  * Store the LowPtr<T> in `reg' into `mem', with storage size `size'.
  */

--- a/hphp/runtime/vm/jit/irlower-call.cpp
+++ b/hphp/runtime/vm/jit/irlower-call.cpp
@@ -156,7 +156,7 @@ void cgCall(IRLS& env, const IRInstruction* inst) {
     auto const pTabOff = safe_cast<int32_t>(Func::prologueTableOff());
     auto const ptrSize = safe_cast<int32_t>(sizeof(LowTCA));
     auto const dest = v.makeReg();
-    v << loadzlq{r_func_prologue_callee()[numArgsInclUnpack * ptrSize + pTabOff], dest};
+    emitLdTCAPtr(v, r_func_prologue_callee()[numArgsInclUnpack * ptrSize + pTabOff], dest);
     v << callphpr{dest, func_prologue_regs(withCtx)};
   } else {
     // It was not statically determined that the arguments are passed in a way
@@ -236,7 +236,7 @@ void cgCallFuncEntry(IRLS& env, const IRInstruction* inst) {
     // Load the FuncEntry address dynamically from the function.
     auto dest = v.makeReg();
     auto const funcEntryOff = safe_cast<int32_t>(Func::funcEntryOff());
-    v << loadzlq{callee[funcEntryOff], dest};
+    emitLdTCAPtr(v, callee[funcEntryOff], dest);
     // We have to use an ifdef instead of `if (use_lowptr)` here due to
     // funcIdOffset only being defined in non-lowptr mode.
 #ifdef USE_LOWPTR

--- a/hphp/runtime/vm/jit/types.h
+++ b/hphp/runtime/vm/jit/types.h
@@ -40,8 +40,13 @@ using CTCA = const unsigned char*;
 
 using TcaRange = folly::Range<TCA>;
 
+#ifndef HHVM_PIE
 using LowTCA = SmallPtr<uint8_t>;
 using AtomicLowTCA = AtomicSmallPtr<uint8_t>;
+#else
+using LowTCA = FullPtr<uint8_t>;
+using AtomicLowTCA = AtomicFullPtr<uint8_t>;
+#endif
 
 struct ctca_identity_hash {
   size_t operator()(CTCA val) const {

--- a/hphp/runtime/vm/jit/unique-stubs.cpp
+++ b/hphp/runtime/vm/jit/unique-stubs.cpp
@@ -297,7 +297,7 @@ TCA emitFuncPrologueRedispatch(CodeBlock& cb, DataBlock& data, const char* name)
     ifThen(v, CC_LE, sf, [&] (Vout& v) {
       // Fast path (numArgs <= numNonVariadicParams). Call the numArgs prologue.
       auto const dest = v.makeReg();
-      v << loadzlq{callee[numArgs * ptrSize + pTabOff], dest};
+      emitLdTCAPtr(v, callee[numArgs * ptrSize + pTabOff], dest);
       v << jmpr{dest, func_prologue_regs(true)};
     });
 
@@ -361,7 +361,11 @@ TCA emitFuncPrologueRedispatch(CodeBlock& cb, DataBlock& data, const char* name)
 
     // Call the numNonVariadicParams + 1 prologue.
     auto const dest = v.makeReg();
-    v << loadzlq{Vreg(r_func_prologue_callee())[numNewArgs * ptrSize + pTabOff], dest};
+    emitLdTCAPtr(
+      v,
+      Vreg(r_func_prologue_callee())[numNewArgs * ptrSize + pTabOff],
+      dest
+    );
     v << tailcallstubr{dest, func_prologue_regs(true)};
   }, name);
 }
@@ -419,7 +423,7 @@ TCA emitFuncPrologueRedispatchUnpack(CodeBlock& main, CodeBlock& cold,
     auto const pTabOff = safe_cast<int32_t>(Func::prologueTableOff());
     auto const ptrSize = safe_cast<int32_t>(sizeof(LowTCA));
     auto const dest = v.makeReg();
-    v << loadzlq{callee[numNewArgs * ptrSize + pTabOff], dest};
+    emitLdTCAPtr(v, callee[numNewArgs * ptrSize + pTabOff], dest);
     v << tailcallstubr{dest, func_prologue_regs(true)};
   }, name);
 

--- a/hphp/util/CMakeLists.txt
+++ b/hphp/util/CMakeLists.txt
@@ -60,6 +60,10 @@ HHVM_RENDER_CONFIG_SPECIFICATION(
 auto_source_group("hphp_util" "${CMAKE_CURRENT_SOURCE_DIR}"
   ${ASM_SOURCES} ${CXX_SOURCES} ${HEADER_SOURCES})
 
+if (ENABLE_PIE)
+  target_compile_definitions(hphp_util PUBLIC HHVM_PIE FULLPTR_FOR_BUILTINS)
+endif()
+
 target_link_libraries(hphp_util brotli folly zstd)
 if (LIBNUMA_LIBRARIES)
   target_link_libraries(hphp_util ${LIBNUMA_LIBRARIES})

--- a/hphp/util/alloc-defs.h
+++ b/hphp/util/alloc-defs.h
@@ -48,11 +48,22 @@ constexpr bool use_jemalloc =
 #endif
   ;
 
+// Whether to use custom jemalloc arenas that allocate
+// from well-defined address ranges.
+// This is incompatible with OSS PIE builds.
+constexpr bool use_position_dependent_jemalloc_arenas =
+#if USE_JEMALLOC && !defined(HHVM_PIE)
+  true
+#else
+  false
+#endif
+;
+
 // When we have control over the virtual address space for the heap, all
 // static/uncounted strings/arrays have addresses lower than kUncountedMaxAddr,
 // and all counted HeapObjects have higher addresses.
 constexpr bool addr_encodes_persistency =
-#if USE_JEMALLOC && defined(__x86_64__) && defined(__linux__)
+#if USE_JEMALLOC && defined(__x86_64__) && defined(__linux__) && !defined(HHVM_PIE)
   true
 #else
   false

--- a/hphp/util/process.cpp
+++ b/hphp/util/process.cpp
@@ -34,6 +34,7 @@
 #include <set>
 #include <fstream>
 
+#include "hphp/util/alloc-defs.h"
 #include "hphp/util/hugetlb.h"
 #include "hphp/util/managed-arena.h"
 #include "hphp/util/user-info.h"
@@ -421,21 +422,24 @@ void ProcStatus::update() {
     }
 #ifdef USE_JEMALLOC
     mallctl_epoch();
-    size_t unused = 0;
-    // Various arenas where range of hugetlb pages can be reserved but only
-    // partially used.
-    unused += alloc::getRange(alloc::AddrRangeClass::Low).retained();
-#ifdef USE_PACKEDPTR
-    unused += alloc::getRange(alloc::AddrRangeClass::Mid).retained();
-#endif
-    unused += alloc::getRange(alloc::AddrRangeClass::Uncounted).retained();
-    for (auto const arena : alloc::g_auto_arenas) {
-      if (arena) unused += arena->retained();
+
+    if constexpr (use_position_dependent_jemalloc_arenas) {
+      size_t unused = 0;
+      // Various arenas where range of hugetlb pages can be reserved but only
+      // partially used.
+      unused += alloc::getRange(alloc::AddrRangeClass::Low).retained();
+  #ifdef USE_PACKEDPTR
+      unused += alloc::getRange(alloc::AddrRangeClass::Mid).retained();
+  #endif
+      unused += alloc::getRange(alloc::AddrRangeClass::Uncounted).retained();
+      for (auto const arena : alloc::g_auto_arenas) {
+        if (arena) unused += arena->retained();
+      }
+      for (auto const arena : alloc::g_local_arenas) {
+        if (arena) unused += arena->retained();
+      }
+      updateUnused(unused >> 10); // convert to kB
     }
-    for (auto const arena : alloc::g_local_arenas) {
-      if (arena) unused += arena->retained();
-    }
-    updateUnused(unused >> 10); // convert to kB
 #endif
   }
 }


### PR DESCRIPTION
When built with jemalloc, HHVM defines several custom arenas that allocate from well-known address ranges. This historically was gated behind the Meta-specific `USE_JEMALLOC_EXTENT_HOOKS` define, which was removed in early September by upstream. PIE builds of HHVM are broken as a result since the entire arrangement appears to rely on at least the translation cache being in a predefined memory location, which PIE ipso facto precludes.

So, have the `ENABLE_PIE` build flag define an `ENABLE_PIE` define and a `use_position_dependent_jemalloc_arenas` constexpr to disable the problematic behavior. Reinstate and use the previous limited arena setup for PIE builds where only the low arena exists and is backed by sbrk(2) rather than mmap, as it was prior to D78567435.

PIE also means we can't use 32-bit SmallPtrs for things like function pointers, so define `FULLPTR_FOR_BUILTINS` in PIE builds and use `emitLdPackedPtr` when referring to them in the JIT rather than 32-bit-only instructions.