### PR TITLE
Add OSS configuration for sbcc extension

### DIFF
--- a/hphp/runtime/ext/sbcc/config.cmake
+++ b/hphp/runtime/ext/sbcc/config.cmake
@@ -1,0 +1,9 @@
+HHVM_DEFINE_EXTENSION("sbcc"
+  SOURCES
+    ext_sbcc.cpp
+    format/sbcc-cache.cpp
+    format/sbcc-reader.cpp
+    format/sbcc-writer.cpp
+  SYSTEMLIB
+    ext_sbcc.php
+)

--- a/hphp/util/hphp-config.h.in
+++ b/hphp/util/hphp-config.h.in
@@ -88,7 +88,7 @@ ${HHVM_COMPILES_DEFINE_STRING}
 #endif
 
 #ifdef USE_CMAKE
-# if ${HHVM_EXTENSION_COUNT} != 100
+# if ${HHVM_EXTENSION_COUNT} != 102
 #  error You need to update the config file for the new builtin extension, and add the define to the FB section
 # endif
 ${HHVM_EXTENSIONS_ENABLED_DEFINE_STRING}


### PR DESCRIPTION
Add a minimal config so that extension autodiscovery doesn't pick up sbcc-compiler files (which would cause an error due to duplicate `main` definitions). sbcc-compiler support for OSS to follow separately once I have time to look into it.