### PR TITLE
Support compressing static assets

### DIFF
--- a/hphp/doc/configs.specification
+++ b/hphp/doc/configs.specification
@@ -318,6 +318,10 @@ The format can be found in hphp/tools/configs/generate_configs.rs
 - int Server.GzipMaxCompressionLevel = 9, UNKNOWN
 - bool Server.GzipUseLocalArena = false, UNKNOWN
 
+  Enable compression of static assets served by HHVM
+
+- bool Server.AllowStaticAssetsCompression = false, UNKNOWN
+
   Enable additional for config.hdf overwrite inputs to scuba:hhvm_config_hdf_logs (eg. machine, cpu, tier, tag etc)
 
 - bool Server.LogTierOverwriteInputs = false, ffledgling

--- a/hphp/runtime/server/http-request-handler.cpp
+++ b/hphp/runtime/server/http-request-handler.cpp
@@ -140,7 +140,6 @@ HttpRequestHandler::HttpRequestHandler(int timeout)
 void HttpRequestHandler::sendStaticContent(Transport *transport,
                                            const char *data, int len,
                                            time_t mtime,
-                                           bool compressed,
                                            const std::string &cmd,
                                            const char *ext) {
   assertx(ext);
@@ -194,9 +193,11 @@ void HttpRequestHandler::sendStaticContent(Transport *transport,
 
   // misnomer, it means we have made decision on compression, transport
   // should not attempt to compress it.
-  transport->disableCompression();
+  if (!Cfg::Server::AllowStaticAssetsCompression) {
+    transport->disableCompression();
+  }
 
-  transport->sendRaw(data, len, 200, compressed);
+  transport->sendRaw(data, len, 200, false);
   transport->onSendEnd();
 }
 
@@ -337,7 +338,7 @@ void HttpRequestHandler::handleRequest(Transport *transport) {
         // local cache file is not valuable, maybe misleading. This way
         // the Last-Modified header will not show in response.
         // stat(Cfg::Server::FileCache.c_str(), &st);
-        sendStaticContent(transport, content->buffer, content->size, 0, false,
+        sendStaticContent(transport, content->buffer, content->size, 0,
                           path, ext);
         ServerStats::LogPage(path, 200);
         return;
@@ -639,7 +640,7 @@ bool HttpRequestHandler::handleFileRequest(Transport* transport,
       ::close(fd);
       buffer[len] = 0;
       sendStaticContent(transport, buffer, len, stat_buf.st_mtime,
-                        false, path, ext);
+                        path, ext);
       ServerStats::LogPage(path, 200);
       return true;
     }

--- a/hphp/runtime/server/http-request-handler.h
+++ b/hphp/runtime/server/http-request-handler.h
@@ -62,7 +62,7 @@ private:
                          const std::string& path, const char* ext);
   bool handleProxyRequest(Transport *transport, bool force);
   void sendStaticContent(Transport *transport, const char *data, int len,
-                         time_t mtime, bool compressed,
+                         time_t mtime,
                          const std::string &cmd,
                          const char *ext);
   bool executePHPRequest(Transport *transport, RequestURI &reqURI);


### PR DESCRIPTION
HHVM has support for serving static assets via the builtin server, but they're always served uncompressed. It would be valuable if these responses were compressed in some development setups.

So, introduce a new runtime option `Server.AllowStaticAssetsCompression` that defaults to `false` and allows on-the-fly compression of static assets if enabled. Remove the confusing `compressed` parameter from `sendStaticContent` as it appears to have been once used to indicate whether the content was precompressed but is now always `false`.