### PR TITLE
Add CMake for sbcc-compiler

### DIFF
--- a/CMake/HPHPSetup.cmake
+++ b/CMake/HPHPSetup.cmake
@@ -36,6 +36,7 @@ set(HHVM_WRAP_SYMS)
 set(HHVM_LINK_LIBRARIES
   $<TARGET_PROPERTY:onig,INTERFACE_LINK_LIBRARIES>
   ${HHVM_WRAP_SYMS}
+  hphp_process_init
   hphp_analysis
   hphp_system
   hphp_zend

--- a/hphp/hhvm/CMakeLists.txt
+++ b/hphp/hhvm/CMakeLists.txt
@@ -3,12 +3,14 @@ include(HHVMExtensionConfig)
 set(CXX_SOURCES)
 auto_sources(files "*.cpp" "")
 list(APPEND CXX_SOURCES ${files})
+list(REMOVE_ITEM CXX_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/process-init.cpp)
+
+add_library(hphp_process_init STATIC process-init.cpp)
+hphp_link(hphp_process_init)
 
 get_object_libraries_objects(additionalObjects ${HHVM_WHOLE_ARCHIVE_LIBRARIES})
 add_executable(hhvm ${CXX_SOURCES} ${additionalObjects})
-target_link_libraries(
-  hhvm ${HHVM_LINK_LIBRARIES} ${EZC_LINK_LIBRARIES} ${HRE_LINK_LIBRARIES}
-)
+target_link_libraries(hhvm ${HHVM_LINK_LIBRARIES} ${EZC_LINK_LIBRARIES} ${HRE_LINK_LIBRARIES})
 link_object_libraries(hhvm ${HHVM_WHOLE_ARCHIVE_LIBRARIES})
 
 hphp_link(hhvm)

--- a/hphp/runtime/ext/CMakeLists.txt
+++ b/hphp/runtime/ext/CMakeLists.txt
@@ -42,11 +42,32 @@ add_object_library(hphp_runtime_ext
   ${CXX_SOURCES} ${C_SOURCES} ${ASM_SOURCES} ${HEADER_SOURCES})
 auto_source_group("hphp_runtime_ext" "${CMAKE_CURRENT_SOURCE_DIR}"
   ${ASM_SOURCES} ${C_SOURCES} ${CXX_SOURCES} ${HEADER_SOURCES})
-target_link_libraries(hphp_runtime_ext hphp_runtime_static hphp_system)
+target_link_libraries(hphp_runtime_ext hphp_sbcc_writer hphp_runtime_static hphp_system)
 object_library_ld_link_libraries(hphp_runtime_ext hphp_zend ${HRE_LINK_LIBRARIES})
 object_library_hphp_link(hphp_runtime_ext)
 HHVM_CONFIGURE_TARGET_FOR_EXTENSION_DEPENDENCIES(hphp_runtime_ext)
 HHVM_PUBLIC_HEADERS(ext ${HEADER_SOURCES})
+
+add_library(hphp_sbcc_writer STATIC
+  sbcc/format/sbcc-writer.cpp
+)
+hphp_link(hphp_sbcc_writer)
+
+add_executable(hphp_sbcc_compiler
+  sbcc/build/main.cpp
+  sbcc/build/sbcc-compiler.cpp
+  sbcc/build/sbcc-file-list.cpp
+  sbcc/build/sbcc-local.cpp
+)
+hphp_link(hphp_sbcc_compiler)
+target_link_libraries(hphp_sbcc_compiler hphp_process_init)
+link_object_libraries(hphp_sbcc_compiler ${HHVM_WHOLE_ARCHIVE_LIBRARIES})
+# tests expect sbcc-build to live under ext/sbcc
+set_target_properties(hphp_sbcc_compiler PROPERTIES
+  OUTPUT_NAME sbcc-build
+  RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/sbcc)
+embed_sections(hphp_sbcc_compiler ${CMAKE_CURRENT_BINARY_DIR}/sbcc/sbcc-build)
+HHVM_INSTALL(hphp_sbcc_compiler bin)
 
 set_property(
   DIRECTORY

--- a/hphp/runtime/ext/sbcc/config.cmake
+++ b/hphp/runtime/ext/sbcc/config.cmake
@@ -1,9 +1,8 @@
 HHVM_DEFINE_EXTENSION("sbcc"
   SOURCES
-    ext_sbcc.cpp
     format/sbcc-cache.cpp
     format/sbcc-reader.cpp
-    format/sbcc-writer.cpp
+    ext_sbcc.cpp
   SYSTEMLIB
     ext_sbcc.php
 )

--- a/hphp/runtime/test/CMakeLists.txt
+++ b/hphp/runtime/test/CMakeLists.txt
@@ -3,7 +3,6 @@ include_directories(${GTEST_INCLUDE_DIRS})
 
 set(CXX_SOURCES)
 auto_sources(files "*.cpp" "RECURSE" "${CMAKE_CURRENT_SOURCE_DIR}")
-list(APPEND CXX_SOURCES ${files} "${CMAKE_CURRENT_SOURCE_DIR}/../../hhvm/process-init.cpp")
 
 set(HEADER_SOURCES)
 auto_sources(files "*.h" "RECURSE" "${CMAKE_CURRENT_SOURCE_DIR}")

--- a/hphp/test/CMakeLists.txt
+++ b/hphp/test/CMakeLists.txt
@@ -8,7 +8,6 @@ foreach (dir ${RECURSIVE_SOURCE_SUBDIRS})
 endforeach(dir ${RECURSIVE_SOURCE_SUBDIRS})
 
 list(APPEND CXX_SOURCES ${files})
-list(APPEND CXX_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/../hhvm/process-init.cpp")
 
 if(NOT HAVE_CUSTOM_LIBEVENT)
   list(REMOVE_ITEM CXX_SOURCES

--- a/hphp/tools/tc-print/CMakeLists.txt
+++ b/hphp/tools/tc-print/CMakeLists.txt
@@ -7,7 +7,6 @@ set(
   offline-trans-data.cpp
   perf-events.cpp
   printir-annotation.cpp
-  ../../hhvm/process-init.cpp
   repo-wrapper.cpp
   std-logger.cpp
   tc-print.cpp


### PR DESCRIPTION
Add appropriate CMake for `sbcc-compiler` so that it can be built in OSS. For this to work, split out a new `hphp_process_init` target shared between `hhvm` and `sbcc-compiler` and likewise move sbcc format files into their own library.

Happy to rework this to use a target arrangement closer to the internal BUCK build too - if you want me to do so, remember I can't see Phab comments! :)