### PR TITLE
Flush instruction cache for arm64 near literal loads

### DIFF
--- a/hphp/runtime/vm/jit/vasm-emit-arm.cpp
+++ b/hphp/runtime/vm/jit/vasm-emit-arm.cpp
@@ -872,6 +872,8 @@ void Vgen::handleLiterals(Venv& env) {
         Instruction::Cast(literalAddress),
         Instruction::Cast(pl.patchAddress)
       );
+      auto const start = reinterpret_cast<CodeAddress>(patchStartActual);
+      DataBlock::syncDirect(start, start + kInstructionSize);
       continue;
     }
 


### PR DESCRIPTION
On aarch64 we ran into occasional segfaults when running a benchmark script[1]:
```
(lldb) bt 5
* thread #1, name = 'hhvm', stop reason = signal SIGBUS: illegal alignment
  * frame #0: 0x0000000018000052
    frame #1: 0x000000000600162c
    frame #2: 0x00000000060005cc
    frame #3: 0x00000000013e0cf8 hhvm`HPHP::jit::enterTC(start=<unavailable>) at enter-tc.cpp:82:3
    frame #4: 0x000000000117bbac hhvm`HPHP::enterVMAtFunc(enterFnAr=<unavailable>, posArgcInclUnpack=<unavailable>, allNamedParamsPassed=<unavailable>) at bytecode.cpp:866:3 [artificial]
```

This seems to be because the aarch64 JIT doesn't flush the instruction cache when emitting a near literal load and so we end up jumping to the wrong target:
```
(lldb) register read
General Purpose Registers:
        x0 = 0x00000000000000b1
        x1 = 0x0000000000000000
        x2 = 0x0000000000000046
        x3 = 0x00000000000000a0
        x4 = 0x00000000000001d2
        x5 = 0x0000000000000002
        x6 = 0x0000000000000000
        x7 = 0x0000000000000000
        x8 = 0x00000000001d8f70
        x9 = 0x0000fffff5f34f90
       x10 = 0x0000fffff1324ce0
       x11 = 0x00000000001d8ed0
       x12 = 0x000000000000000f
       x13 = 0x0000000000000001
       x14 = 0x000000000000000a
       x15 = 0x0000000000000018
       x16 = 0x00000000000007d0
       x17 = 0x00000000013195da  hhvm`bool HPHP::jit::(anonymous namespace)::collect_component<HPHP::jit::ALocal>(HPHP::jit::AliasAnalysis&, HPHP::Optional<HPHP::jit::ALocal>, folly::F14NodeMap<HPHP::jit::AliasClass, std::__1::bitset<512ul>, HPHP::jit::AliasClass::Hash, std::__1::equal_to<HPHP::jit::AliasClass>, std::__1::allocator<std::__1::pair<HPHP::jit::AliasClass const, std::__1::bitset<512ul>>>>&) + 618 [inlined] HPHP::Optional<HPHP::jit::ALocal>::operator*() & + 22 at optional.h:61:5
  hhvm`bool HPHP::jit::(anonymous namespace)::collect_component<HPHP::jit::ALocal>(HPHP::jit::AliasAnalysis&, HPHP::Optional<HPHP::jit::ALocal>, folly::F14NodeMap<HPHP::jit::AliasClass, std::__1::bitset<512ul>, HPHP::jit::AliasClass::Hash, std::__1::equal_to<HPHP::jit::AliasClass>, std::__1::allocator<std::__1::pair<HPHP::jit::AliasClass const, std::__1::bitset<512ul>>>>&) + 596 at alias-analysis.cpp:203:39
       x18 = 0x0000000018000052
       x19 = 0x00000000000044c0
       x20 = 0x0000000000000006
       x21 = 0x013195da00000046
       x22 = 0x0000000000000046
       x23 = 0x0000000000000008
       x24 = 0x0000000000000000
       x25 = 0x0000000000000008
       x26 = 0x0000000000000046
       x27 = 0x0000ffffee000000
       x28 = 0x0000ffffed53ff60
        fp = 0x0000ffffed53ffd0
        lr = 0x000000000600162c
        sp = 0x0000ffffffffdc50
        pc = 0x0000000018000052
      cpsr = 0x80000400

(lldb) up 2
frame #2: 0x00000000060005cc
->  0x60005cc: ldr    w18, 0x60005d4
    0x60005d0: br     x18
    0x60005d4: <unknown>
    0x60005d8: brk    #0
(lldb) memory read --format x --size 4 --count 12 0x60005cc
0x060005cc: 0x18000052 0xd61f0240 0x06000000 0xd4200000
0x060005dc: 0xd503201f 0xd503201f 0xd503201f 0xd503201f
0x060005ec: 0xd503201f 0xd503201f 0xd503201f 0xd503201f
```

So flush the instruction cache like we already do for the far literal load path since D96648232.

Initial diagnosis via LLDB MCP + Codex.

[1] https://gist.github.com/mszabo-wikia/fa67242336357cec7429e732d35ebdce