### PR TITLE
Lowercase fizz reference in proxygen listfile

### DIFF
--- a/third-party/proxygen/CMakeLists.txt
+++ b/third-party/proxygen/CMakeLists.txt
@@ -47,7 +47,7 @@ ExternalProject_Add(
     -DZSTD_INCLUDE_DIR=${ZSTD_INCLUDE_DIR}
     -DZSTD_LIBRARY_RELEASE=${ZSTD_LIBRARY}
 
-    "-DFizz_DIR=${FIZZ_INSTALL_DIR}/lib/cmake/fizz"
+    "-Dfizz_DIR=${FIZZ_INSTALL_DIR}/lib/cmake/fizz"
     "-Dfmt_DIR=${fmt_DIR}"
     "-Dfolly_DIR=${FOLLY_INSTALL_DIR}/lib/cmake/folly"
     "-Dwangle_DIR=${WANGLE_INSTALL_DIR}/lib/cmake/wangle"


### PR DESCRIPTION
Since D91009064 the proxygen listfile explicitly looks for `fizz` via the lowercase name, so help it find the installed CMake config.