### PR TITLE
AArch64: Use storepair more when storing out constant values

### DIFF
--- a/hphp/runtime/vm/jit/vasm-simplify-arm.cpp
+++ b/hphp/runtime/vm/jit/vasm-simplify-arm.cpp
@@ -262,8 +262,7 @@ int is_adjacent_vptr64(const Vptr64& a, const Vptr64& b, int32_t step, int32_t m
 }
 
 bool is_valid_reg_for_storepair(Env& env, Vreg s) {
-  if (s.isGP())
-    return true;
+  if (s.isGP()) return true;
 
   auto const op_it = env.unit.regToConst.find(s);
   return op_it != env.unit.regToConst.end() && op_it->second.kind != Vconst::Double;


### PR DESCRIPTION
We sometimes see sequences like this:

store %123(...b), [addr + 8]
store %124(...q), [addr]

The existing storepair simplify code requires that the stored registers be physical GP registers, presumably because the lowering for storepair/storepairl cannot handle FP/SIMD regs. However, during register allocation we materialise these constants and end up with the sequence:

ldimmb ... => x0
store x0, [addr + 8]
ldimmq ... => x0
store x0, [addr]

which then makes it very difficult to combine these into storepairs in the post-regalloc simplify pass. This PR permits combining pairs of stores prior to regalloc, provided we can show they are either:

1. A GP physical register, or
2. An integer constant that will be materialised into a GP reg.