### PR TITLE
Fix enum formatting in ext_watchman.cpp

### DIFF
--- a/hphp/runtime/ext/watchman/ext_watchman.cpp
+++ b/hphp/runtime/ext/watchman/ext_watchman.cpp
@@ -245,7 +245,7 @@ folly::dynamic makeDynamic(const HPHP::TypedValue& data) {
     default:
       SystemLib::throwInvalidOperationExceptionObject(fmt::format(
         "HPHP::Variant to folly::dynamic conversion failed! Got an "
-        "unconvertible Variant of type {}...", data.type()));
+        "unconvertible Variant of type {}...", fmt::underlying(data.type())));
   }
   not_reached();
 }


### PR DESCRIPTION
Meta's internal tooling does this automatically
but OSS needs some help when formatting types
that aren't formattable by default.