### PR TITLE
Fix SOAP map decode to check xmlValue for missing value

### DIFF
--- a/hphp/runtime/ext/soap/encoding.cpp
+++ b/hphp/runtime/ext/soap/encoding.cpp
@@ -2592,7 +2592,7 @@ static Variant to_zval_map(encodeType* /*type*/, xmlNodePtr data) {
       }
 
       xmlValue = get_node(item->children, "value");
-      if (!xmlKey) {
+      if (!xmlValue) {
         throw SoapException( "Encoding: Can't decode map, missing value");
       }
 


### PR DESCRIPTION
## Summary
In `to_zval_map()`, after loading the `value` child into `xmlValue`, the next guard still tested `xmlKey`. That does not match the "missing value" error and can miss a missing value node.

## Test plan
- [ ] Run or add a SOAP encoding test if one fits this path; otherwise rely on code inspection and CI.