### PR TITLE
JIT: keep generated code RX except during scoped RWX writes

### DIFF
--- a/hphp/runtime/vm/jit/code-cache.cpp
+++ b/hphp/runtime/vm/jit/code-cache.cpp
@@ -28,6 +28,18 @@
 #include "hphp/util/numa.h"
 #include "hphp/util/trace.h"
 
+#include <algorithm>
+#include <atomic>
+#include <cstring>
+#include <mutex>
+#include <pthread.h>
+#include <sched.h>
+#include <vector>
+
+#include <errno.h>
+#include <sys/mman.h>
+#include <unistd.h>
+
 namespace HPHP::jit {
 
 TRACE_SET_MOD(mcg)
@@ -36,12 +48,165 @@ TRACE_SET_MOD(mcg)
 
 namespace {
 
+std::recursive_mutex& codeWriteMutex() {
+  static std::recursive_mutex mutex;
+  return mutex;
+}
+
+constexpr uint64_t kForkBlocked = uint64_t{1} << 63;
+constexpr uint64_t kWriteCountMask = ~kForkBlocked;
+std::atomic<uint64_t> g_codeWriteState{0};
+std::atomic<bool> g_forkInProgress{false};
+thread_local uint32_t g_codeWriteDepth{0};
+
+void enterCodeWrite() {
+  if (g_codeWriteDepth++ != 0) return;
+  while (true) {
+    auto state = g_codeWriteState.load(std::memory_order_acquire);
+    if (state & kForkBlocked) {
+      ::sched_yield();
+      continue;
+    }
+    always_assert((state & kWriteCountMask) != kWriteCountMask);
+    if (g_codeWriteState.compare_exchange_weak(
+          state, state + 1, std::memory_order_acquire,
+          std::memory_order_relaxed)) return;
+  }
+}
+
+void leaveCodeWrite() {
+  always_assert(g_codeWriteDepth != 0);
+  if (--g_codeWriteDepth == 0) {
+    g_codeWriteState.fetch_sub(1, std::memory_order_release);
+  }
+}
+
+void blockCodeWrites() {
+  auto state = g_codeWriteState.load(std::memory_order_acquire);
+  while (!g_codeWriteState.compare_exchange_weak(
+      state, state | kForkBlocked, std::memory_order_acq_rel,
+      std::memory_order_acquire)) {
+  }
+  while (g_codeWriteState.load(std::memory_order_acquire) & kWriteCountMask) {
+    ::sched_yield();
+  }
+}
+
+void unblockCodeWrites() {
+  auto state = g_codeWriteState.load(std::memory_order_acquire);
+  while (true) {
+    always_assert(state & kForkBlocked);
+    if (g_codeWriteState.compare_exchange_weak(
+          state, state & kWriteCountMask, std::memory_order_release,
+          std::memory_order_acquire)) return;
+  }
+}
+
+void lockForkTransaction() {
+  bool expected = false;
+  while (!g_forkInProgress.compare_exchange_weak(
+      expected, true, std::memory_order_acquire,
+      std::memory_order_relaxed)) {
+    expected = false;
+    ::sched_yield();
+  }
+}
+
+void unlockForkTransaction() {
+  g_forkInProgress.store(false, std::memory_order_release);
+}
+
+void ensureCodeWriteAtfork() {
+  static std::once_flag once;
+  std::call_once(once, [] {
+    auto const result = pthread_atfork(
+      [] {
+        lockForkTransaction();
+        blockCodeWrites();
+      },
+      [] {
+        unblockCodeWrites();
+        unlockForkTransaction();
+      },
+      [] {
+        g_codeWriteDepth = 0;
+        unblockCodeWrites();
+        unlockForkTransaction();
+      }
+    );
+    always_assert_flog(result == 0, "pthread_atfork failed: {}", result);
+  });
+}
+
+std::vector<std::pair<CodeAddress, CodeAddress>>& codeWriteActive() {
+  thread_local std::vector<std::pair<CodeAddress, CodeAddress>> active;
+  return active;
+}
+
+size_t codeProtectGranularity() {
+  if (Cfg::CodeCache::MapTCHuge) return size2m;
+  auto const pageSize = ::sysconf(_SC_PAGESIZE);
+  return pageSize > 0 ? static_cast<size_t>(pageSize) : 4096;
+}
+
+void checkedProtect(CodeAddress address, size_t size, int protection) {
+  if (!size) return;
+  auto const result = ::mprotect(address, size, protection);
+  always_assert_flog(
+    result == 0,
+    "mprotect({:#x}, {}, {:#x}) failed: {}",
+    reinterpret_cast<uintptr_t>(address), size, protection, strerror(errno)
+  );
+}
+
+CodeAddress alignDownAddress(ConstCodeAddress address, size_t granularity) {
+  auto const value = reinterpret_cast<uintptr_t>(address);
+  return reinterpret_cast<CodeAddress>(value & ~(granularity - 1));
+}
+
+CodeAddress alignUpAddress(ConstCodeAddress address, size_t granularity) {
+  auto const value = reinterpret_cast<uintptr_t>(address);
+  return reinterpret_cast<CodeAddress>(
+    (value + granularity - 1) & ~(granularity - 1)
+  );
+}
+
+std::vector<std::pair<CodeAddress, CodeAddress>> subtractCovered(
+    CodeAddress begin, CodeAddress end,
+    const std::vector<std::pair<CodeAddress, CodeAddress>>& covered) {
+  std::vector<std::pair<CodeAddress, CodeAddress>> uncovered;
+  if (begin >= end) return uncovered;
+
+  auto current = begin;
+  auto sorted = covered;
+  std::sort(sorted.begin(), sorted.end(),
+            [](auto const& lhs, auto const& rhs) {
+              return lhs.first < rhs.first;
+            });
+  for (auto const& interval : sorted) {
+    if (interval.second <= current) continue;
+    if (interval.first >= end) break;
+    if (interval.first > current) {
+      uncovered.emplace_back(current, std::min(interval.first, end));
+    }
+    if (interval.second > current) current = interval.second;
+    if (current >= end) break;
+  }
+  if (current < end) uncovered.emplace_back(current, end);
+  return uncovered;
+}
+
+} // namespace
+
+namespace {
+
 void enhugen(void* base, unsigned numMB) {
   if (Cfg::CodeCache::MapTCHuge) {
     assertx((uintptr_t(base) & (size2m - 1)) == 0);
     assertx(numMB < (1 << 12));
     remap_interleaved_2m_pages(base, /* number of 2M pages */ numMB / 2);
-    madvise(base, numMB << 20, MADV_DONTFORK);
+    // Keep huge-page code mappings forkable. Child JIT writes use ordinary
+    // anonymous COW together with CodeWriteScope's temporary mprotect.
   }
 }
 
@@ -270,11 +435,6 @@ CodeCache::CodeCache() {
   TRACE(1, "init gdata @%p\n", m_all.frontier());
   m_data.ensure(*this, kGDataSize);
 
-  // The default on linux for the newly allocated memory is read/write/exec
-  // but on some systems its just read/write. Call unprotect to ensure that
-  // the memory is marked executable.
-  unprotect();
-
   // Assert that no one is actually writing to or reading from the pseudo
   // addresses used to emit thread local translations
   if (thread_local_size) {
@@ -371,12 +531,116 @@ bool CodeCache::isValidCodeAddress(ConstCodeAddress addr) const {
      addr >= m_threadLocalStart + m_threadLocalSize);
 }
 
+bool CodeCache::isProtectedCodeAddress(ConstCodeAddress addr) const {
+  if (addr == nullptr || !m_all.contains(addr)) return false;
+  if (m_threadLocalStart && addr >= m_threadLocalStart &&
+      addr < m_threadLocalStart + m_threadLocalSize) {
+    return false;
+  }
+  auto const index = static_cast<size_t>((addr - m_base) >> 21);
+  if (index >= m_blocks.size()) return false;
+  auto const block = m_blocks[index].load(std::memory_order_relaxed);
+  return block && block->name() != kGdataName && block->contains(addr);
+}
+
 void CodeCache::protect() {
   mprotect(m_base, m_codeSize, PROT_READ | PROT_EXEC);
 }
 
 void CodeCache::unprotect() {
   mprotect(m_base, m_codeSize, PROT_READ | PROT_WRITE | PROT_EXEC);
+}
+
+CodeWriteScope::CodeWriteScope(CodeBlock& block) {
+  if (block.base() == nullptr || block.size() == 0) return;
+  init(block.base(), block.base() + block.size());
+}
+
+CodeWriteScope::CodeWriteScope(CodeAddress begin, CodeAddress end) {
+  init(begin, end);
+}
+
+CodeWriteScope::CodeWriteScope(ConstCodeAddress begin,
+                               ConstCodeAddress end) {
+  init(begin, end);
+}
+
+void CodeWriteScope::init(ConstCodeAddress begin, ConstCodeAddress end) {
+  if (begin == nullptr || end == nullptr || begin >= end) return;
+  auto const* code = tc::g_code;
+  if (!code || !code->isProtectedCodeAddress(begin) ||
+      !code->isProtectedCodeAddress(end - 1)) {
+    return;
+  }
+
+  auto const granularity = codeProtectGranularity();
+  auto const alignedBegin = alignDownAddress(begin, granularity);
+  auto const alignedEnd = alignUpAddress(end, granularity);
+  if (alignedBegin >= alignedEnd) return;
+
+  ensureCodeWriteAtfork();
+  enterCodeWrite();
+  m_mutex = &codeWriteMutex();
+  m_mutex->lock();
+  m_locked = true;
+  auto& active = codeWriteActive();
+  try {
+    for (auto const& interval : subtractCovered(
+           alignedBegin, alignedEnd, active)) {
+      checkedProtect(interval.first, interval.second - interval.first,
+                     PROT_READ | PROT_WRITE | PROT_EXEC);
+      try {
+        active.push_back(interval);
+        m_owned.push_back(interval);
+      } catch (...) {
+        checkedProtect(interval.first, interval.second - interval.first,
+                       PROT_READ | PROT_EXEC);
+        for (auto it = active.begin(); it != active.end(); ++it) {
+          if (*it == interval) {
+            active.erase(it);
+            break;
+          }
+        }
+        throw;
+      }
+    }
+  } catch (...) {
+    for (auto const& interval : m_owned) {
+      checkedProtect(interval.first, interval.second - interval.first,
+                     PROT_READ | PROT_EXEC);
+      for (auto it = active.begin(); it != active.end(); ++it) {
+        if (*it == interval) {
+          active.erase(it);
+          break;
+        }
+      }
+    }
+    m_owned.clear();
+    m_locked = false;
+    m_mutex->unlock();
+    m_mutex = nullptr;
+    leaveCodeWrite();
+    throw;
+  }
+}
+
+CodeWriteScope::~CodeWriteScope() {
+  if (!m_locked) return;
+  auto& active = codeWriteActive();
+  for (auto const& interval : m_owned) {
+    checkedProtect(interval.first, interval.second - interval.first,
+                   PROT_READ | PROT_EXEC);
+    for (auto it = active.begin(); it != active.end(); ++it) {
+      if (*it == interval) {
+        active.erase(it);
+        break;
+      }
+    }
+  }
+  m_owned.clear();
+  m_mutex->unlock();
+  m_mutex = nullptr;
+  leaveCodeWrite();
 }
 
 const bool CodeCache::isAnySectionFull() const {
@@ -431,8 +695,8 @@ void CodeCache::SectionImpl<name, code, overAllocate, forwardAllocation, pageSiz
   }
 
   if (code) {
-    mprotect(block->frontier(), block->size(),
-             PROT_READ | PROT_WRITE | PROT_EXEC);
+    checkedProtect(block->frontier(), block->size(),
+                   PROT_READ | PROT_EXEC);
   }
 
   size_t first = (block->base() - cc.base()) >> 21;

--- a/hphp/runtime/vm/jit/code-cache.h
+++ b/hphp/runtime/vm/jit/code-cache.h
@@ -21,6 +21,10 @@
 
 #include "hphp/util/data-block.h"
 
+#include <mutex>
+#include <utility>
+#include <vector>
+
 namespace HPHP::jit {
 
 namespace tc {
@@ -153,6 +157,7 @@ struct CodeCache {
     return addr - m_base;
   }
   bool isValidCodeAddress(ConstCodeAddress addr) const;
+  bool isProtectedCodeAddress(ConstCodeAddress addr) const;
 
   bool inMain(ConstCodeAddress addr) const {
     return m_all.contains(addr) && blockFor(addr).name() == kMainName;
@@ -343,6 +348,32 @@ private:
   DataBlock* m_data;
   bool m_isLocal;
   bool m_isOwned;
+};
+
+/*
+ * Serialize writes to published JIT code and open only the affected pages for
+ * the duration of the write. Nested scopes share their parent's writable
+ * intervals, so an inner scope cannot restore a page while an outer scope is
+ * still emitting into it.
+ */
+struct CodeWriteScope {
+  CodeWriteScope() = default;
+  explicit CodeWriteScope(CodeBlock& block);
+  CodeWriteScope(CodeAddress begin, CodeAddress end);
+  CodeWriteScope(ConstCodeAddress begin, ConstCodeAddress end);
+  ~CodeWriteScope();
+
+  CodeWriteScope(const CodeWriteScope&) = delete;
+  CodeWriteScope& operator=(const CodeWriteScope&) = delete;
+  CodeWriteScope(CodeWriteScope&&) = delete;
+  CodeWriteScope& operator=(CodeWriteScope&&) = delete;
+
+private:
+  void init(ConstCodeAddress begin, ConstCodeAddress end);
+
+  bool m_locked{false};
+  std::recursive_mutex* m_mutex{nullptr};
+  std::vector<std::pair<CodeAddress, CodeAddress>> m_owned;
 };
 
 }

--- a/hphp/runtime/vm/jit/relocation-arm.cpp
+++ b/hphp/runtime/vm/jit/relocation-arm.cpp
@@ -19,6 +19,7 @@
 #include "hphp/runtime/vm/jit/abi-arm.h"
 #include "hphp/runtime/vm/jit/align-arm.h"
 #include "hphp/runtime/vm/jit/cg-meta.h"
+#include "hphp/runtime/vm/jit/code-cache.h"
 #include "hphp/runtime/vm/jit/containers.h"
 #include "hphp/runtime/vm/jit/service-requests.h"
 #include "hphp/runtime/vm/jit/smashable-instr-arm.h"
@@ -1917,6 +1918,8 @@ void adjustForRelocation(RelocationInfo& rel, TCA srcStart, TCA srcEnd) {
     always_assert(end);
   }
 
+  CodeWriteScope scope(reinterpret_cast<TCA>(start),
+                       reinterpret_cast<TCA>(end));
   adjustInstructions(rel, start, end, false);
 }
 
@@ -1927,6 +1930,8 @@ void adjustForRelocation(RelocationInfo& rel, TCA srcStart, TCA srcEnd) {
 void adjustCodeForRelocation(RelocationInfo& rel, CGMeta& meta) {
   for (auto codePtr : meta.codePointers) {
     if (auto adjusted = rel.adjustedAddressAfter(*codePtr)) {
+      CodeWriteScope scope(reinterpret_cast<TCA>(codePtr),
+                           reinterpret_cast<TCA>(codePtr) + sizeof(TCA));
       *codePtr = adjusted;
     }
   }

--- a/hphp/runtime/vm/jit/relocation-x64.cpp
+++ b/hphp/runtime/vm/jit/relocation-x64.cpp
@@ -18,6 +18,7 @@
 
 #include "hphp/runtime/vm/jit/align-x64.h"
 #include "hphp/runtime/vm/jit/cg-meta.h"
+#include "hphp/runtime/vm/jit/code-cache.h"
 #include "hphp/runtime/vm/jit/smashable-instr.h"
 
 #include "hphp/util/configs/jit.h"
@@ -298,6 +299,7 @@ void adjustForRelocation(RelocationInfo& rel, TCA srcStart, TCA srcEnd) {
   } else {
     always_assert(end);
   }
+  CodeWriteScope scope(start, end);
   while (start != end) {
     assertx(start < end);
     DecodedInstruction di(start);
@@ -348,6 +350,8 @@ void adjustForRelocation(RelocationInfo& rel, TCA srcStart, TCA srcEnd) {
 void adjustCodeForRelocation(RelocationInfo& rel, CGMeta& fixups) {
   for (auto codePtr : fixups.codePointers) {
     if (TCA adjusted = rel.adjustedAddressAfter(*codePtr)) {
+      CodeWriteScope scope(reinterpret_cast<TCA>(codePtr),
+                           reinterpret_cast<TCA>(codePtr) + sizeof(TCA));
       *codePtr = adjusted;
     }
   }

--- a/hphp/runtime/vm/jit/relocation.cpp
+++ b/hphp/runtime/vm/jit/relocation.cpp
@@ -15,6 +15,7 @@
 */
 
 #include "hphp/runtime/vm/jit/relocation.h"
+#include "hphp/runtime/vm/jit/code-cache.h"
 #ifdef __aarch64__
 #include "hphp/runtime/vm/jit/relocation-arm.h"
 #else
@@ -382,6 +383,7 @@ size_t relocate(RelocationInfo& rel,
                 CodeBlock& srcBlock,
                 CGMeta& fixups,
                 AreaIndex codeArea) {
+  CodeWriteScope scope(destBlock);
   return ARCH_SWITCH_CALL(relocate, rel, destBlock, start, end, srcBlock,
                           fixups, codeArea);
 }

--- a/hphp/runtime/vm/jit/smashable-instr-arm.cpp
+++ b/hphp/runtime/vm/jit/smashable-instr-arm.cpp
@@ -442,9 +442,14 @@ bool optimizeSmashedJcc(TCA inst) {
 
   if (is_int28(offset)) {
     auto const veneerInstrs = load.instrCount() + 1; // load + BR
+    auto const veneerTCA = reinterpret_cast<TCA>(
+      const_cast<vixl::Instruction*>(veneer)
+    );
+    CodeWriteScope scope(veneerTCA,
+                         veneerTCA + veneerInstrs * kInstructionSize);
     CodeBlock tmpBlock;
     tmpBlock.init(
-      (TCA)veneer,
+      veneerTCA,
       veneerInstrs * kInstructionSize,
       "optimizeSmashedJcc"
     );

--- a/hphp/runtime/vm/jit/smashable-instr-arm.h
+++ b/hphp/runtime/vm/jit/smashable-instr-arm.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include "hphp/runtime/vm/jit/align-arm.h"
+#include "hphp/runtime/vm/jit/code-cache.h"
 #include "hphp/runtime/vm/jit/types.h"
 #include "hphp/runtime/vm/jit/phys-reg.h"
 
@@ -101,6 +102,7 @@ inline uint32_t makeTarget32(T target) {
 }
 
 inline void patchTarget32(TCA inst, TCA target) {
+  CodeWriteScope scope(inst, inst + 4);
   *reinterpret_cast<uint32_t*>(inst) = makeTarget32(target);
   auto const begin = inst;
   auto const end = begin + 4;
@@ -109,6 +111,7 @@ inline void patchTarget32(TCA inst, TCA target) {
 
 inline void patchTarget64(TCA inst, TCA target) {
   assertx(is_aligned(inst - kSmashMovqImmOff, Alignment::SmashMovq));
+  CodeWriteScope scope(inst, inst + 8);
   *reinterpret_cast<uint64_t*>(inst) = reinterpret_cast<uint64_t>(target);
   auto const begin = inst;
   auto const end = begin + 8;
@@ -117,6 +120,7 @@ inline void patchTarget64(TCA inst, TCA target) {
 
 inline void smashInst(TCA addr, uint32_t newInst) {
   assertx(((uint64_t)addr & 3) == 0);
+  CodeWriteScope scope(addr, addr + 4);
   *reinterpret_cast<uint32_t*>(addr) = newInst;
   auto const begin = addr;
   auto const end = begin + 4;

--- a/hphp/runtime/vm/jit/smashable-instr-x64.cpp
+++ b/hphp/runtime/vm/jit/smashable-instr-x64.cpp
@@ -16,6 +16,7 @@
 
 #include "hphp/runtime/vm/jit/smashable-instr-x64.h"
 
+#include "hphp/runtime/vm/jit/code-cache.h"
 #include "hphp/util/asm-x64.h"
 #include "hphp/util/data-block.h"
 
@@ -83,21 +84,25 @@ TCA emitSmashableJcc(CodeBlock& cb, CGMeta& fixups, TCA target,
 
 void smashMovq(TCA inst, uint64_t imm) {
   always_assert(is_aligned(inst, Alignment::SmashMovq));
+  CodeWriteScope scope(inst, inst + smashableMovqLen());
   *reinterpret_cast<uint64_t*>(inst + kSmashMovqImmOff) = imm;
 }
 
 void smashCmpq(TCA inst, uint32_t imm) {
   always_assert(is_aligned(inst, Alignment::SmashCmpq));
+  CodeWriteScope scope(inst, inst + smashableCmpqLen());
   *reinterpret_cast<uint32_t*>(inst + kSmashCmpqImmOff) = imm;
 }
 
 void smashCall(TCA inst, TCA target) {
   always_assert(is_aligned(inst, Alignment::SmashCall));
+  CodeWriteScope scope(inst, inst + smashableCallLen());
   X64Assembler::patchCall(inst, inst, target);
 }
 
 void smashJmp(TCA inst, TCA target) {
   always_assert(is_aligned(inst, Alignment::SmashJmp));
+  CodeWriteScope scope(inst, inst + smashableJmpLen());
 
   // Smashing jmps can be tricky because we sometimes override the entire five
   // byte instruction with a nop rather than updating the four byte immediate.
@@ -143,14 +148,17 @@ void smashJmp(TCA inst, TCA target) {
 
 void smashJcc(TCA inst, TCA target) {
   always_assert(is_aligned(inst, Alignment::SmashJcc));
+  CodeWriteScope scope(inst, inst + smashableJccLen());
   X64Assembler::patchJcc(inst, inst, target);
 }
 
 void smashInterceptJcc(TCA inst) {
+  CodeWriteScope scope(inst, inst + 6);
   X64Assembler::patchInterceptJcc(inst);
 }
 
 void smashInterceptJmp(TCA inst) {
+  CodeWriteScope scope(inst, inst + 5);
   X64Assembler::patchInterceptJmp(inst);
 }
 

--- a/hphp/runtime/vm/jit/tc-recycle.cpp
+++ b/hphp/runtime/vm/jit/tc-recycle.cpp
@@ -22,6 +22,7 @@
 #include "hphp/runtime/vm/treadmill.h"
 
 #include "hphp/runtime/vm/jit/cg-meta.h"
+#include "hphp/runtime/vm/jit/code-cache.h"
 #include "hphp/runtime/vm/jit/func-order.h"
 #include "hphp/runtime/vm/jit/types.h"
 #include "hphp/runtime/vm/jit/prof-data.h"
@@ -266,6 +267,7 @@ void clearRange(TCA start, size_t len, const char* info) {
   if (len == 0) {
     return;
   }
+  CodeWriteScope scope(start, start + len);
   CodeBlock cb;
   cb.init(start, len, info);
 

--- a/hphp/runtime/vm/jit/tc-relocate.cpp
+++ b/hphp/runtime/vm/jit/tc-relocate.cpp
@@ -16,6 +16,7 @@
 
 #include "hphp/runtime/vm/jit/tc.h"
 #include "hphp/runtime/vm/jit/relocation.h"
+#include "hphp/runtime/vm/jit/code-cache.h"
 
 #include "hphp/runtime/vm/jit/cg-meta.h"
 #include "hphp/runtime/vm/jit/print.h"
@@ -99,6 +100,8 @@ void relocateTranslation(
     assertx(!main.contains(ib.toSmash()));
     assertx(!cold.contains(ib.toSmash()));
   }
+  CodeWriteScope mainScope(main);
+  CodeWriteScope coldScope(cold);
   memset(main.base(), 0xcc, main.frontier() - main.base());
   memset(cold.base(), 0xcc, cold.frontier() - cold.base());
   if (arch::any<arch::ARM>()) {

--- a/hphp/runtime/vm/jit/unique-stubs-resumable.cpp
+++ b/hphp/runtime/vm/jit/unique-stubs-resumable.cpp
@@ -595,6 +595,10 @@ void UniqueStubs::emitAllResumable(CodeCache& code, Debug::DebugInfo& dbg) {
   auto& hotBlock = optView.main();
   auto& data = view.data();
 
+  CodeWriteScope mainScope(view.main());
+  CodeWriteScope coldScope(view.cold());
+  CodeWriteScope hotScope(hotBlock);
+
   auto const hot = [&]() -> CodeBlock& {
     return hotBlock.available() > 512 ? hotBlock : main;
   };

--- a/hphp/runtime/vm/jit/unique-stubs.cpp
+++ b/hphp/runtime/vm/jit/unique-stubs.cpp
@@ -1508,6 +1508,11 @@ void UniqueStubs::emitAll(CodeCache& code, Debug::DebugInfo& dbg) {
   auto& hotBlock = optView.main();
   auto& data = view.data();
 
+  CodeWriteScope mainScope(main);
+  CodeWriteScope coldScope(cold);
+  CodeWriteScope frozenScope(frozen);
+  CodeWriteScope hotScope(hotBlock);
+
   auto const hot = [&]() -> CodeBlock& {
     return hotBlock.available() > 512 ? hotBlock : main;
   };

--- a/hphp/runtime/vm/jit/vasm-emit.cpp
+++ b/hphp/runtime/vm/jit/vasm-emit.cpp
@@ -21,6 +21,7 @@
 #include "hphp/runtime/vm/jit/align.h"
 #include "hphp/runtime/vm/jit/asm-info.h"
 #include "hphp/runtime/vm/jit/cg-meta.h"
+#include "hphp/runtime/vm/jit/code-cache.h"
 #include "hphp/runtime/vm/jit/ir-unit.h"
 #include "hphp/runtime/vm/jit/print.h"
 #include "hphp/runtime/vm/jit/relocation.h"
@@ -123,7 +124,22 @@ void optimize(Vunit& vunit, const Abi& abi, bool regalloc) {
 }
 
 void emit(Vunit& vunit, Vtext& vtext, CGMeta& meta, AsmInfo* ai) {
-  ARCH_SWITCH_CALL(emit, vunit, vtext, meta, ai);
+  auto const& areas = vtext.areas();
+  if (areas.empty()) {
+    ARCH_SWITCH_CALL(emit, vunit, vtext, meta, ai);
+  } else if (areas.size() == 1) {
+    CodeWriteScope scope(areas[0].code);
+    ARCH_SWITCH_CALL(emit, vunit, vtext, meta, ai);
+  } else if (areas.size() == 2) {
+    CodeWriteScope mainScope(areas[0].code);
+    CodeWriteScope coldScope(areas[1].code);
+    ARCH_SWITCH_CALL(emit, vunit, vtext, meta, ai);
+  } else {
+    CodeWriteScope mainScope(areas[0].code);
+    CodeWriteScope coldScope(areas[1].code);
+    CodeWriteScope frozenScope(areas[2].code);
+    ARCH_SWITCH_CALL(emit, vunit, vtext, meta, ai);
+  }
 }
 
 void emitVunit(Vunit& vunit, const IRUnit* unit,


### PR DESCRIPTION
Keep JIT code-cache sections read-execute (RX) by default instead of leaving them writable. Use CodeWriteScope to temporarily change affected pages to read-write-execute (RWX) for code emission and modification, then restore RX when the scope exits.

Apply these scopes to code emission, instruction smashing, relocation, recycling, and stub generation. Serialize protection changes and track nested scopes so overlapping writes restore permissions correctly.

Coordinate writes with pthread_atfork and retain forkable huge-page code mappings so child writes preserve copy-on-write behavior.