### PR TITLE
Fix indirect fixup handling on aarch64 via frame-pointer-anchored scan

### DIFF
--- a/hphp/runtime/vm/jit/fixup.cpp
+++ b/hphp/runtime/vm/jit/fixup.cpp
@@ -21,6 +21,7 @@
 
 #include "hphp/runtime/vm/jit/tc.h"
 
+#include "hphp/util/arch.h"
 #include "hphp/util/configs/jit.h"
 
 TRACE_SET_MOD(fixup)
@@ -125,7 +126,33 @@ bool getFrameRegs(VMFrame frame, VMRegs* outVMRegs) {
   if (fixup->isIndirect()) {
     auto const ar = frame.m_prevCfa - kNativeFrameSize;
     TRACE(3, "getFrameRegs: fp %p -> %s\n", (void*) ar, fixup->show().c_str());
-    auto const ripAddr = ar + fixup->ripOffset();
+    auto ripAddr = ar + fixup->ripOffset();
+
+    // On aarch64, clang release builds may allocate locals above the frame record,
+    // which causes the CFA-relative %rip offset of indirect fixups to be incorrect,
+    // as they assume that the CFA = fp + kNativeFrameSize.
+    // Since the fixup is tied to the VM frame we already hold,
+    // scan further up the stack looking for the first ActRec-shaped slot with a matching
+    // `m_sfp` whose `m_savedRip` resolves to a valid, non-indirect fixup.
+    // If the frame does happen to be immediately preceded by the prior frame,
+    // this just matches at the very first candidate.
+    if constexpr (arch::any<arch::ARM>()) {
+      auto const stackEnd = s_stackLimit + s_stackSize;
+      while (ripAddr < stackEnd) {
+        auto const sfpSlot = ripAddr - AROFF(m_savedRip) + AROFF(m_sfp);
+        if (*reinterpret_cast<ActRec**>(sfpSlot) == frame.m_actRec) {
+          auto const candidate = *reinterpret_cast<TCA*>(ripAddr);
+          auto const maybeFixup = s_fixups.find(tc::addrToOffset(candidate));
+          if (maybeFixup && !maybeFixup->isIndirect()) {
+            break;
+          }
+        }
+        ripAddr += sizeof(uintptr_t);
+      }
+      always_assert(ripAddr < stackEnd &&
+                    "Could not locate stub frame for indirect fixup");
+    }
+
     tca = *reinterpret_cast<TCA*>(ripAddr);
     extraSpOffset = fixup->spOffset();
     fixup = s_fixups.find(tc::addrToOffset(tca));


### PR DESCRIPTION
Running `hhvm hphp/test/quick/dv.php` on aarch64 with HHVM compiled in release mode consistently segfaults while syncing the VM state prior to producing a backtrace for a Hack exception (see gist).[1]

The crash happens because fixupWork assumes that aligned native frames directly follow one another as it traverses the chain of frame pointers while looking for the first VM frame, so it ends up using an incorrect CFA for the reconstructed VM frame. But since https://reviews.llvm.org/D65653, clang in release builds may decide to place locals above the frame record, breaking this assumption, as foretold in D29878492.

I tried switching this logic to use the unwinder in D92892655 but that proved to be prohibitively unperformant. However, since we know that the target of the indirect fixup is associated with the first VM frame which is also the next frame, we can scan the stack upwards looking for the first ActRec whose `m_sfp` matches the stored FP for that frame and whose `m_savedRip` resolves to a valid non-indirect fixup. For unpadded frames this just stops on the first iteration step.

[1] https://gist.github.com/mszabo-wikia/187833ee32cd5b6f4efa8bd987a66cd4