### PR TITLE
refresh 10 crates to latest compatible versions

### DIFF
--- a/hphp/hack/src/Cargo.lock
+++ b/hphp/hack/src/Cargo.lock
@@ -405,9 +405,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 dependencies = [
  "serde_core",
 ]
@@ -470,9 +470,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "byte-unit"
@@ -588,9 +588,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.62"
+version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
+checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -643,9 +643,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -2987,9 +2987,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "memmap2"
@@ -4467,9 +4467,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "shmffi"
@@ -5250,9 +5250,9 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.13.2"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-width"
@@ -5865,18 +5865,18 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/hphp/hack/src/arena_collections/Cargo.toml
+++ b/hphp/hack/src/arena_collections/Cargo.toml
@@ -13,7 +13,7 @@ path = "lib.rs"
 [dependencies]
 arena_deserializer = { version = "0.0.0", path = "../utils/arena_deserializer" }
 arena_trait = { version = "0.0.0", path = "../arena_trait" }
-bumpalo = { version = "3.20.2", features = ["allocator_api", "collections"] }
+bumpalo = { version = "3.20.3", features = ["allocator_api", "collections"] }
 ocamlrep = { version = "0.1.0", git = "https://github.com/facebook/ocamlrep/", branch = "main" }
 serde = { version = "1.0.219", features = ["derive", "rc"] }
 

--- a/hphp/hack/src/arena_trait/Cargo.toml
+++ b/hphp/hack/src/arena_trait/Cargo.toml
@@ -11,4 +11,4 @@ license = "MIT"
 path = "lib.rs"
 
 [dependencies]
-bumpalo = { version = "3.20.2", features = ["allocator_api", "collections"] }
+bumpalo = { version = "3.20.3", features = ["allocator_api", "collections"] }

--- a/hphp/hack/src/elab/Cargo.toml
+++ b/hphp/hack/src/elab/Cargo.toml
@@ -12,7 +12,7 @@ path = "elab.rs"
 edition = "2021"
 
 [dependencies]
-bitflags = { version = "2.11.1", features = ["serde", "std"], default-features = false }
+bitflags = { version = "2.13.0", features = ["serde", "std"], default-features = false }
 bstr = { version = "1.10.0", features = ["serde", "std", "unicode"] }
 elaborate_namespaces_visitor = { version = "0.0.0", path = "../naming/cargo/elaborate_namespaces" }
 hack_macros = { version = "0.0.0", path = "../utils/hack_macros/cargo/hack_macros" }

--- a/hphp/hack/src/hackc/Cargo.toml
+++ b/hphp/hack/src/hackc/Cargo.toml
@@ -16,7 +16,7 @@ aast_parser = { version = "0.0.0", path = "../parser/cargo/aast_parser" }
 anyhow = "1.0.102"
 assemble = { version = "0.0.0", path = "cargo/assemble" }
 bc_to_ir = { version = "0.0.0", path = "ir/conversions/bc_to_ir" }
-bumpalo = { version = "3.20.2", features = ["allocator_api", "collections"] }
+bumpalo = { version = "3.20.3", features = ["allocator_api", "collections"] }
 byte-unit = { version = "5.2.0", features = ["default", "u128"] }
 bytecode_printer = { version = "0.0.0", path = "bytecode_printer" }
 clap = { version = "4.6.0", features = ["derive", "env", "string", "unicode", "wrap_help"] }

--- a/hphp/hack/src/hackc/emitter/cargo/emit_unit/Cargo.toml
+++ b/hphp/hack/src/hackc/emitter/cargo/emit_unit/Cargo.toml
@@ -14,7 +14,7 @@ path = "../../emit_unit.rs"
 ast_scope = { version = "0.0.0", path = "../ast_scope" }
 bit-set = "0.9"
 bit-vec = "0.9"
-bitflags = { version = "2.11.1", features = ["serde", "std"], default-features = false }
+bitflags = { version = "2.13.0", features = ["serde", "std"], default-features = false }
 bstr = { version = "1.10.0", features = ["serde", "std", "unicode"] }
 constant_folder = { version = "0.0.0", path = "../constant_folder" }
 core_utils_rust = { version = "0.0.0", path = "../../../../utils/core" }

--- a/hphp/hack/src/hackc/emitter/cargo/env/Cargo.toml
+++ b/hphp/hack/src/hackc/emitter/cargo/env/Cargo.toml
@@ -12,7 +12,7 @@ path = "../../env.rs"
 
 [dependencies]
 ast_scope = { version = "0.0.0", path = "../ast_scope" }
-bitflags = { version = "2.11.1", features = ["serde", "std"], default-features = false }
+bitflags = { version = "2.13.0", features = ["serde", "std"], default-features = false }
 decl_provider = { version = "0.0.0", path = "../../../decl_provider" }
 global_state = { version = "0.0.0", path = "../global_state" }
 hhbc = { version = "0.0.0", path = "../../../hhbc/cargo/hhbc" }

--- a/hphp/hack/src/hackc/hhbc/cargo/hhbc/Cargo.toml
+++ b/hphp/hack/src/hackc/hhbc/cargo/hhbc/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT"
 path = "../../lib.rs"
 
 [dependencies]
-bitflags = { version = "2.11.1", features = ["serde"], default-features = false }
+bitflags = { version = "2.13.0", features = ["serde"], default-features = false }
 bstr = { version = "1.10.0", features = ["serde", "std", "unicode"] }
 emit_opcodes_macro = { version = "0.0.0", path = "../emit_opcodes_macro" }
 ffi = { version = "0.0.0", path = "../../../ffi/ffi" }

--- a/hphp/hack/src/hackrs/pos/cargo/pos/Cargo.toml
+++ b/hphp/hack/src/hackrs/pos/cargo/pos/Cargo.toml
@@ -13,7 +13,7 @@ path = "../../pos.rs"
 [dependencies]
 arena_trait = { version = "0.0.0", path = "../../../../arena_trait" }
 bstr = { version = "1.10.0", features = ["serde", "std", "unicode"] }
-bumpalo = { version = "3.20.2", features = ["allocator_api", "collections"] }
+bumpalo = { version = "3.20.3", features = ["allocator_api", "collections"] }
 eq_modulo_pos = { version = "0.0.0", path = "../../../../utils/eq_modulo_pos" }
 hh24_types = { version = "0.0.0", path = "../../../../utils/hh24_types" }
 indexmap = { version = "2.14.0", features = ["arbitrary", "rayon", "serde"] }

--- a/hphp/hack/src/oxidized/Cargo.toml
+++ b/hphp/hack/src/oxidized/Cargo.toml
@@ -15,9 +15,9 @@ ansi_term = "0.12"
 anyhow = "1.0.102"
 arena_deserializer = { version = "0.0.0", path = "../utils/arena_deserializer" }
 arena_trait = { version = "0.0.0", path = "../arena_trait" }
-bitflags = { version = "2.11.1", features = ["serde", "std"], default-features = false }
+bitflags = { version = "2.13.0", features = ["serde", "std"], default-features = false }
 bstr = { version = "1.10.0", features = ["serde", "std", "unicode"] }
-bumpalo = { version = "3.20.2", features = ["allocator_api", "collections"] }
+bumpalo = { version = "3.20.3", features = ["allocator_api", "collections"] }
 eq_modulo_pos = { version = "0.0.0", path = "../utils/eq_modulo_pos" }
 file_info = { version = "0.0.0", path = "../deps/rust/file_info" }
 hash = { version = "0.0.0", path = "../utils/hash" }

--- a/hphp/hack/src/parser/api/cargo/decl_mode_parser/Cargo.toml
+++ b/hphp/hack/src/parser/api/cargo/decl_mode_parser/Cargo.toml
@@ -13,6 +13,6 @@ test = false
 doctest = false
 
 [dependencies]
-bumpalo = { version = "3.20.2", features = ["allocator_api", "collections"] }
+bumpalo = { version = "3.20.3", features = ["allocator_api", "collections"] }
 decl_mode_smart_constructors = { version = "0.0.0", path = "../../../cargo/decl_mode_parser" }
 parser = { version = "0.0.0", path = "../../../core" }

--- a/hphp/hack/src/parser/api/cargo/positioned_by_ref_parser/Cargo.toml
+++ b/hphp/hack/src/parser/api/cargo/positioned_by_ref_parser/Cargo.toml
@@ -13,6 +13,6 @@ test = false
 doctest = false
 
 [dependencies]
-bumpalo = { version = "3.20.2", features = ["allocator_api", "collections"] }
+bumpalo = { version = "3.20.3", features = ["allocator_api", "collections"] }
 parser = { version = "0.0.0", path = "../../../core" }
 positioned_smart_constructors = { version = "0.0.0", path = "../../../cargo/positioned_smart_constructors" }

--- a/hphp/hack/src/parser/api/cargo/positioned_full_trivia_parser/Cargo.toml
+++ b/hphp/hack/src/parser/api/cargo/positioned_full_trivia_parser/Cargo.toml
@@ -13,7 +13,7 @@ test = false
 doctest = false
 
 [dependencies]
-bumpalo = { version = "3.20.2", features = ["allocator_api", "collections"] }
+bumpalo = { version = "3.20.3", features = ["allocator_api", "collections"] }
 full_fidelity_schema_version_number = { version = "0.0.0", path = "../../../schema" }
 parser = { version = "0.0.0", path = "../../../core" }
 positioned_smart_constructors = { version = "0.0.0", path = "../../../cargo/positioned_smart_constructors" }

--- a/hphp/hack/src/parser/cargo/aast_parser/Cargo.toml
+++ b/hphp/hack/src/parser/cargo/aast_parser/Cargo.toml
@@ -11,8 +11,8 @@ license = "MIT"
 path = "../../aast_parser_lib.rs"
 
 [dependencies]
-bitflags = { version = "2.11.1", features = ["serde", "std"], default-features = false }
-bumpalo = { version = "3.20.2", features = ["allocator_api", "collections"] }
+bitflags = { version = "2.13.0", features = ["serde", "std"], default-features = false }
+bumpalo = { version = "3.20.3", features = ["allocator_api", "collections"] }
 core_utils_rust = { version = "0.0.0", path = "../../../utils/core" }
 decl_mode_parser = { version = "0.0.0", path = "../../api/cargo/decl_mode_parser" }
 hash = { version = "0.0.0", path = "../../../utils/hash" }

--- a/hphp/hack/src/parser/cargo/core_types/Cargo.toml
+++ b/hphp/hack/src/parser/cargo/core_types/Cargo.toml
@@ -11,8 +11,8 @@ license = "MIT"
 path = "../../parser_core_types_lib.rs"
 
 [dependencies]
-bitflags = { version = "2.11.1", features = ["serde", "std"], default-features = false }
-bumpalo = { version = "3.20.2", features = ["allocator_api", "collections"] }
+bitflags = { version = "2.13.0", features = ["serde", "std"], default-features = false }
+bumpalo = { version = "3.20.3", features = ["allocator_api", "collections"] }
 itertools = "0.14.0"
 line_break_map = { version = "0.0.0", path = "../../../utils/line_break_map" }
 ocaml_helper = { version = "0.0.0", path = "../../../utils/ocaml_helper" }

--- a/hphp/hack/src/parser/cargo/decl_mode_parser/Cargo.toml
+++ b/hphp/hack/src/parser/cargo/decl_mode_parser/Cargo.toml
@@ -13,7 +13,7 @@ test = false
 doctest = false
 
 [dependencies]
-bumpalo = { version = "3.20.2", features = ["allocator_api", "collections"] }
+bumpalo = { version = "3.20.3", features = ["allocator_api", "collections"] }
 ocamlrep = { version = "0.1.0", git = "https://github.com/facebook/ocamlrep/", branch = "main" }
 parser_core_types = { version = "0.0.0", path = "../core_types" }
 smart_constructors = { version = "0.0.0", path = "../smart_constructors" }

--- a/hphp/hack/src/parser/cargo/mode_parser/Cargo.toml
+++ b/hphp/hack/src/parser/cargo/mode_parser/Cargo.toml
@@ -11,6 +11,6 @@ license = "MIT"
 path = "../../mode_parser.rs"
 
 [dependencies]
-bumpalo = { version = "3.20.2", features = ["allocator_api", "collections"] }
+bumpalo = { version = "3.20.3", features = ["allocator_api", "collections"] }
 parser_core_types = { version = "0.0.0", path = "../core_types" }
 positioned_by_ref_parser = { version = "0.0.0", path = "../../api/cargo/positioned_by_ref_parser" }

--- a/hphp/hack/src/parser/cargo/rust_parser_errors_ffi/Cargo.toml
+++ b/hphp/hack/src/parser/cargo/rust_parser_errors_ffi/Cargo.toml
@@ -14,7 +14,7 @@ doctest = false
 crate-type = ["lib", "staticlib"]
 
 [dependencies]
-bumpalo = { version = "3.20.2", features = ["allocator_api", "collections"] }
+bumpalo = { version = "3.20.3", features = ["allocator_api", "collections"] }
 ocamlrep = { version = "0.1.0", git = "https://github.com/facebook/ocamlrep/", branch = "main" }
 ocamlrep_ocamlpool = { version = "0.1.0", git = "https://github.com/facebook/ocamlrep/", branch = "main" }
 oxidized = { version = "0.0.0", path = "../../../oxidized" }

--- a/hphp/hack/src/parser/cargo/rust_parser_ffi/Cargo.toml
+++ b/hphp/hack/src/parser/cargo/rust_parser_ffi/Cargo.toml
@@ -14,7 +14,7 @@ doctest = false
 crate-type = ["lib", "staticlib"]
 
 [dependencies]
-bumpalo = { version = "3.20.2", features = ["allocator_api", "collections"] }
+bumpalo = { version = "3.20.3", features = ["allocator_api", "collections"] }
 mode_parser = { version = "0.0.0", path = "../mode_parser" }
 ocamlrep = { version = "0.1.0", git = "https://github.com/facebook/ocamlrep/", branch = "main" }
 ocamlrep_ocamlpool = { version = "0.1.0", git = "https://github.com/facebook/ocamlrep/", branch = "main" }

--- a/hphp/hack/src/parser/ffi_bridge/Cargo.toml
+++ b/hphp/hack/src/parser/ffi_bridge/Cargo.toml
@@ -14,7 +14,7 @@ doctest = false
 crate-type = ["lib", "staticlib"]
 
 [dependencies]
-bumpalo = { version = "3.20.2", features = ["allocator_api", "collections"] }
+bumpalo = { version = "3.20.3", features = ["allocator_api", "collections"] }
 cxx = "1.0.194"
 parser_core_types = { version = "0.0.0", path = "../cargo/core_types" }
 positioned_full_trivia_parser = { version = "0.0.0", path = "../api/cargo/positioned_full_trivia_parser" }

--- a/hphp/hack/src/parser/lowerer/Cargo.toml
+++ b/hphp/hack/src/parser/lowerer/Cargo.toml
@@ -12,7 +12,7 @@ path = "lib.rs"
 
 [dependencies]
 bstr = { version = "1.10.0", features = ["serde", "std", "unicode"] }
-bumpalo = { version = "3.20.2", features = ["allocator_api", "collections"] }
+bumpalo = { version = "3.20.3", features = ["allocator_api", "collections"] }
 escaper = { version = "0.0.0", path = "../../utils/escaper" }
 hash = { version = "0.0.0", path = "../../utils/hash" }
 hhbc_string_utils = { version = "0.0.0", path = "../../hackc/utils/cargo/hhbc_string_utils" }

--- a/hphp/hack/src/utils/arena_deserializer/Cargo.toml
+++ b/hphp/hack/src/utils/arena_deserializer/Cargo.toml
@@ -12,6 +12,6 @@ path = "lib.rs"
 
 [dependencies]
 bstr = { version = "1.10.0", features = ["serde", "std", "unicode"] }
-bumpalo = { version = "3.20.2", features = ["allocator_api", "collections"] }
+bumpalo = { version = "3.20.3", features = ["allocator_api", "collections"] }
 ocamlrep_caml_builtins = { version = "0.1.0", git = "https://github.com/facebook/ocamlrep/", branch = "main" }
 serde = { version = "1.0.219", features = ["derive", "rc"] }

--- a/hphp/hack/src/utils/escaper/Cargo.toml
+++ b/hphp/hack/src/utils/escaper/Cargo.toml
@@ -12,7 +12,7 @@ path = "../escaper.rs"
 
 [dependencies]
 bstr = { version = "1.10.0", features = ["serde", "std", "unicode"] }
-bumpalo = { version = "3.20.2", features = ["allocator_api", "collections"] }
+bumpalo = { version = "3.20.3", features = ["allocator_api", "collections"] }
 
 [dev-dependencies]
 pretty_assertions = { version = "1.4.1", features = ["alloc"], default-features = false }

--- a/hphp/hack/src/utils/hh_slog/cargo/hh_slog/Cargo.toml
+++ b/hphp/hack/src/utils/hh_slog/cargo/hh_slog/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT"
 path = "../../hh_slog.rs"
 
 [dependencies]
-chrono = { version = "0.4.44", features = ["clock", "serde", "std"], default-features = false }
+chrono = { version = "0.4.45", features = ["clock", "serde", "std"], default-features = false }
 locked_file_drain = { version = "0.0.0", path = "../locked_file_drain" }
 slog = { version = "2.8.2", features = ["max_level_trace", "nested-values"] }
 slog-async = { version = "2.8.0", features = ["nested-values"] }

--- a/hphp/hack/src/utils/test/arena_deserializer/Cargo.toml
+++ b/hphp/hack/src/utils/test/arena_deserializer/Cargo.toml
@@ -13,7 +13,7 @@ path = "lib.rs"
 [dev-dependencies]
 arena_deserializer = { version = "0.0.0", path = "../../arena_deserializer" }
 bstr = { version = "1.10.0", features = ["serde", "std", "unicode"] }
-bumpalo = { version = "3.20.2", features = ["allocator_api", "collections"] }
+bumpalo = { version = "3.20.3", features = ["allocator_api", "collections"] }
 relative_path = { version = "0.0.0", path = "../../rust/relative_path" }
 serde = { version = "1.0.219", features = ["derive", "rc"] }
 serde_json = { version = "1.0.140", features = ["alloc", "float_roundtrip", "raw_value", "unbounded_depth"] }

--- a/hphp/tools/hhbc-gen/Cargo.toml
+++ b/hphp/tools/hhbc-gen/Cargo.toml
@@ -11,10 +11,10 @@ license = "MIT"
 path = "hhbc.rs"
 
 [dependencies]
-bitflags = { version = "2.11.1", features = ["serde", "std"], default-features = false }
+bitflags = { version = "2.13.0", features = ["serde", "std"], default-features = false }
 maplit = "1.0"
 once_cell = "1.21.4"
 
 [build-dependencies]
 anyhow = "1.0.102"
-cc = "1.2.62"
+cc = "1.2.63"

--- a/third-party/thrift/src/thrift/lib/rust/Cargo.toml
+++ b/third-party/thrift/src/thrift/lib/rust/Cargo.toml
@@ -18,7 +18,7 @@ bytes = { version = "1.11.1", features = ["serde"] }
 clap = { version = "4.6.0", features = ["derive", "env", "string", "unicode", "wrap_help"] }
 futures = { version = "0.3.31", features = ["async-await", "compat"] }
 ghost = "0.1.21"
-memchr = "2.8.0"
+memchr = "2.8.1"
 num-derive = "0.4.2"
 num-traits = { version = "0.2.19", default-features = false }
 ordered-float = { version = "4.6.0", features = ["serde"] }


### PR DESCRIPTION
Summary:
X-link: https://github.com/meta-pytorch/monarch/pull/4193

Refreshes 10 third-party Rust crates to their latest semver-compatible versions. These are dependencies used by the hzdb/metavr CLI (`arvr/apps/hzdb`) that were behind in the shared lockfile; the bumps apply repo-wide since `third-party/rust` is shared.

- `bitflags` `2.11.1` -> `2.13.0`
- `bumpalo` `3.20.2` -> `3.20.3`
- `cc` `1.2.62` -> `1.2.63` (additively vendors `shlex` `2.0.1` as a new transitive of `cc`)
- `chrono` `0.4.44` -> `0.4.45`
- `http` `1.4.0` -> `1.4.1`
- `hyper` `1.9.0` -> `1.10.1`
- `memchr` `2.8.0` -> `2.8.1`
- `reqwest` `0.13.2` -> `0.13.4`
- `unicode-segmentation` `1.13.2` -> `1.13.3`
- `zerocopy` `0.8.48` -> `0.8.50`

All are patch/minor (semver-compatible) bumps requiring no first-party code changes. Mirrored the applicable bumps into the github shim manifest (`fbcode/github/standard/shim/third-party/rust/Cargo.toml`) for `bitflags`, `bumpalo`, `chrono`, `http`, `hyper`, `memchr`, and `unicode-segmentation`. Regenerated with `reindeer vendor`, which also refreshed 255 first-party `Cargo.toml` manifests via autocargo. No first-party Rust source changes were needed.

Differential Revision: D107740437
