### PR TITLE
Update uuid 1.17 to 1.21.0

### DIFF
--- a/hphp/hack/src/Cargo.lock
+++ b/hphp/hack/src/Cargo.lock
@@ -1948,6 +1948,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
+dependencies = [
+ "cfg-if 1.0.4",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
 name = "getset"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2481,6 +2494,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25a2bc672d1148e28034f176e01fffebb08b35768468cc954630da77a1449005"
+
+[[package]]
 name = "im"
 version = "15.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2717,6 +2736,12 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
@@ -3746,6 +3771,16 @@ checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
 dependencies = [
  "diff",
  "yansi",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -5518,11 +5553,11 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.19.0"
+version = "1.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e054861b4bd027cd373e18e8d8d8e6548085000e41290d95ce0c373a654b4a"
+checksum = "b672338555252d43fd2240c714dc444b8c6fb0a5c5335e65a07bba7742735ddb"
 dependencies = [
- "getrandom 0.3.3",
+ "getrandom 0.4.1",
  "js-sys",
  "wasm-bindgen",
 ]
@@ -5663,7 +5698,16 @@ version = "1.0.1+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.46.0",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
@@ -5709,6 +5753,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap 2.13.0",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap 2.13.0",
+ "semver 1.0.27",
 ]
 
 [[package]]
@@ -6046,6 +6124,94 @@ name = "wit-bindgen"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck 0.5.0",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck 0.5.0",
+ "indexmap 2.13.0",
+ "prettyplease",
+ "syn 2.0.114",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap 2.13.0",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap 2.13.0",
+ "log",
+ "semver 1.0.27",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "write_bytes"

--- a/hphp/hack/src/Cargo.lock
+++ b/hphp/hack/src/Cargo.lock
@@ -392,9 +392,9 @@ checksum = "5f0dc55f2d8a1a85650ac47858bb001b4c0dd73d79e3c455a842925e68d29cd3"
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 dependencies = [
  "serde_core",
 ]

--- a/hphp/hack/src/Cargo.lock
+++ b/hphp/hack/src/Cargo.lock
@@ -1834,15 +1834,15 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures-core"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1851,21 +1851,20 @@ dependencies = [
 
 [[package]]
 name = "futures-task"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-util"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
  "futures-macro",
  "futures-task",
  "pin-project-lite",
- "pin-utils",
  "slab",
 ]
 
@@ -3636,12 +3635,6 @@ name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
-
-[[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"

--- a/hphp/hack/src/Cargo.lock
+++ b/hphp/hack/src/Cargo.lock
@@ -2818,9 +2818,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.28"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 dependencies = [
  "value-bag",
 ]
@@ -5542,9 +5542,9 @@ checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "value-bag"
-version = "1.9.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a84c137d37ab0142f0f2ddfe332651fdbf252e7b7dbb4e67b6c1f1b2e925101"
+checksum = "7ba6f5989077681266825251a52748b8c1d8a4ad098cc37e440103d0ea717fc0"
 dependencies = [
  "value-bag-serde1",
  "value-bag-sval2",
@@ -5552,20 +5552,20 @@ dependencies = [
 
 [[package]]
 name = "value-bag-serde1"
-version = "1.10.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bb773bd36fd59c7ca6e336c94454d9c66386416734817927ac93d81cb3c5b0b"
+checksum = "16530907bfe2999a1773ca5900a65101e092c70f642f25cc23ca0c43573262c5"
 dependencies = [
  "erased-serde 0.4.9",
- "serde",
+ "serde_core",
  "serde_fmt",
 ]
 
 [[package]]
 name = "value-bag-sval2"
-version = "1.10.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53a916a702cac43a88694c97657d449775667bcd14b70419441d05b7fea4a83a"
+checksum = "d00ae130edd690eaa877e4f40605d534790d1cf1d651e7685bd6a144521b251f"
 dependencies = [
  "sval",
  "sval_buffer",

--- a/hphp/hack/src/depgraph/balanced_partition/cargo/balanced_partition/Cargo.toml
+++ b/hphp/hack/src/depgraph/balanced_partition/cargo/balanced_partition/Cargo.toml
@@ -13,5 +13,5 @@ crate-type = ["lib", "staticlib"]
 
 [dependencies]
 itertools = "0.14.0"
-log = { version = "0.4.27", features = ["kv_unstable", "kv_unstable_std"] }
+log = { version = "0.4.29", features = ["kv_unstable", "kv_unstable_std"] }
 rayon = "1.11.0"

--- a/hphp/hack/src/depgraph/cargo/depgraph_writer/Cargo.toml
+++ b/hphp/hack/src/depgraph/cargo/depgraph_writer/Cargo.toml
@@ -14,5 +14,5 @@ crate-type = ["lib", "staticlib"]
 [dependencies]
 bytemuck = { version = "1.24", features = ["const_zeroed", "derive", "min_const_generics", "must_cast", "nightly_portable_simd", "nightly_stdsimd"] }
 dep = { version = "0.0.0", path = "../dep" }
-log = { version = "0.4.27", features = ["kv_unstable", "kv_unstable_std"] }
+log = { version = "0.4.29", features = ["kv_unstable", "kv_unstable_std"] }
 newtype = { version = "0.0.0", path = "../../../utils/newtype" }

--- a/hphp/hack/src/depgraph/depgraph_compress/cargo/depgraph_compress/Cargo.toml
+++ b/hphp/hack/src/depgraph/depgraph_compress/cargo/depgraph_compress/Cargo.toml
@@ -17,7 +17,7 @@ bytemuck = { version = "1.24", features = ["const_zeroed", "derive", "min_const_
 depgraph_reader = { version = "0.0.0", path = "../../../cargo/depgraph_reader" }
 depgraph_writer = { version = "0.0.0", path = "../../../cargo/depgraph_writer" }
 hash = { version = "0.0.0", path = "../../../../utils/hash" }
-log = { version = "0.4.27", features = ["kv_unstable", "kv_unstable_std"] }
+log = { version = "0.4.29", features = ["kv_unstable", "kv_unstable_std"] }
 newtype = { version = "0.0.0", path = "../../../../utils/newtype" }
 rayon = "1.11.0"
 smallvec = { version = "1.15", features = ["impl_bincode", "serde", "specialization", "union"] }

--- a/hphp/hack/src/elab/Cargo.toml
+++ b/hphp/hack/src/elab/Cargo.toml
@@ -12,7 +12,7 @@ path = "elab.rs"
 edition = "2021"
 
 [dependencies]
-bitflags = { version = "2.9", features = ["serde", "std"], default-features = false }
+bitflags = { version = "2.11.0", features = ["serde", "std"], default-features = false }
 bstr = { version = "1.10.0", features = ["serde", "std", "unicode"] }
 elaborate_namespaces_visitor = { version = "0.0.0", path = "../naming/cargo/elaborate_namespaces" }
 hack_macros = { version = "0.0.0", path = "../utils/hack_macros/cargo/hack_macros" }

--- a/hphp/hack/src/hackc/Cargo.toml
+++ b/hphp/hack/src/hackc/Cargo.toml
@@ -41,7 +41,7 @@ ir = { version = "0.0.0", path = "ir" }
 ir_to_bc = { version = "0.0.0", path = "ir/conversions/ir_to_bc" }
 itertools = "0.14.0"
 jwalk = "0.8.1"
-log = { version = "0.4.27", features = ["kv_unstable", "kv_unstable_std"] }
+log = { version = "0.4.29", features = ["kv_unstable", "kv_unstable_std"] }
 multifile_rust = { version = "0.0.0", path = "../utils/multifile" }
 naming_provider = { version = "0.0.0", path = "../hackrs/naming_provider/cargo/naming_provider" }
 options = { version = "0.0.0", path = "compile/cargo/options" }

--- a/hphp/hack/src/hackc/cargo/assemble/Cargo.toml
+++ b/hphp/hack/src/hackc/cargo/assemble/Cargo.toml
@@ -18,7 +18,7 @@ ffi = { version = "0.0.0", path = "../../ffi/ffi" }
 hash = { version = "0.0.0", path = "../../../utils/hash" }
 hhbc = { version = "0.0.0", path = "../../hhbc/cargo/hhbc" }
 hhvm_types_ffi = { version = "0.0.0", path = "../../hhvm_cxx/hhvm_types" }
-log = { version = "0.4.27", features = ["kv_unstable", "kv_unstable_std"] }
+log = { version = "0.4.29", features = ["kv_unstable", "kv_unstable_std"] }
 naming_special_names_rust = { version = "0.0.0", path = "../../../naming" }
 newtype = { version = "0.0.0", path = "../../../utils/newtype" }
 parse_macro = { version = "0.0.0", path = "../parse_macro" }

--- a/hphp/hack/src/hackc/emitter/cargo/emit_unit/Cargo.toml
+++ b/hphp/hack/src/hackc/emitter/cargo/emit_unit/Cargo.toml
@@ -14,7 +14,7 @@ path = "../../emit_unit.rs"
 ast_scope = { version = "0.0.0", path = "../ast_scope" }
 bit-set = "0.5"
 bit-vec = "0.6"
-bitflags = { version = "2.9", features = ["serde", "std"], default-features = false }
+bitflags = { version = "2.11.0", features = ["serde", "std"], default-features = false }
 bstr = { version = "1.10.0", features = ["serde", "std", "unicode"] }
 constant_folder = { version = "0.0.0", path = "../constant_folder" }
 core_utils_rust = { version = "0.0.0", path = "../../../../utils/core" }

--- a/hphp/hack/src/hackc/emitter/cargo/env/Cargo.toml
+++ b/hphp/hack/src/hackc/emitter/cargo/env/Cargo.toml
@@ -12,7 +12,7 @@ path = "../../env.rs"
 
 [dependencies]
 ast_scope = { version = "0.0.0", path = "../ast_scope" }
-bitflags = { version = "2.9", features = ["serde", "std"], default-features = false }
+bitflags = { version = "2.11.0", features = ["serde", "std"], default-features = false }
 decl_provider = { version = "0.0.0", path = "../../../decl_provider" }
 global_state = { version = "0.0.0", path = "../global_state" }
 hhbc = { version = "0.0.0", path = "../../../hhbc/cargo/hhbc" }

--- a/hphp/hack/src/hackc/hhbc/cargo/hhbc/Cargo.toml
+++ b/hphp/hack/src/hackc/hhbc/cargo/hhbc/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT"
 path = "../../lib.rs"
 
 [dependencies]
-bitflags = { version = "2.9", features = ["serde"], default-features = false }
+bitflags = { version = "2.11.0", features = ["serde"], default-features = false }
 bstr = { version = "1.10.0", features = ["serde", "std", "unicode"] }
 emit_opcodes_macro = { version = "0.0.0", path = "../emit_opcodes_macro" }
 ffi = { version = "0.0.0", path = "../../../ffi/ffi" }

--- a/hphp/hack/src/hackc/ir/assemble/Cargo.toml
+++ b/hphp/hack/src/hackc/ir/assemble/Cargo.toml
@@ -15,6 +15,6 @@ anyhow = "1.0.98"
 hash = { version = "0.0.0", path = "../../../utils/hash" }
 ir_core = { version = "0.0.0", path = "../ir_core" }
 itertools = "0.14.0"
-log = { version = "0.4.27", features = ["kv_unstable", "kv_unstable_std"] }
+log = { version = "0.4.29", features = ["kv_unstable", "kv_unstable_std"] }
 naming_special_names_rust = { version = "0.0.0", path = "../../../naming" }
 parse_macro_ir = { version = "0.0.0", path = "../cargo/parse_macro" }

--- a/hphp/hack/src/hackc/ir/conversions/bc_to_ir/Cargo.toml
+++ b/hphp/hack/src/hackc/ir/conversions/bc_to_ir/Cargo.toml
@@ -15,5 +15,5 @@ b2i_macros = { version = "0.0.0", path = "b2i_macros" }
 ffi = { version = "0.0.0", path = "../../../ffi/ffi" }
 hhbc = { version = "0.0.0", path = "../../../hhbc/cargo/hhbc" }
 ir = { version = "0.0.0", path = "../.." }
-log = { version = "0.4.27", features = ["kv_unstable", "kv_unstable_std"] }
+log = { version = "0.4.29", features = ["kv_unstable", "kv_unstable_std"] }
 newtype = { version = "0.0.0", path = "../../../../utils/newtype" }

--- a/hphp/hack/src/hackc/ir/conversions/ir_to_bc/Cargo.toml
+++ b/hphp/hack/src/hackc/ir/conversions/ir_to_bc/Cargo.toml
@@ -16,6 +16,6 @@ hhbc = { version = "0.0.0", path = "../../../hhbc/cargo/hhbc" }
 instruction_sequence = { version = "0.0.0", path = "../../../emitter/cargo/instruction_sequence" }
 ir = { version = "0.0.0", path = "../.." }
 itertools = "0.14.0"
-log = { version = "0.4.27", features = ["kv_unstable", "kv_unstable_std"] }
+log = { version = "0.4.29", features = ["kv_unstable", "kv_unstable_std"] }
 smallvec = { version = "1.15", features = ["impl_bincode", "serde", "specialization", "union"] }
 stack_depth = { version = "0.0.0", path = "../../../utils/cargo/stack_depth" }

--- a/hphp/hack/src/hackc/ir/conversions/textual/cargo/textual/Cargo.toml
+++ b/hphp/hack/src/hackc/ir/conversions/textual/cargo/textual/Cargo.toml
@@ -20,7 +20,7 @@ hhbc = { version = "0.0.0", path = "../../../../../hhbc/cargo/hhbc" }
 hhbc_string_utils = { version = "0.0.0", path = "../../../../../utils/cargo/hhbc_string_utils" }
 ir = { version = "0.0.0", path = "../../../.." }
 itertools = "0.14.0"
-log = { version = "0.4.27", features = ["kv_unstable", "kv_unstable_std"] }
+log = { version = "0.4.29", features = ["kv_unstable", "kv_unstable_std"] }
 naming_special_names_rust = { version = "0.0.0", path = "../../../../../../naming" }
 newtype = { version = "0.0.0", path = "../../../../../../utils/newtype" }
 regex = "1.12.2"

--- a/hphp/hack/src/hackc/ir/passes/Cargo.toml
+++ b/hphp/hack/src/hackc/ir/passes/Cargo.toml
@@ -14,7 +14,7 @@ path = "lib.rs"
 analysis = { version = "0.0.0", path = "../analysis" }
 ir_core = { version = "0.0.0", path = "../ir_core" }
 itertools = "0.14.0"
-log = { version = "0.4.27", features = ["kv_unstable", "kv_unstable_std"] }
+log = { version = "0.4.29", features = ["kv_unstable", "kv_unstable_std"] }
 newtype = { version = "0.0.0", path = "../../../utils/newtype" }
 print = { version = "0.0.0", path = "../print" }
 

--- a/hphp/hack/src/hackc/sem_diff/Cargo.toml
+++ b/hphp/hack/src/hackc/sem_diff/Cargo.toml
@@ -19,5 +19,5 @@ hash = { version = "0.0.0", path = "../../utils/hash" }
 hhbc = { version = "0.0.0", path = "../hhbc/cargo/hhbc" }
 hhbc-gen = { version = "0.0.0", path = "../../../../tools/hhbc-gen" }
 itertools = "0.14.0"
-log = { version = "0.4.27", features = ["kv_unstable", "kv_unstable_std"] }
+log = { version = "0.4.29", features = ["kv_unstable", "kv_unstable_std"] }
 newtype = { version = "0.0.0", path = "../../utils/newtype" }

--- a/hphp/hack/src/hackc/utils/cargo/stack_depth/Cargo.toml
+++ b/hphp/hack/src/hackc/utils/cargo/stack_depth/Cargo.toml
@@ -14,6 +14,6 @@ path = "../../stack_depth.rs"
 ffi = { version = "0.0.0", path = "../../../ffi/ffi" }
 hhbc = { version = "0.0.0", path = "../../../hhbc/cargo/hhbc" }
 hhbc-gen = { version = "0.0.0", path = "../../../../../../tools/hhbc-gen" }
-log = { version = "0.4.27", features = ["kv_unstable", "kv_unstable_std"] }
+log = { version = "0.4.29", features = ["kv_unstable", "kv_unstable_std"] }
 newtype = { version = "0.0.0", path = "../../../../utils/newtype" }
 thiserror = "2.0.18"

--- a/hphp/hack/src/hh_fanout/cargo/hh_fanout_build/Cargo.toml
+++ b/hphp/hack/src/hh_fanout/cargo/hh_fanout_build/Cargo.toml
@@ -20,7 +20,7 @@ depgraph_compress = { version = "0.0.0", path = "../../../depgraph/depgraph_comp
 depgraph_reader = { version = "0.0.0", path = "../../../depgraph/cargo/depgraph_reader" }
 depgraph_writer = { version = "0.0.0", path = "../../../depgraph/cargo/depgraph_writer" }
 hash = { version = "0.0.0", path = "../../../utils/hash" }
-log = { version = "0.4.27", features = ["kv_unstable", "kv_unstable_std"] }
+log = { version = "0.4.29", features = ["kv_unstable", "kv_unstable_std"] }
 memmap2 = "0.9.5"
 newtype = { version = "0.0.0", path = "../../../utils/newtype" }
 parking_lot = { version = "0.12.1", features = ["send_guard"] }

--- a/hphp/hack/src/hh_fanout/cargo/hh_fanout_dep_graph_is_subgraph_rust/Cargo.toml
+++ b/hphp/hack/src/hh_fanout/cargo/hh_fanout_dep_graph_is_subgraph_rust/Cargo.toml
@@ -16,5 +16,5 @@ crate-type = ["lib", "staticlib"]
 [dependencies]
 depgraph_reader = { version = "0.0.0", path = "../../../depgraph/cargo/depgraph_reader" }
 env_logger = { version = "0.11.8", features = ["color"] }
-log = { version = "0.4.27", features = ["kv_unstable", "kv_unstable_std"] }
+log = { version = "0.4.29", features = ["kv_unstable", "kv_unstable_std"] }
 ocamlrep_ocamlpool = { version = "0.1.0", git = "https://github.com/facebook/ocamlrep/", branch = "main" }

--- a/hphp/hack/src/hh_fanout/cargo/hh_fanout_dep_graph_stats_rust/Cargo.toml
+++ b/hphp/hack/src/hh_fanout/cargo/hh_fanout_dep_graph_stats_rust/Cargo.toml
@@ -17,5 +17,5 @@ crate-type = ["lib", "staticlib"]
 depgraph_reader = { version = "0.0.0", path = "../../../depgraph/cargo/depgraph_reader" }
 env_logger = { version = "0.11.8", features = ["color"] }
 json = "0.12.1"
-log = { version = "0.4.27", features = ["kv_unstable", "kv_unstable_std"] }
+log = { version = "0.4.29", features = ["kv_unstable", "kv_unstable_std"] }
 ocamlrep_ocamlpool = { version = "0.1.0", git = "https://github.com/facebook/ocamlrep/", branch = "main" }

--- a/hphp/hack/src/oxidized/Cargo.toml
+++ b/hphp/hack/src/oxidized/Cargo.toml
@@ -15,7 +15,7 @@ ansi_term = "0.12"
 anyhow = "1.0.98"
 arena_deserializer = { version = "0.0.0", path = "../utils/arena_deserializer" }
 arena_trait = { version = "0.0.0", path = "../arena_trait" }
-bitflags = { version = "2.9", features = ["serde", "std"], default-features = false }
+bitflags = { version = "2.11.0", features = ["serde", "std"], default-features = false }
 bstr = { version = "1.10.0", features = ["serde", "std", "unicode"] }
 bumpalo = { version = "3.19.1", features = ["allocator_api", "collections"] }
 eq_modulo_pos = { version = "0.0.0", path = "../utils/eq_modulo_pos" }

--- a/hphp/hack/src/parser/cargo/aast_parser/Cargo.toml
+++ b/hphp/hack/src/parser/cargo/aast_parser/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT"
 path = "../../aast_parser_lib.rs"
 
 [dependencies]
-bitflags = { version = "2.9", features = ["serde", "std"], default-features = false }
+bitflags = { version = "2.11.0", features = ["serde", "std"], default-features = false }
 bumpalo = { version = "3.19.1", features = ["allocator_api", "collections"] }
 core_utils_rust = { version = "0.0.0", path = "../../../utils/core" }
 decl_mode_parser = { version = "0.0.0", path = "../../api/cargo/decl_mode_parser" }

--- a/hphp/hack/src/parser/cargo/core_types/Cargo.toml
+++ b/hphp/hack/src/parser/cargo/core_types/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT"
 path = "../../parser_core_types_lib.rs"
 
 [dependencies]
-bitflags = { version = "2.9", features = ["serde", "std"], default-features = false }
+bitflags = { version = "2.11.0", features = ["serde", "std"], default-features = false }
 bumpalo = { version = "3.19.1", features = ["allocator_api", "collections"] }
 itertools = "0.14.0"
 line_break_map = { version = "0.0.0", path = "../../../utils/line_break_map" }

--- a/hphp/hack/src/utils/hhvm_options/hhvm_runtime_options/Cargo.toml
+++ b/hphp/hack/src/utils/hhvm_options/hhvm_runtime_options/Cargo.toml
@@ -16,7 +16,7 @@ byteorder = "1.5"
 colored = "2.1.0"
 cxx = "1.0.119"
 hdf = { version = "0.0.0", path = "../../hdf" }
-log = { version = "0.4.27", features = ["kv_unstable", "kv_unstable_std"] }
+log = { version = "0.4.29", features = ["kv_unstable", "kv_unstable_std"] }
 md-5 = "0.10"
 regex = "1.12.2"
 

--- a/hphp/tools/hhbc-gen/Cargo.toml
+++ b/hphp/tools/hhbc-gen/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT"
 path = "hhbc.rs"
 
 [dependencies]
-bitflags = { version = "2.9", features = ["serde", "std"], default-features = false }
+bitflags = { version = "2.11.0", features = ["serde", "std"], default-features = false }
 maplit = "1.0"
 once_cell = "1.21"
 

--- a/third-party/thrift/src/thrift/lib/rust/Cargo.toml
+++ b/third-party/thrift/src/thrift/lib/rust/Cargo.toml
@@ -15,7 +15,7 @@ async-trait = "0.1.86"
 base64 = { version = "0.22.1", features = ["alloc"] }
 bufsize = "1.0.10"
 bytes = { version = "1.11.1", features = ["serde"] }
-futures = { version = "0.3.31", features = ["async-await", "compat"] }
+futures = { version = "0.3.32", features = ["async-await", "compat"] }
 ghost = "0.1.20"
 num-derive = "0.4.2"
 num-traits = { version = "0.2.19", default-features = false }

--- a/third-party/thrift/src/thrift/lib/rust/annotation/all/Cargo.toml
+++ b/third-party/thrift/src/thrift/lib/rust/annotation/all/Cargo.toml
@@ -21,7 +21,7 @@ codegen_includer_proc_macro = { version = "0.1.0", git = "https://github.com/fac
 cpp = { version = "0.0.1+unstable", path = "../cpp" }
 erlang = { version = "0.0.1+unstable", path = "../erlang" }
 fbthrift = { version = "0.0.1+unstable", path = "../.." }
-futures = { version = "0.3.31", features = ["async-await", "compat"] }
+futures = { version = "0.3.32", features = ["async-await", "compat"] }
 go = { version = "0.0.1+unstable", path = "../go" }
 hack = { version = "0.0.1+unstable", path = "../hack" }
 java = { version = "0.0.1+unstable", path = "../java" }

--- a/third-party/thrift/src/thrift/lib/rust/annotation/all/clients/Cargo.toml
+++ b/third-party/thrift/src/thrift/lib/rust/annotation/all/clients/Cargo.toml
@@ -25,7 +25,7 @@ cpp_clients = { version = "0.0.1+unstable", path = "../../cpp/clients" }
 erlang = { version = "0.0.1+unstable", path = "../../erlang" }
 erlang_clients = { version = "0.0.1+unstable", path = "../../erlang/clients" }
 fbthrift = { version = "0.0.1+unstable", path = "../../.." }
-futures = { version = "0.3.31", features = ["async-await", "compat"] }
+futures = { version = "0.3.32", features = ["async-await", "compat"] }
 go = { version = "0.0.1+unstable", path = "../../go" }
 go_clients = { version = "0.0.1+unstable", path = "../../go/clients" }
 hack = { version = "0.0.1+unstable", path = "../../hack" }

--- a/third-party/thrift/src/thrift/lib/rust/annotation/all/mocks/Cargo.toml
+++ b/third-party/thrift/src/thrift/lib/rust/annotation/all/mocks/Cargo.toml
@@ -28,7 +28,7 @@ erlang = { version = "0.0.1+unstable", path = "../../erlang" }
 erlang_clients = { version = "0.0.1+unstable", path = "../../erlang/clients" }
 erlang_mocks = { version = "0.0.1+unstable", path = "../../erlang/mocks" }
 fbthrift = { version = "0.0.1+unstable", path = "../../.." }
-futures = { version = "0.3.31", features = ["async-await", "compat"] }
+futures = { version = "0.3.32", features = ["async-await", "compat"] }
 go = { version = "0.0.1+unstable", path = "../../go" }
 go_clients = { version = "0.0.1+unstable", path = "../../go/clients" }
 go_mocks = { version = "0.0.1+unstable", path = "../../go/mocks" }

--- a/third-party/thrift/src/thrift/lib/rust/annotation/all/services/Cargo.toml
+++ b/third-party/thrift/src/thrift/lib/rust/annotation/all/services/Cargo.toml
@@ -25,7 +25,7 @@ cpp_services = { version = "0.0.1+unstable", path = "../../cpp/services" }
 erlang = { version = "0.0.1+unstable", path = "../../erlang" }
 erlang_services = { version = "0.0.1+unstable", path = "../../erlang/services" }
 fbthrift = { version = "0.0.1+unstable", path = "../../.." }
-futures = { version = "0.3.31", features = ["async-await", "compat"] }
+futures = { version = "0.3.32", features = ["async-await", "compat"] }
 go = { version = "0.0.1+unstable", path = "../../go" }
 go_services = { version = "0.0.1+unstable", path = "../../go/services" }
 hack = { version = "0.0.1+unstable", path = "../../hack" }

--- a/third-party/thrift/src/thrift/lib/rust/annotation/compat/Cargo.toml
+++ b/third-party/thrift/src/thrift/lib/rust/annotation/compat/Cargo.toml
@@ -19,7 +19,7 @@ doc = false
 anyhow = "1.0.98"
 codegen_includer_proc_macro = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
 fbthrift = { version = "0.0.1+unstable", path = "../.." }
-futures = { version = "0.3.31", features = ["async-await", "compat"] }
+futures = { version = "0.3.32", features = ["async-await", "compat"] }
 ref-cast = "1.0.18"
 scope = { version = "0.0.1+unstable", path = "../scope" }
 thiserror = "2.0.18"

--- a/third-party/thrift/src/thrift/lib/rust/annotation/compat/clients/Cargo.toml
+++ b/third-party/thrift/src/thrift/lib/rust/annotation/compat/clients/Cargo.toml
@@ -21,7 +21,7 @@ async-trait = "0.1.86"
 codegen_includer_proc_macro = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
 compat__types = { package = "compat", version = "0.0.1+unstable", path = ".." }
 fbthrift = { version = "0.0.1+unstable", path = "../../.." }
-futures = { version = "0.3.31", features = ["async-await", "compat"] }
+futures = { version = "0.3.32", features = ["async-await", "compat"] }
 scope = { version = "0.0.1+unstable", path = "../../scope" }
 scope_clients = { version = "0.0.1+unstable", path = "../../scope/clients" }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }

--- a/third-party/thrift/src/thrift/lib/rust/annotation/compat/mocks/Cargo.toml
+++ b/third-party/thrift/src/thrift/lib/rust/annotation/compat/mocks/Cargo.toml
@@ -22,7 +22,7 @@ codegen_includer_proc_macro = { version = "0.1.0", git = "https://github.com/fac
 compat__clients = { package = "compat_clients", version = "0.0.1+unstable", path = "../clients" }
 compat__types = { package = "compat", version = "0.0.1+unstable", path = ".." }
 fbthrift = { version = "0.0.1+unstable", path = "../../.." }
-futures = { version = "0.3.31", features = ["async-await", "compat"] }
+futures = { version = "0.3.32", features = ["async-await", "compat"] }
 scope = { version = "0.0.1+unstable", path = "../../scope" }
 scope_clients = { version = "0.0.1+unstable", path = "../../scope/clients" }
 scope_mocks = { version = "0.0.1+unstable", path = "../../scope/mocks" }

--- a/third-party/thrift/src/thrift/lib/rust/annotation/compat/services/Cargo.toml
+++ b/third-party/thrift/src/thrift/lib/rust/annotation/compat/services/Cargo.toml
@@ -21,7 +21,7 @@ async-trait = "0.1.86"
 codegen_includer_proc_macro = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
 compat__types = { package = "compat", version = "0.0.1+unstable", path = ".." }
 fbthrift = { version = "0.0.1+unstable", path = "../../.." }
-futures = { version = "0.3.31", features = ["async-await", "compat"] }
+futures = { version = "0.3.32", features = ["async-await", "compat"] }
 scope = { version = "0.0.1+unstable", path = "../../scope" }
 scope_services = { version = "0.0.1+unstable", path = "../../scope/services" }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }

--- a/third-party/thrift/src/thrift/lib/rust/annotation/cpp/Cargo.toml
+++ b/third-party/thrift/src/thrift/lib/rust/annotation/cpp/Cargo.toml
@@ -19,7 +19,7 @@ doc = false
 anyhow = "1.0.98"
 codegen_includer_proc_macro = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
 fbthrift = { version = "0.0.1+unstable", path = "../.." }
-futures = { version = "0.3.31", features = ["async-await", "compat"] }
+futures = { version = "0.3.32", features = ["async-await", "compat"] }
 ref-cast = "1.0.18"
 scope = { version = "0.0.1+unstable", path = "../scope" }
 thiserror = "2.0.18"

--- a/third-party/thrift/src/thrift/lib/rust/annotation/cpp/clients/Cargo.toml
+++ b/third-party/thrift/src/thrift/lib/rust/annotation/cpp/clients/Cargo.toml
@@ -21,7 +21,7 @@ async-trait = "0.1.86"
 codegen_includer_proc_macro = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
 cpp__types = { package = "cpp", version = "0.0.1+unstable", path = ".." }
 fbthrift = { version = "0.0.1+unstable", path = "../../.." }
-futures = { version = "0.3.31", features = ["async-await", "compat"] }
+futures = { version = "0.3.32", features = ["async-await", "compat"] }
 scope = { version = "0.0.1+unstable", path = "../../scope" }
 scope_clients = { version = "0.0.1+unstable", path = "../../scope/clients" }
 thrift = { version = "0.0.1+unstable", path = "../../thrift" }

--- a/third-party/thrift/src/thrift/lib/rust/annotation/cpp/mocks/Cargo.toml
+++ b/third-party/thrift/src/thrift/lib/rust/annotation/cpp/mocks/Cargo.toml
@@ -22,7 +22,7 @@ codegen_includer_proc_macro = { version = "0.1.0", git = "https://github.com/fac
 cpp__clients = { package = "cpp_clients", version = "0.0.1+unstable", path = "../clients" }
 cpp__types = { package = "cpp", version = "0.0.1+unstable", path = ".." }
 fbthrift = { version = "0.0.1+unstable", path = "../../.." }
-futures = { version = "0.3.31", features = ["async-await", "compat"] }
+futures = { version = "0.3.32", features = ["async-await", "compat"] }
 scope = { version = "0.0.1+unstable", path = "../../scope" }
 scope_clients = { version = "0.0.1+unstable", path = "../../scope/clients" }
 scope_mocks = { version = "0.0.1+unstable", path = "../../scope/mocks" }

--- a/third-party/thrift/src/thrift/lib/rust/annotation/cpp/services/Cargo.toml
+++ b/third-party/thrift/src/thrift/lib/rust/annotation/cpp/services/Cargo.toml
@@ -21,7 +21,7 @@ async-trait = "0.1.86"
 codegen_includer_proc_macro = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
 cpp__types = { package = "cpp", version = "0.0.1+unstable", path = ".." }
 fbthrift = { version = "0.0.1+unstable", path = "../../.." }
-futures = { version = "0.3.31", features = ["async-await", "compat"] }
+futures = { version = "0.3.32", features = ["async-await", "compat"] }
 scope = { version = "0.0.1+unstable", path = "../../scope" }
 scope_services = { version = "0.0.1+unstable", path = "../../scope/services" }
 thrift = { version = "0.0.1+unstable", path = "../../thrift" }

--- a/third-party/thrift/src/thrift/lib/rust/annotation/erlang/Cargo.toml
+++ b/third-party/thrift/src/thrift/lib/rust/annotation/erlang/Cargo.toml
@@ -19,7 +19,7 @@ doc = false
 anyhow = "1.0.98"
 codegen_includer_proc_macro = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
 fbthrift = { version = "0.0.1+unstable", path = "../.." }
-futures = { version = "0.3.31", features = ["async-await", "compat"] }
+futures = { version = "0.3.32", features = ["async-await", "compat"] }
 ref-cast = "1.0.18"
 scope = { version = "0.0.1+unstable", path = "../scope" }
 thiserror = "2.0.18"

--- a/third-party/thrift/src/thrift/lib/rust/annotation/erlang/clients/Cargo.toml
+++ b/third-party/thrift/src/thrift/lib/rust/annotation/erlang/clients/Cargo.toml
@@ -21,7 +21,7 @@ async-trait = "0.1.86"
 codegen_includer_proc_macro = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
 erlang__types = { package = "erlang", version = "0.0.1+unstable", path = ".." }
 fbthrift = { version = "0.0.1+unstable", path = "../../.." }
-futures = { version = "0.3.31", features = ["async-await", "compat"] }
+futures = { version = "0.3.32", features = ["async-await", "compat"] }
 scope = { version = "0.0.1+unstable", path = "../../scope" }
 scope_clients = { version = "0.0.1+unstable", path = "../../scope/clients" }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }

--- a/third-party/thrift/src/thrift/lib/rust/annotation/erlang/mocks/Cargo.toml
+++ b/third-party/thrift/src/thrift/lib/rust/annotation/erlang/mocks/Cargo.toml
@@ -22,7 +22,7 @@ codegen_includer_proc_macro = { version = "0.1.0", git = "https://github.com/fac
 erlang__clients = { package = "erlang_clients", version = "0.0.1+unstable", path = "../clients" }
 erlang__types = { package = "erlang", version = "0.0.1+unstable", path = ".." }
 fbthrift = { version = "0.0.1+unstable", path = "../../.." }
-futures = { version = "0.3.31", features = ["async-await", "compat"] }
+futures = { version = "0.3.32", features = ["async-await", "compat"] }
 scope = { version = "0.0.1+unstable", path = "../../scope" }
 scope_clients = { version = "0.0.1+unstable", path = "../../scope/clients" }
 scope_mocks = { version = "0.0.1+unstable", path = "../../scope/mocks" }

--- a/third-party/thrift/src/thrift/lib/rust/annotation/erlang/services/Cargo.toml
+++ b/third-party/thrift/src/thrift/lib/rust/annotation/erlang/services/Cargo.toml
@@ -21,7 +21,7 @@ async-trait = "0.1.86"
 codegen_includer_proc_macro = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
 erlang__types = { package = "erlang", version = "0.0.1+unstable", path = ".." }
 fbthrift = { version = "0.0.1+unstable", path = "../../.." }
-futures = { version = "0.3.31", features = ["async-await", "compat"] }
+futures = { version = "0.3.32", features = ["async-await", "compat"] }
 scope = { version = "0.0.1+unstable", path = "../../scope" }
 scope_services = { version = "0.0.1+unstable", path = "../../scope/services" }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }

--- a/third-party/thrift/src/thrift/lib/rust/annotation/go/Cargo.toml
+++ b/third-party/thrift/src/thrift/lib/rust/annotation/go/Cargo.toml
@@ -19,7 +19,7 @@ doc = false
 anyhow = "1.0.98"
 codegen_includer_proc_macro = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
 fbthrift = { version = "0.0.1+unstable", path = "../.." }
-futures = { version = "0.3.31", features = ["async-await", "compat"] }
+futures = { version = "0.3.32", features = ["async-await", "compat"] }
 ref-cast = "1.0.18"
 scope = { version = "0.0.1+unstable", path = "../scope" }
 thiserror = "2.0.18"

--- a/third-party/thrift/src/thrift/lib/rust/annotation/go/clients/Cargo.toml
+++ b/third-party/thrift/src/thrift/lib/rust/annotation/go/clients/Cargo.toml
@@ -20,7 +20,7 @@ anyhow = "1.0.98"
 async-trait = "0.1.86"
 codegen_includer_proc_macro = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
 fbthrift = { version = "0.0.1+unstable", path = "../../.." }
-futures = { version = "0.3.31", features = ["async-await", "compat"] }
+futures = { version = "0.3.32", features = ["async-await", "compat"] }
 go__types = { package = "go", version = "0.0.1+unstable", path = ".." }
 scope = { version = "0.0.1+unstable", path = "../../scope" }
 scope_clients = { version = "0.0.1+unstable", path = "../../scope/clients" }

--- a/third-party/thrift/src/thrift/lib/rust/annotation/go/mocks/Cargo.toml
+++ b/third-party/thrift/src/thrift/lib/rust/annotation/go/mocks/Cargo.toml
@@ -20,7 +20,7 @@ anyhow = "1.0.98"
 async-trait = "0.1.86"
 codegen_includer_proc_macro = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
 fbthrift = { version = "0.0.1+unstable", path = "../../.." }
-futures = { version = "0.3.31", features = ["async-await", "compat"] }
+futures = { version = "0.3.32", features = ["async-await", "compat"] }
 go__clients = { package = "go_clients", version = "0.0.1+unstable", path = "../clients" }
 go__types = { package = "go", version = "0.0.1+unstable", path = ".." }
 scope = { version = "0.0.1+unstable", path = "../../scope" }

--- a/third-party/thrift/src/thrift/lib/rust/annotation/go/services/Cargo.toml
+++ b/third-party/thrift/src/thrift/lib/rust/annotation/go/services/Cargo.toml
@@ -20,7 +20,7 @@ anyhow = "1.0.98"
 async-trait = "0.1.86"
 codegen_includer_proc_macro = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
 fbthrift = { version = "0.0.1+unstable", path = "../../.." }
-futures = { version = "0.3.31", features = ["async-await", "compat"] }
+futures = { version = "0.3.32", features = ["async-await", "compat"] }
 go__types = { package = "go", version = "0.0.1+unstable", path = ".." }
 scope = { version = "0.0.1+unstable", path = "../../scope" }
 scope_services = { version = "0.0.1+unstable", path = "../../scope/services" }

--- a/third-party/thrift/src/thrift/lib/rust/annotation/hack/Cargo.toml
+++ b/third-party/thrift/src/thrift/lib/rust/annotation/hack/Cargo.toml
@@ -19,7 +19,7 @@ doc = false
 anyhow = "1.0.98"
 codegen_includer_proc_macro = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
 fbthrift = { version = "0.0.1+unstable", path = "../.." }
-futures = { version = "0.3.31", features = ["async-await", "compat"] }
+futures = { version = "0.3.32", features = ["async-await", "compat"] }
 ref-cast = "1.0.18"
 scope = { version = "0.0.1+unstable", path = "../scope" }
 thiserror = "2.0.18"

--- a/third-party/thrift/src/thrift/lib/rust/annotation/hack/clients/Cargo.toml
+++ b/third-party/thrift/src/thrift/lib/rust/annotation/hack/clients/Cargo.toml
@@ -20,7 +20,7 @@ anyhow = "1.0.98"
 async-trait = "0.1.86"
 codegen_includer_proc_macro = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
 fbthrift = { version = "0.0.1+unstable", path = "../../.." }
-futures = { version = "0.3.31", features = ["async-await", "compat"] }
+futures = { version = "0.3.32", features = ["async-await", "compat"] }
 hack__types = { package = "hack", version = "0.0.1+unstable", path = ".." }
 scope = { version = "0.0.1+unstable", path = "../../scope" }
 scope_clients = { version = "0.0.1+unstable", path = "../../scope/clients" }

--- a/third-party/thrift/src/thrift/lib/rust/annotation/hack/mocks/Cargo.toml
+++ b/third-party/thrift/src/thrift/lib/rust/annotation/hack/mocks/Cargo.toml
@@ -20,7 +20,7 @@ anyhow = "1.0.98"
 async-trait = "0.1.86"
 codegen_includer_proc_macro = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
 fbthrift = { version = "0.0.1+unstable", path = "../../.." }
-futures = { version = "0.3.31", features = ["async-await", "compat"] }
+futures = { version = "0.3.32", features = ["async-await", "compat"] }
 hack__clients = { package = "hack_clients", version = "0.0.1+unstable", path = "../clients" }
 hack__types = { package = "hack", version = "0.0.1+unstable", path = ".." }
 scope = { version = "0.0.1+unstable", path = "../../scope" }

--- a/third-party/thrift/src/thrift/lib/rust/annotation/hack/services/Cargo.toml
+++ b/third-party/thrift/src/thrift/lib/rust/annotation/hack/services/Cargo.toml
@@ -20,7 +20,7 @@ anyhow = "1.0.98"
 async-trait = "0.1.86"
 codegen_includer_proc_macro = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
 fbthrift = { version = "0.0.1+unstable", path = "../../.." }
-futures = { version = "0.3.31", features = ["async-await", "compat"] }
+futures = { version = "0.3.32", features = ["async-await", "compat"] }
 hack__types = { package = "hack", version = "0.0.1+unstable", path = ".." }
 scope = { version = "0.0.1+unstable", path = "../../scope" }
 scope_services = { version = "0.0.1+unstable", path = "../../scope/services" }

--- a/third-party/thrift/src/thrift/lib/rust/annotation/java/Cargo.toml
+++ b/third-party/thrift/src/thrift/lib/rust/annotation/java/Cargo.toml
@@ -19,7 +19,7 @@ doc = false
 anyhow = "1.0.98"
 codegen_includer_proc_macro = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
 fbthrift = { version = "0.0.1+unstable", path = "../.." }
-futures = { version = "0.3.31", features = ["async-await", "compat"] }
+futures = { version = "0.3.32", features = ["async-await", "compat"] }
 ref-cast = "1.0.18"
 scope = { version = "0.0.1+unstable", path = "../scope" }
 thiserror = "2.0.18"

--- a/third-party/thrift/src/thrift/lib/rust/annotation/java/clients/Cargo.toml
+++ b/third-party/thrift/src/thrift/lib/rust/annotation/java/clients/Cargo.toml
@@ -20,7 +20,7 @@ anyhow = "1.0.98"
 async-trait = "0.1.86"
 codegen_includer_proc_macro = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
 fbthrift = { version = "0.0.1+unstable", path = "../../.." }
-futures = { version = "0.3.31", features = ["async-await", "compat"] }
+futures = { version = "0.3.32", features = ["async-await", "compat"] }
 java__types = { package = "java", version = "0.0.1+unstable", path = ".." }
 scope = { version = "0.0.1+unstable", path = "../../scope" }
 scope_clients = { version = "0.0.1+unstable", path = "../../scope/clients" }

--- a/third-party/thrift/src/thrift/lib/rust/annotation/java/mocks/Cargo.toml
+++ b/third-party/thrift/src/thrift/lib/rust/annotation/java/mocks/Cargo.toml
@@ -20,7 +20,7 @@ anyhow = "1.0.98"
 async-trait = "0.1.86"
 codegen_includer_proc_macro = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
 fbthrift = { version = "0.0.1+unstable", path = "../../.." }
-futures = { version = "0.3.31", features = ["async-await", "compat"] }
+futures = { version = "0.3.32", features = ["async-await", "compat"] }
 java__clients = { package = "java_clients", version = "0.0.1+unstable", path = "../clients" }
 java__types = { package = "java", version = "0.0.1+unstable", path = ".." }
 scope = { version = "0.0.1+unstable", path = "../../scope" }

--- a/third-party/thrift/src/thrift/lib/rust/annotation/java/services/Cargo.toml
+++ b/third-party/thrift/src/thrift/lib/rust/annotation/java/services/Cargo.toml
@@ -20,7 +20,7 @@ anyhow = "1.0.98"
 async-trait = "0.1.86"
 codegen_includer_proc_macro = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
 fbthrift = { version = "0.0.1+unstable", path = "../../.." }
-futures = { version = "0.3.31", features = ["async-await", "compat"] }
+futures = { version = "0.3.32", features = ["async-await", "compat"] }
 java__types = { package = "java", version = "0.0.1+unstable", path = ".." }
 scope = { version = "0.0.1+unstable", path = "../../scope" }
 scope_services = { version = "0.0.1+unstable", path = "../../scope/services" }

--- a/third-party/thrift/src/thrift/lib/rust/annotation/python/Cargo.toml
+++ b/third-party/thrift/src/thrift/lib/rust/annotation/python/Cargo.toml
@@ -19,7 +19,7 @@ doc = false
 anyhow = "1.0.98"
 codegen_includer_proc_macro = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
 fbthrift = { version = "0.0.1+unstable", path = "../.." }
-futures = { version = "0.3.31", features = ["async-await", "compat"] }
+futures = { version = "0.3.32", features = ["async-await", "compat"] }
 ref-cast = "1.0.18"
 scope = { version = "0.0.1+unstable", path = "../scope" }
 thiserror = "2.0.18"

--- a/third-party/thrift/src/thrift/lib/rust/annotation/python/clients/Cargo.toml
+++ b/third-party/thrift/src/thrift/lib/rust/annotation/python/clients/Cargo.toml
@@ -20,7 +20,7 @@ anyhow = "1.0.98"
 async-trait = "0.1.86"
 codegen_includer_proc_macro = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
 fbthrift = { version = "0.0.1+unstable", path = "../../.." }
-futures = { version = "0.3.31", features = ["async-await", "compat"] }
+futures = { version = "0.3.32", features = ["async-await", "compat"] }
 python__types = { package = "python", version = "0.0.1+unstable", path = ".." }
 scope = { version = "0.0.1+unstable", path = "../../scope" }
 scope_clients = { version = "0.0.1+unstable", path = "../../scope/clients" }

--- a/third-party/thrift/src/thrift/lib/rust/annotation/python/mocks/Cargo.toml
+++ b/third-party/thrift/src/thrift/lib/rust/annotation/python/mocks/Cargo.toml
@@ -20,7 +20,7 @@ anyhow = "1.0.98"
 async-trait = "0.1.86"
 codegen_includer_proc_macro = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
 fbthrift = { version = "0.0.1+unstable", path = "../../.." }
-futures = { version = "0.3.31", features = ["async-await", "compat"] }
+futures = { version = "0.3.32", features = ["async-await", "compat"] }
 python__clients = { package = "python_clients", version = "0.0.1+unstable", path = "../clients" }
 python__types = { package = "python", version = "0.0.1+unstable", path = ".." }
 scope = { version = "0.0.1+unstable", path = "../../scope" }

--- a/third-party/thrift/src/thrift/lib/rust/annotation/python/services/Cargo.toml
+++ b/third-party/thrift/src/thrift/lib/rust/annotation/python/services/Cargo.toml
@@ -20,7 +20,7 @@ anyhow = "1.0.98"
 async-trait = "0.1.86"
 codegen_includer_proc_macro = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
 fbthrift = { version = "0.0.1+unstable", path = "../../.." }
-futures = { version = "0.3.31", features = ["async-await", "compat"] }
+futures = { version = "0.3.32", features = ["async-await", "compat"] }
 python__types = { package = "python", version = "0.0.1+unstable", path = ".." }
 scope = { version = "0.0.1+unstable", path = "../../scope" }
 scope_services = { version = "0.0.1+unstable", path = "../../scope/services" }

--- a/third-party/thrift/src/thrift/lib/rust/annotation/rust/Cargo.toml
+++ b/third-party/thrift/src/thrift/lib/rust/annotation/rust/Cargo.toml
@@ -19,7 +19,7 @@ doc = false
 anyhow = "1.0.98"
 codegen_includer_proc_macro = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
 fbthrift = { version = "0.0.1+unstable", path = "../.." }
-futures = { version = "0.3.31", features = ["async-await", "compat"] }
+futures = { version = "0.3.32", features = ["async-await", "compat"] }
 ref-cast = "1.0.18"
 scope = { version = "0.0.1+unstable", path = "../scope" }
 thiserror = "2.0.18"

--- a/third-party/thrift/src/thrift/lib/rust/annotation/rust/clients/Cargo.toml
+++ b/third-party/thrift/src/thrift/lib/rust/annotation/rust/clients/Cargo.toml
@@ -20,7 +20,7 @@ anyhow = "1.0.98"
 async-trait = "0.1.86"
 codegen_includer_proc_macro = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
 fbthrift = { version = "0.0.1+unstable", path = "../../.." }
-futures = { version = "0.3.31", features = ["async-await", "compat"] }
+futures = { version = "0.3.32", features = ["async-await", "compat"] }
 rust__types = { package = "rust", version = "0.0.1+unstable", path = ".." }
 scope = { version = "0.0.1+unstable", path = "../../scope" }
 scope_clients = { version = "0.0.1+unstable", path = "../../scope/clients" }

--- a/third-party/thrift/src/thrift/lib/rust/annotation/rust/mocks/Cargo.toml
+++ b/third-party/thrift/src/thrift/lib/rust/annotation/rust/mocks/Cargo.toml
@@ -20,7 +20,7 @@ anyhow = "1.0.98"
 async-trait = "0.1.86"
 codegen_includer_proc_macro = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
 fbthrift = { version = "0.0.1+unstable", path = "../../.." }
-futures = { version = "0.3.31", features = ["async-await", "compat"] }
+futures = { version = "0.3.32", features = ["async-await", "compat"] }
 rust__clients = { package = "rust_clients", version = "0.0.1+unstable", path = "../clients" }
 rust__types = { package = "rust", version = "0.0.1+unstable", path = ".." }
 scope = { version = "0.0.1+unstable", path = "../../scope" }

--- a/third-party/thrift/src/thrift/lib/rust/annotation/rust/services/Cargo.toml
+++ b/third-party/thrift/src/thrift/lib/rust/annotation/rust/services/Cargo.toml
@@ -20,7 +20,7 @@ anyhow = "1.0.98"
 async-trait = "0.1.86"
 codegen_includer_proc_macro = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
 fbthrift = { version = "0.0.1+unstable", path = "../../.." }
-futures = { version = "0.3.31", features = ["async-await", "compat"] }
+futures = { version = "0.3.32", features = ["async-await", "compat"] }
 rust__types = { package = "rust", version = "0.0.1+unstable", path = ".." }
 scope = { version = "0.0.1+unstable", path = "../../scope" }
 scope_services = { version = "0.0.1+unstable", path = "../../scope/services" }

--- a/third-party/thrift/src/thrift/lib/rust/annotation/scope/Cargo.toml
+++ b/third-party/thrift/src/thrift/lib/rust/annotation/scope/Cargo.toml
@@ -19,7 +19,7 @@ doc = false
 anyhow = "1.0.98"
 codegen_includer_proc_macro = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
 fbthrift = { version = "0.0.1+unstable", path = "../.." }
-futures = { version = "0.3.31", features = ["async-await", "compat"] }
+futures = { version = "0.3.32", features = ["async-await", "compat"] }
 ref-cast = "1.0.18"
 thiserror = "2.0.18"
 

--- a/third-party/thrift/src/thrift/lib/rust/annotation/scope/clients/Cargo.toml
+++ b/third-party/thrift/src/thrift/lib/rust/annotation/scope/clients/Cargo.toml
@@ -20,7 +20,7 @@ anyhow = "1.0.98"
 async-trait = "0.1.86"
 codegen_includer_proc_macro = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
 fbthrift = { version = "0.0.1+unstable", path = "../../.." }
-futures = { version = "0.3.31", features = ["async-await", "compat"] }
+futures = { version = "0.3.32", features = ["async-await", "compat"] }
 scope__types = { package = "scope", version = "0.0.1+unstable", path = ".." }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
 

--- a/third-party/thrift/src/thrift/lib/rust/annotation/scope/mocks/Cargo.toml
+++ b/third-party/thrift/src/thrift/lib/rust/annotation/scope/mocks/Cargo.toml
@@ -20,7 +20,7 @@ anyhow = "1.0.98"
 async-trait = "0.1.86"
 codegen_includer_proc_macro = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
 fbthrift = { version = "0.0.1+unstable", path = "../../.." }
-futures = { version = "0.3.31", features = ["async-await", "compat"] }
+futures = { version = "0.3.32", features = ["async-await", "compat"] }
 scope__clients = { package = "scope_clients", version = "0.0.1+unstable", path = "../clients" }
 scope__types = { package = "scope", version = "0.0.1+unstable", path = ".." }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }

--- a/third-party/thrift/src/thrift/lib/rust/annotation/scope/services/Cargo.toml
+++ b/third-party/thrift/src/thrift/lib/rust/annotation/scope/services/Cargo.toml
@@ -20,7 +20,7 @@ anyhow = "1.0.98"
 async-trait = "0.1.86"
 codegen_includer_proc_macro = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
 fbthrift = { version = "0.0.1+unstable", path = "../../.." }
-futures = { version = "0.3.31", features = ["async-await", "compat"] }
+futures = { version = "0.3.32", features = ["async-await", "compat"] }
 scope__types = { package = "scope", version = "0.0.1+unstable", path = ".." }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
 

--- a/third-party/thrift/src/thrift/lib/rust/annotation/thrift/Cargo.toml
+++ b/third-party/thrift/src/thrift/lib/rust/annotation/thrift/Cargo.toml
@@ -19,7 +19,7 @@ doc = false
 anyhow = "1.0.98"
 codegen_includer_proc_macro = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
 fbthrift = { version = "0.0.1+unstable", path = "../.." }
-futures = { version = "0.3.31", features = ["async-await", "compat"] }
+futures = { version = "0.3.32", features = ["async-await", "compat"] }
 ref-cast = "1.0.18"
 scope = { version = "0.0.1+unstable", path = "../scope" }
 thiserror = "2.0.18"

--- a/third-party/thrift/src/thrift/lib/rust/annotation/thrift/clients/Cargo.toml
+++ b/third-party/thrift/src/thrift/lib/rust/annotation/thrift/clients/Cargo.toml
@@ -20,7 +20,7 @@ anyhow = "1.0.98"
 async-trait = "0.1.86"
 codegen_includer_proc_macro = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
 fbthrift = { version = "0.0.1+unstable", path = "../../.." }
-futures = { version = "0.3.31", features = ["async-await", "compat"] }
+futures = { version = "0.3.32", features = ["async-await", "compat"] }
 scope = { version = "0.0.1+unstable", path = "../../scope" }
 scope_clients = { version = "0.0.1+unstable", path = "../../scope/clients" }
 thrift__types = { package = "thrift", version = "0.0.1+unstable", path = ".." }

--- a/third-party/thrift/src/thrift/lib/rust/annotation/thrift/mocks/Cargo.toml
+++ b/third-party/thrift/src/thrift/lib/rust/annotation/thrift/mocks/Cargo.toml
@@ -20,7 +20,7 @@ anyhow = "1.0.98"
 async-trait = "0.1.86"
 codegen_includer_proc_macro = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
 fbthrift = { version = "0.0.1+unstable", path = "../../.." }
-futures = { version = "0.3.31", features = ["async-await", "compat"] }
+futures = { version = "0.3.32", features = ["async-await", "compat"] }
 scope = { version = "0.0.1+unstable", path = "../../scope" }
 scope_clients = { version = "0.0.1+unstable", path = "../../scope/clients" }
 scope_mocks = { version = "0.0.1+unstable", path = "../../scope/mocks" }

--- a/third-party/thrift/src/thrift/lib/rust/annotation/thrift/services/Cargo.toml
+++ b/third-party/thrift/src/thrift/lib/rust/annotation/thrift/services/Cargo.toml
@@ -20,7 +20,7 @@ anyhow = "1.0.98"
 async-trait = "0.1.86"
 codegen_includer_proc_macro = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
 fbthrift = { version = "0.0.1+unstable", path = "../../.." }
-futures = { version = "0.3.31", features = ["async-await", "compat"] }
+futures = { version = "0.3.32", features = ["async-await", "compat"] }
 scope = { version = "0.0.1+unstable", path = "../../scope" }
 scope_services = { version = "0.0.1+unstable", path = "../../scope/services" }
 thrift__types = { package = "thrift", version = "0.0.1+unstable", path = ".." }

--- a/third-party/thrift/src/thrift/lib/rust/deterministic_hash/src/tests/Cargo.toml
+++ b/third-party/thrift/src/thrift/lib/rust/deterministic_hash/src/tests/Cargo.toml
@@ -27,7 +27,7 @@ path = "deterministic_hash_test.rs"
 anyhow = "1.0.98"
 codegen_includer_proc_macro = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
 fbthrift = { version = "0.0.1+unstable", path = "../../.." }
-futures = { version = "0.3.31", features = ["async-await", "compat"] }
+futures = { version = "0.3.32", features = ["async-await", "compat"] }
 indexmap = { version = "2.13.0", features = ["arbitrary", "rayon", "serde"] }
 ref-cast = "1.0.18"
 smallvec = { version = "1.15", features = ["impl_bincode", "serde", "specialization", "union"] }

--- a/third-party/thrift/src/thrift/lib/rust/deterministic_hash/src/tests/clients/Cargo.toml
+++ b/third-party/thrift/src/thrift/lib/rust/deterministic_hash/src/tests/clients/Cargo.toml
@@ -20,7 +20,7 @@ anyhow = "1.0.98"
 async-trait = "0.1.86"
 codegen_includer_proc_macro = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
 fbthrift = { version = "0.0.1+unstable", path = "../../../.." }
-futures = { version = "0.3.31", features = ["async-await", "compat"] }
+futures = { version = "0.3.32", features = ["async-await", "compat"] }
 teststructs__types = { package = "teststructs", version = "0.0.1+unstable", path = ".." }
 thrift = { version = "0.0.1+unstable", path = "../../../../annotation/thrift" }
 thrift_clients = { version = "0.0.1+unstable", path = "../../../../annotation/thrift/clients" }

--- a/third-party/thrift/src/thrift/lib/rust/deterministic_hash/src/tests/mocks/Cargo.toml
+++ b/third-party/thrift/src/thrift/lib/rust/deterministic_hash/src/tests/mocks/Cargo.toml
@@ -20,7 +20,7 @@ anyhow = "1.0.98"
 async-trait = "0.1.86"
 codegen_includer_proc_macro = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
 fbthrift = { version = "0.0.1+unstable", path = "../../../.." }
-futures = { version = "0.3.31", features = ["async-await", "compat"] }
+futures = { version = "0.3.32", features = ["async-await", "compat"] }
 teststructs__clients = { package = "teststructs_clients", version = "0.0.1+unstable", path = "../clients" }
 teststructs__types = { package = "teststructs", version = "0.0.1+unstable", path = ".." }
 thrift = { version = "0.0.1+unstable", path = "../../../../annotation/thrift" }

--- a/third-party/thrift/src/thrift/lib/rust/deterministic_hash/src/tests/services/Cargo.toml
+++ b/third-party/thrift/src/thrift/lib/rust/deterministic_hash/src/tests/services/Cargo.toml
@@ -20,7 +20,7 @@ anyhow = "1.0.98"
 async-trait = "0.1.86"
 codegen_includer_proc_macro = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
 fbthrift = { version = "0.0.1+unstable", path = "../../../.." }
-futures = { version = "0.3.31", features = ["async-await", "compat"] }
+futures = { version = "0.3.32", features = ["async-await", "compat"] }
 teststructs__types = { package = "teststructs", version = "0.0.1+unstable", path = ".." }
 thrift = { version = "0.0.1+unstable", path = "../../../../annotation/thrift" }
 thrift_services = { version = "0.0.1+unstable", path = "../../../../annotation/thrift/services" }

--- a/third-party/thrift/src/thrift/lib/rust/src/dep_tests/cargo_thrift/Cargo.toml
+++ b/third-party/thrift/src/thrift/lib/rust/src/dep_tests/cargo_thrift/Cargo.toml
@@ -19,7 +19,7 @@ doc = false
 anyhow = "1.0.98"
 codegen_includer_proc_macro = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
 fbthrift = { version = "0.0.1+unstable", path = "../../.." }
-futures = { version = "0.3.31", features = ["async-await", "compat"] }
+futures = { version = "0.3.32", features = ["async-await", "compat"] }
 ref-cast = "1.0.18"
 rust = { version = "0.0.1+unstable", path = "../../../annotation/rust" }
 serde = { version = "1.0.219", features = ["derive", "rc"] }

--- a/third-party/thrift/src/thrift/lib/rust/src/dep_tests/cargo_thrift/clients/Cargo.toml
+++ b/third-party/thrift/src/thrift/lib/rust/src/dep_tests/cargo_thrift/clients/Cargo.toml
@@ -20,7 +20,7 @@ anyhow = "1.0.98"
 async-trait = "0.1.86"
 codegen_includer_proc_macro = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
 fbthrift = { version = "0.0.1+unstable", path = "../../../.." }
-futures = { version = "0.3.31", features = ["async-await", "compat"] }
+futures = { version = "0.3.32", features = ["async-await", "compat"] }
 rust = { version = "0.0.1+unstable", path = "../../../../annotation/rust" }
 rust_clients = { version = "0.0.1+unstable", path = "../../../../annotation/rust/clients" }
 test_if__types = { package = "fbthrift_test_if", version = "0.0.1+unstable", path = ".." }

--- a/third-party/thrift/src/thrift/lib/rust/src/dep_tests/cargo_thrift/mocks/Cargo.toml
+++ b/third-party/thrift/src/thrift/lib/rust/src/dep_tests/cargo_thrift/mocks/Cargo.toml
@@ -20,7 +20,7 @@ anyhow = "1.0.98"
 async-trait = "0.1.86"
 codegen_includer_proc_macro = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
 fbthrift = { version = "0.0.1+unstable", path = "../../../.." }
-futures = { version = "0.3.31", features = ["async-await", "compat"] }
+futures = { version = "0.3.32", features = ["async-await", "compat"] }
 rust = { version = "0.0.1+unstable", path = "../../../../annotation/rust" }
 rust_clients = { version = "0.0.1+unstable", path = "../../../../annotation/rust/clients" }
 rust_mocks = { version = "0.0.1+unstable", path = "../../../../annotation/rust/mocks" }

--- a/third-party/thrift/src/thrift/lib/rust/src/dep_tests/cargo_thrift/services/Cargo.toml
+++ b/third-party/thrift/src/thrift/lib/rust/src/dep_tests/cargo_thrift/services/Cargo.toml
@@ -20,7 +20,7 @@ anyhow = "1.0.98"
 async-trait = "0.1.86"
 codegen_includer_proc_macro = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
 fbthrift = { version = "0.0.1+unstable", path = "../../../.." }
-futures = { version = "0.3.31", features = ["async-await", "compat"] }
+futures = { version = "0.3.32", features = ["async-await", "compat"] }
 rust = { version = "0.0.1+unstable", path = "../../../../annotation/rust" }
 rust_services = { version = "0.0.1+unstable", path = "../../../../annotation/rust/services" }
 test_if__types = { package = "fbthrift_test_if", version = "0.0.1+unstable", path = ".." }

--- a/third-party/thrift/src/thrift/lib/rust/src/dep_tests/cargo_thrift_comdef/Cargo.toml
+++ b/third-party/thrift/src/thrift/lib/rust/src/dep_tests/cargo_thrift_comdef/Cargo.toml
@@ -19,7 +19,7 @@ doc = false
 anyhow = "1.0.98"
 codegen_includer_proc_macro = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
 fbthrift = { version = "0.0.1+unstable", path = "../../.." }
-futures = { version = "0.3.31", features = ["async-await", "compat"] }
+futures = { version = "0.3.32", features = ["async-await", "compat"] }
 ref-cast = "1.0.18"
 thiserror = "2.0.18"
 thrift = { version = "0.0.1+unstable", path = "../../../annotation/thrift" }

--- a/third-party/thrift/src/thrift/lib/rust/src/dep_tests/cargo_thrift_comdef/clients/Cargo.toml
+++ b/third-party/thrift/src/thrift/lib/rust/src/dep_tests/cargo_thrift_comdef/clients/Cargo.toml
@@ -20,7 +20,7 @@ anyhow = "1.0.98"
 async-trait = "0.1.86"
 codegen_includer_proc_macro = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
 fbthrift = { version = "0.0.1+unstable", path = "../../../.." }
-futures = { version = "0.3.31", features = ["async-await", "compat"] }
+futures = { version = "0.3.32", features = ["async-await", "compat"] }
 test_competing_defaults_if__types = { package = "test_competing_defaults_if", version = "0.0.1+unstable", path = ".." }
 thrift = { version = "0.0.1+unstable", path = "../../../../annotation/thrift" }
 thrift_clients = { version = "0.0.1+unstable", path = "../../../../annotation/thrift/clients" }

--- a/third-party/thrift/src/thrift/lib/rust/src/dep_tests/cargo_thrift_comdef/mocks/Cargo.toml
+++ b/third-party/thrift/src/thrift/lib/rust/src/dep_tests/cargo_thrift_comdef/mocks/Cargo.toml
@@ -20,7 +20,7 @@ anyhow = "1.0.98"
 async-trait = "0.1.86"
 codegen_includer_proc_macro = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
 fbthrift = { version = "0.0.1+unstable", path = "../../../.." }
-futures = { version = "0.3.31", features = ["async-await", "compat"] }
+futures = { version = "0.3.32", features = ["async-await", "compat"] }
 test_competing_defaults_if__clients = { package = "test_competing_defaults_if_clients", version = "0.0.1+unstable", path = "../clients" }
 test_competing_defaults_if__types = { package = "test_competing_defaults_if", version = "0.0.1+unstable", path = ".." }
 thrift = { version = "0.0.1+unstable", path = "../../../../annotation/thrift" }

--- a/third-party/thrift/src/thrift/lib/rust/src/dep_tests/cargo_thrift_comdef/services/Cargo.toml
+++ b/third-party/thrift/src/thrift/lib/rust/src/dep_tests/cargo_thrift_comdef/services/Cargo.toml
@@ -20,7 +20,7 @@ anyhow = "1.0.98"
 async-trait = "0.1.86"
 codegen_includer_proc_macro = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
 fbthrift = { version = "0.0.1+unstable", path = "../../../.." }
-futures = { version = "0.3.31", features = ["async-await", "compat"] }
+futures = { version = "0.3.32", features = ["async-await", "compat"] }
 test_competing_defaults_if__types = { package = "test_competing_defaults_if", version = "0.0.1+unstable", path = ".." }
 thrift = { version = "0.0.1+unstable", path = "../../../../annotation/thrift" }
 thrift_services = { version = "0.0.1+unstable", path = "../../../../annotation/thrift/services" }

--- a/third-party/thrift/src/thrift/lib/rust/src/dep_tests/cargo_thrift_optdef/Cargo.toml
+++ b/third-party/thrift/src/thrift/lib/rust/src/dep_tests/cargo_thrift_optdef/Cargo.toml
@@ -19,7 +19,7 @@ doc = false
 anyhow = "1.0.98"
 codegen_includer_proc_macro = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
 fbthrift = { version = "0.0.1+unstable", path = "../../.." }
-futures = { version = "0.3.31", features = ["async-await", "compat"] }
+futures = { version = "0.3.32", features = ["async-await", "compat"] }
 ref-cast = "1.0.18"
 thiserror = "2.0.18"
 thrift = { version = "0.0.1+unstable", path = "../../../annotation/thrift" }

--- a/third-party/thrift/src/thrift/lib/rust/src/dep_tests/cargo_thrift_optdef/clients/Cargo.toml
+++ b/third-party/thrift/src/thrift/lib/rust/src/dep_tests/cargo_thrift_optdef/clients/Cargo.toml
@@ -20,7 +20,7 @@ anyhow = "1.0.98"
 async-trait = "0.1.86"
 codegen_includer_proc_macro = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
 fbthrift = { version = "0.0.1+unstable", path = "../../../.." }
-futures = { version = "0.3.31", features = ["async-await", "compat"] }
+futures = { version = "0.3.32", features = ["async-await", "compat"] }
 test_deprecated_optional_with_default_is_some_if__types = { package = "test_deprecated_optional_with_default_is_some_if", version = "0.0.1+unstable", path = ".." }
 thrift = { version = "0.0.1+unstable", path = "../../../../annotation/thrift" }
 thrift_clients = { version = "0.0.1+unstable", path = "../../../../annotation/thrift/clients" }

--- a/third-party/thrift/src/thrift/lib/rust/src/dep_tests/cargo_thrift_optdef/mocks/Cargo.toml
+++ b/third-party/thrift/src/thrift/lib/rust/src/dep_tests/cargo_thrift_optdef/mocks/Cargo.toml
@@ -20,7 +20,7 @@ anyhow = "1.0.98"
 async-trait = "0.1.86"
 codegen_includer_proc_macro = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
 fbthrift = { version = "0.0.1+unstable", path = "../../../.." }
-futures = { version = "0.3.31", features = ["async-await", "compat"] }
+futures = { version = "0.3.32", features = ["async-await", "compat"] }
 test_deprecated_optional_with_default_is_some_if__clients = { package = "test_deprecated_optional_with_default_is_some_if_clients", version = "0.0.1+unstable", path = "../clients" }
 test_deprecated_optional_with_default_is_some_if__types = { package = "test_deprecated_optional_with_default_is_some_if", version = "0.0.1+unstable", path = ".." }
 thrift = { version = "0.0.1+unstable", path = "../../../../annotation/thrift" }

--- a/third-party/thrift/src/thrift/lib/rust/src/dep_tests/cargo_thrift_optdef/services/Cargo.toml
+++ b/third-party/thrift/src/thrift/lib/rust/src/dep_tests/cargo_thrift_optdef/services/Cargo.toml
@@ -20,7 +20,7 @@ anyhow = "1.0.98"
 async-trait = "0.1.86"
 codegen_includer_proc_macro = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
 fbthrift = { version = "0.0.1+unstable", path = "../../../.." }
-futures = { version = "0.3.31", features = ["async-await", "compat"] }
+futures = { version = "0.3.32", features = ["async-await", "compat"] }
 test_deprecated_optional_with_default_is_some_if__types = { package = "test_deprecated_optional_with_default_is_some_if", version = "0.0.1+unstable", path = ".." }
 thrift = { version = "0.0.1+unstable", path = "../../../../annotation/thrift" }
 thrift_services = { version = "0.0.1+unstable", path = "../../../../annotation/thrift/services" }


### PR DESCRIPTION
Summary: Update the uuid Rust crate from version 1.17 to 1.21.0. This is a minor version bump that includes upstream bug fixes and improvements.

Reviewed By: dtolnay

Differential Revision: D93684254
