### PR TITLE
Fix some LLVM 22 errors and warnings in HHVM

### DIFF
--- a/hphp/runtime/vm/jit/prof-data-target-profile.h
+++ b/hphp/runtime/vm/jit/prof-data-target-profile.h
@@ -51,7 +51,7 @@ struct ProfDataTargetProfile {
 
 #define PR(T)                                                  \
  private:                                                      \
-  hphp_fast_map<const rds::Profile, T*, RdsProfileHasher, RdsProfileEquals> m_map ## T; \
+  hphp_fast_map<rds::Profile, T*, RdsProfileHasher, RdsProfileEquals> m_map ## T; \
                                                                \
  public:                                                       \
   void add(const rds::Profile& key, T* value) {                \

--- a/hphp/util/data-block.h
+++ b/hphp/util/data-block.h
@@ -67,8 +67,8 @@ struct DataBlockFull : std::runtime_error {
  */
 struct DataBlock {
   DataBlock() = default;
-  DataBlock(const DataBlock&) = default;
-  DataBlock& operator=(const DataBlock&) = default;
+  DataBlock(const DataBlock&) = delete;
+  DataBlock& operator=(const DataBlock&) = delete;
   DataBlock(DataBlock&& other) = default;
   DataBlock& operator=(DataBlock&& other) = default;
 


### PR DESCRIPTION
Avoid the following:
```
In file included from /home/vagrant/hhvm/hphp/hhvm/process-init.cpp:17:
In file included from /home/vagrant/hhvm/hphp/runtime/vm/bytecode.h:21:
In file included from /home/vagrant/hhvm/hphp/runtime/base/tv-arith.h:18:
In file included from /home/vagrant/hhvm/hphp/runtime/base/tv-mutate.h:22:
In file included from /home/vagrant/hhvm/hphp/runtime/base/tv-refcount.h:23:
In file included from /home/vagrant/hhvm/hphp/runtime/base/object-data.h:27:
In file included from /home/vagrant/hhvm/hphp/runtime/vm/class.h:23:
In file included from /home/vagrant/hhvm/hphp/runtime/base/tv-layout.h:22:
In file included from /home/vagrant/hhvm/hphp/runtime/base/vanilla-vec.h:31:
In file included from /home/vagrant/hhvm/hphp/runtime/vm/jit/vasm-emit.h:19:
In file included from /home/vagrant/hhvm/hphp/runtime/vm/jit/code-cache.h:22:
/home/vagrant/hhvm/hphp/util/data-block.h:70:3: warning: explicitly defaulted copy constructor is implicitly deleted [-Wdefaulted-function-deleted]
   70 |   DataBlock(const DataBlock&) = default;
      |   ^
/home/vagrant/hhvm/hphp/util/data-block.h:386:37: note: copy constructor of 'DataBlock' is implicitly deleted because field 'm_destBuf' has a deleted copy constructor
  386 |   std::unique_ptr<uint8_t, Deleter> m_destBuf{nullptr};
      |                                     ^
/usr/lib/llvm-22/bin/../include/c++/v1/__memory/unique_ptr.h:206:55: note: copy constructor is implicitly deleted because 'unique_ptr<unsigned char, HPHP::DataBlock::Deleter>' has a user-declared move constructor
  206 |   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX23 unique_ptr(unique_ptr&& __u) _NOEXCEPT
      |                                                       ^
/home/vagrant/hhvm/hphp/util/data-block.h:70:33: note: replace 'default' with 'delete'
   70 |   DataBlock(const DataBlock&) = default;
      |                                 ^~~~~~~
      |                                 delete
/home/vagrant/hhvm/hphp/util/data-block.h:71:14: warning: explicitly defaulted copy assignment operator is implicitly deleted [-Wdefaulted-function-deleted]
   71 |   DataBlock& operator=(const DataBlock&) = default;
      |              ^
/home/vagrant/hhvm/hphp/util/data-block.h:386:37: note: copy assignment operator of 'DataBlock' is implicitly deleted because field 'm_destBuf' has a deleted copy assignment operator
  386 |   std::unique_ptr<uint8_t, Deleter> m_destBuf{nullptr};
      |                                     ^
/usr/lib/llvm-22/bin/../include/c++/v1/__memory/unique_ptr.h:206:55: note: copy assignment operator is implicitly deleted because 'unique_ptr<unsigned char, HPHP::DataBlock::Deleter>' has a user-declared move constructor
  206 |   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX23 unique_ptr(unique_ptr&& __u) _NOEXCEPT
      |                                                       ^
/home/vagrant/hhvm/hphp/util/data-block.h:71:44: note: replace 'default' with 'delete'
   71 |   DataBlock& operator=(const DataBlock&) = default;
      |                                            ^~~~~~~
      |                                            delete
2 warnings generated.
```

and:

```
In file included from /home/vagrant/hhvm/hphp/runtime/vm/jit/tc-internal.cpp:17:
In file included from /home/vagrant/hhvm/hphp/runtime/vm/jit/tc-internal.h:19:
In file included from /home/vagrant/hhvm/hphp/runtime/vm/jit/tc.h:19:
In file included from /home/vagrant/hhvm/hphp/runtime/vm/func.h:19:
In file included from /home/vagrant/hhvm/hphp/runtime/base/attr.h:19:
In file included from /usr/lib/llvm-22/bin/../include/c++/v1/string:596:
In file included from /usr/lib/llvm-22/bin/../include/c++/v1/__algorithm/remove.h:12:
In file included from /usr/lib/llvm-22/bin/../include/c++/v1/__algorithm/find.h:24:
In file included from /usr/lib/llvm-22/bin/../include/c++/v1/__string/constexpr_c_functions.h:15:
/usr/lib/llvm-22/bin/../include/c++/v1/__memory/construct_at.h:37:17: error: static_cast from 'const HPHP::rds::Profile * _Nonnull' to 'void *' is not allowed
   37 |   return ::new (static_cast<void*>(__location)) _Tp(std::forward<_Args>(__args)...);
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/lib/llvm-22/bin/../include/c++/v1/__memory/construct_at.h:45:15: note: in instantiation of function template specialization 'std::construct_at<const HPHP::rds::Profile, const HPHP::rds::Profile &, const HPHP::rds::Profile *>' requested here
   45 |   return std::construct_at(__location, std::forward<_Args>(__args)...);
      |               ^
/usr/lib/llvm-22/bin/../include/c++/v1/__memory/allocator_traits.h:302:10: note: in instantiation of function template specialization 'std::__construct_at<const HPHP::rds::Profile, const HPHP::rds::Profile &, const HPHP::rds::Profile *>' requested here
  302 |     std::__construct_at(__p, std::forward<_Args>(__args)...);
      |          ^
/home/vagrant/hhvm-deps/installed/folly/include/folly/container/detail/Util.h:43:41: note: in instantiation of function template specialization 'std::allocator_traits<std::allocator<std::pair<const HPHP::rds::Profile, HPHP::jit::ArrayAccessProfile *>>>::construct<const HPHP::rds::Profile, const HPHP::rds::Profile &, 0>' requested here
   43 |           std::allocator_traits<Alloc>::construct(
      |                                         ^
/usr/lib/llvm-22/bin/../include/c++/v1/__type_traits/invoke.h:77:47: note: in instantiation of function template specialization 'folly::detail::TemporaryEmplaceKey<const HPHP::rds::Profile, std::allocator<std::pair<const HPHP::rds::Profile, HPHP::jit::ArrayAccessProfile *>>>::TemporaryEmplaceKey(std::allocator<std::pair<const HPHP::rds::Profile, HPHP::jit::ArrayAccessProfile *>> &, std::tuple<const HPHP::rds::Profile &> &&)::(lambda)::operator()<const HPHP::rds::Profile &>' requested here
   77 | struct __invoke_result_impl<__void_t<decltype(__builtin_invoke(std::declval<_Args>()...))>, _Args...> {
      |                                               ^
/usr/lib/llvm-22/bin/../include/c++/v1/__type_traits/invoke.h:85:1: note: during template argument deduction for class template partial specialization '__invoke_result_impl<__void_t<decltype(__builtin_invoke(std::declval<_Args>()...))>, _Args...>' [with _Args = <(lambda at /home/vagrant/hhvm-deps/installed/folly/include/folly/container/detail/Util.h:42:9), const HPHP::rds::Profile &>]
   85 | using __invoke_result_t _LIBCPP_NODEBUG = typename __invoke_result<_Args...>::type;
      | ^
/usr/lib/llvm-22/bin/../include/c++/v1/__type_traits/invoke.h:85:1: note: (skipping 4 contexts in backtrace; use -ftemplate-backtrace-limit=0 to see all)
/usr/lib/llvm-22/bin/../include/c++/v1/tuple:1404:34: note: in instantiation of function template specialization 'std::__apply_tuple_impl<(lambda at /home/vagrant/hhvm-deps/installed/folly/include/folly/container/detail/Util.h:42:9), std::tuple<const HPHP::rds::Profile &>, 0UL>' requested here
 1404 |     _LIBCPP_NOEXCEPT_RETURN(std::__apply_tuple_impl(
      |                                  ^
/usr/lib/llvm-22/bin/../include/c++/v1/tuple:1393:27: note: expanded from macro '_LIBCPP_NOEXCEPT_RETURN'
 1393 |         noexcept(noexcept(__VA_ARGS__)) { return __VA_ARGS__; }
      |                           ^
/usr/lib/llvm-22/bin/../include/c++/v1/tuple:1403:55: note: in instantiation of exception specification for 'apply<(lambda at /home/vagrant/hhvm-deps/installed/folly/include/folly/container/detail/Util.h:42:9), std::tuple<const HPHP::rds::Profile &>>' requested here
 1403 | inline _LIBCPP_HIDE_FROM_ABI constexpr decltype(auto) apply(_Fn&& __f, _Tuple&& __t)
      |                                                       ^
/home/vagrant/hhvm-deps/installed/folly/include/folly/container/detail/Util.h:41:5: note: in instantiation of function template specialization 'std::apply<(lambda at /home/vagrant/hhvm-deps/installed/folly/include/folly/container/detail/Util.h:42:9), std::tuple<const HPHP::rds::Profile &>>' requested here
   41 |     apply(
      |     ^
/home/vagrant/hhvm-deps/installed/folly/include/folly/container/detail/Util.h:178:39: note: in instantiation of function template specialization 'folly::detail::TemporaryEmplaceKey<const HPHP::rds::Profile, std::allocator<std::pair<const HPHP::rds::Profile, HPHP::jit::ArrayAccessProfile *>>>::TemporaryEmplaceKey<const HPHP::rds::Profile &>' requested here
  178 |   TemporaryEmplaceKey<KeyType, Alloc> key(
      |                                       ^
/home/vagrant/hhvm/hphp/runtime/vm/jit/prof-data-target-profile.h:60:3: note: in instantiation of function template specialization 'folly::f14::detail::F14BasicMap<folly::f14::detail::VectorContainerPolicy<const HPHP::rds::Profile, HPHP::jit::ArrayAccessProfile *, HPHP::jit::ProfDataTargetProfile::RdsProfileHasher, HPHP::jit::ProfDataTargetProfile::RdsProfileEquals, void, std::integral_constant<bool, true>>>::emplace<const HPHP::rds::Profile &, HPHP::jit::ArrayAccessProfile *&>' requested here
   60 |   RDS_PROFILE_SYMBOLS
      |   ^
/home/vagrant/hhvm/hphp/runtime/base/rds-symbol.h:97:3: note: expanded from macro 'RDS_PROFILE_SYMBOLS'
   97 |   PR(ArrayAccessProfile)  \
      |   ^
/home/vagrant/hhvm/hphp/runtime/vm/jit/prof-data-target-profile.h:58:14: note: expanded from macro 'PR'
   58 |     m_map##T.emplace(key, value);                              \
      |              ^
1 error generated.
```