### PR TITLE
Backport upstream fix for potential PCRE cache deadlock

### DIFF
--- a/hphp/util/concurrent-lru-cache.h
+++ b/hphp/util/concurrent-lru-cache.h
@@ -283,6 +283,7 @@ insert(const TKey& key, const TValue& value) {
     delete node;
     return false;
   }
+  hashAccessor.release();
 
   // Evict if necessary, now that we know the hashmap insertion was successful.
   size_t size = m_size.load();


### PR DESCRIPTION
See https://github.com/facebook/hhvm/issues/9032 for the upstream bug report and fix.

Closes #9032.