### PR TITLE
Disable time measurements for JIT/interpreter timings

### DIFF
--- a/hphp/runtime/vm/workload-stats.cpp
+++ b/hphp/runtime/vm/workload-stats.cpp
@@ -184,6 +184,9 @@ void RequestWorkloadStats::requestShutdown() {
 }
 
 ALWAYS_INLINE void RequestWorkloadStats::transition(State from, State to) {
+// Disable this logic in OSS as these timing measurements
+// are uneconomical without kernel-level nanosecond timing.
+#ifdef HHVM_FACEBOOK
   switch (from) {
   case State::InRequest:
     switch (to) {
@@ -228,6 +231,7 @@ ALWAYS_INLINE void RequestWorkloadStats::transition(State from, State to) {
     }
     break;
   }
+#endif // HHVM_FACEBOOK
 }
 
 void RequestWorkloadStats::enter(State to) {


### PR DESCRIPTION
`WorkloadStats` measures time we spend JIT translating / interpreting PHP code as well as how this compares against overall request time. These are fairly low level and thus of limited use for HHVM end-users.

We found that these measurements take ~37% of CPU time during JIT warmup because OSS HHVM uses `clock_gettime` for current-thread CPU-time measurements while Meta uses an internal helper backed by `perf_events` which has ~67x higher performance.

Confirmed with @vassilmladenov in our previous sync that the preferred approach would be to disable these in OSS instead of trying to open-source `fb_perf_get_thread_cputime_ns`.