### PR TITLE
Make HPHP_VIXL a public compile definition

### DIFF
--- a/hphp/vixl/CMakeLists.txt
+++ b/hphp/vixl/CMakeLists.txt
@@ -4,10 +4,6 @@ set(HEADER_SOURCES)
 auto_sources(files "*.cc" "${CMAKE_CURRENT_SOURCE_DIR}")
 list(APPEND CXX_SOURCES ${files})
 
-if(NOT IS_AARCH64)
-  add_definitions("-DHPHP_VIXL")
-endif()
-
 auto_sources(files "*.cc" "${CMAKE_CURRENT_SOURCE_DIR}/aarch64")
 # Exclude simulator-related .cc files
 list(FILTER files EXCLUDE REGEX "simulator-aarch64\\.cc$")
@@ -25,7 +21,8 @@ HHVM_PUBLIC_HEADERS(vixl ${files})
 
 add_library(vixl STATIC ${CXX_SOURCES} ${HEADER_SOURCES})
 target_compile_definitions(vixl PRIVATE
-  HPHP_VIXL VIXL_INCLUDE_TARGET_AARCH64 VIXL_CODE_BUFFER_MALLOC)
+  VIXL_INCLUDE_TARGET_AARCH64 VIXL_CODE_BUFFER_MALLOC)
+target_compile_definitions(vixl PUBLIC HPHP_VIXL)
 target_link_libraries(vixl hphp_util)
 auto_source_group("vixl" "${CMAKE_CURRENT_SOURCE_DIR}"
   ${CXX_SOURCES} ${HEADER_SOURCES})


### PR DESCRIPTION
D94756745 came with a new listfile for the vixl update (thanks for that!). Update it to make `HPHP_VIXL` a public compile definition so that targets that consume `vixl` have it defined when including vixl headers, otherwise HHVM-specific compatibility methods will be missing.