### PR TITLE
Add ersatz `hh_fanout` for OSS

### DIFF
--- a/hphp/hack/CMakeLists.txt
+++ b/hphp/hack/CMakeLists.txt
@@ -334,6 +334,18 @@ build_cxx_bridge(
  EXTRA_SRCS "${CMAKE_CURRENT_SOURCE_DIR}/src/hackc/hhvm_cxx/hhvm_hhbc_defs/as-hhbc-ffi.cpp"
 )
 
+set(HH_FANOUT_EXECUTABLE "${HACK_BUILD_ROOT}/target/hh_fanout_oss/${PROFILE}/hh_fanout")
+add_custom_command(
+  OUTPUT ${HH_FANOUT_EXECUTABLE}
+  COMMAND
+   . "${CMAKE_CURRENT_BINARY_DIR}/dev_env_rust_only.sh" &&
+    ${INVOKE_CARGO} hh_fanout_oss hh_fanout_oss --exe
+  DEPENDS opam_setup rustc cargo
+  COMMENT "Building hh_fanout"
+)
+
+add_custom_target(hh_fanout DEPENDS ${HH_FANOUT_EXECUTABLE})
+
 if (NOT LZ4_FOUND)
   add_dependencies(hack_dune lz4)
   add_dependencies(hack_dune_debug lz4)
@@ -363,5 +375,9 @@ install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/bin/hackfmt
   COMPONENT dev)
 
 install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/bin/hh_parse
+  DESTINATION bin
+  COMPONENT dev)
+
+install(PROGRAMS ${HH_FANOUT_EXECUTABLE}
   DESTINATION bin
   COMPONENT dev)

--- a/hphp/hack/src/Cargo.toml
+++ b/hphp/hack/src/Cargo.toml
@@ -41,6 +41,7 @@ members = [
     "hh_fanout/cargo/hh_fanout_build_rust",
     "hh_fanout/cargo/hh_fanout_dep_graph_is_subgraph_rust",
     "hh_fanout/cargo/hh_fanout_dep_graph_stats_rust",
+    "hh_fanout/cargo/hh_fanout_oss",
     "hh_naming_table_builder/cargo/naming_table_builder_ffi",
     "naming",
     "naming/cargo/elaborate_namespaces",

--- a/hphp/hack/src/hh_fanout/cargo/hh_fanout_oss/Cargo.toml
+++ b/hphp/hack/src/hh_fanout/cargo/hh_fanout_oss/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "hh_fanout_oss"
+version = "0.1.0"
+edition = "2024"
+repository = "https://github.com/facebook/hhvm"
+license = "MIT"
+
+[[bin]]
+name = "hh_fanout"
+path = "../../hh_fanout_oss/main.rs"
+
+[dependencies]
+clap = { version = "4.5.42", features = ["derive", "env", "string", "unicode", "wrap_help"] }
+hh_fanout_build = { version = "0.0.0", path = "../hh_fanout_build" }

--- a/hphp/hack/src/hh_fanout/hh_fanout_build_rust/build.rs
+++ b/hphp/hack/src/hh_fanout/hh_fanout_build_rust/build.rs
@@ -6,6 +6,7 @@ use std::ffi::OsString;
 use std::fs;
 use std::fs::File;
 use std::io;
+use std::io::{Error, ErrorKind};
 use std::path::Path;
 use std::path::PathBuf;
 use std::sync::atomic::AtomicUsize;
@@ -353,10 +354,16 @@ pub fn build(
 ) -> io::Result<()> {
     let all_edges = match (new_edges_dir, delta_file) {
         (None, None) => {
-            panic!("build: at least one of --edges-dir or --delta-file flags should be passed")
+            return Err(Error::new(
+                ErrorKind::InvalidInput,
+                "build: at least one of --edges-dir or --delta-file flags should be passed",
+            ));
         }
         (Some(_), Some(_)) => {
-            panic!("build: cannot specify both --edges-dir and --delta-file")
+            return Err(Error::new(
+                ErrorKind::InvalidInput,
+                "build: cannot specify both --edges-dir and --delta-file",
+            ));
         }
         (Some(new_edges_dir), None) => {
             info!("Opening binary files in {:?}", new_edges_dir);
@@ -402,7 +409,10 @@ pub fn build(
     info!("Converting to structured_edges & unique hashes done");
 
     if !allow_empty && mem_dep_graph.edge_lists.iter().all(|list| list.is_empty()) {
-        panic!("No input edges. Refusing to build as --allow-empty not set.");
+        return Err(Error::new(
+            ErrorKind::InvalidInput,
+            "No input edges. Refusing to build as --allow-empty not set.",
+        ));
     }
 
     info!("Registering {} unique hashes", mem_dep_graph.hashes.len());

--- a/hphp/hack/src/hh_fanout/hh_fanout_oss/main.rs
+++ b/hphp/hack/src/hh_fanout/hh_fanout_oss/main.rs
@@ -1,0 +1,33 @@
+use std::io;
+use std::path::PathBuf;
+
+use clap::Parser;
+
+/// Executable wrapper around hh_fanout functionality
+/// that provides saved state support for HHVM open-source.
+///
+/// Builds a 64-bit dependency graph from a collection of edges.
+#[derive(Parser)]
+#[command(about)]
+struct Args {
+    /// A file containing a dependency graph delta in binary format,
+    /// as produced by `hh --save-state /path/`.
+    #[arg(long)]
+    delta_file: PathBuf,
+
+    /// Where to put the 64-bit dependency graph.
+    #[arg(long)]
+    output: PathBuf,
+}
+
+fn main() -> io::Result<()> {
+    let args = Args::parse();
+
+    hh_fanout_build::build(
+        false,
+        None,
+        None,
+        Some(args.delta_file.into_os_string()),
+        &args.output,
+    )
+}


### PR DESCRIPTION
The `hh_fanout` binary was removed in D53956499, preventing OSS users from generating dependency graph files needed for loading saved states.

Fortunately, the backing logic still exists in the repo and we can trivially create a Rust executable to expose it again. Do so, replacing some `panic`s in the backing code with `Err` returns for consistency.