### PR TITLE
Fix IDE formatting of correctly formatted files with trailing newlines

### DIFF
--- a/hphp/hack/Makefile.dune
+++ b/hphp/hack/Makefile.dune
@@ -35,6 +35,7 @@ build-hack$(2):
 	dune build \
 		src/hh_server.$(1) \
 		src/hh_client.$(1) \
+		src/hh_single_ide_format.$(1) \
 		src/hh_single_type_check.$(1) \
 		src/hackfmt.$(1) \
 		src/hh_parse.$(1) \
@@ -44,6 +45,7 @@ copy-hack$(2)-files: build-hack$(2)
 	mkdir -p "$(HACK_BIN_DIR)"
 	${COPY_EXE} "$(DUNE_BUILD_DIR)/default/hack/src/hh_server.$(1)" "$(HACK_BIN_DIR)/hh_server$(ext)"
 	${COPY_EXE} "$(DUNE_BUILD_DIR)/default/hack/src/hh_client.$(1)" "$(HACK_BIN_DIR)/hh_client$(ext)"
+	${COPY_EXE} "$(DUNE_BUILD_DIR)/default/hack/src/hh_single_ide_format.$(1)" "$(HACK_BIN_DIR)/hh_single_ide_format$(ext)"
 	${COPY_EXE} "$(DUNE_BUILD_DIR)/default/hack/src/hh_single_type_check.$(1)" "$(HACK_BIN_DIR)/hh_single_type_check$(ext)"
 	${COPY_EXE} "$(DUNE_BUILD_DIR)/default/hack/src/hackfmt.$(1)" "$(HACK_BIN_DIR)/hackfmt$(ext)"
 	${COPY_EXE} "$(DUNE_BUILD_DIR)/default/hack/src/hh_parse.$(1)" "$(HACK_BIN_DIR)/hh_parse$(ext)"

--- a/hphp/hack/src/client/ide_service/ide_format.ml
+++ b/hphp/hack/src/client/ide_service/ide_format.ml
@@ -179,7 +179,7 @@ let minimal_edit (old_src : string) (new_src : string) :
         (List.length old_src_lines - range_end_line)
     in
     let (new_text, start_line_adjustment) =
-      if List.is_empty new_src_novel_lines then
+      if List.is_empty new_src_novel_lines && range_end_line < List.length new_src_lines then
         (*
           Empty `new_src_novel_lines` does not mean that there was no change
           (otherwise we wouldn't have reached here),

--- a/hphp/hack/test/hackfmt/ide_format/newlines3.php
+++ b/hphp/hack/test/hackfmt/ide_format/newlines3.php
@@ -1,0 +1,10 @@
+<?hh
+// Formatting an otherwise-correctly formatted file with trailing newlines
+// should not devour the last line before the newlines.
+class A {
+  public function baz(): int {
+    return 5;
+  }
+}
+
+

--- a/hphp/hack/test/hackfmt/ide_format/newlines3.php.exp
+++ b/hphp/hack/test/hackfmt/ide_format/newlines3.php.exp
@@ -1,0 +1,29 @@
+> lines and columns in ranges are 1-indexed
+received code:
+1 <?hh
+2 // Formatting an otherwise-correctly formatted file with trailing newlines
+3 // should not devour the last line before the newlines.
+4 class A {
+5   public function baz(): int {
+6     return 5;
+7   }
+8 }
+9 
+10 
+
+New text at range 9:1-11:1 (1-indexed) is
+'
+'
+
+Code after applying language server edits:
+'<?hh
+// Formatting an otherwise-correctly formatted file with trailing newlines
+// should not devour the last line before the newlines.
+class A {
+  public function baz(): int {
+    return 5;
+  }
+}
+'
+
+Matched Hackfmt result


### PR DESCRIPTION
Since D60978552, we special-case removing a range of lines during IDE formatting so that T188437747 does not rear its ugly head. However, when document-formatting a file that is already correctly formatted save for some spurious trailing newlines, this logic ends up consuming the last non-newline line. So, only shift the start offset if the last changed line wasn't a trailing line that got removed.

Add a test and wire up `hh_single_ide_format` with the OSS dune build so that IDE format tests can be run.