### PR TITLE
Define an alternate signal handler stack for HHVM threads

### DIFF
--- a/hphp/runtime/base/crash-reporter.cpp
+++ b/hphp/runtime/base/crash-reporter.cpp
@@ -18,6 +18,7 @@
 
 #include "hphp/runtime/base/execution-context.h"
 #include "hphp/runtime/base/file-util.h"
+#include "hphp/runtime/base/init-fini-node.h"
 #include "hphp/runtime/base/program-functions.h"
 #include "hphp/runtime/debugger/debugger.h"
 #include "hphp/runtime/ext/std/ext_std_errorfunc.h"
@@ -42,6 +43,7 @@
 #include "hphp/util/logger.h"
 #include "hphp/util/process.h"
 #include "hphp/util/stack-trace.h"
+#include "hphp/util/thread-local.h"
 
 #include <fcntl.h>
 #include <signal.h>
@@ -470,6 +472,53 @@ void install_crash_reporter() {
   }
   CHECK_ERR(sigaction(SIGABRT, &sa, &osa));
 }
+
+// RAII wrapper for an alternate signal stack of a HHVM worker thread.
+struct SigAltStack {
+  SigAltStack() {
+    // Do nothing if we somehow already have a signal handler stack
+    {
+      stack_t ss{};
+      sigaltstack(nullptr, &ss);
+      if (!(ss.ss_flags & SS_DISABLE)) {
+        return;
+      }
+    }
+    // 128KiB stack space should be plenty.
+    // See `kSmallSigAltStackSize` in folly/src/folly/debugging/symbolizer/SignalHandler.cpp.
+    long minSigStackSize = std::max(0l, long(MINSIGSTKSZ));
+    m_size = std::max(size_t(minSigStackSize), size_t(128*1024));
+    void* stack = mmap(nullptr, m_size, PROT_READ | PROT_WRITE, 
+      MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
+    if (stack != MAP_FAILED) {
+      m_stack = stack;
+
+      stack_t ss{};
+      ss.ss_sp = m_stack;
+      ss.ss_size = m_size;
+      ss.ss_flags = 0;
+      sigaltstack(&ss, nullptr);
+    }
+  }
+
+  ~SigAltStack() {
+    if (m_stack) {
+      stack_t ss{};
+      ss.ss_flags = SS_DISABLE;
+      sigaltstack(&ss, nullptr);
+      munmap(m_stack, m_size);
+    }
+  }
+  
+private:
+  void* m_stack = nullptr;
+  std::size_t m_size = 0;
+};
+
+THREAD_LOCAL_NO_CHECK(SigAltStack, s_sigAltStack);
+InitFiniNode t_altStack([]() {
+  s_sigAltStack.getCheck();
+}, InitFiniNode::When::ThreadInit);
 
 //////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
Today, if an HHVM thread overflows the stack, we try to run the crash reporter and immediately crash due to having overflown the aforementioned stack. It's possible to run into this error state even from userland code, e.g.:
```hack
async function bar(): Awaitable<void> {
	$s = new \HH\Lib\Async\Semaphore(10, async (bool $should_wait) ==> {
		if ($should_wait) {
			await \HH\Asio\usleep(1000 * 100000);
		} else {
			await \HH\Asio\later();
		}
	});

	concurrent {
		await $s->waitForAsync(true);
		await async {
			for ($i = 0; $i < 1000000; $i++) {
				await $s->waitForAsync(false);
			}
		};
	}
}

<<__EntryPoint>>
function mymain(): void {
	\HH\Asio\join(bar());
}
```

This isn't ideal because it prevents reporting tools that process stacktrace files emitted by the crash reporter from accurately reporting these events.

So, use `sigaltstack` to define an alternate signal handler stack for HHVM threads. The folly::Symbolizer docs suggest anything below 64KiB would be insufficient, so size it 128KiB to be safe.