### PR TITLE
vsdebug: Fix double-closing listener FDs

### DIFF
--- a/hphp/runtime/ext/vsdebug/socket_transport.cpp
+++ b/hphp/runtime/ext/vsdebug/socket_transport.cpp
@@ -21,6 +21,8 @@
 #include "hphp/util/configs/debugger.h"
 #include "hphp/util/user-info.h"
 
+#include <algorithm>
+
 #include <pwd.h>
 #include <grp.h>
 #include <sys/socket.h>
@@ -160,9 +162,7 @@ void SocketTransport::listenForClientConnection() {
       freeaddrinfo(ai);
     }
 
-    for (auto it = socketFds.begin(); it != socketFds.end(); it++) {
-      close(*it);
-    }
+    std::for_each(socketFds.begin(), socketFds.end(), close);
 
     close(abortFd);
     m_abortPipeFd[0] = -1;
@@ -574,10 +574,6 @@ void SocketTransport::waitForConnection(
   SCOPE_EXIT {
     if (fds != nullptr) {
       free(fds);
-    }
-
-    for (const int fd : socketFds) {
-      close(fd);
     }
   };
 


### PR DESCRIPTION
While working on D88186184, I noticed that we were closing the listener FDs for the vsdebug server in both `waitForConnection` and `listenForClientConnection`. It does not seem to be causing issues in local testing but it could be a problem if the FD gets reused in a different thread in the meantime. `waitForConnection` is only called at the end of
`listenForClientConnection` so closing the FDs only at the end of `listenForClientConnection` should be fine.