### PR TITLE
Fix crash on shutdown if log sink couldn't be created

### DIFF
--- a/hphp/runtime/server/log-writer.cpp
+++ b/hphp/runtime/server/log-writer.cpp
@@ -51,7 +51,7 @@ std::string FieldGenerator::escapeData(const char* s, int len) {
 }
 
 ClassicWriter::~ClassicWriter() {
-  if (m_channel == LogChannel::REGULAR) {
+  if (m_filelog != nullptr && m_channel == LogChannel::REGULAR) {
     if (m_logdata.file[0] == '|') {
       pclose(m_filelog);
     } else {


### PR DESCRIPTION
Through a misconfiguration, we ended up in a situation where HHVM wasn't able to create its admin server log file. This caused a segfault on shutdown because `m_filelog` was a null pointer. Avoid crashing in this situation by not trying to close the log sink if it is `nullptr`.