### PR TITLE
Add fast nanosecond-resolution per-thread CPU timer

### DIFF
--- a/CMake/HPHPFindLibs.cmake
+++ b/CMake/HPHPFindLibs.cmake
@@ -431,6 +431,10 @@ if (ENABLE_MCROUTER)
   find_package(mcrouter CONFIG REQUIRED)
 endif()
 
+if (TEST_BIN)
+  find_package(GTest REQUIRED)
+endif()
+
 include_directories(${HPHP_HOME}/hphp)
 
 macro(hphp_link target)

--- a/hphp/util/CMakeLists.txt
+++ b/hphp/util/CMakeLists.txt
@@ -81,3 +81,7 @@ endif()
 
 # Allow accessing unstable zstd APIs.
 target_compile_definitions(hphp_util PUBLIC ZSTD_STATIC_LINKING_ONLY)
+
+if (TEST_BIN)
+  add_subdirectory(test)
+endif()

--- a/hphp/util/perf-cputime-ns.cpp
+++ b/hphp/util/perf-cputime-ns.cpp
@@ -1,0 +1,220 @@
+/*
+   +----------------------------------------------------------------------+
+   | HipHop for PHP                                                       |
+   +----------------------------------------------------------------------+
+   | Copyright (c) 2010-present Facebook, Inc. (http://www.facebook.com)  |
+   +----------------------------------------------------------------------+
+   | This source file is subject to version 3.01 of the PHP license,      |
+   | that is bundled with this package in the file LICENSE, and is        |
+   | available through the world-wide-web at the following url:           |
+   | http://www.php.net/license/3_01.txt                                  |
+   | If you did not receive a copy of the PHP license and are unable to   |
+   | obtain it through the world-wide-web, please send a note to          |
+   | license@php.net so we can mail you a copy immediately.               |
+   +----------------------------------------------------------------------+
+*/
+
+#include "hphp/util/perf-cputime-ns.h"
+
+#ifndef HHVM_FACEBOOK
+
+/*
+ * On Linux we can read CLOCK_THREAD_CPUTIME_ID entirely in userspace via the
+ * perf_events interface.  This requires a CPU whose cycle counter we know how
+ * to read (see cpuCycles() in cycles.h) and a kernel new enough to advertise
+ * userspace timekeeping (cap_user_time); we report failure otherwise so the
+ * caller falls back to clock_gettime().
+ */
+#if defined(__linux__) && (defined(__x86_64__) || defined(__aarch64__))
+#define HHVM_USE_PERF_THREAD_CPUTIME 1
+#endif
+
+#ifdef HHVM_USE_PERF_THREAD_CPUTIME
+
+#include <errno.h>
+#include <fcntl.h>
+#include <asm/unistd.h>
+#include <linux/perf_event.h>
+
+#include <folly/String.h>
+#include <folly/portability/SysMman.h>
+#include <folly/portability/Unistd.h>
+#include <folly/system/AtFork.h>
+
+#include "hphp/util/alloc-defs.h"
+#include "hphp/util/cycles.h"
+#include "hphp/util/logger.h"
+#include "hphp/util/safe-cast.h"
+
+namespace HPHP {
+namespace {
+///////////////////////////////////////////////////////////////////////////////
+// Userspace CLOCK_THREAD_CPUTIME_ID via perf_events.
+//
+// We open a PERF_COUNT_SW_TASK_CLOCK software event scoped to the calling
+// thread.  Its `time_enabled` field, exposed on the mmap'd perf_event_mmap_page,
+// is the thread's accumulated on-CPU time in nanoseconds.  When the kernel
+// advertises cap_user_time, the page also exports the constants needed to
+// project that value forward to "now" using the raw cycle counter -- exactly as
+// the kernel does internally -- so we can compute the current thread CPU time
+// without a syscall.  This mirrors the read loop in hardware-counter.cpp.
+
+// Compiler/CPU barrier bracketing the seqlock read, matching the one in
+// hardware-counter.cpp.  x86_64 is strongly ordered so a compiler barrier
+// suffices; aarch64 needs an explicit memory barrier.
+#if defined(__x86_64__)
+#define perf_barrier() __asm__ volatile("" ::: "memory")
+#elif defined(__aarch64__)
+#define perf_barrier() asm volatile("dmb ish" ::: "memory")
+#endif
+
+// Per-thread perf state.  m_fd < 0 means "not yet initialized"; m_meta == null
+// after init means the fast path is unavailable and we should use the syscall.
+struct PerfThreadClock {
+  ~PerfThreadClock() {
+    if (m_meta) {
+      munmap(m_meta, s_pageSize);
+      folly::AtFork::unregisterHandler(this);
+    }
+    if (m_fd >= 0) ::close(m_fd);
+  }
+
+  // Lazily open the event and map its page.  Returns the page on success, or
+  // nullptr if the fast path is unavailable (and won't become available).
+  perf_event_mmap_page* init() {
+    if (m_fd >= 0) return m_meta;
+
+    perf_event_attr pe{};
+    pe.type = PERF_TYPE_SOFTWARE;
+    pe.config = PERF_COUNT_SW_TASK_CLOCK;
+    pe.size = sizeof(pe);
+    // Exclude nothing: CLOCK_THREAD_CPUTIME_ID counts both user and kernel
+    // time spent on behalf of the thread.
+
+    // pid == 0 -> calling thread, cpu == -1 -> follow it across CPUs.
+    auto const ret = syscall(__NR_perf_event_open, &pe, 0, -1, -1, PERF_FLAG_FD_CLOEXEC);
+    if (ret < 0) {
+      Logger::Verbose("perf thread clock: perf_event_open failed with: %s",
+                      folly::errnoStr(errno).c_str());
+      // Leave m_fd >= 0 so we don't retry the syscall on every read.
+      m_fd = kDisabled;
+      return nullptr;
+    }
+    m_fd = safe_cast<int>(ret);
+
+    auto const base = mmap(nullptr, s_pageSize, PROT_READ, MAP_SHARED, m_fd, 0);
+    if (base == MAP_FAILED) {
+      Logger::Verbose("perf thread clock: failed to mmap perf_event: %s",
+                      folly::errnoStr(errno).c_str());
+      return nullptr;
+    }
+    auto const meta = static_cast<perf_event_mmap_page*>(base);
+
+    // Reset resources in fork()'d children.
+    folly::AtFork::registerHandler(
+      this,
+      // prepare
+      {},
+      // parent
+      {},
+      // child
+      [this](){
+        m_fd = -1;
+        m_meta = nullptr;
+      }
+    );
+
+    // Without cap_user_time the kernel won't give us the constants to
+    // extrapolate from the cycle counter; the page is useless to us.
+    if (!meta->cap_user_time) {
+      Logger::Verbose("perf thread clock: cap_user_time unavailable");
+      munmap(meta, s_pageSize);
+      return nullptr;
+    }
+
+    m_meta = meta;
+    return m_meta;
+  }
+
+  static constexpr int kDisabled = -2;
+  int m_fd{-1};
+  perf_event_mmap_page* m_meta{nullptr};
+};
+
+thread_local PerfThreadClock t_threadClock;
+
+///////////////////////////////////////////////////////////////////////////////
+}
+}
+
+// Read the current thread's CPU time in nanoseconds via perf.  Returns 0 and
+// writes *ns on success, or non-zero if the fast path is unavailable.
+int fb_perf_get_thread_cputime_ns(uint64_t* ns) {
+  auto const meta = HPHP::t_threadClock.init();
+  if (!meta) return -1;
+
+  uint32_t seq;
+  uint64_t enabled, cyc, time_offset;
+  uint32_t time_mult;
+  uint16_t time_shift;
+  uint64_t time_cycles = 0, time_mask = ~0ull;
+  bool short_time;
+
+  // Seqlock retry loop: the kernel bumps `lock` around updates from the
+  // context-switch path, so reread until we observe a stable snapshot.
+  do {
+    seq = meta->lock;
+    perf_barrier();
+
+    // For a task-bound software event there is no PMU multiplexing, so
+    // time_enabled == time_running and both accrue only while this thread is
+    // on-CPU -- i.e. exactly CLOCK_THREAD_CPUTIME_ID.  We extrapolate
+    // time_enabled because the kernel's documented formula only projects the
+    // cycle delta onto running when a hardware counter index is live, which a
+    // software event never has.
+    enabled = meta->time_enabled;
+
+    cyc = HPHP::cpuCycles();
+    time_offset = meta->time_offset;
+    time_mult = meta->time_mult;
+    time_shift = meta->time_shift;
+
+    // cap_user_time_short means the hardware cycle counter is narrower than
+    // 64 bits and must be folded against the kernel's last-seen value.
+    short_time = meta->cap_user_time_short;
+    if (short_time) {
+      time_cycles = meta->time_cycles;
+      time_mask = meta->time_mask;
+    }
+
+    perf_barrier();
+  } while (meta->lock != seq);
+
+  if (short_time) {
+    cyc = time_cycles + ((cyc - time_cycles) & time_mask);
+  }
+
+  // Project `enabled` forward by the elapsed cycles, per the formula the
+  // kernel documents in <linux/perf_event.h>.  The calling thread is by
+  // definition currently scheduled, so the full delta has accrued as CPU time.
+  auto const quot = cyc >> time_shift;
+  auto const rem = cyc & ((uint64_t{1} << time_shift) - 1);
+  auto const delta = time_offset + quot * time_mult +
+    ((rem * time_mult) >> time_shift);
+
+  *ns = enabled + delta;
+  return 0;
+}
+
+#undef perf_barrier
+
+#else // !HHVM_USE_PERF_THREAD_CPUTIME
+
+// No userspace fast path on this platform; always fall back to clock_gettime().
+int fb_perf_get_thread_cputime_ns(uint64_t* /*ns*/) {
+  return -1;
+}
+
+#endif
+
+#endif // !HHVM_FACEBOOK

--- a/hphp/util/perf-cputime-ns.h
+++ b/hphp/util/perf-cputime-ns.h
@@ -1,0 +1,35 @@
+/*
+   +----------------------------------------------------------------------+
+   | HipHop for PHP                                                       |
+   +----------------------------------------------------------------------+
+   | Copyright (c) 2010-present Facebook, Inc. (http://www.facebook.com)  |
+   +----------------------------------------------------------------------+
+   | This source file is subject to version 3.01 of the PHP license,      |
+   | that is bundled with this package in the file LICENSE, and is        |
+   | available through the world-wide-web at the following url:           |
+   | http://www.php.net/license/3_01.txt                                  |
+   | If you did not receive a copy of the PHP license and are unable to   |
+   | obtain it through the world-wide-web, please send a note to          |
+   | license@php.net so we can mail you a copy immediately.               |
+   +----------------------------------------------------------------------+
+*/
+
+#pragma once
+
+#include <cstdint>
+
+#ifdef HHVM_FACEBOOK
+#include "common/time/ClockGettimeNS.h" // nolint
+#else
+/*
+ * Read the calling thread's CPU time (CLOCK_THREAD_CPUTIME_ID) in nanoseconds
+ * entirely in userspace, via the Linux perf_events interface, avoiding the
+ * clock_gettime() syscall on a very hot accounting path.
+ *
+ * Writes the value to *ns and returns 0 on success, or returns non-zero if the
+ * fast path is unavailable (unsupported platform/CPU, or a kernel that does not
+ * advertise userspace timekeeping); callers should fall back to clock_gettime()
+ * in that case.
+ */
+int fb_perf_get_thread_cputime_ns(uint64_t* ns);
+#endif

--- a/hphp/util/test/CMakeLists.txt
+++ b/hphp/util/test/CMakeLists.txt
@@ -1,0 +1,18 @@
+# Only the new test is wired up for now; the other *.cpp files in this directory
+# are not yet built.  Add them here as they are brought into the target.
+set(CXX_SOURCES
+  ${CMAKE_CURRENT_SOURCE_DIR}/perf-cputime-ns-test.cpp
+)
+
+add_executable(hphp_util_test ${CXX_SOURCES})
+link_object_libraries(hphp_util_test ${HHVM_WHOLE_ARCHIVE_LIBRARIES})
+target_link_libraries(hphp_util_test ${HHVM_LINK_LIBRARIES} GTest::gtest_main)
+
+auto_source_group("hphp_util_test" "${CMAKE_CURRENT_SOURCE_DIR}" ${CXX_SOURCES})
+
+# Benchmark: perf cputime vs folly::chrono::clock_gettime_ns
+add_executable(hphp_util_bench
+  ${CMAKE_CURRENT_SOURCE_DIR}/perf-cputime-ns-bench.cpp
+)
+link_object_libraries(hphp_util_bench ${HHVM_WHOLE_ARCHIVE_LIBRARIES})
+target_link_libraries(hphp_util_bench ${HHVM_LINK_LIBRARIES} Folly::follybenchmark)

--- a/hphp/util/test/perf-cputime-ns-bench.cpp
+++ b/hphp/util/test/perf-cputime-ns-bench.cpp
@@ -1,0 +1,45 @@
+/*
+   +----------------------------------------------------------------------+
+   | HipHop for PHP                                                       |
+   +----------------------------------------------------------------------+
+   | Copyright (c) 2010-present Facebook, Inc. (http://www.facebook.com)  |
+   +----------------------------------------------------------------------+
+   | This source file is subject to version 3.01 of the PHP license,      |
+   | that is bundled with this package in the file LICENSE, and is        |
+   | available through the world-wide-web at the following url:           |
+   | http://www.php.net/license/3_01.txt                                  |
+   | If you did not receive a copy of the PHP license and are unable to   |
+   | obtain it through the world-wide-web, please send a note to          |
+   | license@php.net so we can mail you a copy immediately.               |
+   +----------------------------------------------------------------------+
+*/
+
+#include "hphp/util/perf-cputime-ns.h"
+
+#include <cstdint>
+
+#include <folly/Benchmark.h>
+#include <folly/BenchmarkUtil.h>
+#include <folly/ClockGettimeWrappers.h>
+#include <folly/init/Init.h>
+
+BENCHMARK(folly_clock_gettime_ns, n) {
+  for (unsigned i = 0; i < n; ++i) {
+    auto ns = folly::chrono::clock_gettime_ns(CLOCK_THREAD_CPUTIME_ID);
+    folly::doNotOptimizeAway(ns);
+  }
+}
+
+BENCHMARK_RELATIVE(perf_get_thread_cputime_ns, n) {
+  uint64_t ns;
+  for (unsigned i = 0; i < n; ++i) {
+    fb_perf_get_thread_cputime_ns(&ns);
+    folly::doNotOptimizeAway(ns);
+  }
+}
+
+int main(int argc, char** argv) {
+  folly::Init init(&argc, &argv, true);
+  folly::runBenchmarks();
+  return 0;
+}

--- a/hphp/util/test/perf-cputime-ns-test.cpp
+++ b/hphp/util/test/perf-cputime-ns-test.cpp
@@ -1,0 +1,136 @@
+/*
+   +----------------------------------------------------------------------+
+   | HipHop for PHP                                                       |
+   +----------------------------------------------------------------------+
+   | Copyright (c) 2010-present Facebook, Inc. (http://www.facebook.com)  |
+   +----------------------------------------------------------------------+
+   | This source file is subject to version 3.01 of the PHP license,      |
+   | that is bundled with this package in the file LICENSE, and is        |
+   | available through the world-wide-web at the following url:           |
+   | http://www.php.net/license/3_01.txt                                  |
+   | If you did not receive a copy of the PHP license and are unable to   |
+   | obtain it through the world-wide-web, please send a note to          |
+   | license@php.net so we can mail you a copy immediately.               |
+   +----------------------------------------------------------------------+
+*/
+
+#ifndef HHVM_FACEBOOK
+
+#include "hphp/util/perf-cputime-ns.h"
+
+#include <cmath>
+#include <ctime>
+#include <cstdint>
+
+#include <folly/ClockGettimeWrappers.h>
+#include <folly/portability/GTest.h>
+
+#include "hphp/util/portability.h"
+
+namespace HPHP {
+namespace {
+
+///////////////////////////////////////////////////////////////////////////////
+
+// Burn a measurable amount of thread CPU time so the two clocks have something
+// to advance through.  Marked volatile so the compiler can't optimize it away.
+NEVER_INLINE int64_t burnCpu(int64_t reps) {
+  volatile int64_t acc = 0;
+  for (int64_t i = 0; i < reps; ++i) {
+    acc += i * 2654435761ull + 1;
+  }
+  return acc;
+}
+
+int64_t follyThreadCpuNs() {
+  return folly::chrono::clock_gettime_ns(CLOCK_THREAD_CPUTIME_ID);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+// The perf-based reader projects the kernel's last on-CPU snapshot forward with
+// the cycle counter, while folly issues the clock_gettime() syscall.  The two
+// observe the same monotonically increasing thread clock at slightly different
+// instants, so a perf read sandwiched between two folly reads must fall within
+// the bracket they form (plus a tolerance for scheduling/measurement noise).
+TEST(PerfCpuTimeNs, BracketedByFolly) {
+  uint64_t perf;
+  if (fb_perf_get_thread_cputime_ns(&perf)) {
+    GTEST_SKIP() << "perf thread cputime unavailable on this platform/kernel";
+  }
+
+  // 50ms of slack: generous enough to absorb a preemption between reads, tight
+  // enough to catch a clock that is wildly wrong (e.g. wall time vs CPU time).
+  constexpr int64_t kToleranceNs = 50'000'000;
+
+  for (int i = 0; i < 100; ++i) {
+    burnCpu(200000);
+
+    auto const before = follyThreadCpuNs();
+    ASSERT_EQ(0, fb_perf_get_thread_cputime_ns(&perf));
+    auto const after = follyThreadCpuNs();
+
+    // Sanity: folly's own clock must not go backwards across the perf read.
+    ASSERT_LE(before, after);
+
+    auto const p = static_cast<int64_t>(perf);
+    EXPECT_GE(p, before - kToleranceNs)
+      << "perf read fell below the bracket at iteration " << i;
+    EXPECT_LE(p, after + kToleranceNs)
+      << "perf read rose above the bracket at iteration " << i;
+  }
+}
+
+// Successive perf reads must be monotonically non-decreasing: it is a clock.
+TEST(PerfCpuTimeNs, Monotonic) {
+  uint64_t prev;
+  if (fb_perf_get_thread_cputime_ns(&prev)) {
+    GTEST_SKIP() << "perf thread cputime unavailable on this platform/kernel";
+  }
+
+  for (int i = 0; i < 1000; ++i) {
+    burnCpu(50000);
+    uint64_t cur;
+    ASSERT_EQ(0, fb_perf_get_thread_cputime_ns(&cur));
+    EXPECT_GE(cur, prev) << "perf clock moved backwards at iteration " << i;
+    prev = cur;
+  }
+}
+
+// Over a fixed chunk of work the perf and folly clocks should report a similar
+// elapsed CPU time -- the deltas should agree closely, which they will not if
+// one of them is actually measuring something else (e.g. wall-clock time).
+TEST(PerfCpuTimeNs, DeltaAgreesWithFolly) {
+  uint64_t perfStart;
+  if (fb_perf_get_thread_cputime_ns(&perfStart)) {
+    GTEST_SKIP() << "perf thread cputime unavailable on this platform/kernel";
+  }
+  auto const follyStart = follyThreadCpuNs();
+
+  // Enough work that the elapsed time dominates per-read measurement noise.
+  for (int i = 0; i < 50; ++i) burnCpu(500000);
+
+  uint64_t perfEnd;
+  ASSERT_EQ(0, fb_perf_get_thread_cputime_ns(&perfEnd));
+  auto const follyEnd = follyThreadCpuNs();
+
+  auto const perfDelta = static_cast<int64_t>(perfEnd - perfStart);
+  auto const follyDelta = follyEnd - follyStart;
+
+  ASSERT_GT(perfDelta, 0);
+  ASSERT_GT(follyDelta, 0);
+
+  // The two elapsed measurements should be within 25% of each other.
+  auto const diff = std::abs(perfDelta - follyDelta);
+  auto const larger = std::max(perfDelta, follyDelta);
+  EXPECT_LT(diff, larger / 4)
+    << "perf delta " << perfDelta << "ns disagrees with folly delta "
+    << follyDelta << "ns";
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+}
+}
+
+#endif // !HHVM_FACEBOOK

--- a/hphp/util/timer.cpp
+++ b/hphp/util/timer.cpp
@@ -22,11 +22,8 @@
 #include <folly/portability/SysTime.h>
 
 #include "hphp/util/logger.h"
+#include "hphp/util/perf-cputime-ns.h"
 #include "hphp/util/trace.h"
-
-#ifdef HHVM_FACEBOOK
-#include "common/time/ClockGettimeNS.h" // nolint
-#endif
 
 namespace HPHP {
 ///////////////////////////////////////////////////////////////////////////////
@@ -164,7 +161,6 @@ int gettime(clockid_t clock, timespec* ts) {
 
   constexpr uint64_t sec_to_ns = 1000000000;
 
-#ifdef HHVM_FACEBOOK
   uint64_t time;
   if (!fb_perf_get_thread_cputime_ns(&time)) {
     time += s_extra_request_nanoseconds;
@@ -172,7 +168,6 @@ int gettime(clockid_t clock, timespec* ts) {
     ts->tv_nsec = time % sec_to_ns;
     return 0;
   }
-#endif
 
   auto const ret = folly::chrono::clock_gettime(clock, ts);
   always_assert(ts->tv_nsec < sec_to_ns);
@@ -193,12 +188,10 @@ int64_t gettime_ns(clockid_t clock) {
     return folly::chrono::clock_gettime_ns(clock);
   }
 
-#ifdef HHVM_FACEBOOK
   uint64_t time;
   if (!fb_perf_get_thread_cputime_ns(&time)) {
     return time + s_extra_request_nanoseconds;
   }
-#endif
 
   return folly::chrono::clock_gettime_ns(clock) + s_extra_request_nanoseconds;
 }


### PR DESCRIPTION
The HHVM JIT is heavily instrumented via scoped `WorkloadStats` structs that call `Timer::GetThreadCPUTimeNanos` to obtain the CPU timer of the current thread. This then calls `fb_perf_get_thread_cputime_ns` in internal Meta builds but falls back to `folly::chrono::clock_gettime_ns` in our OSS build which just wraps `clock_gettime`.

It seems there was an abortive attempt in 2013 to upstream a kernel patch for a fast VDSO implementation of `clock_gettime_ns`, after which `fb_perf_get_thread_cputime_ns` was added to provide a similarly performant nanosecond-resolution timer for the current thread's CPU time using the `perf_events` API.[2] This never made its way into OSS.

We observed the Folly shim to be responsible for 30-40% of CPU usage during JIT compilation while executing warmup code. After rolling out a change disabling it, we saw a double-digit P99 reduction across background jobs latencies and a ~30% increase in deployment speed. So, try to implement (with some AI assistance) an API-compatible `fb_perf_get_thread_cputime_ns` implementation backed by `perf_events` that can be used by HHVM OSS.

On my machine, this is 67x faster than the folly shim:
```
vagrant@hhvm-jammy-vm:~/hhvm$ _build/hphp/util/test/hphp_util_bench --bm_mode=adaptive
E20260618 19:12:04.745777 15497 BenchmarkAdaptive.cpp:549] Did not converge:
  folly_clock_gettime_ns: p33.30=132.3ns to 0.13%, 1025 samples, 1s
    [unstable] 1st=132.76 [132.54, 133.15] 2nd=132.07 [131.97, 132.12]
============================================================================
[...]p/util/test/perf-cputime-ns-bench.cpp     relative  time/iter   iters/s
============================================================================
folly_clock_gettime_ns                                    132.26ns     7.56M
perf_get_thread_cputime_ns                      6760.1%     1.96ns   511.12M
```

[1] https://lore.kernel.org/all/5226FAE1.5070201@fb.com/
[2] https://github.com/facebook/hhvm/commit/28e6bf1525569b6b4ec191140c9ef33b031c9084