### PR TITLE
Automatically symlink compile_commands.json

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,13 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
+# Create symlink to compile_commands.json for IDE to pick it up
+execute_process(
+  COMMAND
+    ${CMAKE_COMMAND} -E create_symlink
+    ${CMAKE_BINARY_DIR}/compile_commands.json
+    ${CMAKE_CURRENT_SOURCE_DIR}/compile_commands.json)
+
 # includes
 SET(
   CMAKE_MODULE_PATH


### PR DESCRIPTION
compile_commands.json allows IDEs to provide go-to definition etc. support, but it gets generated in CMAKE_BINARY_DIR, which may be out of tree when doing an out-of-source build. So, symlink it automatically to allow IDEs to pick it up.