### PR TITLE
Add OSS build CI tests for x64 and arm64

### DIFF
--- a/.github/workflows/oss-build-and-test.yml
+++ b/.github/workflows/oss-build-and-test.yml
@@ -1,0 +1,70 @@
+---
+name: OSS build and tests
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-test:
+    name: ${{ matrix.architecture.name }} / ${{ matrix.compiler.name }}
+    runs-on: ${{ matrix.architecture.runner }}
+    timeout-minutes: 360
+    strategy:
+      fail-fast: false
+      matrix:
+        architecture:
+          - name: x86_64
+            runner: ubuntu-26.04
+          - name: aarch64
+            runner: ubuntu-26.04-arm
+        compiler:
+          - name: clang-21
+            cc: clang-21
+            cxx: clang++-21
+            packages: clang-21 lld-21
+            lld: /usr/bin/ld.lld-21
+          - name: gcc-15
+            cc: gcc-15
+            cxx: g++-15
+            packages: gcc-15 g++-15
+            lld: ""
+    env:
+      HHVM_OSS_WORK_ROOT: ${{ runner.temp }}/hhvm-oss
+      HHVM_BIN: ${{ runner.temp }}/hhvm-oss/hhvm/hphp/hhvm/hhvm
+      HHVM_OSS_BUILD_TOOLS: true
+      HHVM_OSS_CMAKE_BUILD_TYPE: DebugOpt
+      HHVM_OSS_C_COMPILER: ${{ matrix.compiler.cc }}
+      HHVM_OSS_CXX_COMPILER: ${{ matrix.compiler.cxx }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Verify native architecture
+        run: test "$(uname -m)" = "${{ matrix.architecture.name }}"
+      - name: Install and verify compiler
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ${{ matrix.compiler.packages }}
+          actual_version="$("$HHVM_OSS_CXX_COMPILER" -dumpversion | cut -d. -f1)"
+          expected_version="${HHVM_OSS_CXX_COMPILER##*-}"
+          if [ "$actual_version" != "$expected_version" ]; then
+            echo "Expected compiler $expected_version, found $actual_version" >&2
+            exit 1
+          fi
+      - name: Select LLD
+        if: matrix.compiler.lld != ''
+        run: |
+          sudo update-alternatives \
+            --install /usr/bin/ld.lld ld.lld ${{ matrix.compiler.lld }} 1000
+      - name: Build DebugOpt OSS HHVM, HHBBC, and tc-print
+        run: ./build/oss_build.sh
+      - name: Run quick tests
+        run: ./hphp/test/run quick
+      - name: Run slow tests
+        continue-on-error: true
+        run: ./hphp/test/run slow -e ext_sbcc


### PR DESCRIPTION
Summary:
Add land-blocking CI coverage for public HHVM builds on x86_64 and AArch64.

- Define four Sandcastle jobs covering the x64/arm64 and GCC/Clang combinations.
- Keep the detailed distro and compiler-version matrix in `run.sh`: x64 covers Ubuntu 24.04/GCC 14, CentOS Stream 10/GCC 15 or Clang 21, and Ubuntu 26.04/GCC 15 or Clang 21; AArch64 covers Ubuntu 24.04/GCC 14 and CentOS Stream 10/GCC 15 or Clang 21.
- Translate the triggering Sapling diff through CodeSync using the HHVM ShipIt mapping, apply that patch to a fresh clone of public HHVM, and invoke `build/oss_build.sh` in DebugOpt mode with tool builds enabled.
- Build HHVM, HHBBC, and tc-print; require quick tests and treat slow tests as advisory in both Sandcastle and GitHub Actions.
- Verify that each installed compiler resolves to the requested major version before building.
- Configure Sandcastle proxy and TLS access, route ARM Ubuntu packages through `https://ubuntu.mirror.fbinfra.net/ubuntu-ports`, mount the internal mini-opam cache, and redirect dependency hosts unavailable from Sandcastle.
- Add GitHub Actions coverage on Ubuntu 26.04 for x86_64 and AArch64 with GCC 15 and Clang 21.
- Remove the obsolete `oss_devserver_setup.sh` workflow.

Differential Revision: D116527057


