### PR TITLE
Set SOCK_CLOEXEC for debugger sockets

### DIFF
--- a/hphp/runtime/ext/vsdebug/socket_transport.cpp
+++ b/hphp/runtime/ext/vsdebug/socket_transport.cpp
@@ -23,6 +23,7 @@
 
 #include <pwd.h>
 #include <grp.h>
+#include <sys/socket.h>
 
 namespace HPHP {
 namespace VSDEBUG {
@@ -302,7 +303,7 @@ bool SocketTransport::bindAndListenDomain(std::vector<int>& socketFds) {
   struct sockaddr_un addr;
   std::string socketPath = m_domainSocketPath;
 
-  int sockFd = socket(AF_UNIX, SOCK_STREAM, 0);
+  int sockFd = socket(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0);
   if (sockFd < 0) {
     VSDebugLogger::Log(
       VSDebugLogger::LogLevelError,
@@ -360,7 +361,7 @@ bool SocketTransport::bindAndListenTCP(
   std::vector<int>& socketFds
 ) {
   int fd = socket(address->ai_family,
-                  address->ai_socktype,
+                  address->ai_socktype | SOCK_CLOEXEC,
                   address->ai_protocol);
 
   if (fd < 0) {


### PR DESCRIPTION
It's possible to configure HHVM access logs to be sent to a subprocess instead of a file, like so:
```
Log {
	Access {
		* {
			File = |/usr/bin/some_processor.sh | tee -a /tmp/hhvm-access.log
		}
	}
}
```
Under the hood, this is backed by a `popen(3)` syscall in `ClassicWriter`, which ultimately creates a pipe, forks and invokes a shell. If HHVM is running with the debugger enabled (`hhvm.debugger.vs_debug_enable=1`), this subprocess also ends up inheriting the file descriptor backing the listening socket of the debugger. If a connected debugger client then disconnects, the debug server will then restart and try to open a new socket, but fail because the FD remains open in the child process.

So, set `SOCK_CLOEXEC` on these sockets so that they get closed in child processes.