### PR TITLE
Fix clang-diagnostic-conditional-uninitialized errors (thrift)

### DIFF
--- a/third-party/thrift/src/thrift/lib/cpp2/async/RpcTypes.cpp
+++ b/third-party/thrift/src/thrift/lib/cpp2/async/RpcTypes.cpp
@@ -240,7 +240,7 @@ LegacySerializedResponse::extractPayload(
     bool includeEnvelope, int16_t protocolId, int32_t seqId) && {
   int32_t _;
   std::string methodName;
-  MessageType mtype;
+  MessageType mtype = MessageType::T_CALL;
 
   size_t headerSize{0};
   try {


### PR DESCRIPTION
Summary: In preparation for promoting conditional-uninitialized to a compiler error at Meta, this diff stack is resolving cases of this compiler warning in thrift.

Reviewed By: iahs

Differential Revision: D102849847


