### PR TITLE
upgrading tokio to 1.52.1

### DIFF
--- a/hphp/hack/src/Cargo.lock
+++ b/hphp/hack/src/Cargo.lock
@@ -5183,9 +5183,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
 dependencies = [
  "bytes",
  "pin-project-lite",


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookexperimental/dapper/pull/1

X-link: https://github.com/meta-pytorch/monarch/pull/3495

Upgrading `tokio` from `1.50.0` to `1.52.1`.
- All downstream consumers checked with arc rust-check — 0 errors.

Reviewed By: dtolnay

Differential Revision: D101580193
