### PR TITLE
AArch64: Add folds to use new cbz/cbnz block terminators

### DIFF
--- a/hphp/runtime/vm/jit/smashable-instr-arm.cpp
+++ b/hphp/runtime/vm/jit/smashable-instr-arm.cpp
@@ -179,6 +179,14 @@ bool possiblySmashableJcc(TCA inst) {
   return b->IsCondBranchImm() && isVeneer(b->ImmPCOffsetTarget());
 }
 
+bool possiblySmashableCb(TCA inst) {
+  using namespace vixl;
+
+  auto const b = Instruction::Cast(inst);
+
+  return b->IsCompareBranch() && isVeneer(b->ImmPCOffsetTarget());
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 
 void smashMovq(TCA inst, uint64_t target) {

--- a/hphp/runtime/vm/jit/smashable-instr-arm.h
+++ b/hphp/runtime/vm/jit/smashable-instr-arm.h
@@ -68,6 +68,7 @@ void smashInterceptJmp(TCA inst);
 bool possiblySmashableMovq(TCA inst);
 bool possiblySmashableJmp(TCA inst);
 bool possiblySmashableJcc(TCA inst);
+bool possiblySmashableCb(TCA inst);
 
 uint64_t smashableMovqImm(TCA inst);
 uint32_t smashableCmpqImm(TCA inst);

--- a/hphp/runtime/vm/jit/vasm-info.cpp
+++ b/hphp/runtime/vm/jit/vasm-info.cpp
@@ -361,6 +361,10 @@ bool effectsImpl(const Vinstr& inst, bool pure) {
     case Vinstr::callr:
     case Vinstr::calls:
     case Vinstr::callstub:
+    case Vinstr::cbzl:
+    case Vinstr::cbnzl:
+    case Vinstr::cbzq:
+    case Vinstr::cbnzq:
     case Vinstr::conjure:
     case Vinstr::contenter:
     case Vinstr::cqo:

--- a/hphp/runtime/vm/jit/vasm-instr.cpp
+++ b/hphp/runtime/vm/jit/vasm-instr.cpp
@@ -39,6 +39,10 @@ bool isBlockEnd(const Vinstr& inst) {
     case Vinstr::bindjmp:
     case Vinstr::fallback:
     // control flow
+    case Vinstr::cbzl:
+    case Vinstr::cbnzl:
+    case Vinstr::cbzq:
+    case Vinstr::cbnzq:
     case Vinstr::jcc:
     case Vinstr::jmp:
     case Vinstr::jmpr:
@@ -309,6 +313,8 @@ Width width(Vinstr::Opcode op) {
     case Vinstr::cmpli:
     case Vinstr::cmplm:
     case Vinstr::cmplim:
+    case Vinstr::cbzl:
+    case Vinstr::cbnzl:
     case Vinstr::testl:
     case Vinstr::testli:
     case Vinstr::testlim:
@@ -366,6 +372,8 @@ Width width(Vinstr::Opcode op) {
     case Vinstr::cmpqi:
     case Vinstr::cmpqm:
     case Vinstr::cmpqim:
+    case Vinstr::cbzq:
+    case Vinstr::cbnzq:
     case Vinstr::testq:
     case Vinstr::testqi:
     case Vinstr::testqm:

--- a/hphp/runtime/vm/jit/vasm-instr.h
+++ b/hphp/runtime/vm/jit/vasm-instr.h
@@ -367,6 +367,10 @@ struct Vunit;
   O(loadpairl, Inone, U(s), D(d0) D(d1))\
   O(storepair, Inone, U(s0) U(s1) UW(d), Dn)\
   O(storepairl, Inone, U(s0) U(s1) UW(d), Dn)\
+  O(cbzl, Inone, U(s), Dn)\
+  O(cbnzl, Inone, U(s), Dn)\
+  O(cbzq, Inone, U(s), Dn)\
+  O(cbnzq, Inone, U(s), Dn)\
   /* */
 
 /*
@@ -1286,6 +1290,10 @@ struct loadpair { Vptr128 s; Vreg64 d0, d1; };
 struct loadpairl { Vptr64 s; Vreg32 d0, d1; };
 struct storepair { Vreg64 s0, s1; Vptr128 d; };
 struct storepairl { Vreg32 s0, s1; Vptr64 d; };
+struct cbzl { Vreg32 s; Vlabel targets[2]; StringTag tag; };
+struct cbnzl { Vreg32 s; Vlabel targets[2]; StringTag tag; };
+struct cbzq { Vreg64 s; Vlabel targets[2]; StringTag tag; };
+struct cbnzq { Vreg64 s; Vlabel targets[2]; StringTag tag; };
 
 ///////////////////////////////////////////////////////////////////////////////
 

--- a/hphp/runtime/vm/jit/vasm-internal.h
+++ b/hphp/runtime/vm/jit/vasm-internal.h
@@ -67,7 +67,7 @@ struct Venv {
   jit::vector<CodeAddress> addrs;
   jit::vector<CodeAddress> vaddrs;
   jit::vector<AddrPatch> leas;
-  jit::vector<LabelPatch> jmps, jccs;
+  jit::vector<LabelPatch> jmps, jccs, cmpbrs;
   jit::vector<LabelPatch> catches;
   jit::vector<LabelPatch> vveneers;
   jit::vector<LdBindRetAddrPatch> ldbindretaddrs;

--- a/hphp/runtime/vm/jit/vasm.cpp
+++ b/hphp/runtime/vm/jit/vasm.cpp
@@ -31,6 +31,10 @@ namespace HPHP::jit {
 folly::Range<Vlabel*> succs(Vinstr& inst) {
   switch (inst.op) {
     case Vinstr::contenter:    return {inst.contenter_.targets, 2};
+    case Vinstr::cbzl:         return {inst.cbzl_.targets, 2};
+    case Vinstr::cbnzl:        return {inst.cbnzl_.targets, 2};
+    case Vinstr::cbzq:         return {inst.cbzq_.targets, 2};
+    case Vinstr::cbnzq:        return {inst.cbnzq_.targets, 2};
     case Vinstr::jcc:          return {inst.jcc_.targets, 2};
     case Vinstr::interceptjcc: return {inst.interceptjcc_.targets, 2};
     case Vinstr::jmp:          return {&inst.jmp_.target, 1};


### PR DESCRIPTION
We can fold sequences like this:

testl w0, w0
jcc CC_E, label

into a single, new opcode

cbz w0, label

if the flags set by testl are only used by the jcc operation. Not only does this reduce the number of instructions, but it also has the benefit of not clobbering the flags. On AArch64 the branch offset range for cbz/cbnz is identical to b.cc so there is no penalty for using them.