### PR TITLE
Mark debug-only field as [[maybe_unused]]

### DIFF
--- a/hphp/util/extern-worker-detail.h
+++ b/hphp/util/extern-worker-detail.h
@@ -101,7 +101,7 @@ private:
   }
 
   Clock::time_point m_begin;
-  const char* m_msg;
+  [[maybe_unused]] const char* m_msg;
   std::string m_str;
 
   TRACE_SET_MOD(extern_worker)


### PR DESCRIPTION
`m_msg` is only used in debug builds and causes warnings to be logged during release builds, so tell the compiler it's fine if it's unused.