### PR TITLE
AArch64: Try to move 32-bit stores together for pairing

### DIFF
--- a/hphp/runtime/vm/jit/vasm-simplify-arm.cpp
+++ b/hphp/runtime/vm/jit/vasm-simplify-arm.cpp
@@ -176,6 +176,9 @@ bool tryMoveAndPairStores32(Env& env, const storel& st1, Vlabel b, size_t i) {
   // reuse of x0.
   if (!st1.s.isVirt()) return false;
 
+  // Make sure the first store is of the same class of register as the second.
+  if (env.def_insts[st1.s] != Vinstr::ldimml) return false;
+
   // Look for an intervening instruction that can be easily moved. For now, this
   // is limited to patterns like this:
   //  store %t0, ...


### PR DESCRIPTION
We sometimes see sequences of vasm operations like this:

ldimml ..., %x
storel %x, [%sp - 0x80]
ldimml ..., %y
storel %y, [%sp - 0x7c]

The stores are actually contiguous in memory and if they were next to each other they would be paired up into a storepairl. This patch looks for such patterns and rewrites them as

ldimml ..., %x
ldimml ..., %y
storepairl %x, %y, [%sp - 0x80]