### PR TITLE
Wire up autocomplete tests for OSS

### DIFF
--- a/hphp/hack/CMakeLists.txt
+++ b/hphp/hack/CMakeLists.txt
@@ -346,6 +346,7 @@ endif()
 add_custom_target(hack ALL DEPENDS hack_dune "${OPCODE_DATA}")
 add_custom_target(hack_test DEPENDS hack_dune_test "${OPCODE_DATA}")
 
+configure_file(hack_oss_dune_invoke.sh.in hack_oss_dune_invoke.sh ESCAPE_QUOTES @ONLY)
 configure_file(dev_env.sh.in dev_env.sh ESCAPE_QUOTES @ONLY)
 configure_file(dev_env_common.sh.in dev_env_common.sh ESCAPE_QUOTES @ONLY)
 configure_file(dev_env_rust_only.sh.in dev_env_rust_only.sh ESCAPE_QUOTES @ONLY)

--- a/hphp/hack/Makefile.dune
+++ b/hphp/hack/Makefile.dune
@@ -37,6 +37,7 @@ build-hack$(2):
 		src/hh_client.$(1) \
 		src/hh_single_ide_format.$(1) \
 		src/hh_single_type_check.$(1) \
+		src/hh_single_complete.$(1) \
 		src/hackfmt.$(1) \
 		src/hh_parse.$(1) \
 		src/generate_full_fidelity.$(1)

--- a/hphp/hack/hack_oss_dune_invoke.sh.in
+++ b/hphp/hack/hack_oss_dune_invoke.sh.in
@@ -1,0 +1,15 @@
+# Copyright (c) 2026, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the "hack" directory of this source tree.
+
+# This file is processed by cmake; the produced file is intended for both
+# internal usage by the build system, and for direct usage by people working on
+# Hack itself from CMake builds:
+#
+#  . $BUILD_DIR/hphp/hack/dev_env_rust_only.sh
+
+. "@CMAKE_CURRENT_BINARY_DIR@/dev_env_common.sh"
+
+opam exec -- dune "$@"

--- a/hphp/hack/src/dune
+++ b/hphp/hack/src/dune
@@ -84,6 +84,7 @@
  (libraries
   default_injector_config
   file_content
+  folly_stubs
   hh_single_common
   hhi
   search

--- a/hphp/hack/test/parse_errors.py
+++ b/hphp/hack/test/parse_errors.py
@@ -3,9 +3,8 @@
 
 import re
 from dataclasses import dataclass
+from enum import Enum
 from typing import IO, List, Tuple
-
-from python.migrations.py310 import StrEnum310
 
 
 @dataclass
@@ -28,9 +27,11 @@ class PositionedMessage:
     message: str
 
 
-class Severity(StrEnum310):
+class Severity(Enum):
     ERROR = "ERROR"
     WARNING = "WARN"
+    def __format__(self, spec) -> str:
+        return str.__format__(str(self.name), spec)
 
 
 @dataclass


### PR DESCRIPTION
Build `hh_single_complete` via Dune, and use an explicit enum format method in lieu of an FB-specific migration helper for parse_errors.py. Add a helper script that takes care of invoking Dune with the correct environment variables setup so that e.g. `_build/hphp/hack/hack_oss_dune_invoke.sh build @autocomplete` can be used to run autocomplete tests.