### PR TITLE
Use optimised forms of class release functions where possible

### DIFF
--- a/hphp/runtime/base/object-data.cpp
+++ b/hphp/runtime/base/object-data.cpp
@@ -225,6 +225,10 @@ void ObjectData::release(ObjectData* obj, const Class* cls) noexcept {
   AARCH64_WALKABLE_FRAME();
 }
 
+void ObjectData::release2(ObjectData* obj) noexcept {
+  release(obj, obj->m_cls.get());
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 // class info
 

--- a/hphp/runtime/base/object-data.h
+++ b/hphp/runtime/base/object-data.h
@@ -267,6 +267,12 @@ struct ObjectData : Countable, type_scan::MarkCollectable<ObjectData> {
    */
   static void release(ObjectData* obj, const Class* cls) noexcept;
 
+  /*
+   * An optimised version of the above function when the class can be loaded
+   * from the object.
+   */
+  static void release2(ObjectData* obj) noexcept;
+
   Class* getVMClass() const;
   StrNR getClassName() const;
 

--- a/hphp/runtime/vm/class.cpp
+++ b/hphp/runtime/vm/class.cpp
@@ -5260,6 +5260,12 @@ std::vector<Class*> prioritySerializeClasses() {
   return ret;
 }
 
+Optional<OptObjReleaseFunc> Class::optReleaseFunc() const {
+  if (m_releaseFunc == ObjectData::release)
+    return ObjectData::release2;
+  return std::nullopt;
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 
 namespace {

--- a/hphp/runtime/vm/class.h
+++ b/hphp/runtime/vm/class.h
@@ -142,6 +142,7 @@ using ClassPtr = AtomicSharedPackedPtr<Class>;
 // Since native instance dtors can be release functions, they have to have
 // compatible signatures.
 using ObjReleaseFunc = BuiltinDtorFunction;
+using OptObjReleaseFunc = SmallPtr<void(ObjectData*)>;
 
 using ObjectProps = std::conditional<tv_layout::stores_unaligned_typed_values, tv_layout::UnalignedTVLayout, tv_layout::Tv7Up>::type;
 
@@ -824,6 +825,15 @@ public:
   // or a custom native instance dtor.
 
   ObjReleaseFunc releaseFunc() const;
+
+  /////////////////////////////////////////////////////////////////////////////
+  // Optimized Object release.
+  //
+  // Similar to the above, except only the object needs passing to the release
+  // function. The class is obtained directly from the object itself. If an
+  // optimized version does not exist, return std::nullopt.
+
+  Optional<OptObjReleaseFunc> optReleaseFunc() const;
 
   /////////////////////////////////////////////////////////////////////////////
   // Property metadata.                                                 [const]

--- a/hphp/runtime/vm/jit/irlower-refcount.cpp
+++ b/hphp/runtime/vm/jit/irlower-refcount.cpp
@@ -240,6 +240,9 @@ CallSpec makeDtorCall(Vout& v, Type ty, Vloc loc, ArgGroup& args) {
       // a builtin, as only builtins can override release method and builtins
       // never subclass non-builtins.
       if (!isInterface(cls) && !cls->isBuiltin()) {
+        if (auto rf = cls->optReleaseFunc()) {
+          return CallSpec::direct(rf->get());
+        }
         args.reg(emitLdObjClass(v, loc.reg(0), v.makeReg()));
         return CallSpec::direct(cls->releaseFunc().get());
       }


### PR DESCRIPTION
In makeDtorCall we call a release function of the form

void release(ObjectData *obj, Class *cl)

but in some cases we load the second class pointer argument directly from the object pointer. However, we can actually invoke a more optimised version of the release function:

void release2(ObjectData *obj)

and let this release function do the work of extracting the class pointer.

Doing so helps to reduce the total size of the Jit code cache by removing an associated load for every call. It may slightly increase the total instruction execution count by adding an extra level of indirection, but I think it's worth it.