### PR TITLE
Fix spammy -Winconsistent-override in HHVM

### DIFF
--- a/hphp/runtime/ext/reflection/ext_reflection.cpp
+++ b/hphp/runtime/ext/reflection/ext_reflection.cpp
@@ -2592,7 +2592,7 @@ struct ReflectionExtension final : Extension {
       ReflectionExtensionLoader::className());
   }
 
-  std::vector<std::string> hackFiles() const {
+  std::vector<std::string> hackFiles() const override {
     return {
       "ext_reflection.php",
       "ext_reflection-classes.php",

--- a/hphp/runtime/ext/vsdebug/ext_vsdebug.h
+++ b/hphp/runtime/ext/vsdebug/ext_vsdebug.h
@@ -37,7 +37,7 @@ struct VSDebugExtension final : Extension {
   void threadShutdown() override;
   bool moduleEnabled() const override { return m_enabled; }
 
-  std::vector<std::string> hackFiles() const { return {}; }
+  std::vector<std::string> hackFiles() const override { return {}; }
 
   static Debugger* getDebugger() {
     std::atomic_thread_fence(std::memory_order_acquire);

--- a/hphp/runtime/server/transport.h
+++ b/hphp/runtime/server/transport.h
@@ -165,7 +165,7 @@ public:
   /**
    * Request URI.
    */
-  virtual const char *getUrl() = 0;
+  virtual const char *getUrl() override = 0;
   virtual const char *getRemoteHost() = 0;
   virtual uint16_t getRemotePort() = 0;
   // The transport can override REMOTE_ADDR if it has one
@@ -220,7 +220,7 @@ public:
   /**
    * POST request's data.
    */
-  virtual const void *getPostData(size_t &size) = 0;
+  virtual const void *getPostData(size_t &size) override = 0;
   virtual bool hasMorePostData() { return false; }
   virtual const void *getMorePostData(size_t &size) { size = 0;return nullptr; }
   virtual bool getFiles(std::string& /*files*/) { return false; }
@@ -235,7 +235,7 @@ public:
   /**
    * Is this a GET, POST or anything?
    */
-  virtual Method getMethod() = 0;
+  virtual Method getMethod() override = 0;
   virtual const char *getExtendedMethod() { return nullptr;}
   const char *getMethodName() override;
 
@@ -394,7 +394,7 @@ public:
    *   foo/bar?x=1   command is "foo/bar"
    *   /foo/bar?x=1  command is "foo/bar"
    */
-  std::string getCommand();
+  std::string getCommand() override;
 
   /**
    * Get value of a parameter. Returns empty string is not present.


### PR DESCRIPTION
Newer LLVM introduces `-Winconsistent-override` which is quite noisy for a few frequently-included headers in HHVM. Fix occurrences.