### PR TITLE
docs & HSL: update HackC frontend refs to Rust and expand unit test coverage

### DIFF
--- a/hphp/doc/hackers-guide/README.md
+++ b/hphp/doc/hackers-guide/README.md
@@ -52,7 +52,7 @@ token stream and converts that to an [abstract syntax
 tree](https://en.wikipedia.org/wiki/Abstract_syntax_tree), or AST. This AST is
 then converted to a stream of [bytecode
 instructions](https://en.wikipedia.org/wiki/Bytecode) by the bytecode emitter.
-Everything up to this point is written in OCaml; the rest of HHVM is written in
+Everything up to this point is written in Rust (via HackC); the rest of HHVM is written in
 C++ and assembly.
 
 After the bytecode and associated metadata are created, our bytecode optimizer,

--- a/hphp/doc/hackers-guide/glossary.md
+++ b/hphp/doc/hackers-guide/glossary.md
@@ -32,8 +32,8 @@ detail in [bytecode.specification](../bytecode.specification).
 
 ### HackC
 
-The Hack Compiler, HHVM's new frontend (as of mid-2018). A parser and bytecode
-emitter written completely in OCaml.
+The Hack Compiler, HHVM's frontend. A parser and bytecode
+emitter written in Rust.
 
 ### HHAS
 

--- a/hphp/doc/ini.md
+++ b/hphp/doc/ini.md
@@ -26,7 +26,7 @@ hhvm.enable_xhp = true
 
 ## Copying and Symlinking Settings
 
-**NOTE**: This feature only currently work with core system settings. They
+**NOTE**: This feature currently only works with core system settings. They
 don't yet work with extensions, `ini_set()`, etc.
 
 You can also provide wildcards to settings signaling that you want to use the

--- a/hphp/hsl/tests/dict/DictIntrospectTest.php
+++ b/hphp/hsl/tests/dict/DictIntrospectTest.php
@@ -46,6 +46,21 @@ final class DictIntrospectTest extends HackTest {
         dict[1 => 1, 3 => 3, 2 => 2],
         true,
       ),
+      tuple(
+        dict[],
+        dict[],
+        true,
+      ),
+      tuple(
+        dict['foo' => 'bar', 'baz' => 'qux'],
+        dict['baz' => 'qux', 'foo' => 'bar'],
+        true,
+      ),
+      tuple(
+        dict['a' => null],
+        dict['a' => null],
+        true,
+      ),
     ];
   }
 

--- a/hphp/hsl/tests/keyset/KeysetIntrospectTest.php
+++ b/hphp/hsl/tests/keyset/KeysetIntrospectTest.php
@@ -46,6 +46,21 @@ final class KeysetIntrospectTest extends HackTest {
         keyset[1, 3, 2],
         true,
       ),
+      tuple(
+        keyset[],
+        keyset[],
+        true,
+      ),
+      tuple(
+        keyset['a', 'b', 'c'],
+        keyset['c', 'b', 'a'],
+        true,
+      ),
+      tuple(
+        keyset['a', 'b'],
+        keyset['a', 'c'],
+        false,
+      ),
     ];
   }
 

--- a/hphp/hsl/tests/math/MathCompareTest.php
+++ b/hphp/hsl/tests/math/MathCompareTest.php
@@ -26,6 +26,8 @@ final class MathCompareTest extends HackTest {
       tuple(1, 2.0, vec[], 2.0),
       tuple(-1, 1, vec[2, 3, 4, 5], 5),
       tuple(-1, 5, vec[4, 3, 2, 1], 5),
+      tuple(Math\INT64_MIN, 0, vec[Math\INT64_MAX], Math\INT64_MAX),
+      tuple(-10.5, -20.5, vec[-5.5, -30.0], -5.5),
     ];
   }
 
@@ -51,6 +53,8 @@ final class MathCompareTest extends HackTest {
       tuple(1, 2.0, vec[], 1),
       tuple(1, -1, vec[-2, -3, -4, -5], -5),
       tuple(1, -5, vec[-4, -3, -2, -1], -5),
+      tuple(Math\INT64_MAX, 0, vec[Math\INT64_MIN], Math\INT64_MIN),
+      tuple(-10.5, -20.5, vec[-5.5, -30.0], -30.0),
     ];
   }
 
@@ -73,6 +77,8 @@ final class MathCompareTest extends HackTest {
       tuple(0.1, false),
       tuple(-0.1, false),
       tuple(Math\NAN, true),
+      tuple(Math\INF, false),
+      tuple(Math\INT64_MAX, false),
     ];
   }
 
@@ -98,6 +104,8 @@ final class MathCompareTest extends HackTest {
       tuple(1, 2, 1, false),
       tuple(1, 2, null, false),
       tuple(2, 1, 2, true),
+      tuple(-10.0, -10.000000001, null, true),
+      tuple(-10.0, -10.1, 0.2, true),
     ];
   }
 

--- a/hphp/hsl/tests/math/MathExtendedSuiteTest.php
+++ b/hphp/hsl/tests/math/MathExtendedSuiteTest.php
@@ -1,0 +1,167 @@
+<?hh
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the hphp/hsl/ subdirectory of this source tree.
+ *
+ */
+
+use namespace HH\Lib\Math;
+use function HH\__Private\MiniTest\expect;
+use type HH\__Private\MiniTest\{DataProvider, HackTest};
+
+final class MathExtendedSuiteTest extends HackTest {
+
+  public static function provideTrigIdentities(): vec<(float, float)> {
+    return vec[
+      tuple(0.0, 0.0),
+      tuple(M_PI / 6.0, 0.5),
+      tuple(M_PI / 4.0, M_SQRT1_2),
+      tuple(M_PI / 2.0, 1.0),
+      tuple(M_PI, 0.0),
+      tuple(3.0 * M_PI / 2.0, -1.0),
+      tuple(2.0 * M_PI, 0.0),
+    ];
+  }
+
+  <<DataProvider('provideTrigIdentities')>>
+  public function testSineCosinePythagorean(float $angle, float $expectedSin): void {
+    $sinVal = Math\sin($angle);
+    $cosVal = Math\cos($angle);
+    expect($sinVal * $sinVal + $cosVal * $cosVal)->toAlmostEqual(1.0);
+  }
+
+  public static function provideExponentialLogarithmPairs(): vec<(float)> {
+    return vec[
+      tuple(0.1),
+      tuple(0.5),
+      tuple(1.0),
+      tuple(2.718281828459),
+      tuple(10.0),
+      tuple(100.0),
+      tuple(1234.5678),
+    ];
+  }
+
+  <<DataProvider('provideExponentialLogarithmPairs')>>
+  public function testExpLogInversion(float $val): void {
+    $logVal = Math\log($val);
+    $expVal = Math\exp($logVal);
+    expect($expVal)->toAlmostEqual($val);
+  }
+
+  public static function provideBaseConvertExtended(): vec<(string, int, int, string)> {
+    return vec[
+      tuple('255', 10, 16, 'ff'),
+      tuple('ff', 16, 10, '255'),
+      tuple('11111111', 2, 16, 'ff'),
+      tuple('ff', 16, 2, '11111111'),
+      tuple('377', 8, 10, '255'),
+      tuple('255', 10, 8, '377'),
+      tuple('z', 36, 10, '35'),
+      tuple('35', 10, 36, 'z'),
+      tuple('1000000', 10, 36, 'lfl0'),
+      tuple('lfl0', 36, 10, '1000000'),
+    ];
+  }
+
+  <<DataProvider('provideBaseConvertExtended')>>
+  public function testBaseConvertExtended(
+    string $value,
+    int $fromBase,
+    int $toBase,
+    string $expected,
+  ): void {
+    expect(Math\base_convert($value, $fromBase, $toBase))->toEqual($expected);
+  }
+
+  public function testLogCustomBase(): void {
+    expect(Math\log(8.0, 2.0))->toAlmostEqual(3.0);
+    expect(Math\log(100.0, 10.0))->toAlmostEqual(2.0);
+    expect(Math\log(81.0, 3.0))->toAlmostEqual(4.0);
+    expect(Math\log(1024.0, 2.0))->toAlmostEqual(10.0);
+  }
+
+  public function testLogInvariants(): void {
+    expect(() ==> Math\log(0.0))->toThrow(InvariantException::class);
+    expect(() ==> Math\log(-5.0))->toThrow(InvariantException::class);
+    expect(() ==> Math\log(10.0, 0.0))->toThrow(InvariantException::class);
+    expect(() ==> Math\log(10.0, 1.0))->toThrow(InvariantException::class);
+    expect(() ==> Math\log(10.0, -2.0))->toThrow(InvariantException::class);
+  }
+
+  public static function provideRoundingModes(): vec<(float, int, float)> {
+    return vec[
+      tuple(1.23456, 2, 1.23),
+      tuple(1.23556, 2, 1.24),
+      tuple(1234.56, -2, 1200.0),
+      tuple(1256.56, -2, 1300.0),
+      tuple(-1.235, 2, -1.24),
+      tuple(-1.234, 2, -1.23),
+      tuple(0.0, 4, 0.0),
+    ];
+  }
+
+  <<DataProvider('provideRoundingModes')>>
+  public function testRoundingModes(float $val, int $precision, float $expected): void {
+    expect(Math\round($val, $precision))->toEqual($expected);
+  }
+
+  public static function provideCeilFloorPairs(): vec<(num, float, float)> {
+    return vec[
+      tuple(2.3, 3.0, 2.0),
+      tuple(-2.3, -2.0, -3.0),
+      tuple(5.0, 5.0, 5.0),
+      tuple(-5.0, -5.0, -5.0),
+      tuple(0.0, 0.0, 0.0),
+      tuple(0.00001, 1.0, 0.0),
+      tuple(-0.00001, 0.0, -1.0),
+    ];
+  }
+
+  <<DataProvider('provideCeilFloorPairs')>>
+  public function testCeilAndFloor(num $val, float $expectedCeil, float $expectedFloor): void {
+    expect(Math\ceil($val))->toEqual($expectedCeil);
+    expect(Math\floor($val))->toEqual($expectedFloor);
+  }
+
+  public function testIntDivInvariants(): void {
+    expect(Math\int_div(10, 3))->toEqual(3);
+    expect(Math\int_div(-10, 3))->toEqual(-3);
+    expect(Math\int_div(10, -3))->toEqual(-3);
+    expect(Math\int_div(-10, -3))->toEqual(3);
+    expect(Math\int_div(0, 5))->toEqual(0);
+
+    expect(() ==> Math\int_div(10, 0))->toThrow(DivisionByZeroException::class);
+  }
+
+  public static function provideFromBaseCases(): vec<(string, int, int)> {
+    return vec[
+      tuple('0', 2, 0),
+      tuple('1', 2, 1),
+      tuple('10', 2, 2),
+      tuple('1010', 2, 10),
+      tuple('77', 8, 63),
+      tuple('ff', 16, 255),
+      tuple('FF', 16, 255),
+      tuple('z', 36, 35),
+      tuple('Z', 36, 35),
+      tuple('10', 36, 36),
+    ];
+  }
+
+  <<DataProvider('provideFromBaseCases')>>
+  public function testFromBaseCases(string $str, int $base, int $expected): void {
+    expect(Math\from_base($str, $base))->toEqual($expected);
+  }
+
+  public function testFromBaseInvariants(): void {
+    expect(() ==> Math\from_base('', 10))->toThrow(InvariantException::class);
+    expect(() ==> Math\from_base('10', 1))->toThrow(InvariantException::class);
+    expect(() ==> Math\from_base('10', 37))->toThrow(InvariantException::class);
+    expect(() ==> Math\from_base('2', 2))->toThrow(InvariantException::class);
+    expect(() ==> Math\from_base('g', 16))->toThrow(InvariantException::class);
+  }
+}

--- a/hphp/hsl/tests/regex/RegexTest.php
+++ b/hphp/hsl/tests/regex/RegexTest.php
@@ -397,6 +397,8 @@ final class RegexTest extends HackTest {
       tuple(re"/hello world/", '/hello world/'),
       tuple(re"/foo[1-9]/", '/foo[1-9]/'),
       tuple(re"/ahh.*/", '/ahh.*/'),
+      tuple(re"/^https?:\\/\\//i", '/^https?:\\/\\//i'),
+      tuple(re"/\\d{3}-\\d{4}/", '/\\d{3}-\\d{4}/'),
     ];
   }
 

--- a/hphp/hsl/tests/str/StrExtendedSuiteTest.php
+++ b/hphp/hsl/tests/str/StrExtendedSuiteTest.php
@@ -1,0 +1,174 @@
+<?hh
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the hphp/hsl/ subdirectory of this source tree.
+ *
+ */
+
+use namespace HH\Lib\Str;
+use function HH\__Private\MiniTest\expect;
+use type HH\__Private\MiniTest\{DataProvider, HackTest};
+
+final class StrExtendedSuiteTest extends HackTest {
+
+  public static function provideFormatAndChunkCases(): vec<(string, int, vec<string>)> {
+    return vec[
+      tuple('abcdefghij', 2, vec['ab', 'cd', 'ef', 'gh', 'ij']),
+      tuple('abcdefghij', 3, vec['abc', 'def', 'ghi', 'j']),
+      tuple('a', 5, vec['a']),
+      tuple('', 3, vec[]),
+      tuple('hello world', 5, vec['hello', ' worl', 'd']),
+    ];
+  }
+
+  <<DataProvider('provideFormatAndChunkCases')>>
+  public function testChunk(string $input, int $size, vec<string> $expected): void {
+    expect(Str\chunk($input, $size))->toEqual($expected);
+  }
+
+  public function testChunkInvalidSize(): void {
+    expect(() ==> Str\chunk('test', 0))->toThrow(InvariantException::class);
+    expect(() ==> Str\chunk('test', -1))->toThrow(InvariantException::class);
+  }
+
+  public static function provideTrimCases(): vec<(string, ?string, string, string, string)> {
+    return vec[
+      tuple('  hello  ', null, 'hello', 'hello  ', '  hello'),
+      tuple('---hello---', '-', 'hello', 'hello---', '---hello'),
+      tuple('abcHELLOcba', 'abc', 'HELLO', 'HELLOcba', 'abcHELLO'),
+      tuple('', null, '', '', ''),
+      tuple('   ', null, '', '', ''),
+    ];
+  }
+
+  <<DataProvider('provideTrimCases')>>
+  public function testTrim(
+    string $input,
+    ?string $charlist,
+    string $expectedBoth,
+    string $expectedLeft,
+    string $expectedRight,
+  ): void {
+    if ($charlist === null) {
+      expect(Str\trim($input))->toEqual($expectedBoth);
+      expect(Str\trim_left($input))->toEqual($expectedLeft);
+      expect(Str\trim_right($input))->toEqual($expectedRight);
+    } else {
+      expect(Str\trim($input, $charlist))->toEqual($expectedBoth);
+      expect(Str\trim_left($input, $charlist))->toEqual($expectedLeft);
+      expect(Str\trim_right($input, $charlist))->toEqual($expectedRight);
+    }
+  }
+
+  public static function providePaddingCases(): vec<(string, int, string, string, string, string)> {
+    return vec[
+      tuple('cat', 6, '-', '---cat', 'cat---', '-cat--'),
+      tuple('cat', 5, 'ab', 'abcat', 'catab', 'acatb'),
+      tuple('hello', 3, 'x', 'hello', 'hello', 'hello'),
+      tuple('', 4, 'o', 'oooo', 'oooo', 'oooo'),
+    ];
+  }
+
+  <<DataProvider('providePaddingCases')>>
+  public function testPadding(
+    string $input,
+    int $length,
+    string $padStr,
+    string $expectedLeft,
+    string $expectedRight,
+    string $expectedBoth,
+  ): void {
+    expect(Str\pad_left($input, $length, $padStr))->toEqual($expectedLeft);
+    expect(Str\pad_right($input, $length, $padStr))->toEqual($expectedRight);
+
+    expect(Str\pad_left($input, $length, $padStr))->toEqual($expectedLeft);
+  }
+
+  public static function provideCapitalizeCases(): vec<(string, string, string, string)> {
+    return vec[
+      tuple('hello world', 'HELLO WORLD', 'hello world', 'Hello world'),
+      tuple('hEllO WoRlD', 'HELLO WORLD', 'hello world', 'HEllO WoRlD'),
+      tuple('1234!', '1234!', '1234!', '1234!'),
+      tuple('', '', '', ''),
+    ];
+  }
+
+  <<DataProvider('provideCapitalizeCases')>>
+  public function testCaseConversions(
+    string $input,
+    string $upper,
+    string $lower,
+    string $capitalized,
+  ): void {
+    expect(Str\uppercase($input))->toEqual($upper);
+    expect(Str\lowercase($input))->toEqual($lower);
+    expect(Str\capitalize($input))->toEqual($capitalized);
+  }
+
+  public static function provideSplitAndJoinCases(): vec<(string, string, vec<string>)> {
+    return vec[
+      tuple('a,b,c', ',', vec['a', 'b', 'c']),
+      tuple('apple::banana::cherry', '::', vec['apple', 'banana', 'cherry']),
+      tuple('no_delimiter', ',', vec['no_delimiter']),
+      tuple('', ',', vec['']),
+    ];
+  }
+
+  <<DataProvider('provideSplitAndJoinCases')>>
+  public function testSplitAndJoin(
+    string $input,
+    string $delimiter,
+    vec<string> $expectedSplit,
+  ): void {
+    expect(Str\split($input, $delimiter))->toEqual($expectedSplit);
+    expect(Str\join($expectedSplit, $delimiter))->toEqual($input);
+  }
+
+  public function testSplitEmptyDelimiter(): void {
+    expect(() ==> Str\split('test', ''))->toThrow(InvariantException::class);
+  }
+
+  public static function provideRepeatCases(): vec<(string, int, string)> {
+    return vec[
+      tuple('a', 5, 'aaaaa'),
+      tuple('abc', 3, 'abcabcabc'),
+      tuple('abc', 0, ''),
+      tuple('', 10, ''),
+    ];
+  }
+
+  <<DataProvider('provideRepeatCases')>>
+  public function testRepeat(string $input, int $multiplier, string $expected): void {
+    expect(Str\repeat($input, $multiplier))->toEqual($expected);
+  }
+
+  public function testRepeatNegativeMultiplier(): void {
+    expect(() ==> Str\repeat('test', -1))->toThrow(InvariantException::class);
+  }
+
+  public static function provideReplaceCases(): vec<(string, string, string, string)> {
+    return vec[
+      tuple('the quick brown fox', 'quick', 'slow', 'the slow brown fox'),
+      tuple('foo bar foo baz foo', 'foo', 'qux', 'qux bar qux baz qux'),
+      tuple('hello', 'world', 'there', 'hello'),
+      tuple('aaa', 'a', 'bb', 'bbbbbb'),
+    ];
+  }
+
+  <<DataProvider('provideReplaceCases')>>
+  public function testReplace(
+    string $haystack,
+    string $needle,
+    string $replacement,
+    string $expected,
+  ): void {
+    expect(Str\replace($haystack, $needle, $replacement))->toEqual($expected);
+  }
+
+  public function testReplaceEmptyNeedle(): void {
+    expect(() ==> Str\replace('test', '', 'x'))->toThrow(InvariantException::class);
+  }
+}

--- a/hphp/hsl/tests/str/StrIntrospectTest.php
+++ b/hphp/hsl/tests/str/StrIntrospectTest.php
@@ -375,6 +375,11 @@ final class StrIntrospectTest extends HackTest {
         'HELLO',
         false,
       ),
+      tuple(
+        '🚀 launch',
+        '🚀',
+        true,
+      ),
     ];
   }
 
@@ -419,6 +424,11 @@ final class StrIntrospectTest extends HackTest {
         'HELLO',
         true,
       ),
+      tuple(
+        '🚀 launch',
+        '🚀',
+        true,
+      ),
     ];
   }
 
@@ -432,3 +442,4 @@ final class StrIntrospectTest extends HackTest {
   }
 
 }
+

--- a/hphp/hsl/tests/vec/VecExtendedSuiteTest.php
+++ b/hphp/hsl/tests/vec/VecExtendedSuiteTest.php
@@ -1,0 +1,151 @@
+<?hh
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the hphp/hsl/ subdirectory of this source tree.
+ *
+ */
+
+use namespace HH\Lib\{C, Vec};
+use function HH\__Private\MiniTest\expect;
+use type HH\__Private\MiniTest\{DataProvider, HackTest};
+
+final class VecExtendedSuiteTest extends HackTest {
+
+  public static function provideConcatCases(): vec<(Traversable<int>, Traversable<int>, vec<int>)> {
+    return vec[
+      tuple(vec[1, 2], vec[3, 4], vec[1, 2, 3, 4]),
+      tuple(vec[], vec[1, 2], vec[1, 2]),
+      tuple(vec[1, 2], vec[], vec[1, 2]),
+      tuple(vec[], vec[], vec[]),
+    ];
+  }
+
+  <<DataProvider('provideConcatCases')>>
+  public function testConcat(
+    Traversable<int> $first,
+    Traversable<int> $second,
+    vec<int> $expected,
+  ): void {
+    expect(Vec\concat($first, $second))->toEqual($expected);
+  }
+
+  public static function provideFillCases(): vec<(int, int, vec<int>)> {
+    return vec[
+      tuple(5, 42, vec[42, 42, 42, 42, 42]),
+      tuple(1, 0, vec[0]),
+      tuple(0, 7, vec[]),
+    ];
+  }
+
+  <<DataProvider('provideFillCases')>>
+  public function testFill(int $size, int $value, vec<int> $expected): void {
+    expect(Vec\fill($size, $value))->toEqual($expected);
+  }
+
+  public function testFillNegativeSize(): void {
+    expect(() ==> Vec\fill(-1, 5))->toThrow(InvariantException::class);
+  }
+
+  public static function provideFilterCases(): vec<(vec<int>, (function(int): bool), vec<int>)> {
+    return vec[
+      tuple(vec[1, 2, 3, 4, 5, 6], $x ==> $x % 2 === 0, vec[2, 4, 6]),
+      tuple(vec[1, 3, 5], $x ==> $x % 2 === 0, vec[]),
+      tuple(vec[2, 4, 6], $x ==> $x % 2 === 0, vec[2, 4, 6]),
+      tuple(vec[], $x ==> true, vec[]),
+    ];
+  }
+
+  <<DataProvider('provideFilterCases')>>
+  public function testFilter(
+    vec<int> $input,
+    (function(int): bool) $predicate,
+    vec<int> $expected,
+  ): void {
+    expect(Vec\filter($input, $predicate))->toEqual($expected);
+  }
+
+  public static function provideMapCases(): vec<(vec<int>, (function(int): int), vec<int>)> {
+    return vec[
+      tuple(vec[1, 2, 3], $x ==> $x * 2, vec[2, 4, 6]),
+      tuple(vec[0, -1, 5], $x ==> $x + 10, vec[10, 9, 15]),
+      tuple(vec[], $x ==> $x, vec[]),
+    ];
+  }
+
+  <<DataProvider('provideMapCases')>>
+  public function testMap(
+    vec<int> $input,
+    (function(int): int) $fn,
+    vec<int> $expected,
+  ): void {
+    expect(Vec\map($input, $fn))->toEqual($expected);
+  }
+
+  public static function provideReverseCases(): vec<(vec<mixed>, vec<mixed>)> {
+    return vec[
+      tuple(vec[1, 2, 3, 4], vec[4, 3, 2, 1]),
+      tuple(vec['a', 'b', 'c'], vec['c', 'b', 'a']),
+      tuple(vec[42], vec[42]),
+      tuple(vec[], vec[]),
+    ];
+  }
+
+  <<DataProvider('provideReverseCases')>>
+  public function testReverse(vec<mixed> $input, vec<mixed> $expected): void {
+    expect(Vec\reverse($input))->toEqual($expected);
+  }
+
+  public static function provideSortCases(): vec<(vec<int>, vec<int>)> {
+    return vec[
+      tuple(vec[5, 2, 8, 1, 9], vec[1, 2, 5, 8, 9]),
+      tuple(vec[-3, 0, -10, 5], vec[-10, -3, 0, 5]),
+      tuple(vec[1], vec[1]),
+      tuple(vec[], vec[]),
+    ];
+  }
+
+  <<DataProvider('provideSortCases')>>
+  public function testSort(vec<int> $input, vec<int> $expected): void {
+    expect(Vec\sort($input))->toEqual($expected);
+  }
+
+  public static function provideZipCases(): vec<(vec<int>, vec<string>, vec<(int, string)>)> {
+    return vec[
+      tuple(
+        vec[1, 2, 3],
+        vec['a', 'b', 'c'],
+        vec[tuple(1, 'a'), tuple(2, 'b'), tuple(3, 'c')],
+      ),
+      tuple(
+        vec[1, 2],
+        vec['a', 'b', 'c'],
+        vec[tuple(1, 'a'), tuple(2, 'b')],
+      ),
+      tuple(
+        vec[1, 2, 3],
+        vec['a'],
+        vec[tuple(1, 'a')],
+      ),
+      tuple(vec[], vec['a', 'b'], vec[]),
+    ];
+  }
+
+  <<DataProvider('provideZipCases')>>
+  public function testZip(
+    vec<int> $first,
+    vec<string> $second,
+    vec<(int, string)> $expected,
+  ): void {
+    expect(Vec\zip($first, $second))->toEqual($expected);
+  }
+
+  public function testRangeAndCount(): void {
+    expect(Vec\range(1, 5))->toEqual(vec[1, 2, 3, 4, 5]);
+    expect(Vec\range(5, 1))->toEqual(vec[5, 4, 3, 2, 1]);
+    expect(Vec\range(1, 1))->toEqual(vec[1]);
+    expect(C\count(Vec\range(1, 100)))->toEqual(100);
+  }
+}

--- a/hphp/hsl/tests/vec/VecSelectTest.php
+++ b/hphp/hsl/tests/vec/VecSelectTest.php
@@ -594,4 +594,11 @@ final class VecSelectTest extends HackTest {
       ->toEqual($expected);
   }
 
+  public function testSliceEdgeCases(): void {
+    expect(Vec\slice(vec[1, 2, 3, 4, 5], 0, 0))->toEqual(vec[]);
+    expect(Vec\slice(vec[1, 2, 3], 1, 100))->toEqual(vec[2, 3]);
+    expect(Vec\slice(vec[], 0, 5))->toEqual(vec[]);
+  }
+
 }
+


### PR DESCRIPTION
## Description

This PR contributes documentation updates, configuration spec fixes, and 550+ lines of new unit test coverage across the Hack Standard Library (HSL).

### 1. Developer Documentation & Config
- Updated `hphp/doc/hackers-guide/README.md` and `hphp/doc/hackers-guide/glossary.md` to state that the Hack Compiler frontend (`hackc`) and bytecode emitter are written in **Rust** (updating obsolete references to OCaml).
- Corrected grammar and phrasing in `hphp/doc/ini.md` for wildcard configuration setting symlinking and copying.

### 2. Hack Standard Library (HSL) Test Coverage
- **Math**: Created `MathExtendedSuiteTest.php` and updated `MathCompareTest.php` with tests for trigonometric identities, exponential/logarithmic inverse pairs, base conversions, rounding modes, integer division exceptions, and float comparison edge cases.
- **Str**: Created `StrExtendedSuiteTest.php` and updated `StrIntrospectTest.php` with tests for chunking, trimming, padding, case folding (`uppercase`, `lowercase`, `capitalize`), multibyte emoji prefixes, splitting/joining, and string replacement.
- **Vec**: Created `VecExtendedSuiteTest.php` and updated `VecSelectTest.php` with tests for `concat`, `fill`, `filter`, `map`, `reverse`, `sort`, `zip`, and `range`.
- **Keyset & Dict**: Added test tuples to `KeysetIntrospectTest.php` and `DictIntrospectTest.php` for empty keysets/dicts, string key mappings, and null value handling.
- **Regex**: Added pattern string representation tests to `RegexTest.php`.